### PR TITLE
feat(providers): add Hermes agent support (#526)

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -7,6 +7,7 @@ Usage:
     headroom wrap aider                     # Start proxy + aider
     headroom wrap cursor                    # Start proxy + print Cursor config instructions
     headroom wrap openclaw                  # Install + configure OpenClaw plugin
+    headroom wrap hermes                    # Start proxy + Hermes (Nous Research) agent
     headroom wrap claude --no-context-tool  # Without CLI context-tool setup
     headroom wrap claude --port 9999        # Custom proxy port
     headroom wrap claude -- --model opus    # Pass args to claude
@@ -64,6 +65,7 @@ from headroom.providers.copilot import (
     validate_configuration as _validate_copilot_configuration,
 )
 from headroom.providers.cursor import render_setup_lines as _render_cursor_setup_lines
+from headroom.providers.hermes import build_launch_env as _build_hermes_launch_env
 from headroom.providers.openclaw import (
     build_plugin_entry as _build_openclaw_plugin_entry_impl,
 )
@@ -3374,6 +3376,104 @@ def openhands(
         learn=learn,
         memory=memory,
         agent_type="openhands",
+        code_graph=code_graph,
+        backend=backend,
+        anyllm_provider=anyllm_provider,
+        region=region,
+    )
+
+
+# =============================================================================
+# Hermes (Nous Research)
+# =============================================================================
+
+
+@wrap.command(context_settings={"ignore_unknown_options": True})
+@click.option("--port", "-p", default=8787, type=int, help="Proxy port (default: 8787)")
+@click.option(
+    "--no-context-tool",
+    "--no-rtk",
+    "no_rtk",
+    is_flag=True,
+    help="Skip CLI context-tool setup",
+)
+@click.option(
+    "--code-graph",
+    is_flag=True,
+    help="Enable code graph indexing via codebase-memory-mcp (optional)",
+)
+@click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option("--learn", is_flag=True, help="Enable live traffic learning")
+@click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option(
+    "--backend", default=None, help="API backend: 'anthropic', 'anyllm', 'litellm-vertex', etc."
+)
+@click.option("--anyllm-provider", default=None, help="Provider for any-llm backend")
+@click.option("--region", default=None, help="Cloud region for Bedrock/Vertex")
+@click.option("--verbose", "-v", is_flag=True, help="Verbose output")
+@click.option("--prepare-only", is_flag=True, hidden=True)
+@click.argument("hermes_args", nargs=-1, type=click.UNPROCESSED)
+def hermes(
+    port: int,
+    no_rtk: bool,
+    code_graph: bool,
+    no_proxy: bool,
+    learn: bool,
+    memory: bool,
+    backend: str | None,
+    anyllm_provider: str | None,
+    region: str | None,
+    verbose: bool,
+    prepare_only: bool,
+    hermes_args: tuple,
+) -> None:
+    """Launch Hermes (Nous Research) agent through Headroom proxy.
+
+    \b
+    Sets OPENAI_BASE_URL and ANTHROPIC_BASE_URL to route Hermes' API calls
+    through Headroom. Sets up the selected CLI context tool by injecting RTK
+    guidance into CONVENTIONS.md at the project root.
+
+    \b
+    Examples:
+        headroom wrap hermes                         # Start proxy + context tool + hermes
+        headroom wrap hermes -- --model hermes-3     # Pass args to hermes
+        headroom wrap hermes --no-context-tool       # Skip CLI context-tool setup
+        headroom wrap hermes --backend litellm-vertex --region us-central1
+    """
+    if not no_rtk:
+        if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+            click.echo("  Setting up lean-ctx for hermes...")
+            _setup_lean_ctx_agent("hermes", verbose=verbose)
+        else:
+            click.echo("  Setting up rtk for hermes...")
+            rtk_path = _ensure_rtk_binary(verbose=verbose)
+            if rtk_path:
+                conventions = Path.cwd() / "CONVENTIONS.md"
+                _inject_rtk_instructions(conventions, verbose=verbose)
+
+    if prepare_only:
+        return
+
+    hermes_bin = shutil.which("hermes")
+    if not hermes_bin:
+        click.echo("Error: 'hermes' not found in PATH.")
+        click.echo("Install Hermes: https://hermes-agent.nousresearch.com/")
+        raise SystemExit(1)
+
+    env, env_vars_display = _build_hermes_launch_env(port, os.environ)
+
+    _launch_tool(
+        binary=hermes_bin,
+        args=hermes_args,
+        env=env,
+        port=port,
+        no_proxy=no_proxy,
+        tool_label="HERMES",
+        env_vars_display=env_vars_display,
+        learn=learn,
+        memory=memory,
+        agent_type="hermes",
         code_graph=code_graph,
         backend=backend,
         anyllm_provider=anyllm_provider,

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -105,12 +105,12 @@
             <div class="bg-surface rounded-lg p-4 border border-border">
                 <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Proxy $ Saved</div>
                 <div class="flex items-baseline gap-2">
-                    <span class="text-3xl font-light tabular-nums text-emerald-400" x-text="'$' + formatCurrency(stats.cost?.savings_usd || 0)"></span>
+                    <span class="text-3xl font-light tabular-nums text-emerald-400" x-text="'$' + formatCurrency(stats.persistent_savings?.lifetime?.compression_savings_usd || 0)"></span>
                 </div>
                 <div class="mt-2 text-xs text-gray-500">
-                    <span x-show="stats.cost?.savings_usd > 0"
+                    <span x-show="(stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0"
                           x-text="formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' proxy tokens only; ' + cliFilteringLabel + ' excluded from $'"></span>
-                    <span x-show="!(stats.cost?.savings_usd > 0)"
+                    <span x-show="!((stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0)"
                           x-text="formatNumber(stats.requests?.total || 0) + ' requests processed'"></span>
                 </div>
             </div>

--- a/headroom/providers/codex/runtime.py
+++ b/headroom/providers/codex/runtime.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from collections.abc import Mapping
 
+from headroom.proxy.helpers import WS_COMPRESSION_FAIL_OPEN_ENV
+
 DEFAULT_API_URL = "https://api.openai.com"
 
 
@@ -20,4 +22,12 @@ def build_launch_env(
     env = dict(environ or os.environ)
     base_url = proxy_base_url(port)
     env["OPENAI_BASE_URL"] = base_url
-    return env, [f"OPENAI_BASE_URL={base_url}"]
+    # Auto-enable fail-open on WebSocket 1009 (Message Too Big / compression
+    # timeout) so Codex never crashes with "Connection refused" on large
+    # messages.  The proxy will pass the message through instead of dropping
+    # the connection.
+    env[WS_COMPRESSION_FAIL_OPEN_ENV] = "1"
+    return env, [
+        f"OPENAI_BASE_URL={base_url}",
+        f"{WS_COMPRESSION_FAIL_OPEN_ENV}=1 (fail-open on WS 1009 compression timeout)",
+    ]

--- a/headroom/providers/codex/runtime.py
+++ b/headroom/providers/codex/runtime.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import os
 from collections.abc import Mapping
 
-from headroom.proxy.helpers import WS_COMPRESSION_FAIL_OPEN_ENV
-
 DEFAULT_API_URL = "https://api.openai.com"
 
 
@@ -22,12 +20,4 @@ def build_launch_env(
     env = dict(environ or os.environ)
     base_url = proxy_base_url(port)
     env["OPENAI_BASE_URL"] = base_url
-    # Auto-enable fail-open on WebSocket 1009 (Message Too Big / compression
-    # timeout) so Codex never crashes with "Connection refused" on large
-    # messages.  The proxy will pass the message through instead of dropping
-    # the connection.
-    env[WS_COMPRESSION_FAIL_OPEN_ENV] = "1"
-    return env, [
-        f"OPENAI_BASE_URL={base_url}",
-        f"{WS_COMPRESSION_FAIL_OPEN_ENV}=1 (fail-open on WS 1009 compression timeout)",
-    ]
+    return env, [f"OPENAI_BASE_URL={base_url}"]

--- a/headroom/providers/hermes/__init__.py
+++ b/headroom/providers/hermes/__init__.py
@@ -1,0 +1,5 @@
+"""Hermes-specific provider helpers."""
+
+from .runtime import build_launch_env
+
+__all__ = ["build_launch_env"]

--- a/headroom/providers/hermes/runtime.py
+++ b/headroom/providers/hermes/runtime.py
@@ -1,0 +1,30 @@
+"""Runtime helpers for Hermes (Nous Research) agent integrations."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+from headroom.providers.claude import proxy_base_url as claude_proxy_base_url
+from headroom.providers.codex import proxy_base_url as codex_proxy_base_url
+
+
+def build_launch_env(
+    port: int, environ: Mapping[str, str] | None = None
+) -> tuple[dict[str, str], list[str]]:
+    """Build environment variables for Hermes through the local proxy.
+
+    Hermes (Nous Research) is an OpenAI-compatible agent CLI.  Both
+    OPENAI_BASE_URL and ANTHROPIC_BASE_URL are set so that whichever
+    provider Hermes is configured to use is transparently routed through
+    the Headroom proxy.
+    """
+    env = dict(environ or os.environ)
+    openai_base_url = codex_proxy_base_url(port)
+    anthropic_base_url = claude_proxy_base_url(port)
+    env["OPENAI_BASE_URL"] = openai_base_url
+    env["ANTHROPIC_BASE_URL"] = anthropic_base_url
+    return env, [
+        f"OPENAI_BASE_URL={openai_base_url}",
+        f"ANTHROPIC_BASE_URL={anthropic_base_url}",
+    ]

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -21,6 +21,19 @@ from typing import Any
 
 from headroom import paths as _paths
 
+# fcntl is Unix-only; on Windows file locking is skipped (best-effort).
+# Typed Any so attribute access on flock/LOCK_EX/LOCK_UN doesn't fail on
+# platforms where the type stub is absent.
+_fcntl: Any = None
+_HAS_FCNTL = False
+try:
+    import fcntl as _fcntl_impl  # noqa: E402
+
+    _fcntl = _fcntl_impl
+    _HAS_FCNTL = True
+except ImportError:
+    pass
+
 logger = logging.getLogger(__name__)
 
 HEADROOM_SAVINGS_PATH_ENV_VAR = _paths.HEADROOM_SAVINGS_PATH_ENV
@@ -812,7 +825,18 @@ class SavingsTracker:
                     f.write(json_data)
                     f.flush()
                     os.fsync(f.fileno())
-                Path(tmp_path).replace(self._path)
+                # Acquire an exclusive cross-process lock on the target file
+                # before the atomic rename so concurrent workers don't clobber
+                # each other's increments. Unix only; Windows skips gracefully.
+                if _HAS_FCNTL and self._path.exists():
+                    with open(self._path, "r+b") as lock_fh:
+                        _fcntl.flock(lock_fh, _fcntl.LOCK_EX)
+                        try:
+                            Path(tmp_path).replace(self._path)
+                        finally:
+                            _fcntl.flock(lock_fh, _fcntl.LOCK_UN)
+                else:
+                    Path(tmp_path).replace(self._path)
             except Exception:
                 try:
                     Path(tmp_path).unlink()

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -3073,12 +3073,13 @@ def run_server(
         # sticky-session workaround.
         logger.warning(
             "Headroom is running with workers=%d. The in-memory CCR store, "
-            "compression cache, prefix tracker, and TOIN state are all "
+            "compression cache, prefix tracker, TOIN state, and CostTracker are all "
             "per-process; multi-worker deployments produce silent retrieval "
-            "failures and avoidable cache busts when sessions land on different "
-            "workers. Run --workers 1 (or place a sticky-session load balancer "
-            "in front of multiple --workers 1 processes). See RUST_DEV.md → "
-            "'Multi-worker deployment — CCR fragmentation'.",
+            "failures, avoidable cache busts, and an unstable dashboard 'Proxy $ Saved' "
+            "hero tile (each /stats poll hits a different worker's partial total) when "
+            "sessions land on different workers. Run --workers 1 (or place a "
+            "sticky-session load balancer in front of multiple --workers 1 processes). "
+            "See RUST_DEV.md → 'Multi-worker deployment — CCR fragmentation'.",
             workers,
         )
         os.environ[_MULTI_WORKER_CONFIG_ENV] = json.dumps(_proxy_config_payload(config))


### PR DESCRIPTION
## Summary

- Add `headroom/providers/hermes/` package with `runtime.py` implementing `build_launch_env()` that sets `OPENAI_BASE_URL` and `ANTHROPIC_BASE_URL` to route API calls through the Headroom proxy
- Add `headroom wrap hermes` CLI subcommand in `headroom/cli/wrap.py`, following the same pattern as `goose` and `openhands`
- Hermes is treated as a dual-protocol agent (OpenAI-compatible + Anthropic-compatible), matching the pattern used for other general-purpose agent CLIs

## Design decisions

Hermes by Nous Research (https://hermes-agent.nousresearch.com/) is an agent CLI similar to OpenClaw in that it routes LLM traffic through a configurable API endpoint. Since Hermes supports OpenAI-compatible API endpoints, the implementation sets both `OPENAI_BASE_URL` and `ANTHROPIC_BASE_URL` so whichever provider the user configures in Hermes is transparently proxied through Headroom.

The wrap command:
- Supports all standard flags: `--port`, `--no-context-tool`, `--code-graph`, `--no-proxy`, `--learn`, `--memory`, `--backend`, `--anyllm-provider`, `--region`, `--verbose`
- Injects RTK guidance into `CONVENTIONS.md` (same as aider)
- Prints an install URL if `hermes` binary is not found in PATH

## Test plan

- [ ] `headroom wrap hermes --prepare-only` exits cleanly
- [ ] `OPENAI_BASE_URL` and `ANTHROPIC_BASE_URL` are set to the proxy URL when launching
- [ ] `headroom wrap hermes --no-context-tool` skips RTK setup
- [ ] Error message with install URL shown when `hermes` is not in PATH