### PR TITLE
fix: restore semantic release versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,78 +81,10 @@ jobs:
               f.write(f"level={level}\n")
           PYEOF
 
-      - name: Compute version from canonical + commit height
+      - name: Compute semantic version from canonical + release history
         id: ver
         run: |
-          python - <<'PYEOF'
-          import subprocess, os, re, tomllib
-
-          with open("pyproject.toml", "rb") as f:
-              data = tomllib.load(f)
-          canonical = data["project"]["version"]
-          major, minor, patch = map(int, re.match(r"(\d+)\.(\d+)\.(\d+)", canonical).groups())
-
-          level = os.environ.get("LEVEL", "patch")
-          manual = os.environ.get("MANUAL_VER", "")
-
-          if manual:
-              new_ver = manual
-              bump = "manual"
-              npm_ver = manual
-              canonical_out = ""
-              height_out = "0"
-              previous_tag_out = ""
-          else:
-              # Find last tag matching v{canonical}.*
-              tag_prefix = f"v{canonical}."
-              tag_result = subprocess.run(
-                  ["git", "tag", "-l", f"{tag_prefix}*"],
-                  capture_output=True, text=True, check=False
-              )
-              tags = [t.strip() for t in tag_result.stdout.strip().split("\n") if t.strip()]
-
-              if tags:
-                  # Sort by version number, get highest
-                  def parse_tag(t):
-                      v = t.lstrip("v")
-                      parts = re.match(r"(\d+)\.(\d+)\.(\d+)\.(\d+)", v)
-                      return tuple(int(x) for x in parts.groups()) if parts else (0, 0, 0, 0)
-                  tags.sort(key=parse_tag, reverse=True)
-                  last_tag = tags[0]
-                  prev_height = int(last_tag.rsplit(".", 1)[-1])
-
-                  # Count commits since the last tagged release
-                  count_result = subprocess.run(
-                      ["git", "rev-list", f"{last_tag}..HEAD", "--count"],
-                      capture_output=True, text=True, check=False
-                  )
-                  height = int(count_result.stdout.strip())
-              else:
-                  # No prior tag at this canonical level — height = 0
-                  prev_height = 0
-                  height = 0
-
-              # Determine bump
-              if level == "major":
-                  new_ver = f"{major + 1}.0.0.0"
-                  npm_ver = f"{major + 1}.0.0"
-              elif level == "minor":
-                  new_ver = f"{major}.{minor + 1}.0.0"
-                  npm_ver = f"{major}.{minor + 1}.0"
-              else:  # patch
-                  new_ver = f"{canonical}.{prev_height + 1}"
-                  npm_ver = f"{major}.{minor}.{patch + 1}"
-
-              bump = level
-
-          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-              f.write(f"version={new_ver}\n")
-              f.write(f"npm_version={npm_ver}\n")
-              f.write(f"canonical={canonical_out if manual else canonical}\n")
-              f.write(f"height={height_out if manual else height}\n")
-              f.write(f"bump={bump}\n")
-              f.write(f"previous_tag={previous_tag_out if manual else (last_tag if tags else '')}\n")
-          PYEOF
+          python -m headroom.release_version
         env:
           LEVEL: ${{ steps.bump.outputs.level }}
           MANUAL_VER: ${{ github.event.inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   detect-version:
     runs-on: ubuntu-latest
@@ -290,6 +294,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create v${{ needs.detect-version.outputs.version }} \
-            --title "Release v${{ needs.detect-version.outputs.version }}" \
-            --notes-file .changelog.md
+          TAG="v${{ needs.detect-version.outputs.version }}"
+          TITLE="Release v${{ needs.detect-version.outputs.version }}"
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            gh release edit "$TAG" --title "$TITLE" --notes-file .changelog.md
+          else
+            gh release create "$TAG" --title "$TITLE" --notes-file .changelog.md
+          fi

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2532,7 +2532,8 @@ if __name__ == "__main__":
         "--openai-api-url", help=f"Custom OpenAI API URL (default: {HeadroomProxy.OPENAI_API_URL})"
     )
     parser.add_argument(
-        "--anthropic-api-url", help=f"Custom Anthropic API URL (default: {HeadroomProxy.ANTHROPIC_API_URL})"
+        "--anthropic-api-url",
+        help=f"Custom Anthropic API URL (default: {HeadroomProxy.ANTHROPIC_API_URL})",
     )
 
     # Backend (anthropic direct, bedrock, openrouter, anyllm, or litellm-<provider>)

--- a/headroom/release_version.py
+++ b/headroom/release_version.py
@@ -95,9 +95,10 @@ def compute_release_version(
     """Compute the next release version from the canonical version and existing tags."""
 
     if manual_version:
+        manual = str(SemVer.parse(manual_version))
         return ReleaseVersionInfo(
-            version=manual_version,
-            npm_version=manual_version,
+            version=manual,
+            npm_version=manual,
             canonical=canonical_version,
             height="0",
             bump="manual",

--- a/headroom/release_version.py
+++ b/headroom/release_version.py
@@ -130,8 +130,8 @@ def get_canonical_version(root: Path) -> str:
         import tomli as tomllib
 
     with open(root / "pyproject.toml", "rb") as file:
-        data = tomllib.load(file)
-    return data["project"]["version"]
+        project = tomllib.load(file)["project"]
+    return str(project["version"])
 
 
 def list_release_tags(root: Path) -> list[str]:

--- a/headroom/release_version.py
+++ b/headroom/release_version.py
@@ -9,8 +9,6 @@ from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-import tomllib
-
 SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?$")
 
@@ -125,6 +123,11 @@ def compute_release_version(
 
 def get_canonical_version(root: Path) -> str:
     """Read the canonical project version from pyproject.toml."""
+
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+        import tomli as tomllib
 
     with open(root / "pyproject.toml", "rb") as file:
         data = tomllib.load(file)

--- a/headroom/release_version.py
+++ b/headroom/release_version.py
@@ -1,0 +1,193 @@
+"""Release version helpers for the GitHub Actions release workflow."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import tomllib
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?$")
+
+
+@dataclass(frozen=True, order=True)
+class SemVer:
+    """Semantic version tuple with simple bump helpers."""
+
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, value: str) -> SemVer:
+        match = SEMVER_RE.match(value)
+        if not match:
+            raise ValueError(f"Invalid semantic version: {value}")
+        return cls(*(int(part) for part in match.groups()))
+
+    def bump(self, level: str) -> SemVer:
+        if level == "major":
+            return SemVer(self.major + 1, 0, 0)
+        if level == "minor":
+            return SemVer(self.major, self.minor + 1, 0)
+        if level == "patch":
+            return SemVer(self.major, self.minor, self.patch + 1)
+        raise ValueError(f"Unsupported bump level: {level}")
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+@dataclass(frozen=True)
+class ReleaseVersionInfo:
+    """Workflow outputs for release version calculation."""
+
+    version: str
+    npm_version: str
+    canonical: str
+    height: str
+    bump: str
+    previous_tag: str
+
+    def as_outputs(self) -> dict[str, str]:
+        return {
+            "version": self.version,
+            "npm_version": self.npm_version,
+            "canonical": self.canonical,
+            "height": self.height,
+            "bump": self.bump,
+            "previous_tag": self.previous_tag,
+        }
+
+
+def normalize_release_tag(tag: str) -> SemVer:
+    """Collapse historic 4-part release tags into a standard semver version."""
+
+    match = RELEASE_TAG_RE.match(tag)
+    if not match:
+        raise ValueError(f"Invalid release tag: {tag}")
+    major, minor, patch, extra = match.groups()
+    return SemVer(int(major), int(minor), int(patch) + int(extra or 0))
+
+
+def find_latest_release_tag(tags: Sequence[str]) -> str | None:
+    """Return the latest release tag after normalizing legacy 4-part tags."""
+
+    candidates: list[tuple[SemVer, str]] = []
+    for tag in tags:
+        if RELEASE_TAG_RE.match(tag):
+            candidates.append((normalize_release_tag(tag), tag))
+    if not candidates:
+        return None
+    candidates.sort(reverse=True)
+    return candidates[0][1]
+
+
+def compute_release_version(
+    canonical_version: str,
+    level: str,
+    tags: Sequence[str],
+    manual_version: str = "",
+) -> ReleaseVersionInfo:
+    """Compute the next release version from the canonical version and existing tags."""
+
+    if manual_version:
+        return ReleaseVersionInfo(
+            version=manual_version,
+            npm_version=manual_version,
+            canonical=canonical_version,
+            height="0",
+            bump="manual",
+            previous_tag="",
+        )
+
+    canonical = SemVer.parse(canonical_version)
+    previous_tag = find_latest_release_tag(tags)
+    current = canonical
+    if previous_tag is not None:
+        current = max(current, normalize_release_tag(previous_tag))
+
+    next_version = str(current.bump(level))
+    return ReleaseVersionInfo(
+        version=next_version,
+        npm_version=next_version,
+        canonical=canonical_version,
+        height="0",
+        bump=level,
+        previous_tag=previous_tag or "",
+    )
+
+
+def get_canonical_version(root: Path) -> str:
+    """Read the canonical project version from pyproject.toml."""
+
+    with open(root / "pyproject.toml", "rb") as file:
+        data = tomllib.load(file)
+    return data["project"]["version"]
+
+
+def list_release_tags(root: Path) -> list[str]:
+    """List release tags from the local Git checkout."""
+
+    result = subprocess.run(
+        ["git", "tag", "-l", "v*"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [tag.strip() for tag in result.stdout.splitlines() if tag.strip()]
+
+
+def commit_height_since(root: Path, previous_tag: str) -> str:
+    """Count commits since the previous release tag for changelog/debug outputs."""
+
+    if not previous_tag:
+        return "0"
+
+    result = subprocess.run(
+        ["git", "rev-list", f"{previous_tag}..HEAD", "--count"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() or "0"
+
+
+def write_github_outputs(info: ReleaseVersionInfo, output_path: str) -> None:
+    """Append workflow outputs to the GitHub Actions output file."""
+
+    with open(output_path, "a", encoding="utf-8") as output_file:
+        for key, value in info.as_outputs().items():
+            output_file.write(f"{key}={value}\n")
+
+
+def main() -> None:
+    root = Path.cwd()
+    manual_version = os.environ.get("MANUAL_VER", "").strip()
+    level = os.environ.get("LEVEL", "patch").strip() or "patch"
+
+    info = compute_release_version(
+        canonical_version=get_canonical_version(root),
+        level=level,
+        tags=list_release_tags(root),
+        manual_version=manual_version,
+    )
+    info = replace(info, height=commit_height_since(root, info.previous_tag))
+
+    output_path = os.environ.get("GITHUB_OUTPUT", "").strip()
+    if output_path:
+        write_github_outputs(info, output_path)
+        return
+
+    for key, value in info.as_outputs().items():
+        print(f"{key}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/headroom/release_version.py
+++ b/headroom/release_version.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import os
 import re
 import subprocess
-import tomllib
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
+
+import tomllib
 
 SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?$")

--- a/headroom/release_version.py
+++ b/headroom/release_version.py
@@ -63,27 +63,46 @@ class ReleaseVersionInfo:
         }
 
 
-def normalize_release_tag(tag: str) -> SemVer:
-    """Collapse historic 4-part release tags into a standard semver version."""
+@dataclass(frozen=True, order=True)
+class ReleaseTag:
+    """Parsed release tag metadata used for sorting and normalization."""
+
+    version: SemVer
+    legacy_height: int = -1
+    raw: str = ""
+
+
+def parse_release_tag(tag: str) -> ReleaseTag:
+    """Parse a release tag, preserving legacy fourth-component ordering."""
 
     match = RELEASE_TAG_RE.match(tag)
     if not match:
         raise ValueError(f"Invalid release tag: {tag}")
     major, minor, patch, extra = match.groups()
-    return SemVer(int(major), int(minor), int(patch) + int(extra or 0))
+    return ReleaseTag(
+        version=SemVer(int(major), int(minor), int(patch)),
+        legacy_height=int(extra) if extra is not None else -1,
+        raw=tag,
+    )
+
+
+def normalize_release_tag(tag: str) -> SemVer:
+    """Collapse historic 4-part release tags into their base semantic version."""
+
+    return parse_release_tag(tag).version
 
 
 def find_latest_release_tag(tags: Sequence[str]) -> str | None:
     """Return the latest release tag after normalizing legacy 4-part tags."""
 
-    candidates: list[tuple[SemVer, str]] = []
+    candidates: list[ReleaseTag] = []
     for tag in tags:
         if RELEASE_TAG_RE.match(tag):
-            candidates.append((normalize_release_tag(tag), tag))
+            candidates.append(parse_release_tag(tag))
     if not candidates:
         return None
     candidates.sort(reverse=True)
-    return candidates[0][1]
+    return candidates[0].raw
 
 
 def compute_release_version(

--- a/scripts/changelog-gen.py
+++ b/scripts/changelog-gen.py
@@ -16,9 +16,10 @@ COMMIT_PATTERN = re.compile(
     r"^(feat|fix|ci|chore|perf|refactor|docs|style|test)(\(.+\))?(!)?:\s*(.+)$"
 )
 BREAKING_CHANGE_PATTERN = re.compile(r"^BREAKING CHANGE:\s*(.+)$", re.MULTILINE)
-# Pattern to match each commit entry: subject, optional body, |, hash
-# %s%n%b|%H format: "subject\nbody|hash" or "subject|hash" if no body
 COMMIT_ENTRY_PATTERN = re.compile(r"^(.+?)(?:\n(.+))?\|(\w+)$", re.MULTILINE)
+FIELD_SEP = "\x1f"
+RECORD_SEP = "\x1e"
+GIT_LOG_FORMAT = "%s%x1f%b%x1f%h%x1e"
 
 TYPE_LABELS: dict[str, str] = {
     "feat": "Features",
@@ -30,6 +31,7 @@ TYPE_LABELS: dict[str, str] = {
     "docs": "Documentation",
     "style": "Styles",
     "test": "Tests",
+    "other": "Other Changes",
 }
 
 
@@ -41,33 +43,93 @@ class ParsedCommit(NamedTuple):
     hash: str
 
 
+def iter_commit_entries(log_output: str) -> list[tuple[str, str, str]]:
+    """Split raw git log output into (subject, body, hash) tuples."""
+
+    if not log_output.strip():
+        return []
+
+    if RECORD_SEP in log_output and FIELD_SEP in log_output:
+        entries: list[tuple[str, str, str]] = []
+        for raw_entry in log_output.split(RECORD_SEP):
+            if not raw_entry:
+                continue
+            if FIELD_SEP not in raw_entry:
+                continue
+            subject, body_and_hash = raw_entry.split(FIELD_SEP, 1)
+            if FIELD_SEP not in body_and_hash:
+                continue
+            body, commit_hash = body_and_hash.rsplit(FIELD_SEP, 1)
+            entries.append((subject.strip(), body.strip(), commit_hash.strip()))
+        return entries
+
+    return [
+        (
+            match.group(1).strip(),
+            (match.group(2) or "").strip(),
+            match.group(3).strip(),
+        )
+        for match in COMMIT_ENTRY_PATTERN.finditer(log_output)
+    ]
+
+
+def get_merge_summary(subject: str, body: str) -> str:
+    """Return the first meaningful summary line for a merge commit."""
+
+    if not subject.startswith("Merge "):
+        return ""
+
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
 def parse_commits(log_output: str) -> list[ParsedCommit]:
     """Parse git log output into structured commits."""
+
     commits: list[ParsedCommit] = []
 
-    for match in COMMIT_ENTRY_PATTERN.finditer(log_output):
-        subject = match.group(1)
-        body = match.group(2) or ""
-        commit_hash = match.group(3)
-
+    for subject, body, commit_hash in iter_commit_entries(log_output):
         is_breaking = bool(BREAKING_CHANGE_PATTERN.search(body))
-        commit_match = COMMIT_PATTERN.match(subject)
-        if commit_match:
-            commit_type = commit_match.group(1)
+        merge_summary = get_merge_summary(subject, body)
+        candidates = [subject]
+        if merge_summary:
+            candidates.insert(0, merge_summary)
+
+        for candidate in candidates:
+            commit_match = COMMIT_PATTERN.match(candidate)
+            if not commit_match:
+                continue
+
             scope = commit_match.group(2)
             if scope:
-                scope = scope[1:-1]  # Remove parentheses
-            is_breaking = is_breaking or bool(commit_match.group(3))  # ! in subject
-            message = commit_match.group(4)
+                scope = scope[1:-1]
             commits.append(
                 ParsedCommit(
-                    type=commit_type,
+                    type=commit_match.group(1),
                     scope=scope,
-                    breaking=is_breaking,
-                    message=message,
+                    breaking=is_breaking or bool(commit_match.group(3)),
+                    message=commit_match.group(4),
                     hash=commit_hash,
                 )
             )
+            break
+        else:
+            fallback_message = merge_summary or subject
+            if not fallback_message or fallback_message.startswith("Merge "):
+                continue
+            commits.append(
+                ParsedCommit(
+                    type="other",
+                    scope=None,
+                    breaking=is_breaking,
+                    message=fallback_message,
+                    hash=commit_hash,
+                )
+            )
+
     return commits
 
 
@@ -109,7 +171,7 @@ def generate_changelog(version: str, commits: list[ParsedCommit]) -> str:
 
 def run_git_log(since: str | None, cwd: Path) -> str:
     """Run git log command and return output."""
-    cmd = ["git", "log", "--pretty=format:%s%n%b|%H"]
+    cmd = ["git", "log", "--first-parent", f"--pretty=format:{GIT_LOG_FORMAT}"]
     if since:
         cmd.append(f"{since}..HEAD")
     else:

--- a/scripts/tests/test_changelog_gen.py
+++ b/scripts/tests/test_changelog_gen.py
@@ -22,17 +22,23 @@ _spec.loader.exec_module(_changelog_gen)
 
 COMMIT_PATTERN = _changelog_gen.COMMIT_PATTERN
 BREAKING_CHANGE_PATTERN = _changelog_gen.BREAKING_CHANGE_PATTERN
+FIELD_SEP = _changelog_gen.FIELD_SEP
+RECORD_SEP = _changelog_gen.RECORD_SEP
 ParsedCommit = _changelog_gen.ParsedCommit
 generate_changelog = _changelog_gen.generate_changelog
+iter_commit_entries = _changelog_gen.iter_commit_entries
 parse_commits = _changelog_gen.parse_commits
+
+
+def make_log_entry(subject: str, commit_hash: str, body: str = "") -> str:
+    return f"{subject}{FIELD_SEP}{body}{FIELD_SEP}{commit_hash}{RECORD_SEP}"
 
 
 class TestParseCommits:
     """Tests for parse_commits function."""
 
     def test_parses_feat_commit(self) -> None:
-        # Format: subject|hash
-        log_output = "feat(core): add feature|abc1234"
+        log_output = make_log_entry("feat(core): add feature", "abc1234")
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].type == "feat"
@@ -42,7 +48,7 @@ class TestParseCommits:
         assert commits[0].breaking is False
 
     def test_parses_fix_commit(self) -> None:
-        log_output = "fix(ui): fix bug|def5678"
+        log_output = make_log_entry("fix(ui): fix bug", "def5678")
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].type == "fix"
@@ -51,7 +57,7 @@ class TestParseCommits:
         assert commits[0].hash == "def5678"
 
     def test_parses_ci_commit(self) -> None:
-        log_output = "ci: update github actions|xyz789"
+        log_output = make_log_entry("ci: update github actions", "xyz789")
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].type == "ci"
@@ -60,63 +66,104 @@ class TestParseCommits:
         assert commits[0].hash == "xyz789"
 
     def test_parses_chore_commit(self) -> None:
-        log_output = "chore: cleanup|xyz999"
+        log_output = make_log_entry("chore: cleanup", "xyz999")
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].type == "chore"
         assert commits[0].scope is None
 
     def test_parses_perf_commit(self) -> None:
-        log_output = "perf(dashboard): improve performance|abc111"
+        log_output = make_log_entry("perf(dashboard): improve performance", "abc111")
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].type == "perf"
         assert commits[0].scope == "dashboard"
 
     def test_parses_refactor_commit(self) -> None:
-        log_output = "refactor(api): refactor endpoint|abc222"
+        log_output = make_log_entry("refactor(api): refactor endpoint", "abc222")
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].type == "refactor"
         assert commits[0].scope == "api"
 
     def test_parses_docs_commit(self) -> None:
-        log_output = "docs: update readme|abc333"
+        log_output = make_log_entry("docs: update readme", "abc333")
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].type == "docs"
 
     def test_parses_style_commit(self) -> None:
-        log_output = "style: format code|abc444"
+        log_output = make_log_entry("style: format code", "abc444")
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].type == "style"
 
     def test_parses_test_commit(self) -> None:
-        log_output = "test: add tests for feature|abc555"
+        log_output = make_log_entry("test: add tests for feature", "abc555")
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].type == "test"
 
     def test_detects_breaking_change_in_body(self) -> None:
-        # Format: subject\nbody|hash
-        log_output = "feat(core): add feature\nBREAKING CHANGE: api changed|abc666"
+        log_output = make_log_entry(
+            "feat(core): add feature",
+            "abc666",
+            "BREAKING CHANGE: api changed",
+        )
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].breaking is True
 
     def test_detects_breaking_change_exclamation(self) -> None:
-        log_output = "feat(core)!: api changed|abc777"
+        log_output = make_log_entry("feat(core)!: api changed", "abc777")
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].breaking is True
 
     def test_no_scope_no_problem(self) -> None:
-        log_output = "feat: simple feature|abc888"
+        log_output = make_log_entry("feat: simple feature", "abc888")
         commits = parse_commits(log_output)
         assert len(commits) == 1
         assert commits[0].scope is None
         assert commits[0].message == "simple feature"
+
+    def test_uses_pr_title_from_merge_commit_body(self) -> None:
+        log_output = make_log_entry(
+            "Merge pull request #173 from JerrettDavis/fix/pipeline-permissions-and-docs",
+            "73f6673",
+            "fix: repair release and docs pipelines",
+        )
+        commits = parse_commits(log_output)
+        assert len(commits) == 1
+        assert commits[0].type == "fix"
+        assert commits[0].message == "repair release and docs pipelines"
+
+    def test_falls_back_to_other_changes_for_non_conventional_merge(self) -> None:
+        log_output = make_log_entry(
+            "Merge pull request #186 from skorokithakis/patch-1",
+            "1e80ee3",
+            "Add support for custom Anthropic API URL",
+        )
+        commits = parse_commits(log_output)
+        assert len(commits) == 1
+        assert commits[0].type == "other"
+        assert commits[0].message == "Add support for custom Anthropic API URL"
+
+    def test_iter_commit_entries_parses_real_git_log_delimiters(self) -> None:
+        log_output = make_log_entry(
+            "fix: patch release flow", "abc1234", "BREAKING CHANGE: no"
+        ) + make_log_entry("docs: update readme", "def5678")
+        assert iter_commit_entries(log_output) == [
+            ("fix: patch release flow", "BREAKING CHANGE: no", "abc1234"),
+            ("docs: update readme", "", "def5678"),
+        ]
+
+    def test_iter_commit_entries_keeps_field_separator_inside_body(self) -> None:
+        body = f"line one{FIELD_SEP}line two"
+        log_output = make_log_entry("fix: patch release flow", "abc1234", body)
+        assert iter_commit_entries(log_output) == [
+            ("fix: patch release flow", body, "abc1234"),
+        ]
 
 
 class TestGenerateChangelog:
@@ -178,19 +225,33 @@ class TestGenerateChangelog:
         result = generate_changelog("0.6.0", commits)
         assert "Breaking Changes" not in result
 
+    def test_includes_other_changes_section(self) -> None:
+        commits = [
+            ParsedCommit(
+                type="other",
+                scope=None,
+                breaking=False,
+                message="Add support for custom Anthropic API URL",
+                hash="abc123",
+            )
+        ]
+        result = generate_changelog("0.6.0", commits)
+        assert "### Other Changes" in result
+        assert "- Add support for custom Anthropic API URL (abc123)" in result
+
 
 class TestIntegrationWithMock:
     """Integration tests with mocked subprocess.run."""
 
     def test_full_flow_with_mocked_git(self) -> None:
-        # Simulate git log output with format: subject|hash
-        # Breaking change in body: subject\nbody lines|hash
         log_output = (
-            "feat(core): add new feature|abc1234\n"
-            "fix(ui): fix bug|def5678\n"
-            "ci: update github actions|xyz789\n"
-            "feat(outer): breaking change\nBREAKING CHANGE: this is breaking|bbb111\n"
-            "chore: cleanup|yyy999"
+            make_log_entry("feat(core): add new feature", "abc1234")
+            + make_log_entry("fix(ui): fix bug", "def5678")
+            + make_log_entry("ci: update github actions", "xyz789")
+            + make_log_entry(
+                "feat(outer): breaking change", "bbb111", "BREAKING CHANGE: this is breaking"
+            )
+            + make_log_entry("chore: cleanup", "yyy999")
         )
         commits = parse_commits(log_output)
 

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,6 +1,12 @@
 """Tests for release version normalization and bumping."""
 
-from headroom.release_version import compute_release_version, normalize_release_tag
+import pytest
+
+from headroom.release_version import (
+    compute_release_version,
+    find_latest_release_tag,
+    normalize_release_tag,
+)
 
 
 def test_normalize_release_tag_preserves_three_part_tag() -> None:
@@ -61,3 +67,17 @@ def test_manual_version_override_uses_single_semver() -> None:
     assert info.npm_version == "0.6.0"
     assert info.previous_tag == ""
     assert info.bump == "manual"
+
+
+def test_manual_version_override_rejects_legacy_four_part_version() -> None:
+    with pytest.raises(ValueError, match="Invalid semantic version"):
+        compute_release_version(
+            canonical_version="0.5.25",
+            level="patch",
+            tags=["v0.5.25.2"],
+            manual_version="0.5.25.3",
+        )
+
+
+def test_find_latest_release_tag_prefers_highest_normalized_version() -> None:
+    assert find_latest_release_tag(["v0.5.25.2", "v0.5.27", "not-a-tag"]) == "v0.5.27"

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -6,6 +6,7 @@ from headroom.release_version import (
     compute_release_version,
     find_latest_release_tag,
     normalize_release_tag,
+    parse_release_tag,
 )
 
 
@@ -14,7 +15,7 @@ def test_normalize_release_tag_preserves_three_part_tag() -> None:
 
 
 def test_normalize_release_tag_collapses_four_part_tag() -> None:
-    assert str(normalize_release_tag("v0.5.25.2")) == "0.5.27"
+    assert str(normalize_release_tag("v0.5.25.2")) == "0.5.25"
 
 
 def test_compute_patch_release_from_four_part_history() -> None:
@@ -24,8 +25,8 @@ def test_compute_patch_release_from_four_part_history() -> None:
         tags=["v0.5.20", "v0.5.25.1", "v0.5.25.2"],
     )
 
-    assert info.version == "0.5.28"
-    assert info.npm_version == "0.5.28"
+    assert info.version == "0.5.26"
+    assert info.npm_version == "0.5.26"
     assert info.previous_tag == "v0.5.25.2"
     assert info.bump == "patch"
 
@@ -81,3 +82,13 @@ def test_manual_version_override_rejects_legacy_four_part_version() -> None:
 
 def test_find_latest_release_tag_prefers_highest_normalized_version() -> None:
     assert find_latest_release_tag(["v0.5.25.2", "v0.5.27", "not-a-tag"]) == "v0.5.27"
+
+
+def test_find_latest_release_tag_prefers_higher_legacy_height_with_same_base() -> None:
+    assert find_latest_release_tag(["v0.5.25.2", "v0.5.25.3", "v0.5.25"]) == "v0.5.25.3"
+
+
+def test_parse_release_tag_preserves_legacy_height_for_sorting() -> None:
+    tag = parse_release_tag("v0.5.25.3")
+    assert str(tag.version) == "0.5.25"
+    assert tag.legacy_height == 3

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,0 +1,63 @@
+"""Tests for release version normalization and bumping."""
+
+from headroom.release_version import compute_release_version, normalize_release_tag
+
+
+def test_normalize_release_tag_preserves_three_part_tag() -> None:
+    assert str(normalize_release_tag("v0.5.20")) == "0.5.20"
+
+
+def test_normalize_release_tag_collapses_four_part_tag() -> None:
+    assert str(normalize_release_tag("v0.5.25.2")) == "0.5.27"
+
+
+def test_compute_patch_release_from_four_part_history() -> None:
+    info = compute_release_version(
+        canonical_version="0.5.25",
+        level="patch",
+        tags=["v0.5.20", "v0.5.25.1", "v0.5.25.2"],
+    )
+
+    assert info.version == "0.5.28"
+    assert info.npm_version == "0.5.28"
+    assert info.previous_tag == "v0.5.25.2"
+    assert info.bump == "patch"
+
+
+def test_compute_minor_release_from_four_part_history() -> None:
+    info = compute_release_version(
+        canonical_version="0.5.25",
+        level="minor",
+        tags=["v0.5.20", "v0.5.25.1", "v0.5.25.2"],
+    )
+
+    assert info.version == "0.6.0"
+    assert info.npm_version == "0.6.0"
+    assert info.previous_tag == "v0.5.25.2"
+    assert info.bump == "minor"
+
+
+def test_compute_patch_release_from_canonical_without_tags() -> None:
+    info = compute_release_version(
+        canonical_version="0.5.25",
+        level="patch",
+        tags=[],
+    )
+
+    assert info.version == "0.5.26"
+    assert info.npm_version == "0.5.26"
+    assert info.previous_tag == ""
+
+
+def test_manual_version_override_uses_single_semver() -> None:
+    info = compute_release_version(
+        canonical_version="0.5.25",
+        level="patch",
+        tags=["v0.5.25.2"],
+        manual_version="0.6.0",
+    )
+
+    assert info.version == "0.6.0"
+    assert info.npm_version == "0.6.0"
+    assert info.previous_tag == ""
+    assert info.bump == "manual"


### PR DESCRIPTION
## Summary
- replace the inline release version math with a tested helper module
- normalize legacy four-part tags like v0.5.25.2 into semantic versions for the next bump
- make the workflow emit one semantic version for both packages and the GitHub release tag

## Validation
- pytest -q tests/test_release_version.py
- local simulation resolves legacy four-part tags to one valid semantic version