### PR TITLE
Add Hermes agent wrap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Headroom compresses everything your AI agent reads — tool outputs, logs, RAG c
 
 - **Library** — `compress(messages)` in Python or TypeScript, inline in any app
 - **Proxy** — `headroom proxy --port 8787`, zero code changes, any language
-- **Agent wrap** — `headroom wrap claude|codex|cursor|aider|copilot` in one command
+- **Agent wrap** — `headroom wrap claude|codex|cursor|aider|copilot|hermes` in one command
 - **MCP server** — `headroom_compress`, `headroom_retrieve`, `headroom_stats` for any MCP client
 - **Cross-agent memory** — shared store across Claude, Codex, Gemini, auto-dedup
 - **`headroom learn`** — mines failed sessions, writes corrections to `CLAUDE.md` / `AGENTS.md`
@@ -138,9 +138,21 @@ Reproduce: `python -m headroom.evals suite --tier 1` · [Full benchmarks & metho
 | Cursor      | ✅              | prints config — paste once       |
 | Aider       | ✅              | starts proxy + launches          |
 | Copilot CLI | ✅              | starts proxy + launches          |
+| Hermes      | ✅              | OpenRouter/custom endpoint paths |
 | OpenClaw    | ✅              | installs as ContextEngine plugin |
 
 Any OpenAI-compatible client works via `headroom proxy`. MCP-native: `headroom mcp install`.
+
+### Hermes Agent
+
+Headroom can launch [Hermes Agent](https://hermes-agent.nousresearch.com/) through the local proxy:
+
+```bash
+headroom wrap hermes
+headroom wrap hermes --provider-mode custom -- --help
+```
+
+The default mode routes Hermes OpenRouter traffic by setting `OPENROUTER_BASE_URL=http://127.0.0.1:8787/v1`. Use `--provider-mode custom` for Hermes configs that should use `HERMES_INFERENCE_PROVIDER=custom` and `CUSTOM_BASE_URL` instead. Hermes registers retrieval through its native `headroom_retrieve` plugin; Headroom therefore suppresses proxy-side CCR tool injection for Hermes unless `HEADROOM_HERMES_CCR_TOOL=1` is set.
 
 ### GitHub Copilot CLI subscription mode
 

--- a/docs/spec/002-architecture.md
+++ b/docs/spec/002-architecture.md
@@ -140,6 +140,7 @@ class HeadroomClient:
 - `claude` — Wrap Claude Code
 - `copilot` — Wrap GitHub Copilot
 - `codex` — Wrap OpenAI Codex
+- `hermes` — Wrap Hermes Agent
 - `aider` — Wrap Aider
 - `cursor` — Wrap Cursor
 - `openclaw` — Wrap OpenClaw

--- a/docs/spec/008-capabilities.md
+++ b/docs/spec/008-capabilities.md
@@ -226,6 +226,12 @@ class AnchorConfig:
 - Code completion optimization
 - Batch request support
 
+### Hermes
+
+- OpenRouter-compatible routing through `OPENROUTER_BASE_URL`
+- Custom endpoint routing through `HERMES_INFERENCE_PROVIDER=custom` and `CUSTOM_BASE_URL`
+- Hermes-aware CCR behavior that relies on native plugin registration for retrieval
+
 ### Gemini
 
 - Multi-modal inputs

--- a/docs/spec/015-interfaces.md
+++ b/docs/spec/015-interfaces.md
@@ -106,6 +106,7 @@ headroom wrap [OPTIONS] -- <command> [args...]
 - `claude` — Wrap Claude Code
 - `copilot` — Wrap GitHub Copilot
 - `codex` — Wrap OpenAI Codex
+- `hermes` — Wrap Hermes Agent
 - `aider` — Wrap Aider
 - `cursor` — Wrap Cursor
 - `openclaw` — Wrap OpenClaw

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -4,6 +4,7 @@ Usage:
     headroom wrap claude                    # Start proxy + context tool + claude
     headroom wrap copilot -- --model ...    # Start proxy + launch GitHub Copilot CLI
     headroom wrap codex                     # Start proxy + OpenAI Codex CLI
+    headroom wrap hermes                    # Start proxy + Hermes Agent
     headroom wrap aider                     # Start proxy + aider
     headroom wrap cursor                    # Start proxy + print Cursor config instructions
     headroom wrap openclaw                  # Install + configure OpenClaw plugin
@@ -308,6 +309,7 @@ def _start_proxy(
     openai_api_url: str | None = None,
     anthropic_api_url: str | None = None,
     copilot_api_token: str | None = None,
+    proxy_env_overrides: dict[str, str] | None = None,
 ) -> subprocess.Popen:
     """Start Headroom proxy as a background subprocess.
 
@@ -360,6 +362,8 @@ def _start_proxy(
     # Ensure proxy subprocess uses UTF-8 (Windows defaults to cp1252)
     proxy_env = os.environ.copy()
     proxy_env["PYTHONIOENCODING"] = "utf-8"
+    if proxy_env_overrides:
+        proxy_env.update(proxy_env_overrides)
 
     # Tell the proxy which agent is being wrapped (for traffic learning output)
     if agent_type != "unknown":
@@ -1833,6 +1837,7 @@ def _ensure_proxy(
     openai_api_url: str | None = None,
     anthropic_api_url: str | None = None,
     copilot_api_token: str | None = None,
+    proxy_env_overrides: dict[str, str] | None = None,
 ) -> subprocess.Popen | None:
     """Start or verify proxy. Returns process handle if we started it."""
     helpers = _live_wrap_module()
@@ -2024,6 +2029,7 @@ def _ensure_proxy(
                     openai_api_url=openai_api_url,
                     anthropic_api_url=anthropic_api_url,
                     copilot_api_token=copilot_api_token,
+                    proxy_env_overrides=proxy_env_overrides,
                 ),
             )
             click.echo(f"  Proxy ready on http://127.0.0.1:{port}")
@@ -2215,6 +2221,7 @@ def _launch_tool(
     region: str | None = None,
     openai_api_url: str | None = None,
     copilot_api_token: str | None = None,
+    proxy_env_overrides: dict[str, str] | None = None,
 ) -> None:
     """Common logic: start proxy, launch tool, clean up."""
     proxy_holder: list[subprocess.Popen | None] = [None]
@@ -2243,6 +2250,7 @@ def _launch_tool(
             region=region,
             openai_api_url=openai_api_url,
             copilot_api_token=copilot_api_token,
+            proxy_env_overrides=proxy_env_overrides,
         )
 
         if code_graph:
@@ -2467,6 +2475,7 @@ def wrap() -> None:
     Supported tools (one Click subcommand per tool):
         headroom wrap claude              # Claude Code (Anthropic)
         headroom wrap codex               # OpenAI Codex CLI
+        headroom wrap hermes              # Hermes Agent
         headroom wrap copilot -- --model claude-sonnet-4-20250514
         headroom wrap aider               # Aider
         headroom wrap cursor              # Cursor (prints config instructions)
@@ -2494,6 +2503,147 @@ def wrap() -> None:
 @main.group()
 def unwrap() -> None:
     """Undo durable Headroom wrapping for supported tools."""
+
+
+# =============================================================================
+# Hermes Agent
+# =============================================================================
+
+
+def _build_hermes_launch_env(
+    port: int,
+    base_env: dict[str, str],
+    *,
+    provider_mode: str = "openrouter",
+    debug_shape: bool = False,
+) -> tuple[dict[str, str], list[str]]:
+    """Build a Hermes launch environment without editing Hermes config.yaml.
+
+    Hermes 0.15.x resolves OpenRouter from OPENROUTER_BASE_URL, not
+    OPENAI_BASE_URL. For explicit custom routing, Hermes should be launched as
+    provider=custom so OpenRouter credentials are not reused for loopback.
+    """
+    env = dict(base_env)
+    proxy_base = f"http://127.0.0.1:{port}/v1"
+    env["HEADROOM_HERMES_MODE"] = "1"
+    if debug_shape:
+        env["HEADROOM_HERMES_DEBUG_SHAPE"] = "1"
+    display = ["HEADROOM_HERMES_MODE=1"]
+
+    if provider_mode == "custom":
+        env["HERMES_INFERENCE_PROVIDER"] = "custom"
+        env["CUSTOM_BASE_URL"] = proxy_base
+        display.extend(
+            [
+                "HERMES_INFERENCE_PROVIDER=custom",
+                f"CUSTOM_BASE_URL={proxy_base}",
+            ]
+        )
+    elif provider_mode == "openrouter":
+        env["OPENROUTER_BASE_URL"] = proxy_base
+        display.append(f"OPENROUTER_BASE_URL={proxy_base}")
+    else:
+        raise click.ClickException("--provider-mode must be 'openrouter' or 'custom'")
+
+    if debug_shape:
+        display.append("HEADROOM_HERMES_DEBUG_SHAPE=1")
+    return env, display
+
+
+@wrap.command(context_settings={"ignore_unknown_options": True})
+@click.option("--port", "-p", default=8787, type=int, help="Proxy port (default: 8787)")
+@click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option("--learn", is_flag=True, help="Enable live traffic learning")
+@click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option(
+    "--provider-mode",
+    type=click.Choice(["openrouter", "custom"]),
+    default="openrouter",
+    show_default=True,
+    help="Hermes provider routing mode to use for the proxy.",
+)
+@click.option(
+    "--debug-shape",
+    is_flag=True,
+    help="Log sanitized Hermes request/response shape diagnostics.",
+)
+@click.option(
+    "--backend",
+    default=None,
+    help=(
+        "API backend for the proxy: 'anthropic', 'anyllm', 'litellm-vertex', "
+        "etc. (env: HEADROOM_BACKEND)"
+    ),
+)
+@click.option(
+    "--anyllm-provider",
+    default=None,
+    help=(
+        "Provider for any-llm backend: openai, mistral, groq, etc. "
+        "(env: HEADROOM_ANYLLM_PROVIDER)"
+    ),
+)
+@click.option("--region", default=None, help="Cloud region for Bedrock/Vertex")
+@click.option("--prepare-only", is_flag=True, hidden=True)
+@click.argument("hermes_args", nargs=-1, type=click.UNPROCESSED)
+def hermes(
+    port: int,
+    no_proxy: bool,
+    learn: bool,
+    memory: bool,
+    provider_mode: str,
+    debug_shape: bool,
+    backend: str | None,
+    anyllm_provider: str | None,
+    region: str | None,
+    prepare_only: bool,
+    hermes_args: tuple,
+) -> None:
+    """Launch Hermes Agent through Headroom proxy.
+
+    \b
+    Default mode matches Hermes configs that use provider=openrouter by setting
+    OPENROUTER_BASE_URL to Headroom. Use --provider-mode custom to launch Hermes
+    with HERMES_INFERENCE_PROVIDER=custom and CUSTOM_BASE_URL instead.
+    """
+    env, env_vars_display = _build_hermes_launch_env(
+        port,
+        os.environ,
+        provider_mode=provider_mode,
+        debug_shape=debug_shape,
+    )
+    proxy_env_overrides = {"HEADROOM_HERMES_MODE": "1"}
+    if debug_shape:
+        proxy_env_overrides["HEADROOM_HERMES_DEBUG_SHAPE"] = "1"
+    effective_backend = backend or os.environ.get("HEADROOM_BACKEND") or "openrouter"
+    if not backend and not os.environ.get("HEADROOM_BACKEND"):
+        env_vars_display.append("HEADROOM_BACKEND=openrouter")
+    if prepare_only:
+        for line in env_vars_display:
+            click.echo(line)
+        return
+
+    hermes_bin = shutil.which("hermes")
+    if not hermes_bin:
+        click.echo("Error: 'hermes' not found in PATH.")
+        raise SystemExit(1)
+
+    _launch_tool(
+        binary=hermes_bin,
+        args=hermes_args,
+        env=env,
+        port=port,
+        no_proxy=no_proxy,
+        tool_label="HERMES",
+        env_vars_display=env_vars_display,
+        learn=learn,
+        memory=memory,
+        agent_type="hermes",
+        backend=effective_backend,
+        anyllm_provider=anyllm_provider,
+        region=region,
+        proxy_env_overrides=proxy_env_overrides,
+    )
 
 
 # =============================================================================

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -309,6 +309,175 @@ def _compact_openai_responses_tools(
     return updated, True, before, after
 
 
+def _truthy_env(name: str) -> bool:
+    raw = os.getenv(name, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_hermes_request(headers: dict[str, str]) -> bool:
+    if os.getenv("HEADROOM_AGENT_TYPE", "").strip().lower() == "hermes":
+        return True
+    if _truthy_env("HEADROOM_HERMES_MODE"):
+        return True
+    normalized_headers = {str(k).lower(): str(v) for k, v in headers.items()}
+    agent = normalized_headers.get("x-headroom-agent", "") or normalized_headers.get(
+        "x-hermes-agent",
+        "",
+    )
+    user_agent = normalized_headers.get("user-agent", "")
+    return "hermes" in f"{agent} {user_agent}".lower()
+
+
+def _should_inject_ccr_tool_for_request(
+    *,
+    config_enabled: bool,
+    hermes_request: bool,
+) -> bool:
+    """Return whether to advertise Headroom's CCR retrieval tool upstream.
+
+    Hermes executes tool calls through its own registry. Advertising
+    ``headroom_retrieve`` before Hermes has registered that tool causes the
+    model to call a function Hermes cannot execute. Keep transparent
+    compression enabled for Hermes, and allow CCR tool injection only when a
+    user explicitly opts in after wiring the tool/MCP side.
+    """
+    if not config_enabled:
+        return False
+    if hermes_request and not _truthy_env("HEADROOM_HERMES_CCR_TOOL"):
+        return False
+    return True
+
+
+def _count_tool_schema_tokens(tokenizer: Any, tools: Any) -> int:
+    if not tools:
+        return 0
+    serialized = _json_debug_dumps(tools)
+    if hasattr(tokenizer, "count_text"):
+        return tokenizer.count_text(serialized)
+    return tokenizer.count_messages([{"role": "system", "content": serialized}])
+
+
+def _compact_openai_chat_tools_for_hermes(
+    body: dict[str, Any],
+) -> tuple[dict[str, Any], bool, int, int]:
+    """Compact OpenAI chat tool schemas using the existing schema compactor."""
+    if not isinstance(body.get("tools"), list):
+        return body, False, 0, 0
+    compacted, changed, before, after = _compact_openai_responses_tools(
+        {"tools": body.get("tools")}
+    )
+    if not changed:
+        return body, False, before, after
+    updated = copy.deepcopy(body)
+    updated["tools"] = compacted["tools"]
+    return updated, True, before, after
+
+
+def _looks_like_hermes_packed_tool_history(content: str) -> bool:
+    if len(content) < 800:
+        return False
+    lowered = content[:20_000].lower()
+    markers = (
+        '"role": "tool"',
+        '"role":"tool"',
+        "tool_call_id",
+        "tool_result",
+        "terminal output",
+        "exit_code",
+        "stderr",
+        "stdout",
+        "command:",
+        "search results",
+    )
+    return sum(1 for marker in markers if marker in lowered) >= 2
+
+
+def _prepare_hermes_packed_history_messages(
+    messages: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[int]]:
+    """Temporarily expose old tool-like user history to ContentRouter.
+
+    Hermes can pack previous terminal/log/tool history into user-role text.
+    ContentRouter correctly protects user messages, so these old high-volume
+    blobs otherwise never compress. We only retag non-latest, clearly tool-like
+    strings for the compression pass, then restore their original user role
+    before forwarding the request upstream.
+    """
+    if len(messages) < 3:
+        return messages, []
+    prepared = copy.deepcopy(messages)
+    retagged: list[int] = []
+    latest_user_idx = max(
+        (idx for idx, msg in enumerate(messages) if msg.get("role") == "user"),
+        default=-1,
+    )
+    for idx, msg in enumerate(prepared):
+        if idx == latest_user_idx or msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and _looks_like_hermes_packed_tool_history(content):
+            msg["_headroom_original_role"] = "user"
+            msg["role"] = "tool"
+            msg.setdefault("tool_call_id", f"headroom_hermes_history_{idx}")
+            retagged.append(idx)
+    return prepared, retagged
+
+
+def _restore_hermes_packed_history_roles(
+    messages: list[dict[str, Any]],
+    retagged_indices: list[int],
+) -> list[dict[str, Any]]:
+    if not retagged_indices:
+        return messages
+    restored = copy.deepcopy(messages)
+    for idx in retagged_indices:
+        if idx >= len(restored):
+            continue
+        msg = restored[idx]
+        if msg.pop("_headroom_original_role", None) == "user":
+            msg["role"] = "user"
+            if str(msg.get("tool_call_id", "")).startswith("headroom_hermes_history_"):
+                msg.pop("tool_call_id", None)
+    return restored
+
+
+def _openai_chat_response_shape(response_json: Any) -> dict[str, Any]:
+    if not isinstance(response_json, dict):
+        return {"json": False, "type": type(response_json).__name__}
+    choices = response_json.get("choices")
+    first_choice = choices[0] if isinstance(choices, list) and choices else {}
+    message = first_choice.get("message") if isinstance(first_choice, dict) else None
+    if not isinstance(message, dict):
+        message = {}
+    content = message.get("content")
+    tool_calls = message.get("tool_calls")
+    return {
+        "json": True,
+        "choices_count": len(choices) if isinstance(choices, list) else 0,
+        "finish_reason": first_choice.get("finish_reason")
+        if isinstance(first_choice, dict)
+        else None,
+        "has_message": bool(message),
+        "message_role": message.get("role"),
+        "has_content": isinstance(content, str) and bool(content),
+        "content_chars": len(content) if isinstance(content, str) else 0,
+        "has_tool_calls": isinstance(tool_calls, list) and bool(tool_calls),
+        "tool_calls_count": len(tool_calls) if isinstance(tool_calls, list) else 0,
+        "usage_keys": sorted((response_json.get("usage") or {}).keys())
+        if isinstance(response_json.get("usage"), dict)
+        else [],
+    }
+
+
+def _log_hermes_debug_shape(event: str, **payload: Any) -> None:
+    if not _truthy_env("HEADROOM_HERMES_DEBUG_SHAPE"):
+        return
+    logger.info(
+        "event=hermes_debug_shape %s",
+        _json_debug_dumps({"event": event, **payload}),
+    )
+
+
 def _responses_input_item_text_bytes(item: Any) -> int:
     if not isinstance(item, dict):
         return _json_byte_len(item)
@@ -1488,6 +1657,19 @@ class OpenAIHandlerMixin:
             stripped_count=_pre_strip_count_chat,
             request_id=request_id,
         )
+        hermes_request = _is_hermes_request(dict(request.headers.items()))
+        if hermes_request:
+            tags["agent"] = "hermes"
+            _log_hermes_debug_shape(
+                "request_received",
+                request_id=request_id,
+                provider="openai_chat_completions",
+                model=model,
+                message_count=len(messages),
+                roles=[m.get("role") for m in messages if isinstance(m, dict)],
+                tool_count=len(body.get("tools") or []),
+                stream=bool(stream),
+            )
 
         # Memory: Get user ID when memory is enabled. Reads `request.headers`
         # directly because `headers` was stripped of `x-headroom-*` for the
@@ -1589,7 +1771,9 @@ class OpenAIHandlerMixin:
 
         # Token counting
         tokenizer = get_tokenizer(model)
-        original_tokens = tokenizer.count_messages(messages)
+        original_message_tokens = tokenizer.count_messages(messages)
+        original_tool_tokens = _count_tool_schema_tokens(tokenizer, body.get("tools"))
+        original_tokens = original_message_tokens + original_tool_tokens
 
         # Hook: pre_compress
         _hook_biases = None
@@ -1693,10 +1877,18 @@ class OpenAIHandlerMixin:
                     comp_cache = self._get_compression_cache(openai_session_id)
 
                     # Zone 1: Swap cached compressed versions
-                    working_messages = comp_cache.apply_cached(messages)
+                    compression_input_messages = messages
+                    hermes_retagged_indices: list[int] = []
+                    if hermes_request:
+                        compression_input_messages, hermes_retagged_indices = (
+                            _prepare_hermes_packed_history_messages(messages)
+                        )
+                    working_messages = comp_cache.apply_cached(compression_input_messages)
 
                     # Re-freeze boundary
-                    openai_frozen_count = comp_cache.compute_frozen_count(messages)
+                    openai_frozen_count = comp_cache.compute_frozen_count(
+                        compression_input_messages
+                    )
 
                     result = await self._run_compression_in_executor(
                         lambda: self.openai_pipeline.apply(
@@ -1712,22 +1904,41 @@ class OpenAIHandlerMixin:
                     )
 
                     if result.messages != working_messages:
-                        comp_cache.update_from_result(messages, result.messages)
+                        comp_cache.update_from_result(
+                            compression_input_messages,
+                            result.messages,
+                        )
 
                     # Always use pipeline result in token mode
-                    optimized_messages = result.messages
+                    optimized_messages = _restore_hermes_packed_history_roles(
+                        result.messages,
+                        hermes_retagged_indices,
+                    )
                     transforms_applied = result.transforms_applied
+                    if hermes_retagged_indices:
+                        transforms_applied = [
+                            *transforms_applied,
+                            f"hermes:packed_user_history:{len(hermes_retagged_indices)}",
+                        ]
                     pipeline_timing = result.timing
                     # Keep original_tokens as the REAL original (pre-Zone-1-swap)
                     # so tokens_saved captures both Zone 1 + Zone 2 savings.
-                    optimized_tokens = result.tokens_after
+                    optimized_tokens = (
+                        tokenizer.count_messages(optimized_messages) + original_tool_tokens
+                    )
                 else:
+                    compression_input_messages = messages
+                    hermes_retagged_indices = []
+                    if hermes_request:
+                        compression_input_messages, hermes_retagged_indices = (
+                            _prepare_hermes_packed_history_messages(messages)
+                        )
                     result = await self._run_compression_in_executor(
                         lambda: self.openai_pipeline.apply(
-                            messages=messages,
+                            messages=compression_input_messages,
                             model=model,
                             model_limit=context_limit,
-                            context=extract_user_query(messages),
+                            context=extract_user_query(compression_input_messages),
                             frozen_message_count=openai_frozen_count,
                             biases=_hook_biases,
                             compression_policy=compression_policy,
@@ -1735,12 +1946,22 @@ class OpenAIHandlerMixin:
                         timeout=COMPRESSION_TIMEOUT_SECONDS,
                     )
 
-                    if result.messages != messages:
-                        optimized_messages = result.messages
+                    restored_result_messages = _restore_hermes_packed_history_roles(
+                        result.messages,
+                        hermes_retagged_indices,
+                    )
+                    if restored_result_messages != messages:
+                        optimized_messages = restored_result_messages
                         transforms_applied = result.transforms_applied
+                        if hermes_retagged_indices:
+                            transforms_applied = [
+                                *transforms_applied,
+                                f"hermes:packed_user_history:{len(hermes_retagged_indices)}",
+                            ]
                         pipeline_timing = result.timing
-                        original_tokens = result.tokens_before
-                        optimized_tokens = result.tokens_after
+                        optimized_tokens = (
+                            tokenizer.count_messages(optimized_messages) + original_tool_tokens
+                        )
 
                 if result.waste_signals:
                     waste_signals_dict = result.waste_signals.to_dict()
@@ -1778,7 +1999,9 @@ class OpenAIHandlerMixin:
             )
             if routed_event.messages is not None:
                 optimized_messages = routed_event.messages
-                optimized_tokens = tokenizer.count_messages(optimized_messages)
+                optimized_tokens = (
+                    tokenizer.count_messages(optimized_messages) + original_tool_tokens
+                )
                 tokens_saved = original_tokens - optimized_tokens
 
         compressed_event = self.pipeline_extensions.emit(
@@ -1799,7 +2022,9 @@ class OpenAIHandlerMixin:
         )
         if compressed_event.messages is not None:
             optimized_messages = compressed_event.messages
-            optimized_tokens = tokenizer.count_messages(optimized_messages)
+            optimized_tokens = (
+                tokenizer.count_messages(optimized_messages) + original_tool_tokens
+            )
             tokens_saved = original_tokens - optimized_tokens
 
         # Hook: post_compress
@@ -1832,8 +2057,12 @@ class OpenAIHandlerMixin:
         # anchored on the previous turn's tool list never busts.
         tools = body.get("tools")
         _original_tools = tools  # Preserve for diagnostic / future retry
+        ccr_inject_tool_for_request = _should_inject_ccr_tool_for_request(
+            config_enabled=self.config.ccr_inject_tool,
+            hermes_request=hermes_request,
+        )
         if (
-            self.config.ccr_inject_tool or self.config.ccr_inject_system_instructions
+            ccr_inject_tool_for_request or self.config.ccr_inject_system_instructions
         ) and not _bypass:
             injector = CCRToolInjector(
                 provider="openai",
@@ -1844,7 +2073,7 @@ class OpenAIHandlerMixin:
             if self.config.ccr_inject_system_instructions and injector.has_compressed_content:
                 optimized_messages = injector.inject_into_system_message(optimized_messages)
 
-            if self.config.ccr_inject_tool:
+            if ccr_inject_tool_for_request:
                 from headroom.proxy.helpers import apply_session_sticky_ccr_tool
 
                 tools, ccr_tool_injected = apply_session_sticky_ccr_tool(
@@ -1988,6 +2217,26 @@ class OpenAIHandlerMixin:
         if tools or _original_tools is not None:
             body["tools"] = tools
 
+        if hermes_request and not _bypass:
+            compacted_body, tools_compacted, tool_bytes_before, tool_bytes_after = (
+                _compact_openai_chat_tools_for_hermes(body)
+            )
+            if tools_compacted:
+                body = compacted_body
+                tools = body.get("tools")
+                transforms_applied = [
+                    *transforms_applied,
+                    f"hermes:compact_tools:{tool_bytes_before}->{tool_bytes_after}",
+                ]
+                _log_hermes_debug_shape(
+                    "tools_compacted",
+                    request_id=request_id,
+                    model=model,
+                    tool_count=len(tools or []),
+                    bytes_before=tool_bytes_before,
+                    bytes_after=tool_bytes_after,
+                )
+
         presend_event = self.pipeline_extensions.emit(
             PipelineStage.PRE_SEND,
             operation="proxy.request",
@@ -2007,8 +2256,27 @@ class OpenAIHandlerMixin:
             body["tools"] = tools
         if presend_event.headers is not None:
             headers = presend_event.headers
-        optimized_tokens = tokenizer.count_messages(body["messages"])
+        optimized_tokens = tokenizer.count_messages(body["messages"]) + _count_tool_schema_tokens(
+            tokenizer,
+            body.get("tools"),
+        )
         tokens_saved = original_tokens - optimized_tokens
+        if hermes_request:
+            _log_hermes_debug_shape(
+                "request_presend",
+                request_id=request_id,
+                model=model,
+                message_count=len(body.get("messages", [])),
+                roles=[
+                    m.get("role")
+                    for m in body.get("messages", [])
+                    if isinstance(m, dict)
+                ],
+                tool_count=len(body.get("tools") or []),
+                input_tokens_original=original_tokens,
+                input_tokens_optimized=optimized_tokens,
+                transforms_applied=transforms_applied,
+            )
 
         # Route through LiteLLM/any-llm backend if configured
         if self.anthropic_backend is not None:
@@ -2080,6 +2348,15 @@ class OpenAIHandlerMixin:
                         return JSONResponse(
                             status_code=backend_response.status_code,
                             content=backend_response.body,
+                        )
+                    if hermes_request:
+                        _log_hermes_debug_shape(
+                            "upstream_response",
+                            request_id=request_id,
+                            model=model,
+                            backend=getattr(self.anthropic_backend, "name", "backend"),
+                            status_code=backend_response.status_code,
+                            shape=_openai_chat_response_shape(backend_response.body),
                         )
 
                     # CCR Response Handling: intercept headroom_retrieve
@@ -2404,6 +2681,15 @@ class OpenAIHandlerMixin:
                 resp_json = None
                 try:
                     resp_json = response.json()
+                    if hermes_request:
+                        _log_hermes_debug_shape(
+                            "upstream_response",
+                            request_id=request_id,
+                            model=model,
+                            backend="direct",
+                            status_code=response.status_code,
+                            shape=_openai_chat_response_shape(resp_json),
+                        )
                     usage = resp_json.get("usage", {})
                     total_input_tokens = usage.get("prompt_tokens", optimized_tokens)
                     output_tokens = usage.get("completion_tokens", 0)

--- a/tests/test_hermes_adaptation.py
+++ b/tests/test_hermes_adaptation.py
@@ -1,0 +1,426 @@
+import importlib
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+from click.testing import CliRunner
+from fastapi.testclient import TestClient
+
+from headroom.cli.wrap import _build_hermes_launch_env, wrap
+from headroom.proxy.handlers.openai import (
+    _compact_openai_chat_tools_for_hermes,
+    _openai_chat_response_shape,
+    _prepare_hermes_packed_history_messages,
+    _restore_hermes_packed_history_roles,
+    _should_inject_ccr_tool_for_request,
+)
+from headroom.proxy.server import ProxyConfig, create_app
+
+wrap_module = importlib.import_module("headroom.cli.wrap")
+
+
+class _DummyTokenizer:
+    def count_messages(self, messages: list[dict[str, Any]]) -> int:
+        return sum(len(str(message.get("content", ""))) for message in messages)
+
+    def count_text(self, text: str) -> int:
+        return len(text)
+
+
+def _capture_openai_chat_request(
+    client: TestClient,
+    *,
+    headers: dict[str, str] | None = None,
+    body: dict[str, Any],
+) -> tuple[dict[str, Any], httpx.Response]:
+    captured: dict[str, Any] = {}
+    proxy = client.app.state.proxy
+
+    async def _fake_retry(
+        method: str,
+        url: str,
+        request_headers: dict[str, str],
+        request_body: dict[str, Any],
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        captured["method"] = method
+        captured["url"] = url
+        captured["headers"] = request_headers
+        captured["body"] = request_body
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl_hermes_test",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11},
+            },
+        )
+
+    proxy._retry_request = _fake_retry
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": "Bearer sk-test", **(headers or {})},
+        json=body,
+    )
+    return captured, response
+
+
+def test_hermes_openrouter_env_routes_via_openrouter_base_url():
+    env, display = _build_hermes_launch_env(
+        8787,
+        {"OPENROUTER_API_KEY": "sk-openrouter"},
+        provider_mode="openrouter",
+    )
+
+    assert env["OPENROUTER_BASE_URL"] == "http://127.0.0.1:8787/v1"
+    assert "CUSTOM_BASE_URL" not in env
+    assert "HERMES_INFERENCE_PROVIDER" not in env
+    assert "OPENROUTER_BASE_URL=http://127.0.0.1:8787/v1" in display
+
+
+def test_hermes_custom_env_does_not_set_openrouter_base_url():
+    env, display = _build_hermes_launch_env(
+        8788,
+        {"OPENROUTER_API_KEY": "sk-openrouter"},
+        provider_mode="custom",
+        debug_shape=True,
+    )
+
+    assert env["HERMES_INFERENCE_PROVIDER"] == "custom"
+    assert env["CUSTOM_BASE_URL"] == "http://127.0.0.1:8788/v1"
+    assert "OPENROUTER_BASE_URL" not in env
+    assert env["HEADROOM_HERMES_DEBUG_SHAPE"] == "1"
+    assert "CUSTOM_BASE_URL=http://127.0.0.1:8788/v1" in display
+
+
+def test_hermes_prepare_only_defaults_backend_to_openrouter(monkeypatch):
+    monkeypatch.delenv("HEADROOM_BACKEND", raising=False)
+    result = CliRunner().invoke(wrap, ["hermes", "--prepare-only"])
+
+    assert result.exit_code == 0
+    assert "OPENROUTER_BASE_URL=http://127.0.0.1:8787/v1" in result.output
+    assert "HEADROOM_BACKEND=openrouter" in result.output
+
+
+def test_hermes_launch_passes_debug_env_to_proxy(monkeypatch):
+    captured = {}
+
+    def fake_launch_tool(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(wrap_module.shutil, "which", lambda name: "/bin/echo")
+    monkeypatch.setattr(wrap_module, "_launch_tool", fake_launch_tool)
+
+    result = CliRunner().invoke(wrap, ["hermes", "--debug-shape", "--", "-z", "hi"])
+
+    assert result.exit_code == 0
+    assert captured["agent_type"] == "hermes"
+    assert captured["backend"] == "openrouter"
+    assert captured["proxy_env_overrides"] == {
+        "HEADROOM_HERMES_MODE": "1",
+        "HEADROOM_HERMES_DEBUG_SHAPE": "1",
+    }
+    assert "startup_timeout_seconds" not in captured
+
+
+def test_compact_chat_tools_preserves_function_shape():
+    body = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "run",
+                    "description": "  Run   a command.  ",
+                    "parameters": {
+                        "type": "object",
+                        "title": "ToolInput",
+                        "properties": {
+                            "cmd": {
+                                "type": "string",
+                                "description": "  Shell command.  ",
+                                "examples": ["ls"],
+                            }
+                        },
+                    },
+                },
+            }
+        ]
+    }
+
+    compacted, changed, before, after = _compact_openai_chat_tools_for_hermes(body)
+
+    assert changed is True
+    assert after < before
+    assert compacted["tools"][0]["type"] == "function"
+    assert compacted["tools"][0]["function"]["name"] == "run"
+    assert "title" not in compacted["tools"][0]["function"]["parameters"]
+    assert "examples" not in compacted["tools"][0]["function"]["parameters"]["properties"]["cmd"]
+
+
+def test_hermes_disables_ccr_tool_injection_until_explicit_opt_in(monkeypatch):
+    monkeypatch.delenv("HEADROOM_HERMES_CCR_TOOL", raising=False)
+
+    assert (
+        _should_inject_ccr_tool_for_request(
+            config_enabled=True,
+            hermes_request=True,
+        )
+        is False
+    )
+    assert (
+        _should_inject_ccr_tool_for_request(
+            config_enabled=True,
+            hermes_request=False,
+        )
+        is True
+    )
+
+    monkeypatch.setenv("HEADROOM_HERMES_CCR_TOOL", "1")
+
+    assert (
+        _should_inject_ccr_tool_for_request(
+            config_enabled=True,
+            hermes_request=True,
+        )
+        is True
+    )
+
+
+def test_packed_user_history_is_retagged_then_restored():
+    packed = (
+        '{"role":"tool","tool_call_id":"abc","content":"terminal output"}\n'
+        "stdout: line\nstderr: none\nexit_code: 0\n"
+    ) * 40
+    messages = [
+        {"role": "system", "content": "instructions"},
+        {"role": "user", "content": packed},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "current task must stay protected"},
+    ]
+
+    prepared, indices = _prepare_hermes_packed_history_messages(messages)
+
+    assert indices == [1]
+    assert prepared[1]["role"] == "tool"
+    assert prepared[3]["role"] == "user"
+
+    restored = _restore_hermes_packed_history_roles(prepared, indices)
+
+    assert restored[1]["role"] == "user"
+    assert "tool_call_id" not in restored[1]
+    assert restored[1]["content"] == packed
+
+
+def test_response_shape_preserves_content_and_tool_call_signals():
+    content_shape = _openai_chat_response_shape(
+        {
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "hello"},
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+        }
+    )
+    tool_shape = _openai_chat_response_shape(
+        {
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [{"id": "call_1"}],
+                    },
+                }
+            ]
+        }
+    )
+
+    assert content_shape["has_content"] is True
+    assert content_shape["finish_reason"] == "stop"
+    assert tool_shape["has_tool_calls"] is True
+    assert tool_shape["tool_calls_count"] == 1
+
+
+def test_hermes_request_path_suppresses_headroom_ccr_tool(monkeypatch):
+    monkeypatch.delenv("HEADROOM_HERMES_CCR_TOOL", raising=False)
+    monkeypatch.setattr("headroom.tokenizers.get_tokenizer", lambda model: _DummyTokenizer())
+    app = create_app(
+        ProxyConfig(
+            optimize=False,
+            image_optimize=False,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=False,
+            log_requests=False,
+            ccr_inject_tool=True,
+            ccr_handle_responses=False,
+            ccr_context_tracking=False,
+            discover_pipeline_extensions=False,
+        )
+    )
+
+    with TestClient(app) as client:
+        captured, response = _capture_openai_chat_request(
+            client,
+            headers={"User-Agent": "Hermes/0.15"},
+            body={
+                "model": "openrouter/test",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "[10 items compressed. Retrieve more: hash=abc123]",
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "run_shell",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    forwarded_tools = captured["body"].get("tools") or []
+    tool_names = {
+        tool.get("function", {}).get("name")
+        for tool in forwarded_tools
+        if isinstance(tool, dict)
+    }
+    assert "run_shell" in tool_names
+    assert "headroom_retrieve" not in tool_names
+
+
+def test_hermes_request_path_compacts_openai_chat_tools(monkeypatch):
+    monkeypatch.setattr("headroom.tokenizers.get_tokenizer", lambda model: _DummyTokenizer())
+    app = create_app(
+        ProxyConfig(
+            optimize=False,
+            image_optimize=False,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=False,
+            log_requests=False,
+            ccr_inject_tool=False,
+            ccr_handle_responses=False,
+            ccr_context_tracking=False,
+            discover_pipeline_extensions=False,
+        )
+    )
+
+    with TestClient(app) as client:
+        captured, response = _capture_openai_chat_request(
+            client,
+            headers={"User-Agent": "Hermes/0.15"},
+            body={
+                "model": "openrouter/test",
+                "messages": [{"role": "user", "content": "Run a command"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "run_shell",
+                            "description": "  Run   a shell command.  ",
+                            "parameters": {
+                                "type": "object",
+                                "title": "RunShellInput",
+                                "properties": {
+                                    "cmd": {
+                                        "type": "string",
+                                        "description": "  Command to run.  ",
+                                        "examples": ["ls -la"],
+                                    }
+                                },
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    forwarded_tool = captured["body"]["tools"][0]
+    forwarded_params = forwarded_tool["function"]["parameters"]
+    assert forwarded_tool["function"]["name"] == "run_shell"
+    assert "title" not in forwarded_params
+    assert "examples" not in forwarded_params["properties"]["cmd"]
+
+
+def test_hermes_request_path_retags_then_restores_packed_user_history(monkeypatch):
+    monkeypatch.setattr("headroom.tokenizers.get_tokenizer", lambda model: _DummyTokenizer())
+    packed = (
+        '{"role":"tool","tool_call_id":"abc","content":"terminal output"}\n'
+        "stdout: many lines\nstderr: none\nexit_code: 0\n"
+    ) * 40
+    pipeline_seen: dict[str, Any] = {}
+
+    def _pipeline_apply(messages, model, **kwargs):  # noqa: ANN001
+        pipeline_seen["messages"] = messages
+        rewritten = [dict(message) for message in messages]
+        rewritten[1]["content"] = "[packed history compressed]"
+        return SimpleNamespace(
+            messages=rewritten,
+            transforms_applied=["router:text:kompress"],
+            tokens_before=2000,
+            tokens_after=20,
+            timing={},
+            waste_signals=None,
+        )
+
+    app = create_app(
+        ProxyConfig(
+            optimize=True,
+            mode="message",
+            image_optimize=False,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=False,
+            log_requests=False,
+            ccr_inject_tool=False,
+            ccr_handle_responses=False,
+            ccr_context_tracking=False,
+            discover_pipeline_extensions=False,
+        )
+    )
+
+    with TestClient(app) as client:
+        client.app.state.proxy.openai_pipeline = SimpleNamespace(apply=_pipeline_apply)
+        captured, response = _capture_openai_chat_request(
+            client,
+            headers={"User-Agent": "Hermes/0.15"},
+            body={
+                "model": "openrouter/test",
+                "messages": [
+                    {"role": "system", "content": "instructions"},
+                    {"role": "user", "content": packed},
+                    {"role": "assistant", "content": "ok"},
+                    {"role": "user", "content": "current task must stay protected"},
+                ],
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert pipeline_seen["messages"][1]["role"] == "tool"
+    assert pipeline_seen["messages"][1]["tool_call_id"] == "headroom_hermes_history_1"
+    assert pipeline_seen["messages"][3]["role"] == "user"
+
+    forwarded_messages = captured["body"]["messages"]
+    assert forwarded_messages[1]["role"] == "user"
+    assert "tool_call_id" not in forwarded_messages[1]
+    assert forwarded_messages[1]["content"] == "[packed history compressed]"
+    assert forwarded_messages[3]["role"] == "user"
+    assert forwarded_messages[3]["content"] == "current task must stay protected"

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -739,6 +739,29 @@ headroom wrap codex --backend anyllm --anyllm-provider groq
 
 Requires the `codex` binary on the host.
 
+### `headroom wrap hermes`
+
+```bash
+headroom wrap hermes
+headroom wrap hermes --provider-mode custom
+headroom wrap hermes --debug-shape -- --help
+```
+
+| Option / arg | Default | Meaning |
+|---|---|---|
+| `--port`, `-p` | `8787` | Proxy port |
+| `--no-proxy` | off | Reuse an existing proxy |
+| `--learn` | off | Enable live traffic learning |
+| `--memory` | off | Enable persistent cross-session memory |
+| `--provider-mode` | `openrouter` | Route with `OPENROUTER_BASE_URL`; use `custom` for `HERMES_INFERENCE_PROVIDER=custom` and `CUSTOM_BASE_URL` |
+| `--debug-shape` | off | Log sanitized Hermes request/response shape diagnostics |
+| `--backend` | unset | Proxy backend override; defaults to `openrouter` when unset for Hermes |
+| `--anyllm-provider` | unset | `anyllm` provider override |
+| `--region` | unset | Cloud region override |
+| `hermes_args...` | passthrough | Additional Hermes Agent arguments |
+
+Requires the `hermes` binary on the host. Hermes registers retrieval through its native `headroom_retrieve` plugin, so Headroom suppresses normal proxy-side CCR tool injection in Hermes mode unless `HEADROOM_HERMES_CCR_TOOL=1` is set.
+
 ### `headroom wrap copilot`
 
 ```bash

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -99,6 +99,7 @@ Headroom works as a **transparent proxy** (zero code changes), a **Python functi
     headroom wrap claude       # Claude Code
     headroom wrap copilot -- --model claude-sonnet-4-20250514
     headroom wrap codex        # OpenAI Codex CLI
+    headroom wrap hermes       # Hermes Agent
     headroom wrap aider        # Aider
     headroom wrap cursor       # Cursor
     headroom wrap openclaw     # OpenClaw plugin bootstrap
@@ -225,6 +226,21 @@ headroom wrap openclaw
 ```
 
 [OpenClaw Plugin &rarr;](https://github.com/chopratejas/headroom/tree/main/plugins/openclaw)
+
+</div>
+
+<div class="grid-item" markdown>
+
+### Hermes
+
+Launch Hermes Agent through Headroom for OpenRouter-compatible or custom OpenAI-compatible provider paths.
+
+```bash
+headroom wrap hermes
+headroom wrap hermes --provider-mode custom
+```
+
+Hermes retrieval uses the native `headroom_retrieve` plugin in `plugins/hermes`, so the proxy does not inject the generic CCR retrieval tool unless explicitly opted in.
 
 </div>
 

--- a/wiki/integration-guide.md
+++ b/wiki/integration-guide.md
@@ -196,6 +196,9 @@ ANTHROPIC_BASE_URL=http://localhost:8787 claude
 # GitHub Copilot CLI
 headroom wrap copilot -- --model claude-sonnet-4-20250514
 
+# Hermes Agent
+headroom wrap hermes
+
 # Cursor / Any OpenAI client
 OPENAI_BASE_URL=http://localhost:8787/v1 cursor
 ```
@@ -209,6 +212,8 @@ headroom wrap copilot --backend anyllm --anyllm-provider groq -- --model gpt-4o
 By default, `headroom wrap copilot` installs `rtk` and appends token-optimized shell guidance to `.github/copilot-instructions.md` so Copilot sessions reuse the same command-saving conventions as other wrapped agent CLIs. Use `--no-rtk` to skip that step.
 
 For Copilot's **hosted** API (`--subscription` and the implicit OAuth path), Headroom routes to the generic host `https://api.githubcopilot.com`, which serves the full model set. **Enterprise / data-residency** tenants on a dedicated Copilot host pin it with `GITHUB_COPILOT_API_URL` (e.g. `export GITHUB_COPILOT_API_URL=https://api.<your-host>.githubcopilot.com`); the override flows through to the upstream request. See [`TESTING-copilot-subscription.md`](https://github.com/chopratejas/headroom/blob/main/TESTING-copilot-subscription.md).
+
+For Hermes, `headroom wrap hermes` sets `OPENROUTER_BASE_URL` to Headroom's local `/v1` endpoint by default. Use `headroom wrap hermes --provider-mode custom` when Hermes should use `HERMES_INFERENCE_PROVIDER=custom` and `CUSTOM_BASE_URL`. Retrieval for compressed markers is handled by Hermes' native `headroom_retrieve` plugin in `plugins/hermes`, so the proxy does not inject the generic CCR tool for Hermes unless explicitly opted in.
 
 ### With Cloud Providers
 

--- a/wiki/proxy.md
+++ b/wiki/proxy.md
@@ -30,11 +30,16 @@ ANTHROPIC_BASE_URL=http://localhost:8787 claude
 # GitHub Copilot CLI
 headroom wrap copilot -- --model claude-sonnet-4-20250514
 
+# Hermes Agent
+headroom wrap hermes
+
 # OpenAI-compatible clients
 OPENAI_BASE_URL=http://localhost:8787/v1 your-app
 ```
 
 `headroom wrap copilot` uses Copilot CLI's BYOK provider settings under the hood. In `provider-type=auto`, it chooses Headroom's Anthropic route for the default proxy backend and the OpenAI-compatible `/v1` route for translated backends such as `anyllm` and LiteLLM.
+
+`headroom wrap hermes` defaults to Hermes' OpenRouter route by setting `OPENROUTER_BASE_URL` to the local Headroom `/v1` endpoint. Use `--provider-mode custom` to launch Hermes with `HERMES_INFERENCE_PROVIDER=custom` and `CUSTOM_BASE_URL` instead. Hermes-side retrieval is provided by the native plugin under `plugins/hermes/headroom_retrieve`.
 
 Anonymous aggregate telemetry is enabled by default. Opt out with `HEADROOM_TELEMETRY=off` or `headroom proxy --no-telemetry`. Downstream apps can set `HEADROOM_SDK=headroom-app` to override the anonymous telemetry `sdk` label; the default remains `proxy`.
 
@@ -311,6 +316,18 @@ headroom proxy --port 8787
 # In another terminal
 ANTHROPIC_BASE_URL=http://localhost:8787 claude
 ```
+
+## Using with Hermes Agent
+
+```bash
+# Default OpenRouter-compatible Hermes path
+headroom wrap hermes
+
+# Explicit custom endpoint mode
+headroom wrap hermes --provider-mode custom
+```
+
+Hermes registers tools through its own plugin system. Install or enable the Hermes `headroom_retrieve` plugin when you want compressed markers to be reversible from inside Hermes sessions.
 
 ## Using with Cursor
 


### PR DESCRIPTION
## Summary

Adds initial Hermes Agent support via `headroom wrap hermes`.

This MVP focuses on Hermes provider paths that can route through an OpenAI-compatible base URL:

- OpenRouter mode via `OPENROUTER_BASE_URL`
- Custom endpoint mode via `HERMES_INFERENCE_PROVIDER=custom` + `CUSTOM_BASE_URL`
- Hermes-specific proxy environment tagging (`HEADROOM_HERMES_MODE`)
- Hermes request-shape debug logging behind `--debug-shape`
- Tool-schema compaction for Hermes' OpenAI chat-completions requests
- Temporary compression-only retagging for Hermes-packed historical tool output
- Disables `headroom_retrieve` CCR tool injection in Hermes mode unless explicitly opted in with `HEADROOM_HERMES_CCR_TOOL=1`, because Hermes registers retrieval through its native plugin system; see #824

Refs #526.

## Scope

This PR intentionally does not claim support for every Hermes provider. It covers Hermes paths that can route through an OpenAI-compatible base URL. Native/provider-specific transports such as Bedrock, OAuth providers, or Nous Portal are outside this MVP because they need separate auth and request/response handling.

The native Hermes-side `headroom_retrieve` registration is handled by #824. This PR keeps the proxy-side behavior compatible with that by suppressing Headroom's normal CCR tool injection for Hermes unless explicitly opted in.

## Test Plan

- Screenshot/manual smoke evidence is attached in the PR thread: Hermes launched through `headroom wrap hermes`, routed via the local Headroom proxy, and logged `hermes:compact_tools` plus token savings through OpenRouter.
- `python -m ruff check headroom/cli/wrap.py headroom/proxy/handlers/openai.py tests/test_hermes_adaptation.py`
- `python -m pytest -q tests/test_hermes_adaptation.py tests/test_proxy_pipeline_lifecycle.py::test_openai_chat_pipeline_events_cover_proxy_lifecycle tests/test_ccr_tool_always_on.py`

Note: full GitHub CI workflows currently require repository-side approval for this forked PR before the matrix can run.
