### PR TITLE
fix(deps): bump brace-expansion for CVE-2026-45149

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1810,7 +1810,7 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
+			"version": "5.0.6",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"


### PR DESCRIPTION
# Summary

Bumps `brace-expansion` to `5.0.6` to remediate **CVE-2026-45149**.

## Defect

CVE-2026-45149: A large numeric range passed to `brace-expansion` defeats the documented `max` DoS protection, causing excessive memory consumption and CPU exhaustion during pattern expansion.

## VIPER Source Hash

`bf3302987a86d3f5`

## Reachability

**Verdict: NOT_REACHABLE** from hermes-agent application/runtime code. See the reachability report from task t_aeeb9d77:

- Lockfile inspected: 10 `brace-expansion` instances identified, all with `dev: true`.
- Source grep: 0 imports/requires of `brace-expansion`, `minimatch`, `glob`, `rimraf`, `mocha`, `filelist`, or `jackspeak` in application source.
- All instances are transitive devDependencies consumed only during linting, bundling, and test cleanup.
- No user-controlled input can reach the vulnerable code path at runtime.

Full report: `/opt/kanban/kanban/workspaces/t_aeeb9d77/brace-expansion-reachability-aeeb9d77.md`

## npm Audit Confirmation

After the bump:
- `brace-expansion` is completely absent from the vulnerability list.
- Remaining audit findings (7 moderate) are unrelated to this CVE and affect `@anthropic-ai/sdk` and `postcss` (build-time only).

## Test Results

`npm ci` installs cleanly, and the test suite passes with no regressions. No functional code changes — this is a lockfile-only dependency bump.

## Acceptance Criteria Amendment

The source finding suggested that if reachability analysis showed the code path was not reachable, the acceptance criteria could be amended. The reachability analysis **confirms NOT_REACHABLE**; however, we still proceed with the bump for dependency hygiene and clean audit output.
