### PR TITLE
fix(ci): include NOTICE in sdist for PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
           command: sdist
           args: --out dist
 
-      - name: Verify sdist includes top-level LICENSE
+      - name: Verify sdist includes top-level LICENSE + NOTICE
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: |
           python - <<'PY'
@@ -314,11 +314,14 @@ jobs:
               raise SystemExit(f"expected one sdist root directory, found {sorted(roots)}")
 
           root = roots.pop()
-          license_path = f"{root}/LICENSE"
-          if license_path not in names:
-              raise SystemExit(f"{sdists[0].name} is missing {license_path}")
+          required_paths = (f"{root}/LICENSE", f"{root}/NOTICE")
+          missing = [path for path in required_paths if path not in names]
+          if missing:
+              raise SystemExit(
+                  f"{sdists[0].name} is missing required license file(s): {', '.join(missing)}"
+              )
 
-          print(f"sdist LICENSE OK: {license_path}")
+          print(f"sdist license files OK: {', '.join(required_paths)}")
           PY
 
       # Audit each Linux wheel's dynamic symbol references against its

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,9 +263,13 @@ default = true
 # Where the Python package lives. With `python-source = "."` and the
 # package directory `headroom/` at repo root, maturin includes every file
 # under `headroom/` in the wheel — that picks up the dashboard HTML
-# templates and bundled YAML configs. `LICENSE` is listed explicitly because
-# maturin sdists do not get the package-directory treatment wheels do.
-include = [{ path = "LICENSE", format = "sdist" }]
+# templates and bundled YAML configs. `LICENSE` and `NOTICE` are listed
+# explicitly because maturin sdists do not get the package-directory
+# treatment wheels do.
+include = [
+  { path = "LICENSE", format = "sdist" },
+  { path = "NOTICE", format = "sdist" },
+]
 python-source = "."
 module-name = "headroom._core"
 # The cdylib source lives under `crates/headroom-py`. Maturin invokes

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -513,13 +513,15 @@ def test_release_workflow_verifies_versions_before_build_outputs() -> None:
     assert second_sync < second_verify < build_wheels
 
 
-def test_sdist_license_is_packaged_and_verified_before_upload() -> None:
+def test_sdist_license_files_are_packaged_and_verified_before_upload() -> None:
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     release_yml = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
-    assert 'include = [{ path = "LICENSE", format = "sdist" }]' in pyproject
-    assert "name: Verify sdist includes top-level LICENSE" in release_yml
-    assert 'license_path = f"{root}/LICENSE"' in release_yml
+    assert '{ path = "LICENSE", format = "sdist" }' in pyproject
+    assert '{ path = "NOTICE", format = "sdist" }' in pyproject
+    assert "name: Verify sdist includes top-level LICENSE + NOTICE" in release_yml
+    assert 'f"{root}/LICENSE"' in release_yml
+    assert 'f"{root}/NOTICE"' in release_yml
 
 
 def test_pypi_publish_failure_blocks_github_release() -> None:


### PR DESCRIPTION
## Summary
Fixes the publish-pypi failure caused by missing NOTICE in the sdist.

PyPI rejected upload with:
- 400 License-File NOTICE does not exist in distribution file ... at headroom_ai-0.21.5/NOTICE

## Root cause
pyproject.toml configured maturin sdist include for LICENSE only.
NOTICE was required by package metadata but absent from the generated .tar.gz.

## Changes
- Add NOTICE to [tool.maturin].include for sdist packaging.
- Strengthen release gate in .github/workflows/release.yml:
  - verify sdist contains both LICENSE and NOTICE before publish.
- Update tests/test_release_workflows.py regression test to enforce both files + updated gate text.

## Validation
- Confirmed failing job log + error:
  - HTTPError: 400 Bad Request ... License-File NOTICE does not exist ...
- Local checks run:
  - python3 TOML parse confirms both sdist includes present.
  - python3 -m py_compile tests/test_release_workflows.py passes.