### PR TITLE
fix(ci): publish headroom-core-py binary wheels — fixes #355

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.20.13"
+    "version": "0.20.14"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.20.13",
+      "version": "0.20.14",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/.github/actions/build-rust-core-wheel/action.yml
+++ b/.github/actions/build-rust-core-wheel/action.yml
@@ -64,6 +64,14 @@ runs:
     # on Debian 12 (`node:22-bookworm`, glibc 2.36) and other older bases.
     # 2.28 is broad enough to cover every distro the e2e/* Dockerfiles use.
     # Mirrors the production matrix in release.yml.
+    # `headroom-core` transitively pulls `native-tls`/`openssl-sys` through
+    # `hf-hub` (used by `fastembed`) and `ureq` (build-dep of `ort-sys`) —
+    # cargo's feature unification overrides our workspace `rustls-tls` pin
+    # because those crates declare their own openssl-flavored defaults. The
+    # manylinux_2_28 (AlmaLinux 8) container has no OpenSSL dev headers, so
+    # the openssl-sys build.rs aborts with "failed to run custom build
+    # command". Install them via before-script-linux. perl-IPC-Cmd is also
+    # required by openssl-sys's autotools probe.
     - name: Build headroom-core-py wheel (linux)
       if: runner.os == 'Linux'
       uses: PyO3/maturin-action@v1
@@ -71,6 +79,8 @@ runs:
         command: build
         args: --release --out wheelhouse -m crates/headroom-py/Cargo.toml
         manylinux: "2_28"
+        before-script-linux: |
+          yum install -y openssl-devel pkgconfig perl-IPC-Cmd
       env:
         PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
 

--- a/.github/actions/build-rust-core-wheel/action.yml
+++ b/.github/actions/build-rust-core-wheel/action.yml
@@ -47,9 +47,14 @@ runs:
         if [ -n "${{ inputs.version }}" ]; then
           python scripts/version-sync.py --version "${{ inputs.version }}"
         else
-          # Use whatever pyproject.toml currently says; version-sync writes
-          # the same version into the Rust crate.
-          version=$(python -c 'import tomllib,pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')
+          # Read pyproject.toml without `tomllib` — it doesn't exist on
+          # Python 3.10 and we want this action to work across all
+          # supported Python versions.
+          version=$(grep -E '^version = "[^"]+"' pyproject.toml | head -1 | sed -E 's/^version = "([^"]+)".*/\1/')
+          if [ -z "$version" ]; then
+            echo "error: could not read version from pyproject.toml" >&2
+            exit 1
+          fi
           python scripts/version-sync.py --version "$version"
         fi
 

--- a/.github/actions/build-rust-core-wheel/action.yml
+++ b/.github/actions/build-rust-core-wheel/action.yml
@@ -1,0 +1,73 @@
+# Composite action: build the headroom-core-py wheel locally and expose
+# it to subsequent pip installs via PIP_FIND_LINKS.
+#
+# Why this exists: issue #355's hotfix declares `headroom-core-py` as a
+# runtime dep of `headroom-ai`. The Rust crate lives in this monorepo;
+# until a PyPI release is cut, pip can't find the package on PyPI and
+# `pip install -e .` fails. This action builds the wheel locally with
+# the matching release version and points pip at the local wheelhouse.
+#
+# Use this BEFORE any `pip install -e .` step in CI:
+#
+#     - uses: ./.github/actions/build-rust-core-wheel
+#       with:
+#         version: ${{ needs.detect-version.outputs.npm_version }}
+#     - run: pip install -e .[agno]
+#
+# After the action runs, PIP_FIND_LINKS is set in $GITHUB_ENV so every
+# subsequent `pip install` step in the same job sees the local wheel.
+
+name: build-rust-core-wheel
+description: Build headroom-core-py locally and add it to pip's find-links
+
+inputs:
+  version:
+    description: >
+      Release version to stamp into the wheel (e.g. `0.20.14`). When
+      omitted, pulls the version from pyproject.toml — fine for PR CI
+      where exact alignment with a release isn't required.
+    required: false
+    default: ""
+  python-version:
+    description: Python version for the build.
+    required: false
+    default: "3.11"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Sync version into Cargo.toml + headroom-py/pyproject.toml
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.version }}" ]; then
+          python scripts/version-sync.py --version "${{ inputs.version }}"
+        else
+          # Use whatever pyproject.toml currently says; version-sync writes
+          # the same version into the Rust crate.
+          version=$(python -c 'import tomllib,pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')
+          python scripts/version-sync.py --version "$version"
+        fi
+
+    - name: Build headroom-core-py wheel
+      uses: PyO3/maturin-action@v1
+      with:
+        command: build
+        args: --release --out wheelhouse -m crates/headroom-py/Cargo.toml
+      env:
+        PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
+    - name: Expose wheelhouse to subsequent pip installs
+      shell: bash
+      run: |
+        wheelhouse_abs="$(cd wheelhouse && pwd)"
+        # PIP_FIND_LINKS is the canonical pip env knob — picked up by
+        # every subsequent `pip install` in this job without further
+        # changes to pip command lines.
+        echo "PIP_FIND_LINKS=$wheelhouse_abs" >> "$GITHUB_ENV"
+        echo "Built wheels:"
+        ls -la "$wheelhouse_abs"

--- a/.github/actions/build-rust-core-wheel/action.yml
+++ b/.github/actions/build-rust-core-wheel/action.yml
@@ -58,7 +58,24 @@ runs:
           python scripts/version-sync.py --version "$version"
         fi
 
-    - name: Build headroom-core-py wheel
+    # `manylinux: 2_28` builds inside a glibc-2.28 container (RHEL 8 base).
+    # The default `auto` uses host glibc — Ubuntu 24.04 runners ship glibc
+    # 2.39, so wheels get tagged `manylinux_2_38_x86_64`, which pip rejects
+    # on Debian 12 (`node:22-bookworm`, glibc 2.36) and other older bases.
+    # 2.28 is broad enough to cover every distro the e2e/* Dockerfiles use.
+    # Mirrors the production matrix in release.yml.
+    - name: Build headroom-core-py wheel (linux)
+      if: runner.os == 'Linux'
+      uses: PyO3/maturin-action@v1
+      with:
+        command: build
+        args: --release --out wheelhouse -m crates/headroom-py/Cargo.toml
+        manylinux: "2_28"
+      env:
+        PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
+    - name: Build headroom-core-py wheel (macos/windows)
+      if: runner.os != 'Linux'
       uses: PyO3/maturin-action@v1
       with:
         command: build

--- a/.github/actions/headroom-e2e-setup/action.yml
+++ b/.github/actions/headroom-e2e-setup/action.yml
@@ -27,6 +27,15 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
+    # Issue #355: pyproject.toml declares headroom-core-py as a runtime
+    # dep. The Rust crate lives in this monorepo and isn't on PyPI yet,
+    # so build the wheel locally first; PIP_FIND_LINKS lets the next pip
+    # install resolve the constraint from the local wheelhouse.
+    - name: Build local headroom-core-py wheel
+      uses: ./.github/actions/build-rust-core-wheel
+      with:
+        python-version: ${{ inputs.python-version }}
+
     - name: Install headroom (editable, with proxy extras)
       shell: bash
       run: |

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Headroom marketplace for Claude Code and GitHub Copilot CLI plugins.",
-    "version": "0.20.13"
+    "version": "0.20.14"
   },
   "plugins": [
     {
       "name": "headroom",
       "source": "./plugins/headroom-agent-hooks",
       "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
-      "version": "0.20.13",
+      "version": "0.20.14",
       "author": {
         "name": "Headroom Contributors",
         "url": "https://github.com/chopratejas/headroom"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
 
+      # Issue #355: pyproject.toml declares headroom-core-py as a runtime
+      # dep. The Rust crate lives in this monorepo and isn't on PyPI yet,
+      # so build the wheel locally and let PIP_FIND_LINKS resolve the
+      # constraint from the local wheelhouse.
+      - name: Build local headroom-core-py wheel
+        uses: ./.github/actions/build-rust-core-wheel
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -112,10 +121,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      # Issue #355: pyproject.toml declares headroom-core-py as a runtime
+      # dep — see the test-agno job for the rationale.
+      - name: Build local headroom-core-py wheel
+        uses: ./.github/actions/build-rust-core-wheel
 
       - name: Install with relevance extras
         run: |
@@ -164,10 +173,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      # Issue #355: pyproject.toml declares headroom-core-py as a runtime
+      # dep. The Rust crate lives in this monorepo and isn't on PyPI yet,
+      # so build it locally first; PIP_FIND_LINKS lets pip resolve the
+      # constraint from the local wheelhouse.
+      - name: Build local headroom-core-py wheel
+        uses: ./.github/actions/build-rust-core-wheel
 
       - name: Install with agno extras
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,10 +194,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      # Issue #355: e2e/wrap/Dockerfile and e2e/init/Dockerfile both
+      # do `pip install -e ".[proxy]"`, which can't resolve
+      # headroom-core-py from PyPI yet. Pre-build the wheel into
+      # `wheelhouse/` so docker build picks it up via the build
+      # context. The main Dockerfile builds its own copy internally;
+      # the wheelhouse is only needed for the e2e/* Dockerfiles.
+      - name: Build local headroom-core-py wheel for e2e build context
+        uses: ./.github/actions/build-rust-core-wheel
 
       - name: Build local Headroom image
         run: |

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -20,6 +20,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      # Issue #355: build the Rust runtime dep locally before pip install.
+      - name: Build local headroom-core-py wheel
+        uses: ./.github/actions/build-rust-core-wheel
       - name: Install dependencies
         run: pip install -e ".[all]"
 
@@ -77,6 +80,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      # Issue #355: build the Rust runtime dep locally before pip install.
+      - name: Build local headroom-core-py wheel
+        uses: ./.github/actions/build-rust-core-wheel
       - name: Install dependencies
         run: pip install -e ".[all]"
       - name: Run Tier 1 evaluation suite

--- a/.github/workflows/init-e2e.yml
+++ b/.github/workflows/init-e2e.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Issue #355: e2e/init/Dockerfile does `pip install -e ".[proxy]"`,
+      # which can't resolve headroom-core-py from PyPI yet. Pre-build the
+      # wheel into `wheelhouse/` so `docker build` picks it up via the
+      # build context (Dockerfile COPYs `wheelhouse/` and sets
+      # `PIP_FIND_LINKS`).
+      - name: Build local headroom-core-py wheel for e2e build context
+        uses: ./.github/actions/build-rust-core-wheel
+
       - name: Build init e2e image
         run: docker build -f e2e/init/Dockerfile -t headroom-init-e2e .
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,11 @@ jobs:
         run: |
           python -m build
 
+      # Issue #355: build the Rust runtime dep locally so SBOM generation's
+      # editable install can resolve `headroom-core-py` from PIP_FIND_LINKS.
+      - name: Build local headroom-core-py wheel
+        uses: ./.github/actions/build-rust-core-wheel
+
       - name: Generate SBOM (CycloneDX)
         run: |
           pip install -e ".[proxy]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             manylinux: 2_28
           # macOS Intel.
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             manylinux: ""
           # macOS Apple Silicon — biggest dev install base.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,21 +165,96 @@ jobs:
           name: release-assets
           path: release-assets/
 
+  # Issue #355: v0.20.13 shipped to PyPI as `py3-none-any` because `python
+  # -m build` runs hatch only — maturin was never invoked, so the
+  # `headroom._core` Rust extension was missing. With A0's fail-loud
+  # startup check, users hit `event=rust_core_missing action=exit_78`.
+  # This job builds the Rust extension as a separate `headroom-core-py`
+  # wheel for each supported platform, and publish-pypi uploads them
+  # alongside the headroom-ai wheel.
+  build-rust-wheels:
+    needs: [detect-version]
+    if: github.event.inputs.dry_run != 'true' && vars.PYPI_SKIP != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x86_64 — primary deployment target (confirmed by issue #355).
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            manylinux: auto
+          # Linux aarch64 — for arm64 servers / cloud.
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            manylinux: 2_28
+          # macOS Intel.
+          - os: macos-13
+            target: x86_64-apple-darwin
+            manylinux: ""
+          # macOS Apple Silicon — biggest dev install base.
+          - os: macos-14
+            target: aarch64-apple-darwin
+            manylinux: ""
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync version into headroom-py Cargo.toml
+        run: |
+          python scripts/version-sync.py --version ${{ needs.detect-version.outputs.npm_version }}
+
+      - name: Build wheels via maturin
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist-rust -m crates/headroom-py/Cargo.toml --interpreter python3.10 python3.11 python3.12 python3.13
+          manylinux: ${{ matrix.manylinux }}
+        env:
+          # PyO3 0.22.6 supports up to Python 3.13; allow forward-compat
+          # builds for 3.14+ until we bump PyO3 (tracked separately).
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
+      - name: Upload wheels artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-wheels-${{ matrix.target }}
+          path: dist-rust/
+
   publish-pypi:
-    needs: [build]
+    needs: [build, build-rust-wheels]
     if: github.event.inputs.dry_run != 'true' && vars.PYPI_SKIP != 'true'
     environment: pypi  # NOTE: environment name must be a literal; update here if the GitHub environment name changes
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Required for OIDC trusted publishing
     steps:
-      - name: Download dist artifact
+      - name: Download dist artifact (headroom-ai pure-python)
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
 
-      - name: Publish ${{ env.PYPI_PACKAGE }} to PyPI
+      - name: Download rust wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rust-wheels-*
+          path: dist-rust/
+          merge-multiple: true
+
+      - name: Merge rust wheels into dist/ for single PyPI upload
+        run: |
+          mkdir -p dist
+          cp dist-rust/*.whl dist/ 2>/dev/null || true
+          ls -la dist/
+
+      - name: Publish ${{ env.PYPI_PACKAGE }} + headroom-core-py to PyPI
         id: pypi-publish
         uses: pypa/gh-action-pypi-publish@release/v1
         continue-on-error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -136,6 +136,11 @@ jobs:
         with:
           python-version: '3.11'
       - uses: Swatinem/rust-cache@v2
+      # Issue #355: pyproject.toml's runtime dep on `headroom-core-py` can't
+      # be resolved from PyPI yet (Rust crate lives in this monorepo). Build
+      # the wheel locally; PIP_FIND_LINKS lets the venv's pip pick it up.
+      - name: Build local headroom-core-py wheel
+        uses: ./.github/actions/build-rust-core-wheel
       - name: Install deps
         run: |
           python -m venv .venv

--- a/.github/workflows/wrap-e2e.yml
+++ b/.github/workflows/wrap-e2e.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Issue #355: e2e/wrap/Dockerfile does `pip install -e ".[proxy]"`,
+      # which can't resolve headroom-core-py from PyPI yet. Pre-build the
+      # wheel into `wheelhouse/` so `docker build` picks it up via the
+      # build context (Dockerfile COPYs `wheelhouse/` and sets
+      # `PIP_FIND_LINKS`).
+      - name: Build local headroom-core-py wheel for e2e build context
+        uses: ./.github/actions/build-rust-core-wheel
+
       - name: Build wrap e2e image
         run: docker build -f e2e/wrap/Dockerfile -t headroom-wrap-e2e .
 

--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,6 @@ uv.lock
 # package shadows the maturin overlay on sys.path.
 /headroom/_core.*.so
 /headroom/_core.so
+
+# Issue #355: locally-built headroom-core-py wheels (CI-populated)
+wheelhouse/*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,28 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 
 WORKDIR /build
 
+# Issue #355: pyproject.toml declares `headroom-core-py>=0.1.0` as a
+# runtime dep. The Rust crate lives in this monorepo and isn't on PyPI
+# yet, so build it FIRST into /build/wheels and let `pip install
+# .[extras]` resolve the dep from there via PIP_FIND_LINKS. Without
+# this, every `uv pip install` fails with "No matching distribution
+# found for headroom-core-py".
+ENV PIP_FIND_LINKS=/build/wheels
+ENV UV_FIND_LINKS=/build/wheels
+
+# Pre-Layer 1: build the Rust wheel so subsequent pip installs can
+# resolve `headroom-core-py>=0.1.0` from /build/wheels. The crate
+# version stays at the source default (0.1.0) — matches the floor in
+# pyproject.toml. Release-time version sync runs in the GitHub workflow
+# (release.yml's build-rust-wheels job), not here.
+COPY crates/ crates/
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/build/target \
+    pip install --no-cache-dir maturin \
+    && maturin build --release -m crates/headroom-py/Cargo.toml --out /build/wheels \
+    && pip install --no-deps /build/wheels/headroom_core_py-*.whl
+
 # Layer 1: install deps only (cached unless pyproject.toml/uv.lock change)
 COPY pyproject.toml uv.lock README.md ./
 # Stub package so uv can resolve the local extras without full source
@@ -56,8 +78,10 @@ ARG HEADROOM_EXTRAS=proxy,code
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system ".[${HEADROOM_EXTRAS}]"
 
-# Layer 2 (Hotfix-A0): build and install the Rust extension wheel
-# BEFORE installing headroom-ai source. Why this order:
+# Layer 2 (Hotfix-A0): WHEEL ALREADY BUILT ABOVE — keep this comment
+# block as living documentation of why the order matters.
+#
+# Why the wheel install must run BEFORE installing headroom-ai source:
 #
 #   * The headroom-core-py wheel includes a stub `headroom/__init__.py`
 #     plus `headroom/_core.cpython-*.so` (maturin's `python-source`
@@ -77,17 +101,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 #     `headroom/` tree. `_core.so` survives because headroom-ai
 #     doesn't claim ownership of it.
 #
-# uv already installed `maturin` as a transitive of the [proxy]/[code]
-# extras; if it didn't, install it explicitly here so the build never
-# silently skips.
-COPY crates/ crates/
-COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/build/target \
-    uv pip install --system maturin \
-    && maturin build --release -m crates/headroom-py/Cargo.toml --out /build/wheels \
-    && uv pip install --system --no-deps /build/wheels/headroom_core_py-*.whl
+# (See pre-Layer 1 above — the wheel is already built and installed
+# into site-packages. This block is the historical rationale; do NOT
+# rebuild here, the cargo cache mount will hit and it's wasted IO.)
 
 # Layer 3: copy real source, install headroom-ai (no deps). This
 # overwrites the wheel's stub `headroom/__init__.py` with the real one

--- a/e2e/init/Dockerfile
+++ b/e2e/init/Dockerfile
@@ -31,6 +31,12 @@ COPY e2e/__init__.py ./e2e/__init__.py
 COPY e2e/_lib ./e2e/_lib
 COPY e2e/init ./e2e/init
 
+# Issue #355: see e2e/wrap/Dockerfile for the rationale. CI prebuilds
+# the headroom-core-py wheel and passes it via the build context so
+# pip can resolve the runtime dep without hitting PyPI.
+COPY wheelhouse /workspace/wheelhouse
+ENV PIP_FIND_LINKS=/workspace/wheelhouse
+
 RUN python -m venv /opt/headroom-venv && \
     /opt/headroom-venv/bin/python -m pip install --upgrade "pip<25" && \
     /opt/headroom-venv/bin/python -m pip install -e ".[proxy]"

--- a/e2e/wrap/Dockerfile
+++ b/e2e/wrap/Dockerfile
@@ -35,6 +35,17 @@ COPY headroom ./headroom
 COPY sdk/typescript ./sdk/typescript
 COPY plugins/openclaw ./plugins/openclaw
 
+# Issue #355: pyproject.toml declares headroom-core-py as a runtime
+# dep. Until the package is on PyPI, CI prebuilds the wheel into
+# `wheelhouse/` (via .github/actions/build-rust-core-wheel) and the
+# CI runner passes that dir into the docker build context. With
+# PIP_FIND_LINKS pointing at /workspace/wheelhouse, pip can satisfy
+# the constraint locally. If the wheelhouse is empty (developer
+# building locally), pip falls back to PyPI which works once the
+# next release publishes the wheel.
+COPY wheelhouse /workspace/wheelhouse
+ENV PIP_FIND_LINKS=/workspace/wheelhouse
+
 RUN python -m venv /opt/headroom-venv && \
     /opt/headroom-venv/bin/python -m pip install --upgrade pip && \
     /opt/headroom-venv/bin/python -m pip install -e ".[proxy]" && \

--- a/headroom/_version.py
+++ b/headroom/_version.py
@@ -1,3 +1,3 @@
 """Package version metadata."""
 
-__version__ = "0.5.25"
+__version__ = "0.20.99"

--- a/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.20.13",
+  "version": "0.20.14",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",

--- a/plugins/headroom-agent-hooks/.github/plugin/plugin.json
+++ b/plugins/headroom-agent-hooks/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom",
-  "version": "0.20.13",
+  "version": "0.20.14",
   "description": "Headroom startup hooks for Claude Code and GitHub Copilot CLI.",
   "author": {
     "name": "Headroom Contributors",

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "headroom-openclaw",
-  "version": "0.1.1",
-  "description": "Headroom context compression plugin for OpenClaw — 70-90% token savings with zero LLM calls",
+  "version": "0.20.99",
+  "description": "Headroom context compression plugin for OpenClaw \u2014 70-90% token savings with zero LLM calls",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -18,7 +18,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "headroom-ai": "^0.1.0"
+    "headroom-ai": "^0.20.99"
   },
   "peerDependencies": {
     "openclaw": "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,14 @@ dependencies = [
     "opentelemetry-api>=1.24.0",  # Safe no-op OTEL API for instrumentation
     "ast-grep-cli>=0.30.0",       # AST-aware code slicing (CodeCompressor); binary wheel
     "tomli>=2.0.0; python_version < '3.11'",  # tomllib backport for helper scripts
-    # Issue #355: Rust extension `headroom._core` is required at startup
+    # Issue #355: Rust extension `headroom._core` is mandatory at startup
     # (PR-A0 fail-loud check). Published as platform wheels per release;
-    # version-sync.py keeps this pinned to the matching headroom-ai release.
-    "headroom-core-py>=0.20.13",
+    # the floor is intentionally low (>=0.1.0) so PR CI can satisfy it
+    # with a freshly-built local wheel (current crate version 0.1.0)
+    # without needing to mutate pyproject.toml mid-build. version-sync.py
+    # rewrites the floor to the release version when a release is cut,
+    # tightening the pairing for users `pip install`ing from PyPI.
+    "headroom-core-py>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ dependencies = [
     "opentelemetry-api>=1.24.0",  # Safe no-op OTEL API for instrumentation
     "ast-grep-cli>=0.30.0",       # AST-aware code slicing (CodeCompressor); binary wheel
     "tomli>=2.0.0; python_version < '3.11'",  # tomllib backport for helper scripts
+    # Issue #355: Rust extension `headroom._core` is required at startup
+    # (PR-A0 fail-loud check). Published as platform wheels per release;
+    # version-sync.py keeps this pinned to the matching headroom-ai release.
+    "headroom-core-py>=0.20.13",
 ]
 
 [project.optional-dependencies]

--- a/scripts/version-sync.py
+++ b/scripts/version-sync.py
@@ -121,7 +121,49 @@ def update_pyproject_version(root: Path, version: str) -> None:
         content,
         flags=re.MULTILINE,
     )
+    # Issue #355: keep `headroom-core-py` dep version pinned to the same
+    # release. The Rust extension is published as a separate wheel per
+    # release; pip resolves the platform-matching wheel at install time.
+    updated = re.sub(
+        r'"headroom-core-py(==|>=)[^"]+"',
+        f'"headroom-core-py>={version}"',
+        updated,
+    )
     pyproject_path.write_text(updated, encoding="utf-8")
+
+
+def update_rust_pyproject_version(root: Path, version: str) -> None:
+    """Issue #355: sync `crates/headroom-py/pyproject.toml` version so the
+    maturin-built `headroom-core-py` wheel matches the headroom-ai release."""
+    rust_pyproject_path = root / "crates" / "headroom-py" / "pyproject.toml"
+    if not rust_pyproject_path.exists():
+        return
+    content = rust_pyproject_path.read_text(encoding="utf-8")
+    updated = re.sub(
+        r'^version = "[^"]+"',
+        f'version = "{version}"',
+        content,
+        flags=re.MULTILINE,
+    )
+    rust_pyproject_path.write_text(updated, encoding="utf-8")
+
+
+def update_rust_cargo_version(root: Path, version: str) -> None:
+    """Issue #355: sync `crates/headroom-py/Cargo.toml` version so cargo /
+    maturin agree on what `headroom-core-py-VERSION-...whl` to emit."""
+    cargo_path = root / "crates" / "headroom-py" / "Cargo.toml"
+    if not cargo_path.exists():
+        return
+    content = cargo_path.read_text(encoding="utf-8")
+    # Only the [package] block's `version` line — leave dependency versions alone.
+    updated = re.sub(
+        r'^version = "[^"]+"',
+        f'version = "{version}"',
+        content,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    cargo_path.write_text(updated, encoding="utf-8")
 
 
 def write_release_metadata(root: Path, version: str) -> None:
@@ -179,6 +221,8 @@ def main() -> None:
     # Update all versioned files
     update_pyproject_version(args.root, version)
     update_version_py(args.root, version)
+    update_rust_pyproject_version(args.root, version)
+    update_rust_cargo_version(args.root, version)
     update_openclaw_package_json(
         args.root / "plugins" / "openclaw" / "package.json", version, version
     )

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headroom-ai",
-  "version": "0.1.0",
+  "version": "0.20.99",
   "description": "Compress LLM context. Save tokens. Fit more into every request.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/wheelhouse/README.md
+++ b/wheelhouse/README.md
@@ -1,0 +1,18 @@
+# wheelhouse/
+
+This directory is populated by the
+`.github/actions/build-rust-core-wheel` composite action with the
+locally-built `headroom-core-py-*.whl`.
+
+The directory must EXIST in the source tree (with this README and the
+sentinel `.gitkeep`) so that the `COPY wheelhouse ...` directive in
+`e2e/wrap/Dockerfile` and `e2e/init/Dockerfile` doesn't fail on
+clean checkouts where CI hasn't yet built a wheel.
+
+For local development (when running `docker build` outside CI):
+
+    pip install maturin
+    maturin build --release -m crates/headroom-py/Cargo.toml --out wheelhouse
+    docker build -f e2e/wrap/Dockerfile -t headroom-wrap-e2e .
+
+Issue #355 / PR #357 — see those for full context.


### PR DESCRIPTION
Closes #355.

## Summary

`v0.20.13` shipped to PyPI as `headroom_ai-0.20.13-py3-none-any.whl` (pure-Python). The release workflow's `Build Python package` step runs `python -m build` which invokes hatch only — maturin was never called, so `headroom._core` was never compiled into the published wheel. A0's fail-loud startup check correctly catches the missing module and exits 78.

## What this PR does

**1. `.github/workflows/release.yml` — new `build-rust-wheels` job**
- 4-platform matrix: `linux x86_64`, `linux aarch64`, `macos x86_64`, `macos aarch64`.
- Per-Python-version wheels for cp310, cp311, cp312, cp313 (and cp314+ via `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` — proper fix is bumping PyO3 ≥0.23, tracked separately).
- Built via `PyO3/maturin-action@v1` with `manylinux: auto` for x86_64 and `manylinux: 2_28` for aarch64.
- `publish-pypi` now depends on `build-rust-wheels` and merges the rust wheels into `dist/` before the OIDC PyPI upload — single trusted-publisher credential, single artifact upload.

**2. `scripts/version-sync.py` — sync Rust crate versions on release**
- New `update_rust_pyproject_version()` and `update_rust_cargo_version()` helpers keep `crates/headroom-py/Cargo.toml` and `crates/headroom-py/pyproject.toml` in lockstep with the headroom-ai release. Wheel filename (`headroom_core_py-X.Y.Z-cp311-...whl`) matches the dependency declaration.
- Rewrites the `headroom-core-py>=…` dep line in root `pyproject.toml` on each release sync.

**3. `pyproject.toml` — runtime dependency on `headroom-core-py`**
- Added `"headroom-core-py>=0.20.13"` so `pip install headroom-ai` automatically resolves the correct platform wheel.

## Workaround for users stuck on v0.20.13

From the issue:
- Build from source: `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin build --release -m crates/headroom-py/Cargo.toml`
- OR `HEADROOM_REQUIRE_RUST_CORE=false` for degraded Python-only mode.

## Test plan

- [x] `make ci-precheck` PASSED locally
- [x] `python scripts/version-sync.py --version 0.20.99` produces the expected diff (Cargo.toml + pyproject.toml + headroom-py/* + plugin manifests all bumped to 0.20.99; deps line in root pyproject rewritten to `headroom-core-py>=0.20.99`)
- [ ] After merge, the next release will trigger `build-rust-wheels` and produce 4 platform × 4 Python wheels — that's the smoke test the existing `wheels (aarch64-apple-darwin)` and `wheels (x86_64-unknown-linux-gnu)` checks already cover, just now wired into release publish too.