### PR TITLE
fix(proxy): log litellm/anyllm-backend requests so they appear in dashboard Recent Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   branches, mirroring the existing direct-OpenAI / Anthropic paths
   (`handlers/streaming.py:_stream_response`).
 
+- **Streaming requests routed through non-Anthropic backends now report
+  `output_tokens` correctly** instead of always being `0`. The
+  `_stream_openai_via_backend` path in `handlers/streaming.py` was
+  yielding upstream chunks unparsed, so neither `metrics.record_request`
+  nor the dashboard's "Recent Requests" panel ever saw completion
+  tokens. The fix mirrors the direct-OpenAI streaming branch in
+  `handlers/openai.py`: auto-inject `stream_options.include_usage=True`
+  (only when the caller has not set it) and parse SSE chunks through
+  `_parse_sse_usage_from_buffer(..., "openai")` as they pass through,
+  capturing `completion_tokens` from the final usage chunk and using it
+  for both metrics and the request log.
+
 - **`Learned: error recovery` section in MEMORY.md no longer bloats with
   stale, one-shot, or contradictory entries.** The matchers paired up
   unrelated tool calls (e.g. `state.rs` and `lib.rs` in the same dir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Dashboard "Recent Requests" / `/transformations/feed` now shows
+  traffic routed through non-Anthropic backends** (`litellm-*`, `anyllm`,
+  `openrouter`). The `/v1/chat/completions` backend-routed branches in
+  `handlers/openai.py` (non-streaming) and `handlers/streaming.py`
+  (`_stream_openai_via_backend`) called `metrics.record_request(...)` —
+  so `/stats` aggregate counters and the durable savings store were
+  correct — but did not call `self.logger.log(RequestLog(...))`. As a
+  result, the in-memory deque feeding `/stats.recent_requests` and
+  `/transformations/feed` was never populated for those backends, and
+  the dashboard's live feed stayed empty even while compression and
+  routing worked. Added the missing `RequestLog` emission in both
+  branches, mirroring the existing direct-OpenAI / Anthropic paths
+  (`handlers/streaming.py:_stream_response`).
+
 - **`Learned: error recovery` section in MEMORY.md no longer bloats with
   stale, one-shot, or contradictory entries.** The matchers paired up
   unrelated tool calls (e.g. `state.rs` and `lib.rs` in the same dir

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -815,6 +815,38 @@ class OpenAIHandlerMixin:
                         pipeline_timing=pipeline_timing,
                     )
 
+                    # Log to in-memory request logger so /stats `recent_requests`
+                    # and /transformations/feed surface backend-routed traffic
+                    # (litellm-*, anyllm, openrouter). Without this, dashboards
+                    # show savings totals (from metrics) but an empty live feed
+                    # for any non-Anthropic backend.
+                    if getattr(self, "logger", None) is not None:
+                        from headroom.proxy.models import RequestLog
+
+                        self.logger.log(
+                            RequestLog(
+                                request_id=request_id,
+                                timestamp=datetime.now().isoformat(),
+                                provider=self.anthropic_backend.name,
+                                model=model,
+                                input_tokens_original=original_tokens,
+                                input_tokens_optimized=optimized_tokens,
+                                output_tokens=output_tokens,
+                                tokens_saved=tokens_saved,
+                                savings_percent=(tokens_saved / original_tokens * 100)
+                                if original_tokens > 0
+                                else 0,
+                                optimization_latency_ms=optimization_latency,
+                                total_latency_ms=total_latency,
+                                tags=tags or {},
+                                cache_hit=False,
+                                transforms_applied=transforms_applied,
+                                request_messages=body.get("messages")
+                                if getattr(self.config, "log_full_messages", False)
+                                else None,
+                            )
+                        )
+
                     if tokens_saved > 0:
                         logger.info(
                             f"[{request_id}] {model}: {original_tokens:,} → {optimized_tokens:,} "

--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -1233,10 +1233,42 @@ class StreamingMixin:
 
         assert self.anthropic_backend is not None
 
+        # Inject stream_options.include_usage=True so the upstream emits a
+        # final usage chunk we can parse for output_tokens. Mirrors the
+        # direct-OpenAI streaming branch in handlers/openai.py. We only set
+        # the flag when the caller has not taken a stance, so explicit
+        # `include_usage: false` is preserved.
+        if "stream_options" not in body:
+            body["stream_options"] = {"include_usage": True}
+        elif isinstance(body.get("stream_options"), dict):
+            body["stream_options"].setdefault("include_usage", True)
+
+        # Mutable state used by the generator to accumulate output_tokens
+        # parsed out of the SSE chunks as they pass through.
+        stream_state: dict[str, Any] = {
+            "output_tokens": 0,
+            "sse_buffer": bytearray(),
+        }
+
         async def generate():
             try:
                 async for sse_chunk in self.anthropic_backend.stream_openai_message(body, headers):
-                    yield sse_chunk.encode() if isinstance(sse_chunk, str) else sse_chunk
+                    chunk_bytes = sse_chunk.encode() if isinstance(sse_chunk, str) else sse_chunk
+                    yield chunk_bytes
+
+                    # Parse usage out of the buffered bytes (handles SSE events
+                    # split across backend chunk boundaries). The OpenAI-format
+                    # final chunk carries `usage.completion_tokens`.
+                    try:
+                        stream_state["sse_buffer"].extend(chunk_bytes)
+                        usage = self._parse_sse_usage_from_buffer(stream_state, "openai")
+                        if usage and "output_tokens" in usage:
+                            stream_state["output_tokens"] = usage["output_tokens"]
+                    except Exception as parse_err:  # noqa: BLE001
+                        logger.debug(
+                            f"[{request_id}] usage parse error "
+                            f"via {self.anthropic_backend.name}: {parse_err}"
+                        )
             except Exception as e:
                 logger.error(f"[{request_id}] Backend streaming error: {e}")
                 error_data = {
@@ -1250,11 +1282,12 @@ class StreamingMixin:
                 yield b"data: [DONE]\n\n"
             finally:
                 total_latency = (time.time() - start_time) * 1000
+                output_tokens = stream_state["output_tokens"]
                 await self.metrics.record_request(
                     provider=self.anthropic_backend.name,
                     model=model,
                     input_tokens=optimized_tokens,
-                    output_tokens=0,  # Unknown in streaming
+                    output_tokens=output_tokens,
                     tokens_saved=tokens_saved,
                     latency_ms=total_latency,
                     cached=False,
@@ -1277,7 +1310,7 @@ class StreamingMixin:
                             model=model,
                             input_tokens_original=original_tokens,
                             input_tokens_optimized=optimized_tokens,
-                            output_tokens=0,  # Unknown in streaming
+                            output_tokens=output_tokens,
                             tokens_saved=tokens_saved,
                             savings_percent=(tokens_saved / original_tokens * 100)
                             if original_tokens > 0

--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -1261,6 +1261,38 @@ class StreamingMixin:
                     overhead_ms=optimization_latency,
                     pipeline_timing=pipeline_timing,
                 )
+
+                # Log to in-memory request logger so /stats `recent_requests`
+                # and /transformations/feed surface backend-routed streaming
+                # traffic (litellm-*, anyllm, openrouter). Mirrors the non-
+                # streaming branch in openai.py.
+                if getattr(self, "logger", None) is not None:
+                    from headroom.proxy.models import RequestLog
+
+                    self.logger.log(
+                        RequestLog(
+                            request_id=request_id,
+                            timestamp=datetime.now().isoformat(),
+                            provider=self.anthropic_backend.name,
+                            model=model,
+                            input_tokens_original=original_tokens,
+                            input_tokens_optimized=optimized_tokens,
+                            output_tokens=0,  # Unknown in streaming
+                            tokens_saved=tokens_saved,
+                            savings_percent=(tokens_saved / original_tokens * 100)
+                            if original_tokens > 0
+                            else 0,
+                            optimization_latency_ms=optimization_latency,
+                            total_latency_ms=total_latency,
+                            tags=tags or {},
+                            cache_hit=False,
+                            transforms_applied=transforms_applied,
+                            request_messages=body.get("messages")
+                            if getattr(self.config, "log_full_messages", False)
+                            else None,
+                        )
+                    )
+
                 if tokens_saved > 0:
                     logger.info(
                         f"[{request_id}] {model}: {original_tokens:,} → {optimized_tokens:,} "


### PR DESCRIPTION
## Description

Two related bugs in headroom's request reporting for non-Anthropic backends (`litellm-*`, `anyllm`, `openrouter`), found while wiring headroom in front of Azure OpenAI for the [Factory `droid` CLI](https://docs.factory.ai/cli/byok/openai-anthropic):

1. **Backend-routed `/v1/chat/completions` traffic never appeared in the dashboard's "Recent Requests" panel** (`/transformations/feed`, `/stats.recent_requests`). The non-streaming branch in `handlers/openai.py` and the streaming branch `_stream_openai_via_backend` in `handlers/streaming.py` called `self.metrics.record_request(...)` but never `self.logger.log(RequestLog(...))`, so the in-memory deque feeding those endpoints was empty.

2. **Streaming requests routed via a non-Anthropic backend always reported `output_tokens=0`**. `_stream_openai_via_backend` forwarded upstream chunks verbatim without parsing them, and the `finally:` block hard-coded `output_tokens=0` ("Unknown in streaming"). Direct-OpenAI streaming already auto-injects `stream_options.include_usage=True` and parses the final usage chunk with `_parse_sse_usage_from_buffer`; the backend-routed path didn't.

## Context / motivation

Setup that surfaced both issues:

- One headroom instance on `:8787` with the default `--backend anthropic` for the existing OpenAI / Anthropic / Copilot passthrough entries.
- A second headroom instance on `:8788` with `--backend litellm-azure` (built-in litellm bridge to Azure OpenAI), `AZURE_API_KEY` / `AZURE_API_BASE` / `AZURE_API_VERSION` exported.
- droid `customModels` entries with `provider: "generic-chat-completion-api"`, `baseUrl: "http://localhost:8788/v1"`, `model: "azure/gpt-5.5"` (or `azure/gpt-5.4"`), the real Azure key in `apiKey` (so headroom forwards it as the upstream `api-key`).

Traffic flowed correctly end-to-end: droid → headroom (compresses) → litellm bridge → Azure → response. `/stats` aggregate counters reflected the requests; `~/.headroom/proxy_savings.json` accumulated savings. But the dashboard panel on `:8788` stayed empty (issue #1), and once issue #1 was fixed the `output` column on every row stayed `0` (issue #2).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes

**Commit 1 — `fix(proxy): log litellm/anyllm-backend requests so they appear in dashboard`**

- `handlers/openai.py`: after `metrics.record_request(...)` in the backend-routed non-streaming branch (`if self.anthropic_backend is not None:` → non-stream), emit `self.logger.log(RequestLog(...))` with the same fields the direct/Anthropic paths use (provider = `self.anthropic_backend.name`, both original and optimized token counts, `tokens_saved`, `savings_percent`, latencies, `transforms_applied`, `tags`, optional `request_messages` gated on `config.log_full_messages`).
- `handlers/streaming.py`: same emission inside the `finally:` block of `_stream_openai_via_backend` (initially with `output_tokens=0` placeholder; superseded by commit 2).
- `CHANGELOG.md`: Unreleased / Fixed entry.

**Commit 2 — `fix(proxy): track output_tokens for streaming requests via litellm/anyllm backend`**

- `handlers/streaming.py`:
  - Auto-inject `stream_options.include_usage=True` when the caller has not set it (`setdefault`-style — explicit `false` is preserved). Mirrors `handlers/openai.py:873-878`.
  - Maintain a small `stream_state = {"output_tokens": 0, "sse_buffer": bytearray()}`. For each upstream chunk, append bytes to the buffer and call `self._parse_sse_usage_from_buffer(stream_state, "openai")`; capture `usage["output_tokens"]` when present (handles SSE events split across backend chunk boundaries — same helper the direct path uses).
  - Pass the captured `output_tokens` to both `metrics.record_request(...)` and `RequestLog(...)`. Removes the two `output_tokens=0` placeholders.
- `CHANGELOG.md`: paired Unreleased / Fixed entry.

No public API or config surface changes. The added imports (`RequestLog`, `datetime`) are inside conditionals only triggered when `self.logger` is set, matching the convention in `_stream_response`.

## Testing

Verified manually against headroom 0.20.27 patched with both commits:

1. Started a headroom instance with `--backend litellm-azure --mode token` on `:8788` (Azure env vars set).
2. **Non-streaming** `/v1/chat/completions` (`stream:false`, `model=azure/gpt-5.5`): before commit 1 — `/transformations/feed` empty; after — entry appears with `provider="litellm-azure"`, correct token counts, `transforms_applied` populated, `output_tokens` from `usage.completion_tokens` (was already on this path).
3. **Streaming** `/v1/chat/completions` (`stream:true`):
   - With **no** `stream_options` in the request: before commit 2, no usage chunk arrived from upstream; after, headroom auto-injects `include_usage=true` and the upstream emits the final usage chunk (verified by tailing the response body).
   - With explicit `stream_options.include_usage:true` in the request: chunk passes through unchanged.
   - In both cases `/stats.recent_requests` and `/transformations/feed` now show real `output_tokens` (e.g., `output_tokens: 38` from a droid call that produced a 38-token reply).
4. End-to-end via droid CLI (`droid exec --model "custom:gpt-5.5-(Headroom-Azure)-0" ...`): rows on `:8788/dashboard` show `model`, `input` (orig + optimized), `saved`, `latency`, **and `output`** all populated correctly.

- [x] Linting passes (`ruff check headroom/proxy/handlers/openai.py headroom/proxy/handlers/streaming.py`)
- [x] Format clean (`ruff format --check ...`)
- [x] Manual testing performed (above, both bugs)
- [ ] Unit tests pass (`pytest`) — not run in this env; happy to add regression tests if you'd like one. Targeted tests would (a) mock `self.anthropic_backend.send_openai_message` to assert `self.logger.log` is called with a `RequestLog` whose `provider == self.anthropic_backend.name`, and (b) feed `_stream_openai_via_backend` a fake async generator that yields a final OpenAI-format `usage` SSE chunk and assert the recorded `output_tokens` matches. Pointers to similar existing tests for the Anthropic streaming path would help me match style.

## Checklist

- [x] My code follows the project's style guidelines (ruff clean, format clean)
- [x] Self-review performed
- [x] Comments added for the new blocks explaining why they exist
- [ ] Documentation updates — not aware of any user-facing doc that needs changing; happy to update if pointed at one.
- [x] No new warnings
- [ ] Regression tests added — see note above.
- [x] CHANGELOG.md updated under `[Unreleased] / Fixed` (one entry per commit).

## Additional Notes

Marked draft so you can flag anything to restructure (e.g., factoring the duplicated `RequestLog(...)` block into a small helper on the mixin) before I add tests and mark it ready.
