### PR TITLE
fix(rust): OpenAI /v1/chat/completions compression interceptor

### DIFF
--- a/crates/headroom-proxy/src/compression/anthropic.rs
+++ b/crates/headroom-proxy/src/compression/anthropic.rs
@@ -18,179 +18,49 @@
 //!
 //! # What we do
 //!
-//! 1. Parse the body as JSON. On failure → passthrough.
-//! 2. Pull `messages` (the only field we touch). On absence → passthrough.
-//! 3. Pull `model` and `max_tokens` to compute the available budget.
-//! 4. Run the ICM's `should_apply` gate. Under-budget → passthrough.
-//! 5. Run `apply()`. Re-insert the (possibly trimmed) `messages` into
-//!    the parsed JSON. Re-serialize.
-//! 6. On *any* error along the way: passthrough with a warn log. The
-//!    proxy must never break a request because compression failed.
+//! Delegate to [`super::messages::compress_messages`] with an
+//! Anthropic-specific output-buffer extractor: pull `max_tokens`,
+//! fall back to the shared default when absent. Everything else —
+//! parse, gate, apply, re-serialize, passthrough on failure — lives
+//! in the provider-agnostic core.
 //!
 //! # What we DON'T do
 //!
-//! - Touch `system`. Anthropic separates system from messages; our
-//!   ICM operates on the messages list. The system tokens are
+//! - Touch `system`. Anthropic separates system from messages; ICM
+//!   operates on the messages list. The system tokens are
 //!   "invisible" to ICM's budget calculation, which means we
 //!   under-count slightly — that's fine (we'll compress less than
 //!   strictly necessary, never more).
 //! - Touch `tools`, `temperature`, `top_p`, etc. These pass through
 //!   verbatim because they're tiny and load-bearing for behaviour.
-//! - Compress individual content blocks. That's content-router /
-//!   pipeline work, scoped to a follow-up PR. ICM operates at the
-//!   message-list level only.
 
 use bytes::Bytes;
 use serde_json::Value;
 
-use headroom_core::context::{ApplyCtx, IntelligentContextManager};
+use headroom_core::context::IntelligentContextManager;
 
-use super::model_limits::context_window_for;
+use super::messages::{compress_messages, Outcome};
 
-/// What happened. Used for the request-level tracing log.
-#[derive(Debug)]
-pub enum Outcome {
-    /// Body was unchanged. Reasons listed in `reason`.
-    Passthrough { reason: PassthroughReason },
-    /// ICM ran but didn't drop anything (already under budget).
-    NoCompression { tokens_before: usize },
-    /// ICM ran and trimmed the message list.
-    Compressed {
-        body: Bytes,
-        tokens_before: usize,
-        tokens_after: usize,
-        strategies_applied: Vec<&'static str>,
-        markers_inserted: Vec<String>,
-    },
-}
-
-/// Why we passed the body through unchanged.
-#[derive(Debug, Clone, Copy)]
-pub enum PassthroughReason {
-    /// JSON parse failed.
-    NotJson,
-    /// `messages` was missing or not a JSON array.
-    NoMessages,
-    /// Re-serialization of the modified body failed (shouldn't
-    /// happen — we just deserialized this shape).
-    SerializeFailed,
-}
-
-/// Run ICM over an Anthropic-shape body. Returns one of:
-///
-/// - `Outcome::Compressed` — caller should forward `outcome.body`
-///   instead of the original bytes.
-/// - `Outcome::NoCompression` — caller forwards the original
-///   bytes; ICM's `should_apply` returned false.
-/// - `Outcome::Passthrough` — same as `NoCompression` from the
-///   caller's perspective, but the reason is parse/serialize-related.
-///
-/// Never returns an error. Compression failures degrade to
-/// passthrough; this is the proxy's safety contract.
+/// Run ICM over an Anthropic-shape body. See
+/// [`super::messages::Outcome`] for the result variants. Never
+/// returns an error; failures degrade to passthrough.
 pub fn maybe_compress(body: &Bytes, icm: &IntelligentContextManager) -> Outcome {
-    let mut parsed: Value = match serde_json::from_slice(body) {
-        Ok(v) => v,
-        Err(_) => {
-            return Outcome::Passthrough {
-                reason: PassthroughReason::NotJson,
-            };
-        }
-    };
-
-    // Move the messages array out of the object so we can hand
-    // ownership to ICM. We re-insert at the end. If `messages` is
-    // missing or not an array, passthrough.
-    let messages = match parsed.get_mut("messages") {
-        Some(Value::Array(_)) => match parsed["messages"].take() {
-            Value::Array(a) => a,
-            _ => unreachable!("just matched as_array"),
-        },
-        _ => {
-            return Outcome::Passthrough {
-                reason: PassthroughReason::NoMessages,
-            };
-        }
-    };
-
-    let model = parsed
-        .get("model")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    // `context_window_for` returns `u32` (LiteLLM-sourced). ICM's
-    // `ApplyCtx::model_limit` wants `usize`. The cast is lossless on
-    // every platform we run on — context windows are far below 4GB.
-    let model_limit = context_window_for(model) as usize;
-
-    // Anthropic requires `max_tokens`; if absent (malformed), assume
-    // a small reservation rather than zero so we don't pretend the
-    // whole window is available for input.
-    let output_buffer = parsed
-        .get("max_tokens")
-        .and_then(Value::as_u64)
-        .map(|v| v as usize)
-        .unwrap_or(4_096);
-
-    // Cheap pre-check before the real apply call. Saves the cost of
-    // a full message-list traversal when the request is small.
-    if !icm.should_apply(&messages, model_limit, output_buffer) {
-        // Restore messages and return without compression.
-        parsed["messages"] = Value::Array(messages);
-        // Compute tokens_before from the re-inserted form for log
-        // accuracy. Cheap: it's the same walk should_apply already
-        // did, but we don't have the count back from that call. We
-        // skip the recount and return 0; the caller's log just
-        // shows "no_compression" without a number, which is fine.
-        return Outcome::NoCompression { tokens_before: 0 };
-    }
-
-    let result = icm.apply(
-        messages,
-        ApplyCtx {
-            model_limit,
-            output_buffer: Some(output_buffer),
-            // TODO: detect provider prefix-cached messages from the
-            // request. Anthropic exposes prompt caching via
-            // `cache_control` on content blocks. Until we wire that
-            // detection, we treat the whole list as droppable.
-            frozen_message_count: 0,
-        },
-    );
-
-    // ICM may return tokens_after >= tokens_before when no drops
-    // happened (e.g. everything is protected). Treat that as
-    // no-compression rather than ship a needless re-serialize.
-    if result.tokens_after >= result.tokens_before {
-        // Reinsert the (unchanged) messages and report.
-        parsed["messages"] = Value::Array(result.messages);
-        return Outcome::NoCompression {
-            tokens_before: result.tokens_before,
-        };
-    }
-
-    parsed["messages"] = Value::Array(result.messages);
-
-    let new_body = match serde_json::to_vec(&parsed) {
-        Ok(v) => Bytes::from(v),
-        Err(_) => {
-            return Outcome::Passthrough {
-                reason: PassthroughReason::SerializeFailed,
-            };
-        }
-    };
-
-    Outcome::Compressed {
-        body: new_body,
-        tokens_before: result.tokens_before,
-        tokens_after: result.tokens_after,
-        strategies_applied: result.strategies_applied,
-        markers_inserted: result.markers_inserted,
-    }
+    compress_messages(body, icm, |parsed: &Value| {
+        // Anthropic requires `max_tokens`; absence implies a
+        // malformed request, but we degrade gracefully via the
+        // shared default rather than refusing to compress.
+        parsed
+            .get("max_tokens")
+            .and_then(Value::as_u64)
+            .map(|v| v as usize)
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::compression::icm::build_icm;
+    use crate::compression::messages::PassthroughReason;
     use serde_json::json;
 
     fn icm() -> std::sync::Arc<IntelligentContextManager> {
@@ -255,10 +125,8 @@ mod tests {
     #[test]
     fn compresses_when_over_budget() {
         let icm = icm();
-        // Squeeze the available budget by setting a huge max_tokens
-        // so output_buffer eats almost the whole window. With a
-        // 200K window for Claude and max_tokens=199_500, only ~500
-        // tokens are available — anything bigger forces compression.
+        // Squeeze the available budget: max_tokens=199_500 leaves
+        // ~500 tokens for input on a 200K-window model.
         let big_messages: Vec<Value> = (0..30)
             .map(|i| {
                 json!({
@@ -283,10 +151,6 @@ mod tests {
                 ..
             } => {
                 assert!(tokens_after < tokens_before);
-                // The new body is valid JSON with a shorter messages
-                // array (or includes the CCR marker that the shim's
-                // injection logic adds — but the proxy doesn't do
-                // marker injection; that lives in the Python shim).
                 let parsed: Value = serde_json::from_slice(&new_body).unwrap();
                 assert!(parsed["messages"].as_array().is_some());
             }
@@ -296,8 +160,6 @@ mod tests {
 
     #[test]
     fn unknown_model_does_not_panic() {
-        // Should fall back to the default 128K window and behave
-        // like any other request.
         let icm = icm();
         let body = Bytes::from(
             json!({
@@ -307,7 +169,7 @@ mod tests {
             })
             .to_string(),
         );
-        let _ = maybe_compress(&body, &icm); // shouldn't panic
+        let _ = maybe_compress(&body, &icm);
     }
 
     #[test]
@@ -320,6 +182,6 @@ mod tests {
             })
             .to_string(),
         );
-        let _ = maybe_compress(&body, &icm); // shouldn't panic
+        let _ = maybe_compress(&body, &icm);
     }
 }

--- a/crates/headroom-proxy/src/compression/messages.rs
+++ b/crates/headroom-proxy/src/compression/messages.rs
@@ -1,0 +1,161 @@
+//! Provider-agnostic core for "JSON body with a `messages` array".
+//!
+//! Both Anthropic `/v1/messages` and OpenAI `/v1/chat/completions`
+//! follow the same overall pattern:
+//!
+//! 1. Body is JSON.
+//! 2. Top-level field `messages` is an array we can hand to ICM.
+//! 3. Top-level `model` field selects the context window.
+//! 4. Some "reserved for output" field caps how much input we can fit.
+//!
+//! What differs between providers is small:
+//!
+//! - **Anthropic** uses `max_tokens` (required) and keeps the system
+//!   prompt in a separate top-level `system` field.
+//! - **OpenAI** uses `max_completion_tokens` (newer, o-series) or
+//!   `max_tokens` (classic) — both optional — and includes the system
+//!   message inside `messages` as `role:"system"`.
+//!
+//! Neither difference matters at this layer: ICM operates on the
+//! messages list and respects `role:"system"` via SafetyRails. The
+//! only provider-specific bit is *where to find the output buffer
+//! token count*. We capture that as a closure passed by the caller.
+//!
+//! # Failure-mode contract
+//!
+//! Compression must never break a request. Every error path
+//! (parse, missing field, serialize) degrades to a passthrough
+//! variant. The proxy then forwards the original buffered bytes.
+
+use bytes::Bytes;
+use serde_json::Value;
+
+use headroom_core::context::{ApplyCtx, IntelligentContextManager};
+
+use super::model_limits::context_window_for;
+
+/// What happened. Used for the request-level tracing log.
+#[derive(Debug)]
+pub enum Outcome {
+    /// Body was unchanged. Reason explains why.
+    Passthrough { reason: PassthroughReason },
+    /// ICM ran but didn't drop anything (already under budget).
+    NoCompression { tokens_before: usize },
+    /// ICM ran and trimmed the message list.
+    Compressed {
+        body: Bytes,
+        tokens_before: usize,
+        tokens_after: usize,
+        strategies_applied: Vec<&'static str>,
+        markers_inserted: Vec<String>,
+    },
+}
+
+/// Why the body was passed through unchanged.
+#[derive(Debug, Clone, Copy)]
+pub enum PassthroughReason {
+    /// JSON parse failed.
+    NotJson,
+    /// `messages` was missing or not a JSON array.
+    NoMessages,
+    /// Re-serialization of the modified body failed.
+    SerializeFailed,
+}
+
+/// Default output reservation when the caller's extractor returns
+/// `None`. 4096 is a defensible middle: small enough that it doesn't
+/// pretend the whole context window is for input, large enough that
+/// short replies fit comfortably.
+pub const DEFAULT_OUTPUT_BUFFER: usize = 4_096;
+
+/// Run ICM over a body whose top-level shape has a `messages` array
+/// and a `model` field. The caller supplies an `extract_output_buffer`
+/// closure that pulls the provider-specific output reservation field
+/// (e.g. Anthropic `max_tokens`, OpenAI `max_completion_tokens`).
+///
+/// Never returns an error; failures degrade to `Outcome::Passthrough`
+/// with a reason variant for the trace log. The caller forwards the
+/// original `body` bytes in that case.
+pub fn compress_messages<F>(
+    body: &Bytes,
+    icm: &IntelligentContextManager,
+    extract_output_buffer: F,
+) -> Outcome
+where
+    F: FnOnce(&Value) -> Option<usize>,
+{
+    let mut parsed: Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(_) => {
+            return Outcome::Passthrough {
+                reason: PassthroughReason::NotJson,
+            };
+        }
+    };
+
+    // Take ownership of the messages array so we can pass `Vec<Value>`
+    // into ICM. Re-insert below.
+    let messages = match parsed.get_mut("messages") {
+        Some(Value::Array(_)) => match parsed["messages"].take() {
+            Value::Array(a) => a,
+            _ => unreachable!("just matched as_array"),
+        },
+        _ => {
+            return Outcome::Passthrough {
+                reason: PassthroughReason::NoMessages,
+            };
+        }
+    };
+
+    let model = parsed
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let model_limit = context_window_for(model) as usize;
+
+    let output_buffer = extract_output_buffer(&parsed).unwrap_or(DEFAULT_OUTPUT_BUFFER);
+
+    if !icm.should_apply(&messages, model_limit, output_buffer) {
+        parsed["messages"] = Value::Array(messages);
+        return Outcome::NoCompression { tokens_before: 0 };
+    }
+
+    let result = icm.apply(
+        messages,
+        ApplyCtx {
+            model_limit,
+            output_buffer: Some(output_buffer),
+            // TODO: detect provider prefix-cached messages (Anthropic
+            // cache_control on content blocks; OpenAI doesn't expose
+            // an equivalent yet). Until wired, treat the whole list
+            // as droppable.
+            frozen_message_count: 0,
+        },
+    );
+
+    if result.tokens_after >= result.tokens_before {
+        parsed["messages"] = Value::Array(result.messages);
+        return Outcome::NoCompression {
+            tokens_before: result.tokens_before,
+        };
+    }
+
+    parsed["messages"] = Value::Array(result.messages);
+
+    let new_body = match serde_json::to_vec(&parsed) {
+        Ok(v) => Bytes::from(v),
+        Err(_) => {
+            return Outcome::Passthrough {
+                reason: PassthroughReason::SerializeFailed,
+            };
+        }
+    };
+
+    Outcome::Compressed {
+        body: new_body,
+        tokens_before: result.tokens_before,
+        tokens_after: result.tokens_after,
+        strategies_applied: result.strategies_applied,
+        markers_inserted: result.markers_inserted,
+    }
+}

--- a/crates/headroom-proxy/src/compression/mod.rs
+++ b/crates/headroom-proxy/src/compression/mod.rs
@@ -9,45 +9,82 @@
 //!
 //! - WebSocket upgrades — handled in the catch-all before
 //!   `forward_http` is called; never reach this module.
-//! - Non-LLM paths (any URL not matching a known provider).
+//! - Non-LLM paths (any URL not classified by [`classify_path`]).
 //! - Non-JSON content types (skip; we don't speculate at body
 //!   contents we don't know how to parse).
 //! - Streaming SSE responses — only the request body is touched;
 //!   responses pass through untouched.
 //!
-//! # Provider matrix (current + planned)
+//! # Provider matrix
 //!
-//! | Provider     | Path                  | Status |
-//! |--------------|-----------------------|--------|
-//! | Anthropic    | `POST /v1/messages`   | ✅ this module |
-//! | OpenAI       | `POST /v1/chat/completions` | follow-up |
-//! | Google       | `POST /v1beta/...`    | follow-up |
-//! | Bedrock      | varied                | follow-up |
+//! | Provider     | Path                              | Status |
+//! |--------------|-----------------------------------|--------|
+//! | Anthropic    | `POST /v1/messages`               | ✅ |
+//! | OpenAI       | `POST /v1/chat/completions`       | ✅ |
+//! | OpenAI       | `POST /v1/responses` (Codex)      | follow-up |
+//! | Google       | `POST /v1beta/...`                | follow-up |
+//! | Bedrock      | varied                            | follow-up |
 //!
 //! # Failure-mode contract
 //!
 //! Compression must NEVER break a request. Every error path —
 //! parse failure, missing field, body too large, unknown model —
 //! falls through to the original body being forwarded unchanged.
-//! Operators see what happened in `tracing` warnings; clients see
-//! their request go through.
 
 pub mod anthropic;
 pub mod icm;
+pub mod messages;
 pub mod model_limits;
+pub mod openai;
 
-pub use anthropic::{maybe_compress, Outcome, PassthroughReason};
 pub use icm::build_icm;
+pub use messages::{Outcome, PassthroughReason};
 
-/// Does this request path target an LLM endpoint we know how to
-/// compress? Cheap pre-filter before buffering the body.
+/// Which compressible LLM endpoint a request matches, if any. Used
+/// by the proxy gate to decide whether to buffer and which provider
+/// shape to apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompressibleEndpoint {
+    /// `POST /v1/messages` (Anthropic Messages API).
+    AnthropicMessages,
+    /// `POST /v1/chat/completions` (OpenAI Chat Completions API,
+    /// also matches OpenRouter and other proxies that present the
+    /// OpenAI surface).
+    OpenAIChatCompletions,
+}
+
+/// Classify a request path into a known provider endpoint, or
+/// `None` when no compression should be applied. Exact-match only —
+/// no prefix matching, so `/v1/messages/123` (a hypothetical
+/// per-message endpoint) doesn't accidentally get treated as a chat
+/// request.
+pub fn classify_path(path: &str) -> Option<CompressibleEndpoint> {
+    match path {
+        "/v1/messages" => Some(CompressibleEndpoint::AnthropicMessages),
+        "/v1/chat/completions" => Some(CompressibleEndpoint::OpenAIChatCompletions),
+        _ => None,
+    }
+}
+
+/// Convenience: would `classify_path(path)` return `Some(_)`? Kept
+/// for callers that don't need the discriminant — primarily existing
+/// telemetry/logging code paths.
 pub fn is_compressible_path(path: &str) -> bool {
-    // Exact-match the Anthropic Messages endpoint. Future providers
-    // get their own arms here. Avoid prefix-matching to keep the
-    // compression scope explicit — `/v1/messages/123` (a
-    // hypothetical future per-message endpoint) shouldn't accidentally
-    // get its body parsed as a chat-completions request.
-    path == "/v1/messages"
+    classify_path(path).is_some()
+}
+
+/// Dispatch a buffered body to the right provider's compressor.
+/// Returns the same provider-agnostic [`Outcome`] regardless of
+/// which arm ran.
+pub fn maybe_compress(
+    body: &bytes::Bytes,
+    icm: &headroom_core::context::IntelligentContextManager,
+    endpoint: CompressibleEndpoint,
+) -> Outcome {
+    match endpoint {
+        CompressibleEndpoint::AnthropicMessages => anthropic::maybe_compress(body, icm),
+        CompressibleEndpoint::OpenAIChatCompletions => openai::maybe_compress(body, icm),
+    }
 }
 
 #[cfg(test)]
@@ -56,15 +93,32 @@ mod tests {
 
     #[test]
     fn anthropic_messages_path_matches() {
+        assert_eq!(
+            classify_path("/v1/messages"),
+            Some(CompressibleEndpoint::AnthropicMessages)
+        );
         assert!(is_compressible_path("/v1/messages"));
     }
 
     #[test]
+    fn openai_chat_completions_matches() {
+        assert_eq!(
+            classify_path("/v1/chat/completions"),
+            Some(CompressibleEndpoint::OpenAIChatCompletions)
+        );
+        assert!(is_compressible_path("/v1/chat/completions"));
+    }
+
+    #[test]
     fn other_paths_skip() {
-        assert!(!is_compressible_path("/v1/messages/123"));
-        assert!(!is_compressible_path("/v1/chat/completions"));
-        assert!(!is_compressible_path("/healthz"));
-        assert!(!is_compressible_path("/"));
-        assert!(!is_compressible_path(""));
+        assert_eq!(classify_path("/v1/messages/123"), None);
+        assert_eq!(classify_path("/v1/responses"), None); // follow-up
+        assert_eq!(
+            classify_path("/v1beta/models/gemini-pro:generateContent"),
+            None
+        );
+        assert_eq!(classify_path("/healthz"), None);
+        assert_eq!(classify_path("/"), None);
+        assert_eq!(classify_path(""), None);
     }
 }

--- a/crates/headroom-proxy/src/compression/openai.rs
+++ b/crates/headroom-proxy/src/compression/openai.rs
@@ -1,0 +1,212 @@
+//! OpenAI `/v1/chat/completions` request compression.
+//!
+//! # Request shape (relevant subset)
+//!
+//! ```json
+//! {
+//!   "model": "gpt-4o-mini",
+//!   "messages": [
+//!     {"role": "system", "content": "..."},
+//!     {"role": "user", "content": "..."},
+//!     {"role": "assistant", "content": "...", "tool_calls": [...]},
+//!     {"role": "tool",    "content": "...", "tool_call_id": "..."}
+//!   ],
+//!   "tools": [...],                          // optional
+//!   "max_tokens": 1024,                      // optional, classic
+//!   "max_completion_tokens": 1024,           // optional, o-series
+//!   "stream": false,
+//!   ...
+//! }
+//! ```
+//!
+//! # Differences from Anthropic
+//!
+//! 1. **System prompt** lives inside `messages` as `role:"system"`.
+//!    ICM's SafetyRails already protects `role:"system"`, so we don't
+//!    need to do anything special — that's exactly the OSS-defining
+//!    "messages-list-shaped" abstraction working as designed.
+//!
+//! 2. **Output buffer field** is either `max_completion_tokens` (the
+//!    new, mandatory field for o1/o3-style reasoning models) OR
+//!    `max_tokens` (the classic field). When both are absent, OpenAI
+//!    defaults the response to "as much as the model can produce";
+//!    we fall back to the shared 4K default rather than assume the
+//!    whole window is for input.
+//!
+//! 3. **Tool atomicity**: OpenAI uses `assistant.tool_calls[]` paired
+//!    with `tool` messages whose `tool_call_id` references the
+//!    assistant message. ICM's `find_tool_units` already handles this
+//!    shape (along with Anthropic's content-block form).
+//!
+//! # What we DON'T do
+//!
+//! - Touch `tools`, `tool_choice`, `response_format`, `seed`,
+//!   `temperature`, `top_p`. These are small and behaviour-defining.
+//! - Touch `function_call` / `functions` (the deprecated pre-tools
+//!   API). ICM doesn't drop these either; they pass through verbatim.
+//! - Compress streaming response bodies. The proxy only buffers the
+//!   *request* body for compression; the SSE response stream is
+//!   forwarded chunk-by-chunk untouched.
+//!
+//! # Azure / OpenRouter / other compatible endpoints
+//!
+//! Path-matched on `/v1/chat/completions` exactly. Azure OpenAI uses
+//! `/openai/deployments/{deployment}/chat/completions` and won't
+//! match — that's intentional. When/if we want Azure support, add a
+//! distinct path arm.
+
+use bytes::Bytes;
+use serde_json::Value;
+
+use headroom_core::context::IntelligentContextManager;
+
+use super::messages::{compress_messages, Outcome};
+
+/// Run ICM over an OpenAI-shape body.
+pub fn maybe_compress(body: &Bytes, icm: &IntelligentContextManager) -> Outcome {
+    compress_messages(body, icm, |parsed: &Value| {
+        // Prefer max_completion_tokens (o-series, newer). Fall back
+        // to max_tokens (classic). OpenAI accepts only one or the
+        // other on a given model; we don't need to add them.
+        parsed
+            .get("max_completion_tokens")
+            .or_else(|| parsed.get("max_tokens"))
+            .and_then(Value::as_u64)
+            .map(|v| v as usize)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compression::icm::build_icm;
+    use crate::compression::messages::PassthroughReason;
+    use serde_json::json;
+
+    fn icm() -> std::sync::Arc<IntelligentContextManager> {
+        build_icm().expect("ICM builds")
+    }
+
+    #[test]
+    fn passthrough_on_invalid_json() {
+        let icm = icm();
+        let body = Bytes::from_static(b"not json at all");
+        match maybe_compress(&body, &icm) {
+            Outcome::Passthrough {
+                reason: PassthroughReason::NotJson,
+            } => {}
+            other => panic!("expected NotJson, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn passthrough_when_messages_missing() {
+        let icm = icm();
+        let body = Bytes::from(json!({"model": "gpt-4o-mini"}).to_string());
+        match maybe_compress(&body, &icm) {
+            Outcome::Passthrough {
+                reason: PassthroughReason::NoMessages,
+            } => {}
+            other => panic!("expected NoMessages, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_compression_when_under_budget() {
+        let icm = icm();
+        let body = Bytes::from(
+            json!({
+                "model": "gpt-4o-mini",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "system", "content": "Be helpful."},
+                    {"role": "user",   "content": "hi"}
+                ]
+            })
+            .to_string(),
+        );
+        match maybe_compress(&body, &icm) {
+            Outcome::NoCompression { .. } => {}
+            other => panic!("expected NoCompression, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compresses_when_over_budget() {
+        let icm = icm();
+        // gpt-4o-mini context window is 128K. Set max_tokens close to
+        // it so output_buffer eats nearly the whole window, forcing
+        // even modest histories over the input budget.
+        let big_messages: Vec<Value> = std::iter::once(json!({
+            "role": "system",
+            "content": "Always be concise."
+        }))
+        .chain((0..40).map(|i| {
+            json!({
+                "role": if i % 2 == 0 { "user" } else { "assistant" },
+                "content": format!("history turn {i} ").repeat(40),
+            })
+        }))
+        .collect();
+        let body = Bytes::from(
+            json!({
+                "model": "gpt-4o-mini",
+                "max_tokens": 127_000,
+                "messages": big_messages,
+            })
+            .to_string(),
+        );
+        match maybe_compress(&body, &icm) {
+            Outcome::Compressed {
+                body: new_body,
+                tokens_before,
+                tokens_after,
+                ..
+            } => {
+                assert!(tokens_after < tokens_before);
+                let parsed: Value = serde_json::from_slice(&new_body).unwrap();
+                let msgs = parsed["messages"].as_array().unwrap();
+                // System message must survive — that's the safety
+                // contract on OpenAI shape (system lives in messages).
+                assert!(
+                    msgs.iter()
+                        .any(|m| m.get("role").and_then(Value::as_str) == Some("system")),
+                    "system message must be preserved after compression"
+                );
+            }
+            other => panic!("expected Compressed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn max_completion_tokens_takes_precedence_over_max_tokens() {
+        // When both are present (transition shape), the newer field
+        // wins because that's the field OpenAI actually applies on
+        // o-series models. We don't simulate apply here — we just
+        // verify the call path doesn't panic and the body parses.
+        let icm = icm();
+        let body = Bytes::from(
+            json!({
+                "model": "gpt-4o-mini",
+                "max_tokens": 100,
+                "max_completion_tokens": 200,
+                "messages": [{"role": "user", "content": "hi"}]
+            })
+            .to_string(),
+        );
+        let _ = maybe_compress(&body, &icm); // shouldn't panic
+    }
+
+    #[test]
+    fn missing_both_token_fields_does_not_panic() {
+        let icm = icm();
+        let body = Bytes::from(
+            json!({
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}]
+            })
+            .to_string(),
+        );
+        let _ = maybe_compress(&body, &icm);
+    }
+}

--- a/crates/headroom-proxy/src/proxy.rs
+++ b/crates/headroom-proxy/src/proxy.rs
@@ -223,9 +223,13 @@ async fn forward_http(
     // passthrough path). This keeps WebSocket upgrades, healthchecks,
     // tool-API endpoints, and SSE streaming from paying any
     // buffering cost.
+    // Classify the path once: `Some(endpoint)` means we know how to
+    // compress this body, `None` means stream as-is. We re-use the
+    // classification below to dispatch to the right provider arm.
+    let endpoint = compression::classify_path(uri.path());
     let should_compress = state.config.compression
         && method == axum::http::Method::POST
-        && compression::is_compressible_path(uri.path())
+        && endpoint.is_some()
         && is_application_json(req.headers())
         && state.icm.is_some();
 
@@ -265,7 +269,8 @@ async fn forward_http(
         // Run the compressor. Failures degrade to passthrough by
         // returning the original buffered bytes.
         let icm = state.icm.as_ref().expect("checked above");
-        let outcome = compression::maybe_compress(&buffered, icm);
+        let endpoint = endpoint.expect("checked above");
+        let outcome = compression::maybe_compress(&buffered, icm, endpoint);
 
         let body_to_send = match outcome {
             compression::Outcome::Compressed {

--- a/crates/headroom-proxy/tests/e2e_openai_compression.rs
+++ b/crates/headroom-proxy/tests/e2e_openai_compression.rs
@@ -338,6 +338,93 @@ async fn streaming_request_round_trips_through_proxy() {
     proxy.shutdown().await;
 }
 
+/// Two requests, identical first ~2K tokens (a "stable system prompt"),
+/// different last user message. Sent through the proxy with compression
+/// enabled. The SECOND request's response should report
+/// `usage.prompt_tokens_details.cached_tokens > 0` because OpenAI
+/// auto-caches the shared prefix (≥1024 tokens, increments of 128).
+///
+/// This test catches the failure mode where compression mutates the
+/// leading messages in a way that breaks the prefix cache hash —
+/// either by re-serializing JSON differently (whitespace, key order),
+/// dropping any leading message, or modifying the system message.
+///
+/// What it does NOT catch:
+/// - Cases where ICM is FORCED to fire (request exceeds budget) and
+///   ICM legitimately drops a message in the cached prefix. That's
+///   an inherent trade-off between "fit in window" and "preserve
+///   cache" that needs a session-aware tracker (see PrefixCacheTracker
+///   in headroom/cache/prefix_tracker.py for the full design).
+#[tokio::test]
+async fn shared_prefix_keeps_openai_cache_when_under_budget() {
+    let Some(api_key) = require_e2e() else { return };
+    let proxy = start_proxy_compression_on().await;
+
+    // ~5K-token shared system prompt — comfortably above OpenAI's
+    // 1024-token floor for prompt caching. The repeat factor was
+    // tuned empirically: 100 yielded only ~700 tokens (under the
+    // floor); 500 yields ~5K which always crosses the threshold.
+    let big_system = "You are a meticulous senior engineer. ".repeat(500);
+
+    let payload_for = |user: &str| {
+        json!({
+            "model": "gpt-4o-mini",
+            "max_tokens": 30,
+            "messages": [
+                {"role": "system", "content": big_system},
+                {"role": "user", "content": user},
+            ],
+        })
+    };
+
+    let client = reqwest::Client::new();
+    let send = |body: Value| {
+        let url = format!("{}/v1/chat/completions", proxy.url());
+        let key = api_key.clone();
+        let c = client.clone();
+        async move {
+            c.post(url)
+                .header("authorization", format!("Bearer {key}"))
+                .header("content-type", "application/json")
+                .json(&body)
+                .send()
+                .await
+                .expect("post")
+        }
+    };
+
+    // Warm the cache.
+    let r1 = send(payload_for("First call: say hi.")).await;
+    assert!(r1.status().is_success());
+    let r1_json: Value = r1.json().await.unwrap();
+    let r1_cached = r1_json["usage"]["prompt_tokens_details"]["cached_tokens"]
+        .as_u64()
+        .unwrap_or(0);
+    eprintln!("first call: cached_tokens={r1_cached} (expected ~0 cold)");
+
+    // Brief pause: OpenAI's cache needs a moment to register on the
+    // shared infra side before a second request sees it.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Second call — same prefix, different final user message.
+    let r2 = send(payload_for("Second call: say bye.")).await;
+    assert!(r2.status().is_success());
+    let r2_json: Value = r2.json().await.unwrap();
+    let r2_cached = r2_json["usage"]["prompt_tokens_details"]["cached_tokens"]
+        .as_u64()
+        .unwrap_or(0);
+    let r2_total = r2_json["usage"]["prompt_tokens"].as_u64().unwrap_or(0);
+    eprintln!("second call: cached_tokens={r2_cached} of {r2_total} prompt tokens");
+
+    assert!(
+        r2_cached >= 1024,
+        "compression broke OpenAI prefix cache: expected ≥1024 cached \
+         tokens on the second call, got {r2_cached} of {r2_total}"
+    );
+
+    proxy.shutdown().await;
+}
+
 // Force a use of the harness's `Arc` type so the `unused_imports`
 // lint doesn't kick in on the lone-test path; tests above don't need
 // it directly but having it imported keeps the file self-consistent

--- a/crates/headroom-proxy/tests/e2e_openai_compression.rs
+++ b/crates/headroom-proxy/tests/e2e_openai_compression.rs
@@ -1,0 +1,355 @@
+//! Real end-to-end tests: Rust proxy (compression on) → OpenAI Chat Completions.
+//!
+//! Spawns the Rust proxy bound to `https://api.openai.com` with
+//! `--compression` enabled, then sends real `/v1/chat/completions`
+//! requests through it. Verifies:
+//!
+//! 1. Small request returns a real completion unchanged.
+//! 2. Oversized request gets compressed AND still returns a real
+//!    completion (i.e. the compression didn't corrupt the body in a
+//!    way the upstream would reject).
+//! 3. Streaming request works through the proxy (request is buffered,
+//!    response stream passes through chunk-by-chunk).
+//!
+//! Skipped unless both:
+//! - `HEADROOM_E2E=1`
+//! - `OPENAI_API_KEY` is set (read from .env at the repo root)
+//!
+//! Run with:
+//!     HEADROOM_E2E=1 cargo test -p headroom-proxy \
+//!         --test e2e_openai_compression -- --nocapture
+
+mod common;
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use headroom_proxy::{build_app, AppState, Config};
+use serde_json::{json, Value};
+use tokio::sync::oneshot;
+use url::Url;
+
+const E2E_GUARD: &str = "HEADROOM_E2E";
+
+fn e2e_enabled() -> bool {
+    std::env::var(E2E_GUARD).ok().as_deref() == Some("1")
+}
+
+/// Locate repo root by walking up from CARGO_MANIFEST_DIR until we find .env.
+fn repo_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        if p.join(".env").exists() && p.join("Cargo.toml").exists() {
+            return p;
+        }
+        if !p.pop() {
+            panic!("could not locate repo root (no .env found)");
+        }
+    }
+}
+
+/// Best-effort .env loader. Does NOT print values.
+fn load_dotenv() {
+    let env_path = repo_root().join(".env");
+    let Ok(contents) = std::fs::read_to_string(&env_path) else {
+        return;
+    };
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((k, v)) = line.split_once('=') else {
+            continue;
+        };
+        let k = k.trim();
+        let v = v.trim().trim_matches('"').trim_matches('\'');
+        if v.is_empty() {
+            continue;
+        }
+        if std::env::var(k).is_err() {
+            // SAFETY: this is test setup, single-threaded before any
+            // tokio task spawns concurrent work.
+            std::env::set_var(k, v);
+        }
+    }
+}
+
+struct ProxyHandle {
+    addr: SocketAddr,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl ProxyHandle {
+    fn url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+    async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        let _ = self.task.await;
+    }
+}
+
+/// Start a Rust proxy with compression ON, pointed at the real
+/// OpenAI API. The harness's default `start_proxy_with` only takes
+/// http upstreams (it builds a `Url` first), so we replicate that
+/// here for an https upstream.
+async fn start_proxy_compression_on() -> ProxyHandle {
+    let upstream: Url = "https://api.openai.com"
+        .parse()
+        .expect("valid OpenAI base URL");
+    let mut config = Config::for_test(upstream);
+    config.compression = true;
+    // OpenAI replies in seconds for non-streaming and within ~60s for
+    // long streams. Use a generous timeout so a slow model doesn't
+    // make the test flake.
+    config.upstream_timeout = Duration::from_secs(120);
+    config.upstream_connect_timeout = Duration::from_secs(10);
+    // OpenAI rejects requests with the wrong Host header; preserve
+    // the client's Host so reqwest sets `api.openai.com` upstream.
+    config.rewrite_host = true;
+
+    let state = AppState::new(config).expect("app state");
+    let app = build_app(state).into_make_service_with_connect_info::<SocketAddr>();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral");
+    let addr = listener.local_addr().expect("local addr");
+    let (tx, rx) = oneshot::channel::<()>();
+    let task = tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    ProxyHandle {
+        addr,
+        shutdown: Some(tx),
+        task,
+    }
+}
+
+/// Skip helper: returns Some(api_key) when ready to run, None when
+/// the test should bail out cleanly.
+fn require_e2e() -> Option<String> {
+    if !e2e_enabled() {
+        eprintln!("skipping: HEADROOM_E2E != 1");
+        return None;
+    }
+    load_dotenv();
+    match std::env::var("OPENAI_API_KEY") {
+        Ok(k) if !k.is_empty() => Some(k),
+        _ => {
+            eprintln!("skipping: OPENAI_API_KEY not set in .env");
+            None
+        }
+    }
+}
+
+#[tokio::test]
+async fn small_request_round_trips_through_proxy() {
+    let Some(api_key) = require_e2e() else { return };
+    let proxy = start_proxy_compression_on().await;
+
+    let payload = json!({
+        "model": "gpt-4o-mini",
+        "max_tokens": 50,
+        "messages": [
+            {"role": "user", "content": "Reply with exactly the word 'pong'."}
+        ],
+    });
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v1/chat/completions", proxy.url()))
+        .header("authorization", format!("Bearer {api_key}"))
+        .header("content-type", "application/json")
+        .json(&payload)
+        .send()
+        .await
+        .expect("post through proxy");
+
+    assert!(
+        resp.status().is_success(),
+        "OpenAI returned {}: {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+    let body: Value = resp.json().await.expect("response is JSON");
+    let content = body["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        !content.is_empty(),
+        "expected non-empty content; got: {body}"
+    );
+    eprintln!("✓ small_request_round_trips: model said {content:?}");
+
+    proxy.shutdown().await;
+}
+
+#[tokio::test]
+async fn oversized_request_compresses_and_still_returns_completion() {
+    let Some(api_key) = require_e2e() else { return };
+    let proxy = start_proxy_compression_on().await;
+
+    // Build a payload that EXCEEDS the model's input budget so ICM
+    // is forced to fire. gpt-4o-mini has a 128K context window; with
+    // max_tokens=4096 reserved for output, the input budget is ~124K
+    // tokens.
+    //
+    // Note: OpenAI rejects requests where max_tokens > the model's
+    // output cap (16384 for gpt-4o-mini). So we can't shrink the
+    // input budget by inflating max_tokens — we have to inflate the
+    // input itself past the 124K-token ceiling and rely on ICM to
+    // trim it back below that line.
+    //
+    // Density: each turn is ~"padding word " × 1000 ≈ 13K chars ≈
+    // 3K tokens. 80 turns ≈ 240K tokens of history — well above the
+    // 124K input budget. ICM must drop ~half the history.
+    let mut messages: Vec<Value> = vec![json!({
+        "role": "system",
+        "content": "You are a terse assistant. Respond with exactly one word."
+    })];
+    for i in 0..80 {
+        messages.push(json!({
+            "role": if i % 2 == 0 { "user" } else { "assistant" },
+            "content": format!("noise turn {i}: ").to_string()
+                + &"padding word ".repeat(1_000),
+        }));
+    }
+    // The final user turn — explicit instruction. ICM's safety rails
+    // keep last_n_turns intact; this must survive every drop.
+    messages.push(json!({
+        "role": "user",
+        "content": "Reply with exactly the word: pong",
+    }));
+
+    let payload = json!({
+        "model": "gpt-4o-mini",
+        // Modest output cap — well within the model's 16384 limit.
+        "max_tokens": 50,
+        "messages": messages,
+    });
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v1/chat/completions", proxy.url()))
+        .header("authorization", format!("Bearer {api_key}"))
+        .header("content-type", "application/json")
+        .json(&payload)
+        .send()
+        .await
+        .expect("post through proxy");
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    assert!(
+        status.is_success(),
+        "expected 2xx after compression; got {status}: {text}"
+    );
+    let body: Value = serde_json::from_str(&text).expect("response is JSON");
+    let content = body["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        !content.is_empty(),
+        "expected non-empty content after compression; got: {body}"
+    );
+    // Usage block tells us how many tokens OpenAI actually saw — a
+    // strong signal that ICM trimmed before we hit the upstream.
+    if let Some(prompt_tokens) = body["usage"]["prompt_tokens"].as_u64() {
+        eprintln!(
+            "✓ oversized_request: model said {content:?}, OpenAI saw {prompt_tokens} prompt tokens"
+        );
+        // ~50 padding turns × 80-token repeat × ~3 char/token would
+        // be enormous. After compression we expect << 100K prompt
+        // tokens — anything below the 128K window is a successful
+        // compression-then-completion.
+        assert!(
+            prompt_tokens < 128_000,
+            "compressed prompt tokens ({prompt_tokens}) should fit within window"
+        );
+    } else {
+        eprintln!("✓ oversized_request: model said {content:?} (no usage block)");
+    }
+
+    proxy.shutdown().await;
+}
+
+#[tokio::test]
+async fn streaming_request_round_trips_through_proxy() {
+    let Some(api_key) = require_e2e() else { return };
+    let proxy = start_proxy_compression_on().await;
+
+    let payload = json!({
+        "model": "gpt-4o-mini",
+        "max_tokens": 30,
+        "stream": true,
+        "messages": [
+            {"role": "user", "content": "Count to three. One number per line."}
+        ],
+    });
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v1/chat/completions", proxy.url()))
+        .header("authorization", format!("Bearer {api_key}"))
+        .header("content-type", "application/json")
+        .json(&payload)
+        .send()
+        .await
+        .expect("post through proxy");
+
+    assert!(
+        resp.status().is_success(),
+        "stream init failed: {} {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+    // SSE chunks should arrive — proxy forwards the response stream
+    // chunk-by-chunk because compression only affects the request.
+    let mut stream = resp.bytes_stream();
+    let mut total_bytes = 0usize;
+    let mut chunks = 0usize;
+    let mut saw_done = false;
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk.expect("stream chunk");
+        total_bytes += bytes.len();
+        chunks += 1;
+        if let Ok(s) = std::str::from_utf8(&bytes) {
+            if s.contains("[DONE]") {
+                saw_done = true;
+            }
+        }
+    }
+    assert!(chunks > 1, "expected multiple SSE chunks, got {chunks}");
+    assert!(total_bytes > 0);
+    assert!(saw_done, "expected `[DONE]` sentinel in stream");
+    eprintln!("✓ streaming_request: {chunks} chunks, {total_bytes} bytes total");
+
+    proxy.shutdown().await;
+}
+
+// Force a use of the harness's `Arc` type so the `unused_imports`
+// lint doesn't kick in on the lone-test path; tests above don't need
+// it directly but having it imported keeps the file self-consistent
+// when extending later. (No-op at runtime.)
+#[allow(dead_code)]
+fn _harness_arc_kept_alive() -> Arc<()> {
+    Arc::new(())
+}
+
+#[allow(dead_code)]
+fn _common_module_referenced() {
+    // Reference the module so cargo doesn't complain about unused
+    // mod common when all tests skip on a CI that has no key.
+    let _ = std::any::type_name::<common::ProxyHandle>();
+}

--- a/crates/headroom-proxy/tests/integration_compression.rs
+++ b/crates/headroom-proxy/tests/integration_compression.rs
@@ -6,11 +6,11 @@
 //! library outcome in isolation.
 //!
 //! Coverage:
-//! - Compression-off (default): proxy is a passthrough, body is byte-identical.
-//! - Compression-on, small body: ICM short-circuits, body unchanged.
-//! - Compression-on, oversized body: ICM trims the messages array.
+//! - Anthropic & OpenAI: off → passthrough, on+short → unchanged,
+//!   on+oversized → trimmed.
 //! - Compression-on, non-JSON body: skipped (Content-Type gate).
 //! - Compression-on, non-LLM path: skipped (path gate).
+//! - OpenAI-specific: system message survives compression.
 
 mod common;
 
@@ -212,5 +212,164 @@ async fn compression_on_non_llm_path_skips() {
 
     let got = captured.lock().unwrap().clone().expect("upstream got body");
     assert_eq!(got, body, "non-LLM path must bypass compression");
+    proxy.shutdown().await;
+}
+
+// ─── OpenAI /v1/chat/completions ─────────────────────────────────────
+
+async fn mount_openai_capture(upstream: &MockServer) -> Arc<Mutex<Option<Vec<u8>>>> {
+    let captured: Arc<Mutex<Option<Vec<u8>>>> = Arc::new(Mutex::new(None));
+    let captured_clone = captured.clone();
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(move |req: &wiremock::Request| {
+            *captured_clone.lock().unwrap() = Some(req.body.clone());
+            ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#)
+        })
+        .mount(upstream)
+        .await;
+    captured
+}
+
+/// Big OpenAI payload: 40 alternating user/assistant turns plus a
+/// system message. max_tokens=127_000 reserves nearly the whole
+/// gpt-4o-mini 128K window for output, forcing input compression.
+fn oversized_openai_payload() -> Value {
+    let mut messages: Vec<Value> = vec![json!({
+        "role": "system",
+        "content": "Always respond concisely.",
+    })];
+    messages.extend((0..40).map(|i| {
+        json!({
+            "role": if i % 2 == 0 { "user" } else { "assistant" },
+            "content": format!("history turn {i} ").repeat(40),
+        })
+    }));
+    json!({
+        "model": "gpt-4o-mini",
+        "max_tokens": 127_000,
+        "messages": messages,
+    })
+}
+
+#[tokio::test]
+async fn openai_compression_off_passes_body_unchanged() {
+    let upstream = MockServer::start().await;
+    let captured = mount_openai_capture(&upstream).await;
+    let proxy = start_proxy_with(&upstream.uri(), |_| {}).await;
+
+    let payload = oversized_openai_payload();
+    let body = serde_json::to_vec(&payload).unwrap();
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v1/chat/completions", proxy.url()))
+        .header("content-type", "application/json")
+        .body(body.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let got = captured.lock().unwrap().clone().expect("upstream got body");
+    assert_eq!(got, body, "compression off — body must be byte-identical");
+    proxy.shutdown().await;
+}
+
+#[tokio::test]
+async fn openai_compression_on_short_body_passes_through() {
+    let upstream = MockServer::start().await;
+    let captured = mount_openai_capture(&upstream).await;
+    let proxy = start_proxy_with(&upstream.uri(), |c| c.compression = true).await;
+
+    let payload = json!({
+        "model": "gpt-4o-mini",
+        "max_tokens": 1024,
+        "messages": [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user",   "content": "hi"},
+        ],
+    });
+    let body = serde_json::to_vec(&payload).unwrap();
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v1/chat/completions", proxy.url()))
+        .header("content-type", "application/json")
+        .body(body.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let got = captured.lock().unwrap().clone().expect("upstream got body");
+    let got_json: Value = serde_json::from_slice(&got).unwrap();
+    let in_messages = payload["messages"].as_array().unwrap().len();
+    let out_messages = got_json["messages"].as_array().unwrap().len();
+    assert_eq!(out_messages, in_messages);
+    proxy.shutdown().await;
+}
+
+#[tokio::test]
+async fn openai_compression_on_oversized_body_trims_messages_keeps_system() {
+    let upstream = MockServer::start().await;
+    let captured = mount_openai_capture(&upstream).await;
+    let proxy = start_proxy_with(&upstream.uri(), |c| c.compression = true).await;
+
+    let payload = oversized_openai_payload();
+    let body = serde_json::to_vec(&payload).unwrap();
+    let in_messages = payload["messages"].as_array().unwrap().len();
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v1/chat/completions", proxy.url()))
+        .header("content-type", "application/json")
+        .body(body.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let got = captured.lock().unwrap().clone().expect("upstream got body");
+    assert_ne!(got, body, "ICM should have trimmed something");
+    let got_json: Value = serde_json::from_slice(&got).unwrap();
+    let out_msgs = got_json["messages"].as_array().unwrap();
+    assert!(
+        out_msgs.len() < in_messages,
+        "expected fewer messages after compression: in={in_messages}, out={}",
+        out_msgs.len()
+    );
+    // OSS-defining safety contract: the system message must survive.
+    assert!(
+        out_msgs
+            .iter()
+            .any(|m| m.get("role").and_then(Value::as_str) == Some("system")),
+        "system message must be preserved after OpenAI compression"
+    );
+    // model + max_tokens preserved verbatim
+    assert_eq!(got_json["model"], payload["model"]);
+    assert_eq!(got_json["max_tokens"], payload["max_tokens"]);
+    proxy.shutdown().await;
+}
+
+#[tokio::test]
+async fn openai_max_completion_tokens_field_works() {
+    // Reasoning models (o1/o3) only accept max_completion_tokens.
+    // Verify the gate accepts that field shape.
+    let upstream = MockServer::start().await;
+    let captured = mount_openai_capture(&upstream).await;
+    let proxy = start_proxy_with(&upstream.uri(), |c| c.compression = true).await;
+
+    let payload = json!({
+        "model": "gpt-4o-mini",
+        "max_completion_tokens": 1024,
+        "messages": [{"role": "user", "content": "hi"}],
+    });
+    let body = serde_json::to_vec(&payload).unwrap();
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v1/chat/completions", proxy.url()))
+        .header("content-type", "application/json")
+        .body(body.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let got = captured.lock().unwrap().clone().expect("upstream got body");
+    // Small request → no compression → body unchanged
+    assert_eq!(got, body);
     proxy.shutdown().await;
 }


### PR DESCRIPTION
## Summary

Second provider arm on the Rust proxy compression gate (stacked on #345).
Same pattern: opt-in `--compression`, buffer-on-LLM-path, ICM trims if
oversized, otherwise pass through.

Verified end-to-end against the **real OpenAI API** with
\`HEADROOM_E2E=1\` and a live key:
- Small request → \"pong\" reply
- ~240K-token request → ICM compressed to **124,650 prompt tokens** (under the 128K window), model still produced \"pong\"
- Streaming (SSE) request → chunks arrive correctly, \`[DONE]\` sentinel observed

## What's new

- \`compression/messages.rs\` — provider-agnostic core extracted out
- \`compression/openai.rs\` — thin wrapper, prefers \`max_completion_tokens\` (o-series) over \`max_tokens\`
- \`compression/anthropic.rs\` — refactored to use the shared core (public API unchanged)
- \`compression/mod.rs\` — \`CompressibleEndpoint\` discriminant + \`classify_path()\` so the gate dispatches with one match
- Mock-based integration tests grow from 5 → 9 (4 new OpenAI cases including system-message-survives assertion)
- New \`tests/e2e_openai_compression.rs\` — 3 real-API tests gated on \`HEADROOM_E2E=1\`

## Quirks worth knowing

1. **OpenAI's system message lives inside \`messages\`.** ICM's SafetyRails already protects \`role:\"system\"\`, so this just works — that's the OSS-defining \"messages-list-shaped\" abstraction.
2. **\`max_tokens\` is a hard output cap, not a budget reservation.** OpenAI rejects \`max_tokens > 16384\` for gpt-4o-mini. The Anthropic test trick of inflating max_tokens to force compression doesn't work here — had to inflate input volume instead. Caught this only via real e2e.
3. **\`max_completion_tokens\` for o1/o3** — checked first.
4. **Tool-call atomicity** — both shapes (Anthropic content-blocks and OpenAI \`tool_calls[]\` + \`role:\"tool\"\`) are already handled by ICM's \`find_tool_units\`.

## Test plan

- [x] Unit tests: 23 passing (compression module — 7 new OpenAI)
- [x] Mock integration: 9 passing
- [x] Real OpenAI e2e: 3/3 passing
- [x] \`cargo test --workspace\` → 891 passed
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` → clean
- [x] \`make ci-precheck\` → green