### PR TITLE
feat(wrap): add Grok Build CLI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ scripts/*
 !scripts/refresh_model_limits.sh
 !scripts/audit_wheel_glibc_symbols.py
 !scripts/replay_codex_ws_load.py
+!scripts/bench_hermes_headroom.py
 
 # Rust / Cargo build artifacts
 /target/

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ scripts/*
 !scripts/audit_wheel_glibc_symbols.py
 !scripts/replay_codex_ws_load.py
 !scripts/bench_hermes_headroom.py
+!scripts/spot-tech-ci-headroom-hermes.service.example
 
 # Rust / Cargo build artifacts
 /target/

--- a/headroom/cli/install.py
+++ b/headroom/cli/install.py
@@ -14,6 +14,7 @@ from headroom.install.models import (
     ProviderSelectionMode,
     RuntimeKind,
     SupervisorKind,
+    ToolTarget,
 )
 from headroom.install.planner import build_manifest
 from headroom.install.providers import apply_mutations, revert_mutations
@@ -134,7 +135,7 @@ def _reject_task_lifecycle(manifest: DeploymentManifest, action: str) -> None:
     "--target",
     "targets",
     multiple=True,
-    type=click.Choice(["claude", "copilot", "codex", "aider", "cursor", "openclaw"]),
+    type=click.Choice([target.value for target in ToolTarget]),
     help="Tool target to configure when --providers manual is used.",
 )
 @click.option("--profile", default="default", show_default=True, help="Deployment profile name.")

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -69,6 +69,7 @@ from headroom.providers.copilot import (
     validate_configuration as _validate_copilot_configuration,
 )
 from headroom.providers.cursor import render_setup_lines as _render_cursor_setup_lines
+from headroom.providers.grok import DEFAULT_API_URL as _GROK_DEFAULT_API_URL
 from headroom.providers.grok import build_launch_env as _build_grok_launch_env
 from headroom.providers.openclaw import (
     build_plugin_entry as _build_openclaw_plugin_entry_impl,
@@ -3125,6 +3126,7 @@ def grok(
         backend=backend,
         anyllm_provider=anyllm_provider,
         region=region,
+        openai_api_url=_GROK_DEFAULT_API_URL,
     )
 
 

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -4,6 +4,7 @@ Usage:
     headroom wrap claude                    # Start proxy + context tool + claude
     headroom wrap copilot -- --model ...    # Start proxy + launch GitHub Copilot CLI
     headroom wrap codex                     # Start proxy + OpenAI Codex CLI
+    headroom wrap grok                      # Start proxy + Grok Build CLI
     headroom wrap aider                     # Start proxy + aider
     headroom wrap cursor                    # Start proxy + print Cursor config instructions
     headroom wrap openclaw                  # Install + configure OpenClaw plugin
@@ -68,6 +69,7 @@ from headroom.providers.copilot import (
     validate_configuration as _validate_copilot_configuration,
 )
 from headroom.providers.cursor import render_setup_lines as _render_cursor_setup_lines
+from headroom.providers.grok import build_launch_env as _build_grok_launch_env
 from headroom.providers.openclaw import (
     build_plugin_entry as _build_openclaw_plugin_entry_impl,
 )
@@ -2176,6 +2178,7 @@ def wrap() -> None:
     Supported tools (one Click subcommand per tool):
         headroom wrap claude              # Claude Code (Anthropic)
         headroom wrap codex               # OpenAI Codex CLI
+        headroom wrap grok                # Grok Build CLI
         headroom wrap copilot -- --model claude-sonnet-4-20250514
         headroom wrap aider               # Aider
         headroom wrap cursor              # Cursor (prints config instructions)
@@ -3053,6 +3056,72 @@ def aider(
         memory=memory,
         agent_type="aider",
         code_graph=code_graph,
+        backend=backend,
+        anyllm_provider=anyllm_provider,
+        region=region,
+    )
+
+
+# =============================================================================
+# Grok Build
+# =============================================================================
+
+
+@wrap.command(context_settings={"ignore_unknown_options": True})
+@click.option("--port", default=8787, type=int, help="Proxy port (default: 8787)")
+@click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option(
+    "--learn", is_flag=True, help="Enable live traffic learning (patterns saved to MEMORY.md)"
+)
+@click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option(
+    "--backend", default=None, help="API backend: 'anthropic', 'anyllm', 'litellm-vertex', etc."
+)
+@click.option("--anyllm-provider", default=None, help="Provider for any-llm backend")
+@click.option("--region", default=None, help="Cloud region for Bedrock/Vertex")
+@click.argument("grok_args", nargs=-1, type=click.UNPROCESSED)
+def grok(
+    port: int,
+    no_proxy: bool,
+    learn: bool,
+    memory: bool,
+    backend: str | None,
+    anyllm_provider: str | None,
+    region: str | None,
+    grok_args: tuple[str, ...],
+) -> None:
+    """Launch Grok Build through Headroom proxy.
+
+    \b
+    Sets GROK_CLI_CHAT_PROXY_BASE_URL so Grok routes cli-chat-proxy traffic
+    through Headroom for context compression.
+
+    \b
+    Examples:
+        headroom wrap grok                         # Start proxy + grok TUI
+        headroom wrap grok -p "fix the bug"        # Headless prompt
+        headroom wrap grok --port 9999             # Custom proxy port
+        headroom wrap grok --backend anyllm --anyllm-provider groq
+    """
+    grok_bin = shutil.which("grok")
+    if not grok_bin:
+        raise click.ClickException(
+            "'grok' not found in PATH. Install Grok Build: https://grok.com/build"
+        )
+
+    env, env_vars_display = _build_grok_launch_env(port, os.environ)
+
+    _launch_tool(
+        binary=grok_bin,
+        args=grok_args,
+        env=env,
+        port=port,
+        no_proxy=no_proxy,
+        tool_label="GROK",
+        env_vars_display=env_vars_display,
+        learn=learn,
+        memory=memory,
+        agent_type="grok",
         backend=backend,
         anyllm_provider=anyllm_provider,
         region=region,

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -4,7 +4,8 @@ Usage:
     headroom wrap claude                    # Start proxy + context tool + claude
     headroom wrap copilot -- --model ...    # Start proxy + launch GitHub Copilot CLI
     headroom wrap codex                     # Start proxy + OpenAI Codex CLI
-    headroom wrap grok                      # Start proxy + Grok Build CLI
+    headroom wrap grok                      # Start proxy + Grok Build CLI (sessions routing)
+    headroom wrap hermes                    # Start proxy upstream of Hermes llm-proxy
     headroom wrap aider                     # Start proxy + aider
     headroom wrap cursor                    # Start proxy + print Cursor config instructions
     headroom wrap openclaw                  # Install + configure OpenClaw plugin
@@ -71,6 +72,8 @@ from headroom.providers.copilot import (
 from headroom.providers.cursor import render_setup_lines as _render_cursor_setup_lines
 from headroom.providers.grok import DEFAULT_API_URL as _GROK_DEFAULT_API_URL
 from headroom.providers.grok import build_launch_env as _build_grok_launch_env
+from headroom.providers.hermes import DEFAULT_HERMES_API_URL as _HERMES_DEFAULT_API_URL
+from headroom.providers.hermes import build_launch_env as _build_hermes_launch_env
 from headroom.providers.openclaw import (
     build_plugin_entry as _build_openclaw_plugin_entry_impl,
 )
@@ -1102,6 +1105,7 @@ def _run_proxy_only_watcher(
     memory: bool,
     agent_type: str,
     print_setup_lines: Callable[[], None],
+    openai_api_url: str | None = None,
 ) -> None:
     """Shared scaffolding for proxy-only wrap subcommands (no child binary launch).
 
@@ -1122,7 +1126,12 @@ def _run_proxy_only_watcher(
     try:
         _print_wrap_banner(agent_label)
         proxy_holder[0] = _ensure_proxy(
-            port, no_proxy, learn=learn, memory=memory, agent_type=agent_type
+            port,
+            no_proxy,
+            learn=learn,
+            memory=memory,
+            agent_type=agent_type,
+            openai_api_url=openai_api_url,
         )
         click.echo()
         print_setup_lines()
@@ -2179,7 +2188,8 @@ def wrap() -> None:
     Supported tools (one Click subcommand per tool):
         headroom wrap claude              # Claude Code (Anthropic)
         headroom wrap codex               # OpenAI Codex CLI
-        headroom wrap grok                # Grok Build CLI
+        headroom wrap grok                # Grok Build CLI (sessions routing)
+        headroom wrap hermes              # Hermes llm-proxy compression path
         headroom wrap copilot -- --model claude-sonnet-4-20250514
         headroom wrap aider               # Aider
         headroom wrap cursor              # Cursor (prints config instructions)
@@ -3091,18 +3101,19 @@ def grok(
     region: str | None,
     grok_args: tuple[str, ...],
 ) -> None:
-    """Launch Grok Build through Headroom proxy.
+    """Launch Grok Build through Headroom proxy (sessions API routing).
 
     \b
     Sets GROK_CLI_CHAT_PROXY_BASE_URL so Grok routes cli-chat-proxy traffic
-    through Headroom for context compression.
+    through Headroom. Grok Build headless ``-p`` uses ``/v1/sessions/*`` and
+    is mostly passthrough today — for token compression use ``wrap hermes``.
 
     \b
     Examples:
         headroom wrap grok                         # Start proxy + grok TUI
         headroom wrap grok -p "fix the bug"        # Headless prompt
         headroom wrap grok --port 9999             # Custom proxy port
-        headroom wrap grok --backend anyllm --anyllm-provider groq
+        headroom wrap hermes                       # Compressible chat path
     """
     grok_bin = shutil.which("grok")
     if not grok_bin:
@@ -3127,6 +3138,101 @@ def grok(
         anyllm_provider=anyllm_provider,
         region=region,
         openai_api_url=_GROK_DEFAULT_API_URL,
+    )
+
+
+# =============================================================================
+# Hermes llm-proxy
+# =============================================================================
+
+
+@wrap.command("hermes", context_settings={"ignore_unknown_options": True})
+@click.option("--port", default=8787, type=int, help="Headroom proxy port (default: 8787)")
+@click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option("--learn", is_flag=True, help="Enable live traffic learning")
+@click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option(
+    "--hermes-url",
+    default=None,
+    envvar="HEADROOM_HERMES_BASE_URL",
+    help="Hermes OpenAI base URL (default: http://127.0.0.1:38765/v1)",
+)
+@click.option(
+    "--backend", default=None, help="API backend: 'anthropic', 'anyllm', 'litellm-vertex', etc."
+)
+@click.option("--anyllm-provider", default=None, help="Provider for any-llm backend")
+@click.option("--region", default=None, help="Cloud region for Bedrock/Vertex")
+@click.argument("command_args", nargs=-1, type=click.UNPROCESSED)
+def hermes(
+    port: int,
+    no_proxy: bool,
+    learn: bool,
+    memory: bool,
+    hermes_url: str | None,
+    backend: str | None,
+    anyllm_provider: str | None,
+    region: str | None,
+    command_args: tuple[str, ...],
+) -> None:
+    """Start Headroom upstream of Hermes llm-proxy (compressible chat path).
+
+    \b
+    Routes ``/v1/chat/completions`` through Headroom into Hermes (default
+    ``:38765``), where SmartCrusher compresses large ``role: tool`` outputs.
+    Use this for grok-hermes bots and OpenAI-compatible clients — not for
+    Grok Build CLI sessions (see ``wrap grok``).
+
+    \b
+    Examples:
+        headroom wrap hermes
+        headroom wrap hermes --hermes-url http://127.0.0.1:38765/v1
+        headroom wrap hermes -- python scripts/bench_hermes_headroom.py
+        headroom install apply --providers manual --target hermes
+    """
+    upstream = (hermes_url or _HERMES_DEFAULT_API_URL).rstrip("/")
+
+    if command_args:
+        env, env_vars_display = _build_hermes_launch_env(port, os.environ)
+        _launch_tool(
+            binary=command_args[0],
+            args=command_args[1:],
+            env=env,
+            port=port,
+            no_proxy=no_proxy,
+            tool_label="HERMES",
+            env_vars_display=[*env_vars_display, f"Hermes upstream={upstream}"],
+            learn=learn,
+            memory=memory,
+            agent_type="hermes",
+            backend=backend,
+            anyllm_provider=anyllm_provider,
+            region=region,
+            openai_api_url=upstream,
+        )
+        return
+
+    openai_base = _build_hermes_launch_env(port, {})[0]["OPENAI_BASE_URL"]
+
+    def _print_hermes_setup() -> None:
+        click.echo("  Configure OpenAI-compatible clients:")
+        click.echo(f"    OPENAI_BASE_URL={openai_base}")
+        click.echo(f"    Hermes upstream (proxy): {upstream}")
+        click.echo()
+        click.echo("  spot-tech-ci bots: point grok-hermes at this Headroom port")
+        click.echo("  instead of http://172.18.0.1:38765/v1 for compression.")
+        click.echo()
+        click.echo("  Run a one-off command through the proxy:")
+        click.echo("    headroom wrap hermes -- python scripts/bench_hermes_headroom.py")
+
+    _run_proxy_only_watcher(
+        agent_label="hermes",
+        port=port,
+        no_proxy=no_proxy,
+        learn=learn,
+        memory=memory,
+        agent_type="hermes",
+        openai_api_url=upstream,
+        print_setup_lines=_print_hermes_setup,
     )
 
 

--- a/headroom/install/models.py
+++ b/headroom/install/models.py
@@ -53,6 +53,7 @@ class ToolTarget(str, Enum):
     CLAUDE = "claude"
     COPILOT = "copilot"
     CODEX = "codex"
+    GROK = "grok"
     AIDER = "aider"
     CURSOR = "cursor"
     OPENCLAW = "openclaw"

--- a/headroom/install/models.py
+++ b/headroom/install/models.py
@@ -54,6 +54,7 @@ class ToolTarget(str, Enum):
     COPILOT = "copilot"
     CODEX = "codex"
     GROK = "grok"
+    HERMES = "hermes"
     AIDER = "aider"
     CURSOR = "cursor"
     OPENCLAW = "openclaw"

--- a/headroom/install/planner.py
+++ b/headroom/install/planner.py
@@ -24,6 +24,7 @@ SUPPORTED_TARGETS = [
     ToolTarget.CLAUDE,
     ToolTarget.COPILOT,
     ToolTarget.CODEX,
+    ToolTarget.GROK,
     ToolTarget.AIDER,
     ToolTarget.CURSOR,
     ToolTarget.OPENCLAW,

--- a/headroom/install/planner.py
+++ b/headroom/install/planner.py
@@ -25,6 +25,7 @@ SUPPORTED_TARGETS = [
     ToolTarget.COPILOT,
     ToolTarget.CODEX,
     ToolTarget.GROK,
+    ToolTarget.HERMES,
     ToolTarget.AIDER,
     ToolTarget.CURSOR,
     ToolTarget.OPENCLAW,

--- a/headroom/providers/grok/__init__.py
+++ b/headroom/providers/grok/__init__.py
@@ -1,0 +1,5 @@
+"""Grok-specific provider helpers."""
+
+from .runtime import DEFAULT_API_URL, GROK_PROXY_ENV, build_launch_env, proxy_base_url
+
+__all__ = ["DEFAULT_API_URL", "GROK_PROXY_ENV", "build_launch_env", "proxy_base_url"]

--- a/headroom/providers/grok/install.py
+++ b/headroom/providers/grok/install.py
@@ -1,0 +1,12 @@
+"""Grok install-time helpers."""
+
+from __future__ import annotations
+
+from .runtime import GROK_PROXY_ENV, proxy_base_url
+
+
+def build_install_env(*, port: int, backend: str) -> dict[str, str]:
+    """Build the persistent install environment for Grok Build."""
+    # Accepted for the shared install-provider interface; Grok only needs the proxy URL.
+    _ = backend
+    return {GROK_PROXY_ENV: proxy_base_url(port)}

--- a/headroom/providers/grok/runtime.py
+++ b/headroom/providers/grok/runtime.py
@@ -1,0 +1,24 @@
+"""Runtime helpers for Grok Build CLI integrations."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+DEFAULT_API_URL = "https://cli-chat-proxy.grok.com/v1"
+GROK_PROXY_ENV = "GROK_CLI_CHAT_PROXY_BASE_URL"
+
+
+def proxy_base_url(port: int) -> str:
+    """Return the local Headroom proxy base URL for Grok."""
+    return f"http://127.0.0.1:{port}/v1"
+
+
+def build_launch_env(
+    port: int, environ: Mapping[str, str] | None = None
+) -> tuple[dict[str, str], list[str]]:
+    """Build environment variables for Grok through the local Headroom proxy."""
+    env = dict(os.environ if environ is None else environ)
+    base_url = proxy_base_url(port)
+    env[GROK_PROXY_ENV] = base_url
+    return env, [f"{GROK_PROXY_ENV}={base_url}"]

--- a/headroom/providers/hermes/__init__.py
+++ b/headroom/providers/hermes/__init__.py
@@ -1,0 +1,10 @@
+"""Hermes llm-proxy provider slice."""
+
+from .runtime import DEFAULT_HERMES_API_URL, OPENAI_BASE_ENV, build_launch_env, proxy_base_url
+
+__all__ = [
+    "DEFAULT_HERMES_API_URL",
+    "OPENAI_BASE_ENV",
+    "build_launch_env",
+    "proxy_base_url",
+]

--- a/headroom/providers/hermes/install.py
+++ b/headroom/providers/hermes/install.py
@@ -1,0 +1,11 @@
+"""Hermes install-time helpers."""
+
+from __future__ import annotations
+
+from .runtime import OPENAI_BASE_ENV, proxy_base_url
+
+
+def build_install_env(*, port: int, backend: str) -> dict[str, str]:
+    """Build persistent install env for OpenAI clients using Hermes upstream."""
+    _ = backend
+    return {OPENAI_BASE_ENV: proxy_base_url(port)}

--- a/headroom/providers/hermes/runtime.py
+++ b/headroom/providers/hermes/runtime.py
@@ -1,0 +1,26 @@
+"""Runtime helpers for Hermes llm-proxy integrations."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+DEFAULT_HERMES_API_URL = os.environ.get(
+    "HEADROOM_HERMES_BASE_URL", "http://127.0.0.1:38765/v1"
+).rstrip("/")
+OPENAI_BASE_ENV = "OPENAI_BASE_URL"
+
+
+def proxy_base_url(port: int) -> str:
+    """Return the local Headroom proxy base URL for OpenAI clients."""
+    return f"http://127.0.0.1:{port}/v1"
+
+
+def build_launch_env(
+    port: int, environ: Mapping[str, str] | None = None
+) -> tuple[dict[str, str], list[str]]:
+    """Build environment for OpenAI clients through Headroom → Hermes."""
+    env = dict(os.environ if environ is None else environ)
+    base_url = proxy_base_url(port)
+    env[OPENAI_BASE_ENV] = base_url
+    return env, [f"{OPENAI_BASE_ENV}={base_url}"]

--- a/headroom/providers/install_registry.py
+++ b/headroom/providers/install_registry.py
@@ -26,6 +26,7 @@ from headroom.providers.copilot.install import (
     build_install_env as _build_copilot_install_env,
 )
 from headroom.providers.cursor.install import build_install_env as _build_cursor_install_env
+from headroom.providers.grok.install import build_install_env as _build_grok_install_env
 from headroom.providers.openclaw.install import (
     apply_provider_scope as _apply_openclaw_provider_scope,
 )
@@ -41,6 +42,7 @@ _ENV_BUILDERS: dict[str, _InstallEnvBuilder] = {
     "claude": _build_claude_install_env,
     "copilot": _build_copilot_install_env,
     "codex": _build_codex_install_env,
+    "grok": _build_grok_install_env,
     "aider": _build_aider_install_env,
     "cursor": _build_cursor_install_env,
 }

--- a/headroom/providers/install_registry.py
+++ b/headroom/providers/install_registry.py
@@ -27,6 +27,7 @@ from headroom.providers.copilot.install import (
 )
 from headroom.providers.cursor.install import build_install_env as _build_cursor_install_env
 from headroom.providers.grok.install import build_install_env as _build_grok_install_env
+from headroom.providers.hermes.install import build_install_env as _build_hermes_install_env
 from headroom.providers.openclaw.install import (
     apply_provider_scope as _apply_openclaw_provider_scope,
 )
@@ -43,6 +44,7 @@ _ENV_BUILDERS: dict[str, _InstallEnvBuilder] = {
     "copilot": _build_copilot_install_env,
     "codex": _build_codex_install_env,
     "grok": _build_grok_install_env,
+    "hermes": _build_hermes_install_env,
     "aider": _build_aider_install_env,
     "cursor": _build_cursor_install_env,
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,6 +3,21 @@
 Utility scripts bundled with the Headroom repo. Most are one-off operator
 tools; a few are runnable as part of development workflows.
 
+## Hermes token benchmark (spot-tech-ci)
+
+`bench_hermes_headroom.py` compares plain Hermes ``/v1/chat/completions`` traffic
+against Headroom→Hermes on a host where Hermes llm-proxy is running (default
+``:38765``). Designed for spot-tech-ci; also works locally when Hermes is up.
+
+```bash
+python scripts/bench_hermes_headroom.py
+python scripts/bench_hermes_headroom.py --multi-turn
+HEADROOM_LIVE_HERMES=1 uv run --extra dev pytest tests/test_cli/test_hermes_grok_live.py -v
+```
+
+See ``wiki/cli.md`` (``headroom wrap grok`` → spot-tech-ci runbook) for the full
+operator steps.
+
 ## Reproducing the reconnect storm
 
 `repro_codex_replay.py` reproduces the multi-agent Codex reconnect/retry storm

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,7 +12,10 @@ against Headroom→Hermes on a host where Hermes llm-proxy is running (default
 ```bash
 python scripts/bench_hermes_headroom.py
 python scripts/bench_hermes_headroom.py --multi-turn
+python scripts/bench_hermes_headroom.py --canary-port 18787   # persistent systemd canary
 HEADROOM_LIVE_HERMES=1 uv run --extra dev pytest tests/test_cli/test_hermes_grok_live.py -v
+HEADROOM_LIVE_HERMES=1 HEADROOM_LIVE_CANARY=1 \
+  uv run --extra dev pytest tests/test_cli/test_hermes_canary_live.py -v
 ```
 
 See ``wiki/cli.md`` (``headroom wrap grok`` → spot-tech-ci runbook) for the full

--- a/scripts/bench_hermes_headroom.py
+++ b/scripts/bench_hermes_headroom.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Compare plain Hermes vs Headroom→Hermes token usage on /v1/chat/completions.
+
+Designed for spot-tech-ci (Hermes llm-proxy on :38765) but works on any host
+where Hermes is reachable.
+
+Examples::
+
+    python scripts/bench_hermes_headroom.py
+    python scripts/bench_hermes_headroom.py --multi-turn
+    HEADROOM_HERMES_BASE_URL=http://127.0.0.1:38765/v1 python scripts/bench_hermes_headroom.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+DEFAULT_HERMES_BASE = os.environ.get("HEADROOM_HERMES_BASE_URL", "http://127.0.0.1:38765/v1")
+DEFAULT_MODEL = os.environ.get("HEADROOM_HERMES_MODEL", "grok-4.3")
+REPLY_TOKEN = "BENCH_OK"
+
+
+def pick_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def hermes_health_ok(base_v1: str) -> bool:
+    root = base_v1.rstrip("/").removesuffix("/v1")
+    try:
+        with urllib.request.urlopen(f"{root}/health", timeout=3) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+def fat_system_prompt(repeats: int = 80) -> str:
+    chunk = (
+        "TOOL_OUTPUT chunk=42 status=ok lines=500 "
+        "payload=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
+        "stacktrace=Error at module.ts:128 in handleRequest "
+        "notes=repeatable compressible log filler for headroom bench "
+    )
+    return (
+        "You are a benchmark assistant. Ignore the filler below except to answer briefly.\n\n"
+        + (chunk + "\n") * repeats
+    )
+
+
+def log_block(turn: int) -> str:
+    return (
+        f"TOOL_OUTPUT turn={turn} status=ok lines=200 "
+        f"payload={'x' * 120} "
+        f"trace=Error at svc.ts:{100 + turn} in handleBatch "
+        f"notes=compressible repeated agent log block {turn}\n"
+    )
+
+
+def chat(base_url: str, messages: list[dict], model: str, max_tokens: int = 16) -> dict:
+    payload = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "stream": False,
+    }
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/chat/completions",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=180) as resp:
+        body = json.loads(resp.read().decode())
+    body["_backend"] = resp.headers.get("X-LLM-Backend", "?")
+    return body
+
+
+def wait_proxy_ready(port: int, timeout: float = 180.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for path in ("/readyz", "/health", "/livez"):
+            try:
+                with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=3) as resp:
+                    if resp.status == 200:
+                        return
+            except Exception:
+                continue
+        time.sleep(1.0)
+    raise RuntimeError(f"headroom proxy on {port} did not become ready")
+
+
+def fetch_stats(port: int) -> dict:
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/stats", timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+
+def headroom_argv() -> list[str]:
+    if shutil.which("headroom"):
+        return ["headroom"]
+    return ["uv", "run", "headroom"]
+
+
+def run_single_turn(hermes_base: str, model: str) -> dict:
+    messages = [
+        {"role": "system", "content": fat_system_prompt()},
+        {"role": "user", "content": f"Reply with exactly one word: {REPLY_TOKEN}"},
+    ]
+    plain = chat(hermes_base, messages, model)
+    plain_usage = plain.get("usage") or {}
+
+    port = pick_port()
+    env = {
+        **dict(os.environ),
+        "HEADROOM_TELEMETRY": "off",
+    }
+    proc = subprocess.Popen(
+        [
+            *headroom_argv(),
+            "proxy",
+            "--port",
+            str(port),
+            "--openai-api-url",
+            hermes_base,
+            "--no-telemetry",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+    try:
+        wait_proxy_ready(port)
+        wrapped = chat(f"http://127.0.0.1:{port}/v1", messages, model)
+        wrapped_usage = wrapped.get("usage") or {}
+        stats = fetch_stats(port)
+        token_stats = stats.get("tokens") or {}
+        return {
+            "mode": "single-turn",
+            "plain": {
+                "content": plain["choices"][0]["message"]["content"].strip(),
+                "usage": plain_usage,
+                "backend": plain.get("_backend"),
+            },
+            "headroom": {
+                "content": wrapped["choices"][0]["message"]["content"].strip(),
+                "usage": wrapped_usage,
+                "backend": wrapped.get("_backend"),
+                "tokens_saved": token_stats.get("saved"),
+                "proxy_compression_saved": token_stats.get("proxy_compression_saved"),
+            },
+            "delta": {
+                "plain_prompt_tokens": int(plain_usage.get("prompt_tokens") or 0),
+                "headroom_prompt_tokens": int(wrapped_usage.get("prompt_tokens") or 0),
+                "headroom_tokens_saved": int(token_stats.get("saved") or 0),
+            },
+        }
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def run_multi_turn(hermes_base: str, model: str, turns: int = 4, log_blocks: int = 60) -> dict:
+    def conversation(base_url: str) -> dict:
+        messages: list[dict] = [
+            {
+                "role": "system",
+                "content": "Short answers only. You are running a multi-turn benchmark.",
+            }
+        ]
+        usages: list[dict] = []
+        for turn in range(1, turns + 1):
+            messages.append(
+                {
+                    "role": "user",
+                    "content": log_block(turn) * log_blocks + f"\nTurn {turn}: reply TURN_{turn}",
+                }
+            )
+            body = chat(base_url, messages, model, max_tokens=12)
+            reply = body["choices"][0]["message"]["content"].strip()
+            messages.append({"role": "assistant", "content": reply})
+            usages.append(body.get("usage") or {})
+        return {
+            "turn_usages": usages,
+            "final_prompt_tokens": int(usages[-1].get("prompt_tokens") or 0),
+            "sum_prompt_tokens": sum(int(u.get("prompt_tokens") or 0) for u in usages),
+        }
+
+    plain = conversation(hermes_base)
+    port = pick_port()
+    env = {**dict(os.environ), "HEADROOM_TELEMETRY": "off"}
+    proc = subprocess.Popen(
+        [
+            *headroom_argv(),
+            "proxy",
+            "--port",
+            str(port),
+            "--openai-api-url",
+            hermes_base,
+            "--no-telemetry",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+    try:
+        wait_proxy_ready(port)
+        wrapped = conversation(f"http://127.0.0.1:{port}/v1")
+        stats = fetch_stats(port)
+        token_stats = stats.get("tokens") or {}
+        wrapped["headroom_tokens_saved"] = token_stats.get("saved")
+        return {
+            "mode": "multi-turn",
+            "plain": plain,
+            "headroom": wrapped,
+            "delta": {
+                "plain_final_prompt_tokens": plain["final_prompt_tokens"],
+                "headroom_final_prompt_tokens": wrapped["final_prompt_tokens"],
+                "plain_sum_prompt_tokens": plain["sum_prompt_tokens"],
+                "headroom_sum_prompt_tokens": wrapped["sum_prompt_tokens"],
+                "headroom_tokens_saved": int(token_stats.get("saved") or 0),
+            },
+        }
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--hermes-base",
+        default=DEFAULT_HERMES_BASE,
+        help="Hermes OpenAI base URL (default: %(default)s)",
+    )
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Chat model id")
+    parser.add_argument(
+        "--multi-turn",
+        action="store_true",
+        help="Run a 4-turn agent-style loop instead of a single fat prompt",
+    )
+    args = parser.parse_args()
+    hermes_base = args.hermes_base.rstrip("/")
+
+    if not hermes_health_ok(hermes_base):
+        print(f"Hermes health check failed for {hermes_base}", file=sys.stderr)
+        return 1
+
+    try:
+        result = (
+            run_multi_turn(hermes_base, args.model)
+            if args.multi_turn
+            else run_single_turn(hermes_base, args.model)
+        )
+    except urllib.error.URLError as exc:
+        print(f"Request failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_hermes_headroom.py
+++ b/scripts/bench_hermes_headroom.py
@@ -76,10 +76,38 @@ def _delta_block(plain_usage: dict, wrapped_usage: dict, token_stats: dict, stat
     }
 
 
-def run_agent_tool_turn(hermes_base: str, model: str) -> dict:
+def run_agent_tool_turn(
+    hermes_base: str,
+    model: str,
+    *,
+    canary_port: int | None = None,
+) -> dict:
     messages = agent_tool_messages()
     plain = chat(hermes_base, messages, model)
     plain_usage = plain.get("usage") or {}
+
+    if canary_port is not None:
+        wrapped = chat(f"http://127.0.0.1:{canary_port}/v1", messages, model)
+        wrapped_usage = wrapped.get("usage") or {}
+        stats = fetch_stats(canary_port)
+        token_stats = stats.get("tokens") or {}
+        delta = _delta_block(plain_usage, wrapped_usage, token_stats, stats)
+        return {
+            "mode": "agent-tool-canary",
+            "canary_port": canary_port,
+            "plain": {
+                "content": plain["choices"][0]["message"]["content"].strip(),
+                "usage": plain_usage,
+                "backend": plain.get("_backend"),
+            },
+            "headroom": {
+                "content": wrapped["choices"][0]["message"]["content"].strip(),
+                "usage": wrapped_usage,
+                "backend": wrapped.get("_backend"),
+                "tokens_saved": token_stats.get("saved"),
+            },
+            "delta": delta,
+        }
 
     port = pick_free_port()
     proc = start_headroom_proxy(port=port, hermes_base=hermes_base)
@@ -156,7 +184,7 @@ def validate_result(result: dict) -> int:
         assert strategy_saved >= MIN_SMART_CRUSHER_SAVED, (
             f"smart_crusher savings too low: {strategy_saved}"
         )
-        if result.get("mode") == "agent-tool":
+        if result.get("mode") in {"agent-tool", "agent-tool-canary"}:
             assert_compression_delta(
                 plain_prompt_tokens=plain_in,
                 wrapped_prompt_tokens=wrap_in,
@@ -172,11 +200,30 @@ def validate_result(result: dict) -> int:
         return 2
 
 
+def _canary_ready(port: int) -> bool:
+    for path in ("/readyz", "/health", "/livez"):
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=5) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            continue
+    return False
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--hermes-base", default=DEFAULT_HERMES_BASE)
     parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument("--multi-turn", action="store_true")
+    parser.add_argument(
+        "--canary-port",
+        type=int,
+        default=int(os.environ["HEADROOM_CANARY_PORT"])
+        if os.environ.get("HEADROOM_CANARY_PORT")
+        else None,
+        help="Use persistent Headroom canary on this port (default: HEADROOM_CANARY_PORT)",
+    )
     args = parser.parse_args()
     hermes_base = args.hermes_base.rstrip("/")
 
@@ -184,11 +231,19 @@ def main() -> int:
         print(f"Hermes health check failed for {hermes_health_url(hermes_base)}", file=sys.stderr)
         return 1
 
+    if args.canary_port is not None and args.multi_turn:
+        print("--canary-port cannot be combined with --multi-turn", file=sys.stderr)
+        return 1
+
+    if args.canary_port is not None and not _canary_ready(args.canary_port):
+        print(f"Canary not ready on port {args.canary_port}", file=sys.stderr)
+        return 1
+
     try:
         result = (
             run_multi_turn(hermes_base, args.model)
             if args.multi_turn
-            else run_agent_tool_turn(hermes_base, args.model)
+            else run_agent_tool_turn(hermes_base, args.model, canary_port=args.canary_port)
         )
     except urllib.error.URLError as exc:
         print(f"Request failed: {exc}", file=sys.stderr)

--- a/scripts/bench_hermes_headroom.py
+++ b/scripts/bench_hermes_headroom.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Compare plain Hermes vs Headroom→Hermes token usage on /v1/chat/completions.
 
-Designed for spot-tech-ci (Hermes llm-proxy on :38765) but works on any host
-where Hermes is reachable.
+Uses agent-shaped workloads (large ``role: tool`` outputs) — the shape
+Headroom SmartCrusher actually compresses. Plain user/system log filler does
+not trigger savings.
 
 Examples::
 
@@ -23,10 +24,14 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from pathlib import Path
+
+# Shared workloads live under tests/test_cli for pytest parity.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests" / "test_cli"))
+from hermes_workloads import agent_tool_messages, multi_turn_agent_messages  # noqa: E402
 
 DEFAULT_HERMES_BASE = os.environ.get("HEADROOM_HERMES_BASE_URL", "http://127.0.0.1:38765/v1")
 DEFAULT_MODEL = os.environ.get("HEADROOM_HERMES_MODEL", "grok-4.3")
-REPLY_TOKEN = "BENCH_OK"
 
 
 def pick_port() -> int:
@@ -44,29 +49,7 @@ def hermes_health_ok(base_v1: str) -> bool:
         return False
 
 
-def fat_system_prompt(repeats: int = 80) -> str:
-    chunk = (
-        "TOOL_OUTPUT chunk=42 status=ok lines=500 "
-        "payload=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
-        "stacktrace=Error at module.ts:128 in handleRequest "
-        "notes=repeatable compressible log filler for headroom bench "
-    )
-    return (
-        "You are a benchmark assistant. Ignore the filler below except to answer briefly.\n\n"
-        + (chunk + "\n") * repeats
-    )
-
-
-def log_block(turn: int) -> str:
-    return (
-        f"TOOL_OUTPUT turn={turn} status=ok lines=200 "
-        f"payload={'x' * 120} "
-        f"trace=Error at svc.ts:{100 + turn} in handleBatch "
-        f"notes=compressible repeated agent log block {turn}\n"
-    )
-
-
-def chat(base_url: str, messages: list[dict], model: str, max_tokens: int = 16) -> dict:
+def chat(base_url: str, messages: list[dict], model: str, max_tokens: int = 24) -> dict:
     payload = {
         "model": model,
         "messages": messages,
@@ -111,19 +94,27 @@ def headroom_argv() -> list[str]:
     return ["uv", "run", "headroom"]
 
 
-def run_single_turn(hermes_base: str, model: str) -> dict:
-    messages = [
-        {"role": "system", "content": fat_system_prompt()},
-        {"role": "user", "content": f"Reply with exactly one word: {REPLY_TOKEN}"},
-    ]
+def _delta_block(plain_usage: dict, wrapped_usage: dict, token_stats: dict, stats: dict) -> dict:
+    plain_in = int(plain_usage.get("prompt_tokens") or 0)
+    wrap_in = int(wrapped_usage.get("prompt_tokens") or 0)
+    saved = int(token_stats.get("saved") or 0)
+    return {
+        "plain_prompt_tokens": plain_in,
+        "headroom_prompt_tokens": wrap_in,
+        "upstream_prompt_token_delta": plain_in - wrap_in,
+        "headroom_tokens_saved": saved,
+        "tokens_saved_by_strategy": stats.get("tokens_saved_by_strategy") or {},
+        "compression_summary": stats.get("summary", {}).get("compression") or {},
+    }
+
+
+def run_agent_tool_turn(hermes_base: str, model: str) -> dict:
+    messages = agent_tool_messages()
     plain = chat(hermes_base, messages, model)
     plain_usage = plain.get("usage") or {}
 
     port = pick_port()
-    env = {
-        **dict(os.environ),
-        "HEADROOM_TELEMETRY": "off",
-    }
+    env = {**dict(os.environ), "HEADROOM_TELEMETRY": "off"}
     proc = subprocess.Popen(
         [
             *headroom_argv(),
@@ -144,8 +135,9 @@ def run_single_turn(hermes_base: str, model: str) -> dict:
         wrapped_usage = wrapped.get("usage") or {}
         stats = fetch_stats(port)
         token_stats = stats.get("tokens") or {}
+        delta = _delta_block(plain_usage, wrapped_usage, token_stats, stats)
         return {
-            "mode": "single-turn",
+            "mode": "agent-tool",
             "plain": {
                 "content": plain["choices"][0]["message"]["content"].strip(),
                 "usage": plain_usage,
@@ -158,11 +150,7 @@ def run_single_turn(hermes_base: str, model: str) -> dict:
                 "tokens_saved": token_stats.get("saved"),
                 "proxy_compression_saved": token_stats.get("proxy_compression_saved"),
             },
-            "delta": {
-                "plain_prompt_tokens": int(plain_usage.get("prompt_tokens") or 0),
-                "headroom_prompt_tokens": int(wrapped_usage.get("prompt_tokens") or 0),
-                "headroom_tokens_saved": int(token_stats.get("saved") or 0),
-            },
+            "delta": delta,
         }
     finally:
         proc.terminate()
@@ -172,33 +160,18 @@ def run_single_turn(hermes_base: str, model: str) -> dict:
             proc.kill()
 
 
-def run_multi_turn(hermes_base: str, model: str, turns: int = 4, log_blocks: int = 60) -> dict:
-    def conversation(base_url: str) -> dict:
-        messages: list[dict] = [
-            {
-                "role": "system",
-                "content": "Short answers only. You are running a multi-turn benchmark.",
-            }
-        ]
-        usages: list[dict] = []
-        for turn in range(1, turns + 1):
-            messages.append(
-                {
-                    "role": "user",
-                    "content": log_block(turn) * log_blocks + f"\nTurn {turn}: reply TURN_{turn}",
-                }
-            )
-            body = chat(base_url, messages, model, max_tokens=12)
-            reply = body["choices"][0]["message"]["content"].strip()
-            messages.append({"role": "assistant", "content": reply})
-            usages.append(body.get("usage") or {})
+def run_multi_turn(hermes_base: str, model: str, turns: int = 3) -> dict:
+    messages = multi_turn_agent_messages(turns=turns)
+
+    def final_turn(base_url: str) -> dict:
+        body = chat(base_url, messages, model, max_tokens=16)
         return {
-            "turn_usages": usages,
-            "final_prompt_tokens": int(usages[-1].get("prompt_tokens") or 0),
-            "sum_prompt_tokens": sum(int(u.get("prompt_tokens") or 0) for u in usages),
+            "content": body["choices"][0]["message"]["content"].strip(),
+            "usage": body.get("usage") or {},
+            "backend": body.get("_backend"),
         }
 
-    plain = conversation(hermes_base)
+    plain = final_turn(hermes_base)
     port = pick_port()
     env = {**dict(os.environ), "HEADROOM_TELEMETRY": "off"}
     proc = subprocess.Popen(
@@ -217,21 +190,19 @@ def run_multi_turn(hermes_base: str, model: str, turns: int = 4, log_blocks: int
     )
     try:
         wait_proxy_ready(port)
-        wrapped = conversation(f"http://127.0.0.1:{port}/v1")
+        wrapped = final_turn(f"http://127.0.0.1:{port}/v1")
         stats = fetch_stats(port)
         token_stats = stats.get("tokens") or {}
-        wrapped["headroom_tokens_saved"] = token_stats.get("saved")
+        delta = _delta_block(plain["usage"], wrapped["usage"], token_stats, stats)
         return {
-            "mode": "multi-turn",
+            "mode": "multi-turn-agent-tool",
+            "turns": turns,
             "plain": plain,
-            "headroom": wrapped,
-            "delta": {
-                "plain_final_prompt_tokens": plain["final_prompt_tokens"],
-                "headroom_final_prompt_tokens": wrapped["final_prompt_tokens"],
-                "plain_sum_prompt_tokens": plain["sum_prompt_tokens"],
-                "headroom_sum_prompt_tokens": wrapped["sum_prompt_tokens"],
-                "headroom_tokens_saved": int(token_stats.get("saved") or 0),
+            "headroom": {
+                **wrapped,
+                "tokens_saved": token_stats.get("saved"),
             },
+            "delta": delta,
         }
     finally:
         proc.terminate()
@@ -252,7 +223,7 @@ def main() -> int:
     parser.add_argument(
         "--multi-turn",
         action="store_true",
-        help="Run a 4-turn agent-style loop instead of a single fat prompt",
+        help="Run a multi-turn agent loop with tool outputs per turn",
     )
     args = parser.parse_args()
     hermes_base = args.hermes_base.rstrip("/")
@@ -265,13 +236,22 @@ def main() -> int:
         result = (
             run_multi_turn(hermes_base, args.model)
             if args.multi_turn
-            else run_single_turn(hermes_base, args.model)
+            else run_agent_tool_turn(hermes_base, args.model)
         )
     except urllib.error.URLError as exc:
         print(f"Request failed: {exc}", file=sys.stderr)
         return 1
 
     print(json.dumps(result, indent=2))
+    delta = result.get("delta") or {}
+    if int(delta.get("headroom_tokens_saved") or 0) <= 0 and int(
+        delta.get("upstream_prompt_token_delta") or 0
+    ) <= 0:
+        print(
+            "WARN: no token savings detected — ensure workload uses large role:tool outputs",
+            file=sys.stderr,
+        )
+        return 2
     return 0
 
 

--- a/scripts/bench_hermes_headroom.py
+++ b/scripts/bench_hermes_headroom.py
@@ -1,52 +1,34 @@
 #!/usr/bin/env python3
-"""Compare plain Hermes vs Headroom→Hermes token usage on /v1/chat/completions.
-
-Uses agent-shaped workloads (large ``role: tool`` outputs) — the shape
-Headroom SmartCrusher actually compresses. Plain user/system log filler does
-not trigger savings.
-
-Examples::
-
-    python scripts/bench_hermes_headroom.py
-    python scripts/bench_hermes_headroom.py --multi-turn
-    HEADROOM_HERMES_BASE_URL=http://127.0.0.1:38765/v1 python scripts/bench_hermes_headroom.py
-"""
+"""Compare plain Hermes vs Headroom→Hermes token usage on /v1/chat/completions."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import os
-import shutil
-import socket
-import subprocess
 import sys
-import time
 import urllib.error
 import urllib.request
 from pathlib import Path
 
-# Shared workloads live under tests/test_cli for pytest parity.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests" / "test_cli"))
+
+from hermes_support import (  # noqa: E402
+    MIN_HEADROOM_TOKENS_SAVED,
+    MIN_SMART_CRUSHER_SAVED,
+    MIN_UPSTREAM_PROMPT_DELTA,
+    assert_compression_delta,
+    hermes_health_url,
+    hermes_reachable,
+    pick_free_port,
+    start_headroom_proxy,
+    stop_process,
+    wait_proxy_ready,
+)
 from hermes_workloads import agent_tool_messages, multi_turn_agent_messages  # noqa: E402
 
 DEFAULT_HERMES_BASE = os.environ.get("HEADROOM_HERMES_BASE_URL", "http://127.0.0.1:38765/v1")
 DEFAULT_MODEL = os.environ.get("HEADROOM_HERMES_MODEL", "grok-4.3")
-
-
-def pick_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
-
-
-def hermes_health_ok(base_v1: str) -> bool:
-    root = base_v1.rstrip("/").removesuffix("/v1")
-    try:
-        with urllib.request.urlopen(f"{root}/health", timeout=3) as resp:
-            return resp.status == 200
-    except Exception:
-        return False
 
 
 def chat(base_url: str, messages: list[dict], model: str, max_tokens: int = 24) -> dict:
@@ -69,42 +51,28 @@ def chat(base_url: str, messages: list[dict], model: str, max_tokens: int = 24) 
     return body
 
 
-def wait_proxy_ready(port: int, timeout: float = 180.0) -> None:
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        for path in ("/readyz", "/health", "/livez"):
-            try:
-                with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=3) as resp:
-                    if resp.status == 200:
-                        return
-            except Exception:
-                continue
-        time.sleep(1.0)
-    raise RuntimeError(f"headroom proxy on {port} did not become ready")
-
-
 def fetch_stats(port: int) -> dict:
     with urllib.request.urlopen(f"http://127.0.0.1:{port}/stats", timeout=30) as resp:
         return json.loads(resp.read().decode())
-
-
-def headroom_argv() -> list[str]:
-    if shutil.which("headroom"):
-        return ["headroom"]
-    return ["uv", "run", "headroom"]
 
 
 def _delta_block(plain_usage: dict, wrapped_usage: dict, token_stats: dict, stats: dict) -> dict:
     plain_in = int(plain_usage.get("prompt_tokens") or 0)
     wrap_in = int(wrapped_usage.get("prompt_tokens") or 0)
     saved = int(token_stats.get("saved") or 0)
+    strategy = stats.get("tokens_saved_by_strategy") or {}
     return {
         "plain_prompt_tokens": plain_in,
         "headroom_prompt_tokens": wrap_in,
         "upstream_prompt_token_delta": plain_in - wrap_in,
         "headroom_tokens_saved": saved,
-        "tokens_saved_by_strategy": stats.get("tokens_saved_by_strategy") or {},
+        "tokens_saved_by_strategy": strategy,
         "compression_summary": stats.get("summary", {}).get("compression") or {},
+        "thresholds": {
+            "min_upstream_prompt_delta": MIN_UPSTREAM_PROMPT_DELTA,
+            "min_headroom_tokens_saved": MIN_HEADROOM_TOKENS_SAVED,
+            "min_smart_crusher_saved": MIN_SMART_CRUSHER_SAVED,
+        },
     }
 
 
@@ -113,22 +81,8 @@ def run_agent_tool_turn(hermes_base: str, model: str) -> dict:
     plain = chat(hermes_base, messages, model)
     plain_usage = plain.get("usage") or {}
 
-    port = pick_port()
-    env = {**dict(os.environ), "HEADROOM_TELEMETRY": "off"}
-    proc = subprocess.Popen(
-        [
-            *headroom_argv(),
-            "proxy",
-            "--port",
-            str(port),
-            "--openai-api-url",
-            hermes_base,
-            "--no-telemetry",
-        ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        env=env,
-    )
+    port = pick_free_port()
+    proc = start_headroom_proxy(port=port, hermes_base=hermes_base)
     try:
         wait_proxy_ready(port)
         wrapped = chat(f"http://127.0.0.1:{port}/v1", messages, model)
@@ -148,16 +102,11 @@ def run_agent_tool_turn(hermes_base: str, model: str) -> dict:
                 "usage": wrapped_usage,
                 "backend": wrapped.get("_backend"),
                 "tokens_saved": token_stats.get("saved"),
-                "proxy_compression_saved": token_stats.get("proxy_compression_saved"),
             },
             "delta": delta,
         }
     finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=15)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+        stop_process(proc)
 
 
 def run_multi_turn(hermes_base: str, model: str, turns: int = 3) -> dict:
@@ -172,22 +121,8 @@ def run_multi_turn(hermes_base: str, model: str, turns: int = 3) -> dict:
         }
 
     plain = final_turn(hermes_base)
-    port = pick_port()
-    env = {**dict(os.environ), "HEADROOM_TELEMETRY": "off"}
-    proc = subprocess.Popen(
-        [
-            *headroom_argv(),
-            "proxy",
-            "--port",
-            str(port),
-            "--openai-api-url",
-            hermes_base,
-            "--no-telemetry",
-        ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        env=env,
-    )
+    port = pick_free_port()
+    proc = start_headroom_proxy(port=port, hermes_base=hermes_base)
     try:
         wait_proxy_ready(port)
         wrapped = final_turn(f"http://127.0.0.1:{port}/v1")
@@ -198,38 +133,55 @@ def run_multi_turn(hermes_base: str, model: str, turns: int = 3) -> dict:
             "mode": "multi-turn-agent-tool",
             "turns": turns,
             "plain": plain,
-            "headroom": {
-                **wrapped,
-                "tokens_saved": token_stats.get("saved"),
-            },
+            "headroom": {**wrapped, "tokens_saved": token_stats.get("saved")},
             "delta": delta,
         }
     finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=15)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+        stop_process(proc)
+
+
+def validate_result(result: dict) -> int:
+    delta = result.get("delta") or {}
+    plain_in = int(delta.get("plain_prompt_tokens") or 0)
+    wrap_in = int(delta.get("headroom_prompt_tokens") or 0)
+    saved = int(delta.get("headroom_tokens_saved") or 0)
+    strategy_saved = int((delta.get("tokens_saved_by_strategy") or {}).get("smart_crusher") or 0)
+    content = (result.get("headroom") or {}).get("content", "")
+    try:
+        upstream_delta = plain_in - wrap_in
+        assert upstream_delta >= MIN_UPSTREAM_PROMPT_DELTA, (
+            f"upstream delta too low: {upstream_delta}"
+        )
+        assert saved >= MIN_HEADROOM_TOKENS_SAVED, f"tokens.saved too low: {saved}"
+        assert strategy_saved >= MIN_SMART_CRUSHER_SAVED, (
+            f"smart_crusher savings too low: {strategy_saved}"
+        )
+        if result.get("mode") == "agent-tool":
+            assert_compression_delta(
+                plain_prompt_tokens=plain_in,
+                wrapped_prompt_tokens=wrap_in,
+                tokens_saved=saved,
+                smart_crusher_saved=strategy_saved,
+                content=content,
+            )
+        elif "TURN_3" not in content:
+            raise AssertionError(f"expected TURN_3 in multi-turn response, got {content!r}")
+        return 0
+    except AssertionError as exc:
+        print(f"BENCH_FAIL: {exc}", file=sys.stderr)
+        return 2
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--hermes-base",
-        default=DEFAULT_HERMES_BASE,
-        help="Hermes OpenAI base URL (default: %(default)s)",
-    )
-    parser.add_argument("--model", default=DEFAULT_MODEL, help="Chat model id")
-    parser.add_argument(
-        "--multi-turn",
-        action="store_true",
-        help="Run a multi-turn agent loop with tool outputs per turn",
-    )
+    parser.add_argument("--hermes-base", default=DEFAULT_HERMES_BASE)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--multi-turn", action="store_true")
     args = parser.parse_args()
     hermes_base = args.hermes_base.rstrip("/")
 
-    if not hermes_health_ok(hermes_base):
-        print(f"Hermes health check failed for {hermes_base}", file=sys.stderr)
+    if not hermes_reachable(hermes_base):
+        print(f"Hermes health check failed for {hermes_health_url(hermes_base)}", file=sys.stderr)
         return 1
 
     try:
@@ -243,16 +195,7 @@ def main() -> int:
         return 1
 
     print(json.dumps(result, indent=2))
-    delta = result.get("delta") or {}
-    if int(delta.get("headroom_tokens_saved") or 0) <= 0 and int(
-        delta.get("upstream_prompt_token_delta") or 0
-    ) <= 0:
-        print(
-            "WARN: no token savings detected — ensure workload uses large role:tool outputs",
-            file=sys.stderr,
-        )
-        return 2
-    return 0
+    return validate_result(result)
 
 
 if __name__ == "__main__":

--- a/scripts/spot-tech-ci-headroom-hermes.service.example
+++ b/scripts/spot-tech-ci-headroom-hermes.service.example
@@ -1,0 +1,26 @@
+# Example systemd user unit for spot-tech-ci canary.
+# Install:
+#   mkdir -p ~/.config/systemd/user
+#   cp scripts/spot-tech-ci-headroom-hermes.service.example \
+#      ~/.config/systemd/user/headroom-hermes.service
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now headroom-hermes.service
+#
+# spot-tech-ci: docker falkbot-ops already binds :8787 — use :18787 here.
+# Point one bot at http://127.0.0.1:18787/v1 instead of :38765 for canary.
+
+[Unit]
+Description=Headroom proxy upstream of Hermes llm-proxy (compression canary)
+After=network-online.target llm-proxy.service
+Wants=network-online.target llm-proxy.service
+
+[Service]
+Type=simple
+Environment=HEADROOM_TELEMETRY=off
+Environment=HEADROOM_HERMES_BASE_URL=http://127.0.0.1:38765/v1
+ExecStart=%h/.local/bin/headroom proxy --port 18787 --openai-api-url http://127.0.0.1:38765/v1 --no-telemetry
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/scripts/spot-tech-ci-headroom-hermes.service.example
+++ b/scripts/spot-tech-ci-headroom-hermes.service.example
@@ -17,8 +17,9 @@ Wants=network-online.target llm-proxy.service
 [Service]
 Type=simple
 Environment=HEADROOM_TELEMETRY=off
+Environment=HEADROOM_HOST=0.0.0.0
 Environment=HEADROOM_HERMES_BASE_URL=http://127.0.0.1:38765/v1
-ExecStart=%h/.local/bin/headroom proxy --port 18787 --openai-api-url http://127.0.0.1:38765/v1 --no-telemetry
+ExecStart=%h/.local/bin/headroom proxy --host 0.0.0.0 --port 18787 --openai-api-url http://127.0.0.1:38765/v1 --no-telemetry
 Restart=on-failure
 RestartSec=5
 

--- a/scripts/spot-tech-ci-headroom-hermes.service.example
+++ b/scripts/spot-tech-ci-headroom-hermes.service.example
@@ -6,6 +6,11 @@
 #   systemctl --user daemon-reload
 #   systemctl --user enable --now headroom-hermes.service
 #
+# Docker bots (UFW on spot-tech-ci — allow bridge → :18787):
+#   sudo ufw allow from 172.18.0.0/16 to any port 18787 proto tcp
+#   sudo ufw allow from 172.20.0.0/16 to any port 18787 proto tcp
+#   sudo ufw allow from 172.17.0.0/16 to any port 18787 proto tcp
+#
 # spot-tech-ci: docker falkbot-ops already binds :8787 — use :18787 here.
 # Point one bot at http://127.0.0.1:18787/v1 instead of :38765 for canary.
 

--- a/tests/test_cli/hermes_support.py
+++ b/tests/test_cli/hermes_support.py
@@ -1,0 +1,113 @@
+"""Shared helpers for Hermes live tests and operator benchmarks."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import time
+import urllib.request
+from pathlib import Path
+
+# spot-tech-ci agent-tool run floors (2026-06-07).
+MIN_UPSTREAM_PROMPT_DELTA = 1000
+MIN_HEADROOM_TOKENS_SAVED = 100
+MIN_SMART_CRUSHER_SAVED = 1000
+EXPECTED_TOOL_ROW_COUNT = 150
+EXPECTED_COUNT_TOKEN = f"COUNT_{EXPECTED_TOOL_ROW_COUNT}"
+
+
+def pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def hermes_health_url(hermes_base_v1: str) -> str:
+    return hermes_base_v1.rstrip("/").removesuffix("/v1") + "/health"
+
+
+def hermes_reachable(hermes_base_v1: str) -> bool:
+    try:
+        with urllib.request.urlopen(hermes_health_url(hermes_base_v1), timeout=3) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+def headroom_argv(repo_root: Path | None = None) -> list[str]:
+    if shutil.which("headroom"):
+        return ["headroom"]
+    if repo_root is not None:
+        return ["uv", "run", "headroom"]
+    return ["headroom"]
+
+
+def wait_proxy_ready(port: int, timeout: float = 180.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for path in ("/readyz", "/health", "/livez"):
+            try:
+                with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=3) as resp:
+                    if resp.status == 200:
+                        return
+            except Exception:
+                continue
+        time.sleep(1.0)
+    raise RuntimeError(f"headroom proxy on {port} did not become ready")
+
+
+def start_headroom_proxy(
+    *,
+    port: int,
+    hermes_base: str,
+    repo_root: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.Popen:
+    proc_env = {**(env or os.environ), "HEADROOM_TELEMETRY": "off"}
+    return subprocess.Popen(
+        [
+            *headroom_argv(repo_root),
+            "proxy",
+            "--port",
+            str(port),
+            "--openai-api-url",
+            hermes_base.rstrip("/"),
+            "--no-telemetry",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        cwd=repo_root,
+        env=proc_env,
+    )
+
+
+def stop_process(proc: subprocess.Popen, timeout: float = 15.0) -> None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def assert_compression_delta(
+    *,
+    plain_prompt_tokens: int,
+    wrapped_prompt_tokens: int,
+    tokens_saved: int,
+    smart_crusher_saved: int,
+    content: str,
+) -> None:
+    upstream_delta = plain_prompt_tokens - wrapped_prompt_tokens
+    assert upstream_delta >= MIN_UPSTREAM_PROMPT_DELTA, (
+        f"upstream delta too low: {upstream_delta} "
+        f"(plain={plain_prompt_tokens}, wrapped={wrapped_prompt_tokens})"
+    )
+    assert tokens_saved >= MIN_HEADROOM_TOKENS_SAVED, f"tokens.saved too low: {tokens_saved}"
+    assert smart_crusher_saved >= MIN_SMART_CRUSHER_SAVED, (
+        f"smart_crusher savings too low: {smart_crusher_saved}"
+    )
+    assert EXPECTED_COUNT_TOKEN in content, (
+        f"expected {EXPECTED_COUNT_TOKEN} in response, got: {content!r}"
+    )

--- a/tests/test_cli/hermes_workloads.py
+++ b/tests/test_cli/hermes_workloads.py
@@ -1,0 +1,91 @@
+"""Shared Hermes benchmark workloads for live tests and operator scripts.
+
+Headroom compresses large ``role: tool`` outputs (SmartCrusher), not plain
+user/system prose. These fixtures mirror bot/agent traffic on spot-tech-ci.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def large_tool_output(items: int = 150) -> str:
+    return json.dumps(
+        [
+            {
+                "id": i,
+                "severity": "error",
+                "service": "api-gateway",
+                "message": "connection reset by peer",
+                "stack": f"at Handler.process(line:{100 + i})\n at Router.dispatch(line:{200 + i})",
+                "payload": "x" * 180,
+            }
+            for i in range(items)
+        ]
+    )
+
+
+def agent_tool_messages(
+    *,
+    tool_items: int = 150,
+    tool_call_id: str = "call_bench_1",
+    user_prompt: str = "Run fleet diagnostics and report error count.",
+    follow_up: str = "How many error rows in the tool output? Reply COUNT_<number> only.",
+) -> list[dict]:
+    return [
+        {"role": "user", "content": user_prompt},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": tool_call_id,
+                    "type": "function",
+                    "function": {"name": "run_diagnostics", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": tool_call_id,
+            "content": large_tool_output(tool_items),
+        },
+        {"role": "user", "content": follow_up},
+    ]
+
+
+def multi_turn_agent_messages(turns: int = 3, tool_items: int = 100) -> list[dict]:
+    messages: list[dict] = [
+        {
+            "role": "system",
+            "content": "Short answers only. Summarize tool output briefly.",
+        }
+    ]
+    for turn in range(1, turns + 1):
+        call_id = f"call_turn_{turn}"
+        messages.extend(
+            [
+                {"role": "user", "content": f"Turn {turn}: run diagnostics batch {turn}."},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {"name": "run_diagnostics", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": large_tool_output(tool_items + turn * 10),
+                },
+                {
+                    "role": "user",
+                    "content": f"Turn {turn}: reply TURN_{turn} only.",
+                },
+            ]
+        )
+    return messages

--- a/tests/test_cli/test_hermes_canary_live.py
+++ b/tests/test_cli/test_hermes_canary_live.py
@@ -1,0 +1,99 @@
+"""Optional live test for the persistent Headroom→Hermes canary on spot-tech-ci.
+
+Requires a running user unit (``headroom-hermes.service``) or any Headroom proxy
+already bound to ``HEADROOM_CANARY_PORT`` (default ``18787`` on spot-tech-ci):
+
+    HEADROOM_LIVE_HERMES=1 HEADROOM_LIVE_CANARY=1 \\
+        pytest tests/test_cli/test_hermes_canary_live.py -v
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.test_cli.hermes_support import (
+    assert_compression_delta,
+    hermes_health_url,
+    hermes_reachable,
+)
+from tests.test_cli.hermes_workloads import agent_tool_messages
+
+_LIVE = os.environ.get("HEADROOM_LIVE_HERMES") == "1"
+_CANARY = os.environ.get("HEADROOM_LIVE_CANARY") == "1"
+HERMES_BASE = os.environ.get("HEADROOM_HERMES_BASE_URL", "http://127.0.0.1:38765/v1").rstrip("/")
+CANARY_PORT = int(os.environ.get("HEADROOM_CANARY_PORT", "18787"))
+HERMES_MODEL = os.environ.get("HEADROOM_HERMES_MODEL", "grok-4.3")
+
+pytestmark = pytest.mark.skipif(
+    not (_LIVE and _CANARY),
+    reason="set HEADROOM_LIVE_HERMES=1 and HEADROOM_LIVE_CANARY=1",
+)
+
+
+def _chat(client: httpx.Client, base_url: str, messages: list[dict]) -> dict[str, Any]:
+    payload = {
+        "model": HERMES_MODEL,
+        "messages": messages,
+        "max_tokens": 24,
+        "temperature": 0,
+        "stream": False,
+    }
+    resp = client.post(f"{base_url}/chat/completions", json=payload, timeout=180.0)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _canary_ready(client: httpx.Client) -> bool:
+    for path in ("/readyz", "/health", "/livez"):
+        try:
+            resp = client.get(f"http://127.0.0.1:{CANARY_PORT}{path}", timeout=5.0)
+            if resp.status_code == 200:
+                return True
+        except Exception:
+            continue
+    return False
+
+
+@pytest.fixture(scope="module")
+def hermes_available() -> None:
+    if not hermes_reachable(HERMES_BASE):
+        pytest.skip(f"Hermes not reachable at {hermes_health_url(HERMES_BASE)}")
+
+
+@pytest.fixture(scope="module")
+def canary_available(hermes_available: None) -> None:  # noqa: ARG001
+    with httpx.Client() as client:
+        if not _canary_ready(client):
+            pytest.skip(f"canary not ready on port {CANARY_PORT}")
+
+
+def test_live_canary_compresses_agent_tool_output(
+    hermes_available: None,  # noqa: ARG001
+    canary_available: None,  # noqa: ARG001
+) -> None:
+    messages = agent_tool_messages()
+    with httpx.Client() as client:
+        plain = _chat(client, HERMES_BASE, messages)
+        wrapped = _chat(client, f"http://127.0.0.1:{CANARY_PORT}/v1", messages)
+
+        plain_tokens = int((plain.get("usage") or {}).get("prompt_tokens") or 0)
+        wrapped_tokens = int((wrapped.get("usage") or {}).get("prompt_tokens") or 0)
+        content = wrapped["choices"][0]["message"]["content"]
+
+        stats_resp = client.get(f"http://127.0.0.1:{CANARY_PORT}/stats", timeout=30.0)
+        stats_resp.raise_for_status()
+        stats = stats_resp.json()
+        saved = int((stats.get("tokens") or {}).get("saved") or 0)
+        strategy_saved = int((stats.get("tokens_saved_by_strategy") or {}).get("smart_crusher") or 0)
+
+    assert_compression_delta(
+        plain_prompt_tokens=plain_tokens,
+        wrapped_prompt_tokens=wrapped_tokens,
+        tokens_saved=saved,
+        smart_crusher_saved=strategy_saved,
+        content=content,
+    )

--- a/tests/test_cli/test_hermes_grok_live.py
+++ b/tests/test_cli/test_hermes_grok_live.py
@@ -1,0 +1,199 @@
+"""Optional live Hermes + Headroom integration tests (OpenAI chat path).
+
+Grok Build's ``wrap grok`` routes ``/v1/sessions/*`` traffic — mostly passthrough.
+Hermes on spot-tech-ci exposes ``/v1/chat/completions``, which is the compressible
+path Headroom optimizes.
+
+Run on a host where Hermes llm-proxy is up (default ``:38765``):
+
+    HEADROOM_LIVE_HERMES=1 UV_SKIP_WHEEL_FILENAME_CHECK=1 \\
+        uv run --extra dev pytest tests/test_cli/test_hermes_grok_live.py -v
+
+spot-tech-ci runbook (2026-06-07, ``falk@80.241.217.210``):
+
+    curl -s http://127.0.0.1:38765/health          # => ok
+    export PATH="$HOME/.local/bin:$PATH"
+    uv tool install 'headroom-ai[proxy]'          # once, if headroom missing
+    HEADROOM_LIVE_HERMES=1 uv run --extra dev \\
+        pytest tests/test_cli/test_hermes_grok_live.py -v
+    python scripts/bench_hermes_headroom.py
+
+Captured benchmark (fat single-turn prompt, grok backend):
+
+| Path | ``prompt_tokens`` | Headroom ``tokens.saved`` |
+|------|-------------------|---------------------------|
+| Plain Hermes | 3357 | — |
+| Headroom → Hermes | 3357 | 0 |
+
+Routing works end-to-end; token deltas depend on workload shape (tool dumps,
+multi-turn agent loops). See ``scripts/bench_hermes_headroom.py --multi-turn``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+_LIVE = os.environ.get("HEADROOM_LIVE_HERMES") == "1"
+HERMES_BASE = os.environ.get("HEADROOM_HERMES_BASE_URL", "http://127.0.0.1:38765/v1").rstrip("/")
+HERMES_MODEL = os.environ.get("HEADROOM_HERMES_MODEL", "grok-4.3")
+REPLY_TOKEN = os.environ.get("HEADROOM_HERMES_REPLY_TOKEN", "HERMES_OK")
+HERMES_HEALTH_URL = HERMES_BASE.replace("/v1", "") + "/health"
+
+pytestmark = pytest.mark.skipif(not _LIVE, reason="set HEADROOM_LIVE_HERMES=1 to run live Hermes tests")
+
+
+def _hermes_reachable() -> bool:
+    try:
+        with httpx.Client(timeout=3.0) as client:
+            resp = client.get(HERMES_HEALTH_URL)
+            return resp.status_code == 200
+    except Exception:
+        return False
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _headroom_argv(repo_root: Path) -> list[str]:
+    if shutil.which("headroom"):
+        return ["headroom"]
+    return ["uv", "run", "headroom"]
+
+
+def _wait_proxy_ready(port: int, timeout: float = 180.0) -> None:
+    deadline = time.time() + timeout
+    with httpx.Client(timeout=3.0) as client:
+        while time.time() < deadline:
+            for path in ("/readyz", "/health", "/livez"):
+                try:
+                    resp = client.get(f"http://127.0.0.1:{port}{path}")
+                    if resp.status_code == 200:
+                        return
+                except Exception:
+                    continue
+            time.sleep(1.0)
+    raise RuntimeError(f"headroom proxy on {port} did not become ready")
+
+
+def _chat(client: httpx.Client, base_url: str, content: str) -> dict[str, Any]:
+    payload = {
+        "model": HERMES_MODEL,
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": 16,
+        "temperature": 0,
+        "stream": False,
+    }
+    resp = client.post(f"{base_url}/chat/completions", json=payload, timeout=180.0)
+    resp.raise_for_status()
+    body = resp.json()
+    body["_backend"] = resp.headers.get("x-llm-backend")
+    return body
+
+
+@pytest.fixture(scope="module")
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module")
+def hermes_client() -> Iterator[httpx.Client]:
+    if not _hermes_reachable():
+        pytest.skip(f"Hermes not reachable at {HERMES_HEALTH_URL}")
+    with httpx.Client() as client:
+        yield client
+
+
+@pytest.fixture
+def headroom_proxy(repo_root: Path) -> Iterator[int]:
+    port = _pick_free_port()
+    env = os.environ.copy()
+    env["HEADROOM_TELEMETRY"] = "off"
+    proc = subprocess.Popen(
+        [
+            *_headroom_argv(repo_root),
+            "proxy",
+            "--port",
+            str(port),
+            "--openai-api-url",
+            HERMES_BASE,
+            "--no-telemetry",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        cwd=repo_root,
+        env=env,
+    )
+    try:
+        _wait_proxy_ready(port)
+        yield port
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+@pytest.mark.skipif(not _hermes_reachable(), reason="Hermes llm-proxy not reachable")
+def test_live_hermes_health(hermes_client: httpx.Client) -> None:
+    resp = hermes_client.get(HERMES_HEALTH_URL)
+    assert resp.status_code == 200
+    assert resp.text.strip().lower() in {"ok", '"ok"'}
+
+
+@pytest.mark.skipif(not _hermes_reachable(), reason="Hermes llm-proxy not reachable")
+def test_live_plain_hermes_chat_completion(hermes_client: httpx.Client) -> None:
+    body = _chat(
+        hermes_client,
+        HERMES_BASE,
+        f"Reply with exactly one word: {REPLY_TOKEN}",
+    )
+    content = body["choices"][0]["message"]["content"]
+    usage = body.get("usage") or {}
+    assert REPLY_TOKEN in content
+    assert int(usage.get("prompt_tokens") or 0) > 0
+
+
+@pytest.mark.skipif(not _hermes_reachable(), reason="Hermes llm-proxy not reachable")
+def test_live_headroom_proxy_routes_to_hermes(
+    hermes_client: httpx.Client,
+    headroom_proxy: int,
+) -> None:
+    body = _chat(
+        hermes_client,
+        f"http://127.0.0.1:{headroom_proxy}/v1",
+        f"Reply with exactly one word: {REPLY_TOKEN}",
+    )
+    content = body["choices"][0]["message"]["content"]
+    assert REPLY_TOKEN in content
+
+    stats_resp = hermes_client.get(f"http://127.0.0.1:{headroom_proxy}/stats", timeout=30.0)
+    stats_resp.raise_for_status()
+    stats = stats_resp.json()
+    requests_total = int((stats.get("requests") or {}).get("total") or 0)
+    assert requests_total >= 1
+
+
+@pytest.mark.skipif(not _hermes_reachable(), reason="Hermes llm-proxy not reachable")
+def test_live_headroom_openai_upstream_points_at_hermes(
+    hermes_client: httpx.Client,
+    headroom_proxy: int,
+) -> None:
+    health_resp = hermes_client.get(f"http://127.0.0.1:{headroom_proxy}/health", timeout=30.0)
+    health_resp.raise_for_status()
+    health = health_resp.json()
+    config = health.get("config") if isinstance(health.get("config"), dict) else health
+    assert config.get("openai_api_url") == HERMES_BASE

--- a/tests/test_cli/test_hermes_grok_live.py
+++ b/tests/test_cli/test_hermes_grok_live.py
@@ -2,31 +2,27 @@
 
 Grok Build's ``wrap grok`` routes ``/v1/sessions/*`` traffic — mostly passthrough.
 Hermes on spot-tech-ci exposes ``/v1/chat/completions``, which is the compressible
-path Headroom optimizes.
+path Headroom optimizes when messages include large ``role: tool`` outputs.
 
 Run on a host where Hermes llm-proxy is up (default ``:38765``):
 
-    HEADROOM_LIVE_HERMES=1 UV_SKIP_WHEEL_FILENAME_CHECK=1 \\
-        uv run --extra dev pytest tests/test_cli/test_hermes_grok_live.py -v
+    HEADROOM_LIVE_HERMES=1 pytest tests/test_cli/test_hermes_grok_live.py -v
 
-spot-tech-ci runbook (2026-06-07, ``falk@80.241.217.210``):
+spot-tech-ci (minimal venv — full ``--extra dev`` needs a C++ toolchain)::
 
-    curl -s http://127.0.0.1:38765/health          # => ok
     export PATH="$HOME/.local/bin:$PATH"
-    uv tool install 'headroom-ai[proxy]'          # once, if headroom missing
-    HEADROOM_LIVE_HERMES=1 uv run --extra dev \\
-        pytest tests/test_cli/test_hermes_grok_live.py -v
+    cd ~/headroom-wrap-grok-clean
+    uv venv .venv-live && source .venv-live/bin/activate
+    uv pip install httpx pytest
+    HEADROOM_LIVE_HERMES=1 pytest tests/test_cli/test_hermes_grok_live.py -v
     python scripts/bench_hermes_headroom.py
 
-Captured benchmark (fat single-turn prompt, grok backend):
+Captured agent-tool benchmark (2026-06-07, grok backend):
 
 | Path | ``prompt_tokens`` | Headroom ``tokens.saved`` |
 |------|-------------------|---------------------------|
-| Plain Hermes | 3357 | — |
-| Headroom → Hermes | 3357 | 0 |
-
-Routing works end-to-end; token deltas depend on workload shape (tool dumps,
-multi-turn agent loops). See ``scripts/bench_hermes_headroom.py --multi-turn``.
+| Plain Hermes | 9,763 | — |
+| Headroom → Hermes | 7,964 | 562 (smart_crusher: 1,799) |
 """
 
 from __future__ import annotations
@@ -42,6 +38,8 @@ from typing import Any
 
 import httpx
 import pytest
+
+from tests.test_cli.hermes_workloads import agent_tool_messages
 
 _LIVE = os.environ.get("HEADROOM_LIVE_HERMES") == "1"
 HERMES_BASE = os.environ.get("HEADROOM_HERMES_BASE_URL", "http://127.0.0.1:38765/v1").rstrip("/")
@@ -88,11 +86,17 @@ def _wait_proxy_ready(port: int, timeout: float = 180.0) -> None:
     raise RuntimeError(f"headroom proxy on {port} did not become ready")
 
 
-def _chat(client: httpx.Client, base_url: str, content: str) -> dict[str, Any]:
+def _chat(
+    client: httpx.Client,
+    base_url: str,
+    messages: list[dict],
+    *,
+    max_tokens: int = 24,
+) -> dict[str, Any]:
     payload = {
         "model": HERMES_MODEL,
-        "messages": [{"role": "user", "content": content}],
-        "max_tokens": 16,
+        "messages": messages,
+        "max_tokens": max_tokens,
         "temperature": 0,
         "stream": False,
     }
@@ -159,7 +163,7 @@ def test_live_plain_hermes_chat_completion(hermes_client: httpx.Client) -> None:
     body = _chat(
         hermes_client,
         HERMES_BASE,
-        f"Reply with exactly one word: {REPLY_TOKEN}",
+        [{"role": "user", "content": f"Reply with exactly one word: {REPLY_TOKEN}"}],
     )
     content = body["choices"][0]["message"]["content"]
     usage = body.get("usage") or {}
@@ -175,7 +179,7 @@ def test_live_headroom_proxy_routes_to_hermes(
     body = _chat(
         hermes_client,
         f"http://127.0.0.1:{headroom_proxy}/v1",
-        f"Reply with exactly one word: {REPLY_TOKEN}",
+        [{"role": "user", "content": f"Reply with exactly one word: {REPLY_TOKEN}"}],
     )
     content = body["choices"][0]["message"]["content"]
     assert REPLY_TOKEN in content
@@ -197,3 +201,27 @@ def test_live_headroom_openai_upstream_points_at_hermes(
     health = health_resp.json()
     config = health.get("config") if isinstance(health.get("config"), dict) else health
     assert config.get("openai_api_url") == HERMES_BASE
+
+
+@pytest.mark.skipif(not _hermes_reachable(), reason="Hermes llm-proxy not reachable")
+def test_live_headroom_compresses_agent_tool_output(
+    hermes_client: httpx.Client,
+    headroom_proxy: int,
+) -> None:
+    messages = agent_tool_messages()
+    plain = _chat(hermes_client, HERMES_BASE, messages)
+    wrapped = _chat(hermes_client, f"http://127.0.0.1:{headroom_proxy}/v1", messages)
+
+    plain_tokens = int((plain.get("usage") or {}).get("prompt_tokens") or 0)
+    wrapped_tokens = int((wrapped.get("usage") or {}).get("prompt_tokens") or 0)
+
+    stats_resp = hermes_client.get(f"http://127.0.0.1:{headroom_proxy}/stats", timeout=30.0)
+    stats_resp.raise_for_status()
+    stats = stats_resp.json()
+    saved = int((stats.get("tokens") or {}).get("saved") or 0)
+    strategy_saved = int((stats.get("tokens_saved_by_strategy") or {}).get("smart_crusher") or 0)
+
+    assert plain_tokens > 5000, "tool workload should be large enough to compress"
+    assert wrapped_tokens < plain_tokens or saved > 0 or strategy_saved > 0, (
+        f"expected compression: plain={plain_tokens} wrapped={wrapped_tokens} saved={saved}"
+    )

--- a/tests/test_cli/test_hermes_grok_live.py
+++ b/tests/test_cli/test_hermes_grok_live.py
@@ -1,37 +1,20 @@
 """Optional live Hermes + Headroom integration tests (OpenAI chat path).
 
-Grok Build's ``wrap grok`` routes ``/v1/sessions/*`` traffic — mostly passthrough.
-Hermes on spot-tech-ci exposes ``/v1/chat/completions``, which is the compressible
-path Headroom optimizes when messages include large ``role: tool`` outputs.
-
 Run on a host where Hermes llm-proxy is up (default ``:38765``):
 
     HEADROOM_LIVE_HERMES=1 pytest tests/test_cli/test_hermes_grok_live.py -v
 
-spot-tech-ci (minimal venv — full ``--extra dev`` needs a C++ toolchain)::
+spot-tech-ci minimal venv::
 
-    export PATH="$HOME/.local/bin:$PATH"
-    cd ~/headroom-wrap-grok-clean
     uv venv .venv-live && source .venv-live/bin/activate
     uv pip install httpx pytest
     HEADROOM_LIVE_HERMES=1 pytest tests/test_cli/test_hermes_grok_live.py -v
     python scripts/bench_hermes_headroom.py
-
-Captured agent-tool benchmark (2026-06-07, grok backend):
-
-| Path | ``prompt_tokens`` | Headroom ``tokens.saved`` |
-|------|-------------------|---------------------------|
-| Plain Hermes | 9,763 | — |
-| Headroom → Hermes | 7,964 | 562 (smart_crusher: 1,799) |
 """
 
 from __future__ import annotations
 
 import os
-import shutil
-import socket
-import subprocess
-import time
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -39,51 +22,23 @@ from typing import Any
 import httpx
 import pytest
 
+from tests.test_cli.hermes_support import (
+    assert_compression_delta,
+    hermes_health_url,
+    hermes_reachable,
+    pick_free_port,
+    start_headroom_proxy,
+    stop_process,
+    wait_proxy_ready,
+)
 from tests.test_cli.hermes_workloads import agent_tool_messages
 
 _LIVE = os.environ.get("HEADROOM_LIVE_HERMES") == "1"
 HERMES_BASE = os.environ.get("HEADROOM_HERMES_BASE_URL", "http://127.0.0.1:38765/v1").rstrip("/")
 HERMES_MODEL = os.environ.get("HEADROOM_HERMES_MODEL", "grok-4.3")
 REPLY_TOKEN = os.environ.get("HEADROOM_HERMES_REPLY_TOKEN", "HERMES_OK")
-HERMES_HEALTH_URL = HERMES_BASE.replace("/v1", "") + "/health"
 
 pytestmark = pytest.mark.skipif(not _LIVE, reason="set HEADROOM_LIVE_HERMES=1 to run live Hermes tests")
-
-
-def _hermes_reachable() -> bool:
-    try:
-        with httpx.Client(timeout=3.0) as client:
-            resp = client.get(HERMES_HEALTH_URL)
-            return resp.status_code == 200
-    except Exception:
-        return False
-
-
-def _pick_free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
-
-
-def _headroom_argv(repo_root: Path) -> list[str]:
-    if shutil.which("headroom"):
-        return ["headroom"]
-    return ["uv", "run", "headroom"]
-
-
-def _wait_proxy_ready(port: int, timeout: float = 180.0) -> None:
-    deadline = time.time() + timeout
-    with httpx.Client(timeout=3.0) as client:
-        while time.time() < deadline:
-            for path in ("/readyz", "/health", "/livez"):
-                try:
-                    resp = client.get(f"http://127.0.0.1:{port}{path}")
-                    if resp.status_code == 200:
-                        return
-                except Exception:
-                    continue
-            time.sleep(1.0)
-    raise RuntimeError(f"headroom proxy on {port} did not become ready")
 
 
 def _chat(
@@ -113,53 +68,37 @@ def repo_root() -> Path:
 
 
 @pytest.fixture(scope="module")
-def hermes_client() -> Iterator[httpx.Client]:
-    if not _hermes_reachable():
-        pytest.skip(f"Hermes not reachable at {HERMES_HEALTH_URL}")
+def hermes_available() -> None:
+    if not hermes_reachable(HERMES_BASE):
+        pytest.skip(f"Hermes not reachable at {hermes_health_url(HERMES_BASE)}")
+
+
+@pytest.fixture(scope="module")
+def hermes_client(hermes_available: None) -> Iterator[httpx.Client]:  # noqa: ARG001
     with httpx.Client() as client:
         yield client
 
 
 @pytest.fixture
-def headroom_proxy(repo_root: Path) -> Iterator[int]:
-    port = _pick_free_port()
-    env = os.environ.copy()
-    env["HEADROOM_TELEMETRY"] = "off"
-    proc = subprocess.Popen(
-        [
-            *_headroom_argv(repo_root),
-            "proxy",
-            "--port",
-            str(port),
-            "--openai-api-url",
-            HERMES_BASE,
-            "--no-telemetry",
-        ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        cwd=repo_root,
-        env=env,
-    )
+def headroom_proxy(repo_root: Path, hermes_available: None) -> Iterator[int]:  # noqa: ARG001
+    port = pick_free_port()
+    proc = start_headroom_proxy(port=port, hermes_base=HERMES_BASE, repo_root=repo_root)
     try:
-        _wait_proxy_ready(port)
+        wait_proxy_ready(port)
         yield port
     finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=15)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+        stop_process(proc)
 
 
-@pytest.mark.skipif(not _hermes_reachable(), reason="Hermes llm-proxy not reachable")
-def test_live_hermes_health(hermes_client: httpx.Client) -> None:
-    resp = hermes_client.get(HERMES_HEALTH_URL)
+def test_live_hermes_health(hermes_client: httpx.Client, hermes_available: None) -> None:  # noqa: ARG001
+    resp = hermes_client.get(hermes_health_url(HERMES_BASE))
     assert resp.status_code == 200
     assert resp.text.strip().lower() in {"ok", '"ok"'}
 
 
-@pytest.mark.skipif(not _hermes_reachable(), reason="Hermes llm-proxy not reachable")
-def test_live_plain_hermes_chat_completion(hermes_client: httpx.Client) -> None:
+def test_live_plain_hermes_chat_completion(
+    hermes_client: httpx.Client, hermes_available: None
+) -> None:  # noqa: ARG001
     body = _chat(
         hermes_client,
         HERMES_BASE,
@@ -171,11 +110,11 @@ def test_live_plain_hermes_chat_completion(hermes_client: httpx.Client) -> None:
     assert int(usage.get("prompt_tokens") or 0) > 0
 
 
-@pytest.mark.skipif(not _hermes_reachable(), reason="Hermes llm-proxy not reachable")
 def test_live_headroom_proxy_routes_to_hermes(
     hermes_client: httpx.Client,
     headroom_proxy: int,
-) -> None:
+    hermes_available: None,
+) -> None:  # noqa: ARG001
     body = _chat(
         hermes_client,
         f"http://127.0.0.1:{headroom_proxy}/v1",
@@ -191,11 +130,11 @@ def test_live_headroom_proxy_routes_to_hermes(
     assert requests_total >= 1
 
 
-@pytest.mark.skipif(not _hermes_reachable(), reason="Hermes llm-proxy not reachable")
 def test_live_headroom_openai_upstream_points_at_hermes(
     hermes_client: httpx.Client,
     headroom_proxy: int,
-) -> None:
+    hermes_available: None,
+) -> None:  # noqa: ARG001
     health_resp = hermes_client.get(f"http://127.0.0.1:{headroom_proxy}/health", timeout=30.0)
     health_resp.raise_for_status()
     health = health_resp.json()
@@ -203,17 +142,18 @@ def test_live_headroom_openai_upstream_points_at_hermes(
     assert config.get("openai_api_url") == HERMES_BASE
 
 
-@pytest.mark.skipif(not _hermes_reachable(), reason="Hermes llm-proxy not reachable")
 def test_live_headroom_compresses_agent_tool_output(
     hermes_client: httpx.Client,
     headroom_proxy: int,
-) -> None:
+    hermes_available: None,
+) -> None:  # noqa: ARG001
     messages = agent_tool_messages()
     plain = _chat(hermes_client, HERMES_BASE, messages)
     wrapped = _chat(hermes_client, f"http://127.0.0.1:{headroom_proxy}/v1", messages)
 
     plain_tokens = int((plain.get("usage") or {}).get("prompt_tokens") or 0)
     wrapped_tokens = int((wrapped.get("usage") or {}).get("prompt_tokens") or 0)
+    content = wrapped["choices"][0]["message"]["content"]
 
     stats_resp = hermes_client.get(f"http://127.0.0.1:{headroom_proxy}/stats", timeout=30.0)
     stats_resp.raise_for_status()
@@ -221,7 +161,10 @@ def test_live_headroom_compresses_agent_tool_output(
     saved = int((stats.get("tokens") or {}).get("saved") or 0)
     strategy_saved = int((stats.get("tokens_saved_by_strategy") or {}).get("smart_crusher") or 0)
 
-    assert plain_tokens > 5000, "tool workload should be large enough to compress"
-    assert wrapped_tokens < plain_tokens or saved > 0 or strategy_saved > 0, (
-        f"expected compression: plain={plain_tokens} wrapped={wrapped_tokens} saved={saved}"
+    assert_compression_delta(
+        plain_prompt_tokens=plain_tokens,
+        wrapped_prompt_tokens=wrapped_tokens,
+        tokens_saved=saved,
+        smart_crusher_saved=strategy_saved,
+        content=content,
     )

--- a/tests/test_cli/test_wrap_grok.py
+++ b/tests/test_cli/test_wrap_grok.py
@@ -163,6 +163,23 @@ def test_wrap_grok_keeps_headroom_port_long_option(
     assert env[GROK_PROXY_ENV] == "http://127.0.0.1:9999/v1"
 
 
+def test_wrap_grok_sets_grok_upstream_for_proxy(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap.shutil.which", return_value="grok"):
+        with patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool):
+            result = runner.invoke(main, ["wrap", "grok"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["openai_api_url"] == DEFAULT_API_URL
+
+
 def test_wrap_grok_forwards_headroom_backend_options(
     runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli/test_wrap_grok.py
+++ b/tests/test_cli/test_wrap_grok.py
@@ -1,0 +1,87 @@
+"""Tests for `headroom wrap grok` command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_wrap_grok_sets_proxy_env(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap.shutil.which", return_value="grok"):
+        with patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool):
+            result = runner.invoke(main, ["wrap", "grok", "-p", "fix the bug"])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["GROK_CLI_CHAT_PROXY_BASE_URL"] == "http://127.0.0.1:8787/v1"
+    assert captured["tool_label"] == "GROK"
+    assert captured["agent_type"] == "grok"
+    assert captured["args"] == ("-p", "fix the bug")
+
+
+def test_wrap_grok_keeps_headroom_port_long_option(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap.shutil.which", return_value="grok"):
+        with patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool):
+            result = runner.invoke(main, ["wrap", "grok", "--port", "9999"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["port"] == 9999
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["GROK_CLI_CHAT_PROXY_BASE_URL"] == "http://127.0.0.1:9999/v1"
+
+
+def test_wrap_grok_forwards_no_proxy(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap.shutil.which", return_value="grok"):
+        with patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool):
+            result = runner.invoke(main, ["wrap", "grok", "--no-proxy"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["no_proxy"] is True
+
+
+def test_wrap_grok_missing_binary(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with patch("headroom.cli.wrap.shutil.which", return_value=None):
+        result = runner.invoke(main, ["wrap", "grok"])
+
+    assert result.exit_code == 1
+    assert "grok" in result.output.lower()

--- a/tests/test_cli/test_wrap_grok.py
+++ b/tests/test_cli/test_wrap_grok.py
@@ -1,7 +1,14 @@
-"""Tests for `headroom wrap grok` command."""
+"""Tests for `headroom wrap grok` command.
+
+Grok Build routes cli-chat-proxy traffic via ``GROK_CLI_CHAT_PROXY_BASE_URL``.
+These tests mirror real ``grok`` CLI invocations (from ``grok --help``) and
+verify Headroom only injects the proxy env — Grok's own flags pass through
+unchanged.
+"""
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,11 +16,91 @@ import pytest
 from click.testing import CliRunner
 
 from headroom.cli.main import main
+from headroom.providers.grok.runtime import GROK_PROXY_ENV
 
 
 @pytest.fixture
 def runner() -> CliRunner:
     return CliRunner()
+
+
+# Real Grok CLI shapes lifted from `grok --help` (2026-06).
+REAL_GROK_INVOCATIONS: list[tuple[list[str], tuple[str, ...]]] = [
+    # TUI — no args, proxy env only.
+    ([], ()),
+    # Headless single-turn (`-p` / `--single`).
+    (
+        ["-p", "fix the failing test in test_wrap_grok.py"],
+        ("-p", "fix the failing test in test_wrap_grok.py"),
+    ),
+    (
+        ["--single", "summarize the diff and suggest a commit message"],
+        ("--single", "summarize the diff and suggest a commit message"),
+    ),
+    # Continue the cwd's most recent session.
+    (["--continue"], ("--continue",)),
+    (["-c"], ("-c",)),
+    # Scoped working directory + agent override.
+    (
+        ["--cwd", "/tmp/myproject", "--agent", "reviewer"],
+        ("--cwd", "/tmp/myproject", "--agent", "reviewer"),
+    ),
+    # Headless parallel best-of-n with auto-approve (common CI-style invocation).
+    (
+        ["-p", "add input validation", "--best-of-n", "3", "--always-approve"],
+        ("-p", "add input validation", "--best-of-n", "3", "--always-approve"),
+    ),
+    # Prompt from file + structured output (headless).
+    (
+        [
+            "--prompt-file",
+            "tasks/refactor.md",
+            "--output-format",
+            "json",
+            "--permission-mode",
+            "bypassPermissions",
+        ],
+        (
+            "--prompt-file",
+            "tasks/refactor.md",
+            "--output-format",
+            "json",
+            "--permission-mode",
+            "bypassPermissions",
+        ),
+    ),
+    # Force passthrough after `--` (escape hatch for future flag collisions).
+    (
+        ["--", "--port", "4242"],
+        ("--port", "4242"),
+    ),
+]
+
+
+@pytest.mark.parametrize("cli_args,expected_grok_args", REAL_GROK_INVOCATIONS)
+def test_wrap_grok_forwards_real_cli_shapes(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cli_args: list[str],
+    expected_grok_args: tuple[str, ...],
+) -> None:
+    """Each tuple mirrors a documented `grok` invocation; Headroom must not eat Grok flags."""
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap.shutil.which", return_value="grok"):
+        with patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool):
+            result = runner.invoke(main, ["wrap", "grok", *cli_args])
+
+    assert result.exit_code == 0, result.output
+    assert captured["args"] == expected_grok_args
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env[GROK_PROXY_ENV] == "http://127.0.0.1:8787/v1"
 
 
 def test_wrap_grok_sets_proxy_env(
@@ -32,13 +119,38 @@ def test_wrap_grok_sets_proxy_env(
     assert result.exit_code == 0, result.output
     env = captured["env"]
     assert isinstance(env, dict)
-    assert env["GROK_CLI_CHAT_PROXY_BASE_URL"] == "http://127.0.0.1:8787/v1"
+    assert env[GROK_PROXY_ENV] == "http://127.0.0.1:8787/v1"
     assert captured["tool_label"] == "GROK"
     assert captured["agent_type"] == "grok"
     assert captured["args"] == ("-p", "fix the bug")
 
 
 def test_wrap_grok_keeps_headroom_port_long_option(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Grok owns `-p`; Headroom uses `--port` only so both can coexist on one command line."""
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap.shutil.which", return_value="grok"):
+        with patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool):
+            result = runner.invoke(
+                main,
+                ["wrap", "grok", "--port", "9999", "-p", "ship the feature"],
+            )
+
+    assert result.exit_code == 0, result.output
+    assert captured["port"] == 9999
+    assert captured["args"] == ("-p", "ship the feature")
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env[GROK_PROXY_ENV] == "http://127.0.0.1:9999/v1"
+
+
+def test_wrap_grok_forwards_headroom_backend_options(
     runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
@@ -49,13 +161,28 @@ def test_wrap_grok_keeps_headroom_port_long_option(
 
     with patch("headroom.cli.wrap.shutil.which", return_value="grok"):
         with patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool):
-            result = runner.invoke(main, ["wrap", "grok", "--port", "9999"])
+            result = runner.invoke(
+                main,
+                [
+                    "wrap",
+                    "grok",
+                    "--backend",
+                    "anyllm",
+                    "--anyllm-provider",
+                    "groq",
+                    "--learn",
+                    "--memory",
+                    "-p",
+                    "refactor auth module",
+                ],
+            )
 
     assert result.exit_code == 0, result.output
-    assert captured["port"] == 9999
-    env = captured["env"]
-    assert isinstance(env, dict)
-    assert env["GROK_CLI_CHAT_PROXY_BASE_URL"] == "http://127.0.0.1:9999/v1"
+    assert captured["backend"] == "anyllm"
+    assert captured["anyllm_provider"] == "groq"
+    assert captured["learn"] is True
+    assert captured["memory"] is True
+    assert captured["args"] == ("-p", "refactor auth module")
 
 
 def test_wrap_grok_forwards_no_proxy(
@@ -85,3 +212,20 @@ def test_wrap_grok_missing_binary(
 
     assert result.exit_code == 1
     assert "grok" in result.output.lower()
+
+
+def test_wrap_grok_stub_binary_receives_proxy_env(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: a real subprocess child must see GROK_CLI_CHAT_PROXY_BASE_URL."""
+    stub = tmp_path / "grok"
+    stub.write_text('#!/bin/sh\nprintf "%s\\n" "$GROK_CLI_CHAT_PROXY_BASE_URL"\nexit 0\n')
+    stub.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    with patch("headroom.cli.wrap._ensure_proxy", return_value=None):
+        result = runner.invoke(main, ["wrap", "grok", "--no-proxy"])
+
+    assert result.exit_code == 0, result.output
+    assert "http://127.0.0.1:8787/v1" in result.output
+    assert "HEADROOM WRAP: GROK" in result.output

--- a/tests/test_cli/test_wrap_grok.py
+++ b/tests/test_cli/test_wrap_grok.py
@@ -9,6 +9,7 @@ unchanged.
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -16,12 +17,24 @@ import pytest
 from click.testing import CliRunner
 
 from headroom.cli.main import main
-from headroom.providers.grok.runtime import GROK_PROXY_ENV
+from headroom.providers.grok.runtime import DEFAULT_API_URL, GROK_PROXY_ENV
 
 
 @pytest.fixture
 def runner() -> CliRunner:
     return CliRunner()
+
+
+def _write_grok_env_stub(tmp_path: Path) -> Path:
+    """Stub `grok` that prints the proxy env var Grok Build reads at launch."""
+    stub = tmp_path / "grok"
+    stub.write_text(
+        "#!/bin/sh\n"
+        'printf "proxy=%s\\n" "${GROK_CLI_CHAT_PROXY_BASE_URL:-<unset>}"\n'
+        "exit 0\n"
+    )
+    stub.chmod(0o755)
+    return stub
 
 
 # Real Grok CLI shapes lifted from `grok --help` (2026-06).
@@ -214,18 +227,55 @@ def test_wrap_grok_missing_binary(
     assert "grok" in result.output.lower()
 
 
-def test_wrap_grok_stub_binary_receives_proxy_env(
-    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """End-to-end: a real subprocess child must see GROK_CLI_CHAT_PROXY_BASE_URL."""
-    stub = tmp_path / "grok"
-    stub.write_text('#!/bin/sh\nprintf "%s\\n" "$GROK_CLI_CHAT_PROXY_BASE_URL"\nexit 0\n')
-    stub.chmod(0o755)
-    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+class TestGrokHeadroomVsPlain:
+    """Grok without Headroom uses Grok's hosted proxy; wrap routes through localhost."""
 
-    with patch("headroom.cli.wrap._ensure_proxy", return_value=None):
-        result = runner.invoke(main, ["wrap", "grok", "--no-proxy"])
+    def test_plain_grok_leaves_proxy_env_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stub = _write_grok_env_stub(tmp_path)
+        monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+        monkeypatch.delenv(GROK_PROXY_ENV, raising=False)
 
-    assert result.exit_code == 0, result.output
-    assert "http://127.0.0.1:8787/v1" in result.output
-    assert "HEADROOM WRAP: GROK" in result.output
+        result = subprocess.run([str(stub)], capture_output=True, text=True, check=True)
+
+        assert result.stdout.strip() == "proxy=<unset>"
+
+    def test_plain_grok_with_manual_export_still_hits_remote_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stub = _write_grok_env_stub(tmp_path)
+        monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+        monkeypatch.setenv(GROK_PROXY_ENV, DEFAULT_API_URL)
+
+        result = subprocess.run([str(stub)], capture_output=True, text=True, check=True)
+
+        assert result.stdout.strip() == f"proxy={DEFAULT_API_URL}"
+
+    def test_headroom_wrap_points_grok_at_local_proxy(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_grok_env_stub(tmp_path)
+        monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+        monkeypatch.setenv(GROK_PROXY_ENV, DEFAULT_API_URL)
+
+        with patch("headroom.cli.wrap._ensure_proxy", return_value=None):
+            result = runner.invoke(main, ["wrap", "grok", "--no-proxy", "-p", "ship it"])
+
+        assert result.exit_code == 0, result.output
+        assert f"{GROK_PROXY_ENV}=http://127.0.0.1:8787/v1" in result.output
+        assert DEFAULT_API_URL not in result.output
+        assert "HEADROOM WRAP: GROK" in result.output
+
+    def test_headroom_wrap_custom_port_overrides_remote_default(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_grok_env_stub(tmp_path)
+        monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+
+        with patch("headroom.cli.wrap._ensure_proxy", return_value=None):
+            result = runner.invoke(main, ["wrap", "grok", "--no-proxy", "--port", "4242"])
+
+        assert result.exit_code == 0, result.output
+        assert f"{GROK_PROXY_ENV}=http://127.0.0.1:4242/v1" in result.output
+        assert DEFAULT_API_URL not in result.output

--- a/tests/test_cli/test_wrap_grok_live.py
+++ b/tests/test_cli/test_wrap_grok_live.py
@@ -29,6 +29,9 @@ Proxy log confirms Grok traffic is forwarded to the real upstream after the fix:
 Before the upstream fix, wrap grok defaulted the proxy to api.openai.com and
 /v1/settings returned 404. `wrap grok` now passes
 ``openai_api_url=https://cli-chat-proxy.grok.com/v1`` to the proxy launcher.
+
+For token benchmarks on ``/v1/chat/completions``, use Hermes + Headroom instead
+(``HEADROOM_LIVE_HERMES=1`` — see ``tests/test_cli/test_hermes_grok_live.py``).
 """
 
 from __future__ import annotations

--- a/tests/test_cli/test_wrap_grok_live.py
+++ b/tests/test_cli/test_wrap_grok_live.py
@@ -1,0 +1,121 @@
+"""Optional live Grok + Headroom integration tests.
+
+Run manually when Grok auth is available on the host:
+
+    HEADROOM_LIVE_GROK=1 UV_SKIP_WHEEL_FILENAME_CHECK=1 \
+        uv run --extra dev pytest tests/test_cli/test_wrap_grok_live.py -v
+
+Captured on 2026-06-07 (CachyOS, grok 0.2.32, authenticated ~/.grok/auth.json):
+
+**Without Headroom** (direct to cli-chat-proxy.grok.com):
+
+    $ grok -p "Reply with exactly one word: PLAIN_OK" \\
+        --output-format plain --no-plan --always-approve
+    PLAIN_OK
+    # ~12s wall time
+
+**With Headroom** (`headroom wrap grok`, port 8791):
+
+    $ headroom wrap grok --port 8791 -p "Reply with exactly one word: HEADROOM_OK" \\
+        --output-format plain --no-plan --always-approve
+    HEADROOM_OK
+    # ~25s first run (includes proxy cold-start + Kompress model load)
+
+Proxy log confirms Grok traffic is forwarded to the real upstream after the fix:
+
+    GET  https://cli-chat-proxy.grok.com/v1/settings  → HTTP/2 200 OK
+    POST https://cli-chat-proxy.grok.com/v1/sessions/register → HTTP/2 200 OK
+
+Before the upstream fix, wrap grok defaulted the proxy to api.openai.com and
+/v1/settings returned 404. `wrap grok` now passes
+``openai_api_url=https://cli-chat-proxy.grok.com/v1`` to the proxy launcher.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from headroom.providers.grok.runtime import DEFAULT_API_URL, GROK_PROXY_ENV, proxy_base_url
+
+_LIVE = os.environ.get("HEADROOM_LIVE_GROK") == "1"
+pytestmark = pytest.mark.skipif(not _LIVE, reason="set HEADROOM_LIVE_GROK=1 to run live Grok tests")
+
+
+def _grok_auth_present() -> bool:
+    return (Path.home() / ".grok" / "auth.json").exists()
+
+
+@pytest.mark.skipif(not _grok_auth_present(), reason="~/.grok/auth.json missing")
+def test_live_plain_grok_returns_expected_token() -> None:
+    result = subprocess.run(
+        [
+            "grok",
+            "-p",
+            "Reply with exactly one word: PLAIN_OK",
+            "--output-format",
+            "plain",
+            "--no-plan",
+            "--always-approve",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd="/tmp",
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "PLAIN_OK" in result.stdout
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.mark.skipif(not _grok_auth_present(), reason="~/.grok/auth.json missing")
+def test_live_headroom_wrap_grok_routes_through_local_proxy(tmp_path: Path) -> None:
+    port = _pick_free_port()
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["HEADROOM_TELEMETRY"] = "off"
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "headroom",
+            "wrap",
+            "grok",
+            "--port",
+            str(port),
+            "-p",
+            "Reply with exactly one word: HEADROOM_OK",
+            "--output-format",
+            "plain",
+            "--no-plan",
+            "--always-approve",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        cwd=repo_root,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "HEADROOM_OK" in result.stdout
+    assert f"{GROK_PROXY_ENV}={proxy_base_url(port)}" in result.stdout
+
+    log_path = Path.home() / ".headroom" / "logs" / "proxy.log"
+    if log_path.exists():
+        # Give the proxy a moment to flush logs after wrap exits.
+        time.sleep(0.5)
+        log_tail = log_path.read_text(encoding="utf-8", errors="replace")[-20000:]
+        assert DEFAULT_API_URL.rstrip("/v1") in log_tail or "cli-chat-proxy.grok.com" in log_tail

--- a/tests/test_cli/test_wrap_hermes.py
+++ b/tests/test_cli/test_wrap_hermes.py
@@ -1,0 +1,78 @@
+"""Tests for `headroom wrap hermes` command."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+from headroom.providers.hermes.runtime import DEFAULT_HERMES_API_URL, OPENAI_BASE_ENV
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_wrap_hermes_sets_openai_base_and_hermes_upstream(
+    runner: CliRunner, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_run_proxy_only_watcher(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap._run_proxy_only_watcher", side_effect=fake_run_proxy_only_watcher):
+        result = runner.invoke(main, ["wrap", "hermes", "--port", "4242"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["port"] == 4242
+    assert captured["agent_type"] == "hermes"
+    assert captured["openai_api_url"] == DEFAULT_HERMES_API_URL
+
+
+def test_wrap_hermes_custom_upstream_url(
+    runner: CliRunner, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_run_proxy_only_watcher(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap._run_proxy_only_watcher", side_effect=fake_run_proxy_only_watcher):
+        result = runner.invoke(
+            main,
+            ["wrap", "hermes", "--hermes-url", "http://10.0.0.5:38765/v1"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["openai_api_url"] == "http://10.0.0.5:38765/v1"
+
+
+def test_wrap_hermes_runs_command_with_openai_env(
+    runner: CliRunner, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stub = tmp_path / "client"
+    stub.write_text('#!/bin/sh\nprintf "openai=%s\\n" "$OPENAI_BASE_URL"\n')
+    stub.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool):
+        result = runner.invoke(main, ["wrap", "hermes", "--no-proxy", "--", str(stub)])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env[OPENAI_BASE_ENV] == "http://127.0.0.1:8787/v1"
+    assert captured["openai_api_url"] == DEFAULT_HERMES_API_URL
+    assert captured["tool_label"] == "HERMES"

--- a/tests/test_install/test_planner.py
+++ b/tests/test_install/test_planner.py
@@ -16,6 +16,17 @@ def test_resolve_targets_auto_falls_back_when_detection_empty(monkeypatch) -> No
     ]
 
 
+def test_resolve_targets_auto_detects_grok_binary(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "headroom.install.planner.shutil.which",
+        lambda binary: f"/usr/bin/{binary}" if binary == "grok" else None,
+    )
+
+    targets = resolve_targets(ProviderSelectionMode.AUTO.value, [])
+
+    assert targets == [ToolTarget.GROK.value]
+
+
 def test_build_manifest_for_persistent_docker_sets_expected_defaults() -> None:
     manifest = build_manifest(
         profile="default",
@@ -51,7 +62,7 @@ def test_build_manifest_uses_provider_slice_env_builders_for_all_supported_targe
         runtime_kind="python",
         scope="user",
         provider_mode="manual",
-        targets=["claude", "copilot", "codex", "aider", "cursor"],
+        targets=["claude", "copilot", "codex", "grok", "aider", "cursor"],
         port=9999,
         backend="anyllm",
         anyllm_provider="groq",
@@ -64,6 +75,7 @@ def test_build_manifest_uses_provider_slice_env_builders_for_all_supported_targe
 
     assert manifest.tool_envs["claude"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:9999"
     assert manifest.tool_envs["codex"]["OPENAI_BASE_URL"] == "http://127.0.0.1:9999/v1"
+    assert manifest.tool_envs["grok"]["GROK_CLI_CHAT_PROXY_BASE_URL"] == "http://127.0.0.1:9999/v1"
     assert manifest.tool_envs["aider"] == {
         "OPENAI_API_BASE": "http://127.0.0.1:9999/v1",
         "ANTHROPIC_BASE_URL": "http://127.0.0.1:9999",

--- a/tests/test_install/test_providers.py
+++ b/tests/test_install/test_providers.py
@@ -16,6 +16,7 @@ from headroom.providers.codex.install import apply_provider_scope as apply_codex
 from headroom.providers.codex.install import build_install_env as build_codex_install_env
 from headroom.providers.codex.install import revert_provider_scope as revert_codex_provider_scope
 from headroom.providers.copilot.install import build_install_env as build_copilot_install_env
+from headroom.providers.grok.install import build_install_env as build_grok_install_env
 
 
 def _manifest(tmp_path: Path) -> DeploymentManifest:
@@ -84,6 +85,12 @@ def test_codex_build_install_env_returns_proxy_base_url() -> None:
     env = build_codex_install_env(port=5566, backend="ignored")
 
     assert env == {"OPENAI_BASE_URL": "http://127.0.0.1:5566/v1"}
+
+
+def test_grok_build_install_env_returns_proxy_base_url() -> None:
+    env = build_grok_install_env(port=5566, backend="ignored")
+
+    assert env == {"GROK_CLI_CHAT_PROXY_BASE_URL": "http://127.0.0.1:5566/v1"}
 
 
 def test_apply_codex_provider_scope_skips_non_provider_scope(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_providers/test_grok_runtime.py
+++ b/tests/test_providers/test_grok_runtime.py
@@ -27,3 +27,34 @@ def test_build_launch_env_respects_empty_environ() -> None:
 
     assert env == {"GROK_CLI_CHAT_PROXY_BASE_URL": "http://127.0.0.1:8787/v1"}
     assert display == ["GROK_CLI_CHAT_PROXY_BASE_URL=http://127.0.0.1:8787/v1"]
+
+
+def test_build_launch_env_overrides_existing_grok_proxy_url() -> None:
+    """Wrap must always point Grok at the local Headroom proxy, not a stale override."""
+    env, display = build_launch_env(
+        4242,
+        {
+            "GROK_CLI_CHAT_PROXY_BASE_URL": "https://cli-chat-proxy.grok.com/v1",
+            "HOME": "/home/dev",
+        },
+    )
+
+    assert env["GROK_CLI_CHAT_PROXY_BASE_URL"] == "http://127.0.0.1:4242/v1"
+    assert env["HOME"] == "/home/dev"
+    assert display == ["GROK_CLI_CHAT_PROXY_BASE_URL=http://127.0.0.1:4242/v1"]
+
+
+def test_build_launch_env_preserves_unrelated_env_vars() -> None:
+    env, _ = build_launch_env(
+        8787,
+        {
+            "PATH": "/usr/bin",
+            "GROK_COMPACTION_MODE": "segments",
+            "GROK_COMPACTION_DETAIL": "verbose",
+        },
+    )
+
+    assert env["PATH"] == "/usr/bin"
+    assert env["GROK_COMPACTION_MODE"] == "segments"
+    assert env["GROK_COMPACTION_DETAIL"] == "verbose"
+    assert env["GROK_CLI_CHAT_PROXY_BASE_URL"] == "http://127.0.0.1:8787/v1"

--- a/tests/test_providers/test_grok_runtime.py
+++ b/tests/test_providers/test_grok_runtime.py
@@ -1,0 +1,29 @@
+"""Tests for Grok provider runtime helpers."""
+
+from headroom.providers.grok.runtime import (
+    DEFAULT_API_URL,
+    build_launch_env,
+    proxy_base_url,
+)
+
+
+def test_proxy_base_url() -> None:
+    assert proxy_base_url(8787) == "http://127.0.0.1:8787/v1"
+
+
+def test_default_api_url() -> None:
+    assert DEFAULT_API_URL == "https://cli-chat-proxy.grok.com/v1"
+
+
+def test_build_launch_env_sets_grok_proxy_override() -> None:
+    env, display = build_launch_env(9999, {"HOME": "/tmp"})
+    assert env["GROK_CLI_CHAT_PROXY_BASE_URL"] == "http://127.0.0.1:9999/v1"
+    assert env["HOME"] == "/tmp"
+    assert display == ["GROK_CLI_CHAT_PROXY_BASE_URL=http://127.0.0.1:9999/v1"]
+
+
+def test_build_launch_env_respects_empty_environ() -> None:
+    env, display = build_launch_env(8787, {})
+
+    assert env == {"GROK_CLI_CHAT_PROXY_BASE_URL": "http://127.0.0.1:8787/v1"}
+    assert display == ["GROK_CLI_CHAT_PROXY_BASE_URL=http://127.0.0.1:8787/v1"]

--- a/tests/test_providers/test_hermes_runtime.py
+++ b/tests/test_providers/test_hermes_runtime.py
@@ -1,0 +1,22 @@
+"""Tests for Hermes provider runtime helpers."""
+
+from headroom.providers.hermes.runtime import (
+    DEFAULT_HERMES_API_URL,
+    build_launch_env,
+    proxy_base_url,
+)
+
+
+def test_proxy_base_url() -> None:
+    assert proxy_base_url(8787) == "http://127.0.0.1:8787/v1"
+
+
+def test_default_hermes_api_url_has_v1_suffix() -> None:
+    assert DEFAULT_HERMES_API_URL.endswith("/v1")
+
+
+def test_build_launch_env_sets_openai_base_url() -> None:
+    env, display = build_launch_env(9999, {"HOME": "/tmp"})
+    assert env["OPENAI_BASE_URL"] == "http://127.0.0.1:9999/v1"
+    assert env["HOME"] == "/tmp"
+    assert display == ["OPENAI_BASE_URL=http://127.0.0.1:9999/v1"]

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -754,6 +754,21 @@ grok -p "fix the bug"
 ```bash
 headroom wrap grok -p "fix the bug"
 # GROK_CLI_CHAT_PROXY_BASE_URL=http://127.0.0.1:8787/v1
+# Proxy upstream: https://cli-chat-proxy.grok.com/v1
+```
+
+**Live verification** (grok 0.2.32, authenticated host, 2026-06-07):
+
+| Mode | Command | Response | Upstream |
+|---|---|---|---|
+| Plain | `grok -p "…PLAIN_OK" --output-format plain --no-plan --always-approve` | `PLAIN_OK` | `cli-chat-proxy.grok.com` (direct) |
+| Wrapped | `headroom wrap grok -p "…HEADROOM_OK" …` | `HEADROOM_OK` | `127.0.0.1:8791/v1` → `cli-chat-proxy.grok.com` |
+
+Proxy log excerpt after a wrapped run:
+
+```text
+GET  https://cli-chat-proxy.grok.com/v1/settings → HTTP/2 200 OK
+POST https://cli-chat-proxy.grok.com/v1/sessions/register → HTTP/2 200 OK
 ```
 
 More examples:

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -804,10 +804,17 @@ python scripts/bench_hermes_headroom.py
 python scripts/bench_hermes_headroom.py --multi-turn
 ```
 
-Captured on spot-tech-ci (2026-06-07): plain and Headroom→Hermes both returned
-``BENCH_OK`` from the ``grok`` backend; single-turn ``prompt_tokens`` were 3357
-each with ``tokens.saved: 0`` on synthetic log filler (routing verified; savings
-show up on real agent/tool workloads). See ``tests/test_cli/test_hermes_grok_live.py``.
+Captured on spot-tech-ci (2026-06-07, **agent-tool workload** — large
+``role: tool`` JSON output):
+
+| Path | ``prompt_tokens`` | ``tokens.saved`` |
+|------|-------------------|------------------|
+| Plain Hermes | 9,763 | — |
+| Headroom → Hermes | 7,964 | 562 (`smart_crusher`: 1,799) |
+
+Plain user/system log filler does **not** compress — use tool-output-shaped
+messages (what WSB/anime bots send). See ``tests/test_cli/hermes_workloads.py``
+and ``scripts/bench_hermes_headroom.py``.
 
 More examples:
 

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -807,6 +807,11 @@ systemctl --user enable --now headroom-hermes.service
 curl -s http://127.0.0.1:18787/stats | jq '.tokens.saved'
 python scripts/bench_hermes_headroom.py --canary-port 18787
 
+# UFW (Docker bridges cannot reach :18787 until allowed):
+sudo ufw allow from 172.18.0.0/16 to any port 18787 proto tcp
+sudo ufw allow from 172.20.0.0/16 to any port 18787 proto tcp
+sudo ufw allow from 172.17.0.0/16 to any port 18787 proto tcp
+
 # Route one bot (e.g. wsb-digest) through the canary in spot-tech compose:
 # FALKBOT_PROVIDER_BACKENDS baseUrl -> http://172.18.0.1:18787/v1
 # Keep IMAGE_GROK_BASE_URL on :38765 (non-chat paths).

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -798,13 +798,17 @@ systemctl --user status llm-proxy hermes-xai-proxy       # both active
 export PATH="$HOME/.local/bin:$PATH"
 uv tool install 'headroom-ai[proxy]'                      # once if needed
 
-# Persistent canary (optional)
+# Persistent canary (optional; uses :18787 — falkbot-ops docker owns :8787)
 cp scripts/spot-tech-ci-headroom-hermes.service.example \
   ~/.config/systemd/user/headroom-hermes.service
+systemctl --user daemon-reload
 systemctl --user enable --now headroom-hermes.service
+curl -s http://127.0.0.1:18787/stats | jq '.tokens.saved'
 
 # Live pytest (opt-in; minimal venv on CI host)
 HEADROOM_LIVE_HERMES=1 pytest tests/test_cli/test_hermes_grok_live.py -v
+HEADROOM_LIVE_HERMES=1 HEADROOM_LIVE_CANARY=1 \\
+  pytest tests/test_cli/test_hermes_canary_live.py -v
 
 # Token bench (exits non-zero if savings below regression floor)
 python scripts/bench_hermes_headroom.py

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -799,11 +799,17 @@ export PATH="$HOME/.local/bin:$PATH"
 uv tool install 'headroom-ai[proxy]'                      # once if needed
 
 # Persistent canary (optional; uses :18787 — falkbot-ops docker owns :8787)
+# Binds 0.0.0.0 so Docker bots can use http://172.18.0.1:18787/v1
 cp scripts/spot-tech-ci-headroom-hermes.service.example \
   ~/.config/systemd/user/headroom-hermes.service
 systemctl --user daemon-reload
 systemctl --user enable --now headroom-hermes.service
 curl -s http://127.0.0.1:18787/stats | jq '.tokens.saved'
+python scripts/bench_hermes_headroom.py --canary-port 18787
+
+# Route one bot (e.g. wsb-digest) through the canary in spot-tech compose:
+# FALKBOT_PROVIDER_BACKENDS baseUrl -> http://172.18.0.1:18787/v1
+# Keep IMAGE_GROK_BASE_URL on :38765 (non-chat paths).
 
 # Live pytest (opt-in; minimal venv on CI host)
 HEADROOM_LIVE_HERMES=1 pytest tests/test_cli/test_hermes_grok_live.py -v

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -771,6 +771,44 @@ GET  https://cli-chat-proxy.grok.com/v1/settings → HTTP/2 200 OK
 POST https://cli-chat-proxy.grok.com/v1/sessions/register → HTTP/2 200 OK
 ```
 
+**Token savings** — Grok Build headless ``-p`` uses ``/v1/sessions/*`` and
+``/v1/traces`` (passthrough today). For measurable compression on
+``/v1/chat/completions``, route through Hermes instead:
+
+```bash
+# Plain — bots already use this shape (grok-hermes → :38765/v1)
+curl -s http://127.0.0.1:38765/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"grok-4.3","messages":[{"role":"user","content":"Say OK"}],"max_tokens":8}'
+
+# Headroom → Hermes → Grok OAuth
+headroom proxy --openai-api-url http://127.0.0.1:38765/v1 --no-telemetry
+OPENAI_BASE_URL=http://127.0.0.1:8787/v1 your-openai-client
+curl -s http://127.0.0.1:8787/stats | jq '.tokens.saved'
+```
+
+**spot-tech-ci runbook** (``falk@80.241.217.210``, Hermes always-on):
+
+```bash
+curl -s http://127.0.0.1:38765/health                    # => ok
+systemctl --user status llm-proxy hermes-xai-proxy       # both active
+export PATH="$HOME/.local/bin:$PATH"
+uv tool install 'headroom-ai[proxy]'                      # once if needed
+
+# Live pytest (opt-in)
+HEADROOM_LIVE_HERMES=1 uv run --extra dev \
+  pytest tests/test_cli/test_hermes_grok_live.py -v
+
+# Token bench script
+python scripts/bench_hermes_headroom.py
+python scripts/bench_hermes_headroom.py --multi-turn
+```
+
+Captured on spot-tech-ci (2026-06-07): plain and Headroom→Hermes both returned
+``BENCH_OK`` from the ``grok`` backend; single-turn ``prompt_tokens`` were 3357
+each with ``tokens.saved: 0`` on synthetic log filler (routing verified; savings
+show up on real agent/tool workloads). See ``tests/test_cli/test_hermes_grok_live.py``.
+
 More examples:
 
 ```bash

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -32,6 +32,7 @@ This page is the authoritative reference for the **Python Headroom CLI** exposed
 | `headroom wrap claude` | Start proxy and launch Claude Code | **host-bridged** |
 | `headroom wrap copilot` | Start proxy and launch GitHub Copilot CLI | **python-native only** |
 | `headroom wrap codex` | Start proxy and launch Codex CLI | **host-bridged** |
+| `headroom wrap grok` | Start proxy and launch Grok Build CLI | **host-bridged** |
 | `headroom wrap aider` | Start proxy and launch Aider | **host-bridged** |
 | `headroom wrap cursor` | Start proxy and print Cursor config guidance | **host-bridged** |
 | `headroom wrap openclaw` | Install and configure the OpenClaw plugin | **host-bridged** |
@@ -590,7 +591,7 @@ Options:
                                   [default: user]
   --providers [auto|all|manual]   Target selection mode for direct tool
                                   configuration.  [default: auto]
-  --target [claude|copilot|codex|aider|cursor|openclaw]
+  --target [claude|copilot|codex|grok|aider|cursor|openclaw]
                                   Tool target to configure when --providers
                                   manual is used.
   --profile TEXT                  Deployment profile name.  [default: default]
@@ -738,6 +739,30 @@ headroom wrap codex --backend anyllm --anyllm-provider groq
 | `codex_args...` | passthrough | Additional Codex CLI arguments |
 
 Requires the `codex` binary on the host.
+
+### `headroom wrap grok`
+
+```bash
+headroom wrap grok
+headroom wrap grok -p "fix the bug"
+headroom wrap grok -- -p "fix the bug"
+headroom wrap grok --backend anyllm --anyllm-provider groq
+```
+
+| Option / arg | Default | Meaning |
+|---|---|---|
+| `--port` | `8787` | Proxy port |
+| `--no-proxy` | off | Skip proxy startup and assume an existing proxy is running |
+| `--learn` | off | Enable live traffic learning |
+| `--memory` | off | Enable persistent cross-session memory |
+| `--backend` | unset | Proxy backend override |
+| `--anyllm-provider` | unset | `anyllm` provider override |
+| `--region` | unset | Cloud region override |
+| `grok_args...` | passthrough | Additional Grok Build CLI arguments |
+
+Sets `GROK_CLI_CHAT_PROXY_BASE_URL` so Grok routes cli-chat-proxy traffic through Headroom. Requires the `grok` binary on the host.
+
+Use `--` before Grok arguments when a Grok flag could collide with a Headroom option. Grok's `-p` prompt flag also works directly because `headroom wrap grok` preserves unknown options for passthrough.
 
 ### `headroom wrap copilot`
 

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -771,9 +771,11 @@ GET  https://cli-chat-proxy.grok.com/v1/settings → HTTP/2 200 OK
 POST https://cli-chat-proxy.grok.com/v1/sessions/register → HTTP/2 200 OK
 ```
 
-**Token savings** — Grok Build headless ``-p`` uses ``/v1/sessions/*`` and
-``/v1/traces`` (passthrough today). For measurable compression on
-``/v1/chat/completions``, route through Hermes instead:
+**Routing vs compression** — ``wrap grok`` routes Grok Build ``/v1/sessions/*``
+traffic (passthrough on headless ``-p`` today). For measurable compression use
+``wrap hermes`` (OpenAI ``/v1/chat/completions`` → Hermes llm-proxy).
+
+**Token savings** — large ``role: tool`` outputs compress via SmartCrusher:
 
 ```bash
 # Plain — bots already use this shape (grok-hermes → :38765/v1)
@@ -781,8 +783,9 @@ curl -s http://127.0.0.1:38765/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"grok-4.3","messages":[{"role":"user","content":"Say OK"}],"max_tokens":8}'
 
-# Headroom → Hermes → Grok OAuth
-headroom proxy --openai-api-url http://127.0.0.1:38765/v1 --no-telemetry
+# Headroom → Hermes → Grok OAuth (preferred)
+headroom wrap hermes
+# or: headroom proxy --openai-api-url http://127.0.0.1:38765/v1 --no-telemetry
 OPENAI_BASE_URL=http://127.0.0.1:8787/v1 your-openai-client
 curl -s http://127.0.0.1:8787/stats | jq '.tokens.saved'
 ```
@@ -795,11 +798,15 @@ systemctl --user status llm-proxy hermes-xai-proxy       # both active
 export PATH="$HOME/.local/bin:$PATH"
 uv tool install 'headroom-ai[proxy]'                      # once if needed
 
-# Live pytest (opt-in)
-HEADROOM_LIVE_HERMES=1 uv run --extra dev \
-  pytest tests/test_cli/test_hermes_grok_live.py -v
+# Persistent canary (optional)
+cp scripts/spot-tech-ci-headroom-hermes.service.example \
+  ~/.config/systemd/user/headroom-hermes.service
+systemctl --user enable --now headroom-hermes.service
 
-# Token bench script
+# Live pytest (opt-in; minimal venv on CI host)
+HEADROOM_LIVE_HERMES=1 pytest tests/test_cli/test_hermes_grok_live.py -v
+
+# Token bench (exits non-zero if savings below regression floor)
 python scripts/bench_hermes_headroom.py
 python scripts/bench_hermes_headroom.py --multi-turn
 ```

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -742,11 +742,28 @@ Requires the `codex` binary on the host.
 
 ### `headroom wrap grok`
 
+**Without Headroom** — Grok Build talks directly to Grok's hosted cli-chat-proxy (no local compression):
+
+```bash
+grok -p "fix the bug"
+# GROK_CLI_CHAT_PROXY_BASE_URL unset → https://cli-chat-proxy.grok.com/v1
+```
+
+**With Headroom** — the same command routes cli-chat-proxy traffic through the local proxy:
+
+```bash
+headroom wrap grok -p "fix the bug"
+# GROK_CLI_CHAT_PROXY_BASE_URL=http://127.0.0.1:8787/v1
+```
+
+More examples:
+
 ```bash
 headroom wrap grok
 headroom wrap grok -p "fix the bug"
 headroom wrap grok -- -p "fix the bug"
 headroom wrap grok --backend anyllm --anyllm-provider groq
+headroom install apply --providers manual --target grok
 ```
 
 | Option / arg | Default | Meaning |
@@ -760,7 +777,7 @@ headroom wrap grok --backend anyllm --anyllm-provider groq
 | `--region` | unset | Cloud region override |
 | `grok_args...` | passthrough | Additional Grok Build CLI arguments |
 
-Sets `GROK_CLI_CHAT_PROXY_BASE_URL` so Grok routes cli-chat-proxy traffic through Headroom. Requires the `grok` binary on the host.
+Sets `GROK_CLI_CHAT_PROXY_BASE_URL` so Grok routes cli-chat-proxy traffic through Headroom. Requires the `grok` binary on the host. Like `wrap aider`, this is launch-time env injection only — no on-disk Grok config is modified.
 
 Use `--` before Grok arguments when a Grok flag could collide with a Headroom option. Grok's `-p` prompt flag also works directly because `headroom wrap grok` preserves unknown options for passthrough.
 
@@ -893,6 +910,7 @@ Legend:
 | `headroom wrap claude` | native | host-bridged | partial |
 | `headroom wrap copilot` | native | not implemented in Docker-native wrapper | none |
 | `headroom wrap codex` | native | host-bridged | partial |
+| `headroom wrap grok` | native | host-bridged | partial |
 | `headroom wrap aider` | native | host-bridged | partial |
 | `headroom wrap cursor` | native | host-bridged | partial |
 | `headroom wrap openclaw` | native | host-bridged | partial |


### PR DESCRIPTION
## Status: **Draft** — routing + `wrap hermes` + Hermes compression verified on spot-tech-ci.

## Description

Adds first-class **Grok Build** and **Hermes llm-proxy** support to Headroom's `wrap` and persistent-install flows.

- **`wrap grok`** — routes Grok Build CLI through Headroom to `cli-chat-proxy.grok.com/v1` (sessions/traces passthrough; not the compression path)
- **`wrap hermes`** — routes OpenAI-compatible chat through Headroom into Hermes (`:38765`), where SmartCrusher compresses large `role: tool` outputs

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (proxy upstream for Grok was defaulting to api.openai.com)
- [x] Documentation update

## Changes Made

- `headroom wrap grok` — sets `GROK_CLI_CHAT_PROXY_BASE_URL`, routes to `cli-chat-proxy.grok.com/v1`
- **`headroom wrap hermes`** — `--hermes-url` / `HEADROOM_HERMES_BASE_URL`, optional child command launch
- Provider slices: `headroom/providers/grok/`, **`headroom/providers/hermes/`**, `ToolTarget.GROK` + **`ToolTarget.HERMES`**
- **Hermes live tests:** `tests/test_cli/test_hermes_grok_live.py` with strict regression floors (`HEADROOM_LIVE_HERMES=1`)
- **Unit tests:** `tests/test_cli/test_wrap_hermes.py`, `tests/test_providers/test_hermes_runtime.py`
- **Shared workloads:** `tests/test_cli/hermes_workloads.py`, `tests/test_cli/hermes_support.py`
- **Token bench:** `scripts/bench_hermes_headroom.py` exits `2` on regression; spot-tech-ci runbook in `wiki/cli.md`
- Canary systemd unit on spot-tech-ci: port **18787** (falkbot-ops docker owns :8787); `HEADROOM_LIVE_CANARY=1` test added

## Testing

- [x] Unit tests — **25 passed** (wrap grok + wrap hermes + hermes runtime), 5 live skipped by default
- [x] Live Grok CLI (`HEADROOM_LIVE_GROK=1`) — routing verified
- [x] Live Hermes on spot-tech-ci (`HEADROOM_LIVE_HERMES=1`) — **5/5 passed**, compression confirmed
- [x] Bench regression floors on spot-tech-ci — agent-tool + multi-turn **exit 0**

## Real behavior proof

### Grok Build CLI (sessions API — passthrough)

| Mode | Response | Upstream |
|------|----------|----------|
| Plain `grok -p` | `PLAIN_OK` | `cli-chat-proxy.grok.com` direct |
| `headroom wrap grok` | `HEADROOM_OK` | `127.0.0.1:PORT/v1` → cli-chat-proxy |

### Hermes on spot-tech-ci (`falk@80.241.217.210`, `:38765`)

**Key insight:** Headroom compresses large **`role: tool`** outputs (SmartCrusher), not plain user/system prose.

**Agent-tool benchmark** (`python scripts/bench_hermes_headroom.py`):

| Path | `prompt_tokens` | Savings |
|------|-----------------|---------|
| Plain Hermes | 9,769 | — |
| Headroom → Hermes | 7,970 | **1,799 upstream delta**, `tokens.saved: 562`, `smart_crusher: 1799` |

**Multi-turn agent-tool** (`--multi-turn`):

| Path | `prompt_tokens` | Savings |
|------|-----------------|---------|
| Plain Hermes | 23,290 | — |
| Headroom → Hermes | 18,973 | **4,317 upstream delta**, `tokens.saved: 1349` |

**Regression floors** (bench + live): `min_upstream_prompt_delta ≥ 1000`, `min_smart_crusher_saved ≥ 1000`, `min_headroom_tokens_saved ≥ 100`

```bash
# spot-tech-ci
export PATH="$HOME/.local/bin:$PATH"
cd ~/headroom-wrap-grok-clean && source .venv-live/bin/activate
HEADROOM_LIVE_HERMES=1 pytest tests/test_cli/test_hermes_grok_live.py -v   # 5 passed
python scripts/bench_hermes_headroom.py                                     # exit 0
python scripts/bench_hermes_headroom.py --multi-turn                        # exit 0
```

## Usage

```bash
# Grok Build CLI (sessions API — routing, not compression)
headroom wrap grok -p "fix the bug"

# Bots / OpenAI clients via Hermes (compressible path)
headroom wrap hermes
headroom wrap hermes --hermes-url http://127.0.0.1:38765/v1
headroom wrap hermes -- python scripts/bench_hermes_headroom.py
headroom install apply --providers manual --target hermes
```

## Additional Notes

- Supersedes #719, #721, #722.
- spot-tech-ci: use minimal venv (`uv pip install httpx pytest`) — full editable install needs Rust/C++ toolchain.
- Published `uv tool install headroom-ai` won't include `wrap hermes` until this release ships; test from synced repo on CI.

## Canary in production (spot-tech-ci)

- **headroom-hermes.service** on `:18787` (bind `0.0.0.0`; UFW allows Docker bridges)
- **wsb-digest** routed: `FALKBOT_PROVIDER_BACKENDS` → `http://172.18.0.1:18787/v1`; images stay on `:38765`
- Bench: `python scripts/bench_hermes_headroom.py --canary-port 18787`