### PR TITLE
feat(compression): add boolean-logic and NL-boolean compression paths

### DIFF
--- a/headroom/transforms/boolean_compressor.py
+++ b/headroom/transforms/boolean_compressor.py
@@ -1,0 +1,423 @@
+"""Boolean algebra compressor — lossless token reduction for boolean logic content.
+
+Two compression paths share this module:
+
+1. BooleanCompressor  — zero LLM calls, always lossless.
+   Handles structured boolean content: truth tables (markdown or plain-text) and
+   expressions written with single uppercase variables (A, B, C …) in any notation
+   (symbolic, English operators, mixed). Uses Quine-McCluskey via boolean-algebra-engine
+   to produce the minimal SOP form.
+
+2. NLBooleanCompressor  — optional, requires an API key (Anthropic or OpenAI).
+   Handles natural-language logic descriptions such as
+   "output is high when door is open AND motion is detected but not both".
+   The NL layer (boolean-algebra-engine[nl]) calls an LLM once to extract the
+   boolean function, then synthesizes the minimal SOP — the math is still lossless.
+   Activated only when ANTHROPIC_API_KEY or OPENAI_API_KEY is set in the environment.
+
+Compression examples:
+  - Truth table (8 rows, ~80 tokens)      → "B.C+A.C+A.B"  (4 tokens,  ~91% savings)
+  - English expression (17 tokens)        → "B.C+A.C+A.B"  (4 tokens,  ~71% savings)
+  - NL description (15 tokens)            → "A^B"          (2 tokens,  ~87% savings)
+
+Telemetry: fires an anonymous PostHog event to the boolean-algebra-engine project
+each time a compression occurs, reporting tokens_before, tokens_after, variable_count,
+and strategy. Respects BOOLCALC_NO_TELEMETRY=1.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    pass
+
+
+# ── Notation normalisation ────────────────────────────────────────────────────
+
+# Order matters: longer patterns before shorter ones
+_NORMALISE_RULES: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bXNOR\b",  re.I), "^"),   # XNOR → ^ (not standard, but handle)
+    (re.compile(r"\bXOR\b",   re.I), "^"),
+    (re.compile(r"\bNAND\b",  re.I), "!."),  # approximate
+    (re.compile(r"\bNOR\b",   re.I), "!+"),  # approximate
+    (re.compile(r"\bNOT\s+",  re.I), "!"),
+    (re.compile(r"\bAND\b",   re.I), "."),
+    (re.compile(r"\bOR\b",    re.I), "+"),
+    (re.compile(r"\|\|"),           "+"),
+    (re.compile(r"&&"),             "."),
+    (re.compile(r"[~¬]"),           "!"),
+    (re.compile(r"\|(?!\|)"),       "+"),
+    (re.compile(r"&(?!&)"),         "."),
+    (re.compile(r"\s+"),            ""),      # strip all whitespace last
+]
+
+
+def _normalise(expr: str) -> str:
+    """Normalise various boolean notations to boolcalc syntax (A.B+!C)."""
+    for pattern, replacement in _NORMALISE_RULES:
+        expr = pattern.sub(replacement, expr)
+    return expr.strip()
+
+
+# ── Truth table parsing ───────────────────────────────────────────────────────
+
+_BINARY_ROW  = re.compile(r"^[\s|]*([01][\s|]+)+[01][\s|]*$")
+_MD_HEADER   = re.compile(r"^\|?\s*([A-Za-z_]\w*\s*\|?\s*)+$")
+_VAR_EXTRACT = re.compile(r"[A-Za-z_]\w*")
+
+
+@dataclass
+class _ParsedTable:
+    variables: list[str]
+    minterms:  list[int]
+
+
+def _try_parse_truth_table(content: str) -> "_ParsedTable | None":
+    """Parse a markdown or space-separated truth table.
+
+    Returns _ParsedTable if confident, None otherwise.
+    """
+    lines = [l.strip() for l in content.strip().splitlines() if l.strip()]
+    # Need at least a header + one data row
+    if len(lines) < 2:
+        return None
+
+    # Find header line (contains variable names, no binary data)
+    header_line = None
+    data_start   = 0
+    for i, line in enumerate(lines):
+        clean = re.sub(r"[|\-:+]", " ", line).strip()
+        words = clean.split()
+        if words and all(re.match(r"^[A-Za-z_]\w*$", w) for w in words):
+            header_line = words
+            data_start  = i + 1
+            # Skip markdown separator row (---|---...)
+            if data_start < len(lines) and re.match(r"^[\s|:\-]+$", lines[data_start]):
+                data_start += 1
+            break
+
+    if header_line is None or len(header_line) < 2:
+        return None
+
+    variables = header_line[:-1]   # all but last column
+    # output_col = header_line[-1]  # not used — last column is output
+
+    if not (1 <= len(variables) <= 8):
+        return None
+
+    # Parse data rows
+    minterms: list[int] = []
+    row_index = 0
+    for line in lines[data_start:]:
+        clean  = re.sub(r"[|\s]+", " ", line).strip()
+        values = clean.split()
+        if not values:
+            continue
+        if not all(v in ("0", "1") for v in values):
+            return None  # non-binary cell → not a truth table
+        if len(values) != len(header_line):
+            return None  # column count mismatch
+        if int(values[-1]) == 1:
+            minterms.append(row_index)
+        row_index += 1
+
+    expected_rows = 2 ** len(variables)
+    if row_index != expected_rows:
+        return None  # incomplete table
+
+    return _ParsedTable(variables=variables, minterms=minterms)
+
+
+# ── Compression result ────────────────────────────────────────────────────────
+
+@dataclass
+class BooleanCompressionResult:
+    compressed:        str
+    original:          str
+    original_tokens:   int
+    compressed_tokens: int
+    variable_count:    int
+    strategy:          str   # "expression" | "truth_table"
+
+    @property
+    def tokens_saved(self) -> int:
+        return max(0, self.original_tokens - self.compressed_tokens)
+
+    @property
+    def savings_pct(self) -> float:
+        if self.original_tokens == 0:
+            return 0.0
+        return 100.0 * self.tokens_saved / self.original_tokens
+
+
+# ── Core compressor ───────────────────────────────────────────────────────────
+
+class BooleanCompressor:
+    """Lossless boolean algebra compressor.
+
+    Requires: pip install boolean-algebra-engine
+    Optional dependency — fails gracefully if not installed.
+    """
+
+    def compress(self, content: str) -> "BooleanCompressionResult | None":
+        """Compress boolean content. Returns None on failure (caller should passthrough)."""
+        try:
+            result = self._compress_truth_table(content)
+            if result is None:
+                result = self._compress_expression(content)
+            return result
+        except Exception as exc:
+            logger.debug("BooleanCompressor: compression failed: %s", exc)
+            return None
+
+    def _compress_truth_table(self, content: str) -> "BooleanCompressionResult | None":
+        parsed = _try_parse_truth_table(content)
+        if parsed is None:
+            return None
+        if not parsed.minterms and len(parsed.variables) > 0:
+            # Contradiction — all outputs 0
+            minimal = "0"
+        elif len(parsed.minterms) == 2 ** len(parsed.variables):
+            # Tautology — all outputs 1
+            minimal = "1"
+        else:
+            try:
+                from boolean_algebra_engine.core.models import TruthTable, TruthTableRow
+                from boolean_algebra_engine import synthesize
+
+                rows: list[TruthTableRow] = []
+                n = len(parsed.variables)
+                for i in range(2 ** n):
+                    bits = [(i >> (n - 1 - j)) & 1 for j in range(n)]
+                    inputs = dict(zip(parsed.variables, bits))
+                    output = 1 if i in parsed.minterms else 0
+                    rows.append(TruthTableRow(inputs=inputs, output=output))
+
+                table = TruthTable(
+                    expression="(truth table)",
+                    variables=list(parsed.variables),
+                    rows=rows,
+                )
+                minimal, _ = synthesize(table)
+            except Exception as exc:
+                logger.debug("BooleanCompressor: synthesize failed: %s", exc)
+                return None
+
+        original_tokens   = len(content.split())
+        compressed_tokens = len(minimal.split())
+        if compressed_tokens >= original_tokens:
+            return None  # no savings
+
+        header = (
+            f"[boolean-simplified: {', '.join(parsed.variables)} → {minimal}]\n"
+        )
+        compressed = header + minimal
+
+        return BooleanCompressionResult(
+            compressed        = compressed,
+            original          = content,
+            original_tokens   = original_tokens,
+            compressed_tokens = len(compressed.split()),
+            variable_count    = len(parsed.variables),
+            strategy          = "truth_table",
+        )
+
+    def _compress_expression(self, content: str) -> "BooleanCompressionResult | None":
+        content_stripped = content.strip()
+        # Only compress if it looks like a single expression (not prose)
+        if "\n" in content_stripped and not re.search(r"\b(AND|OR|NOT|XOR)\b", content_stripped, re.I):
+            return None
+        # Collapse multi-line expressions (each line is one expression or one term)
+        lines = [l.strip() for l in content_stripped.splitlines() if l.strip()]
+        expr_line = " ".join(lines) if len(lines) > 1 else content_stripped
+
+        normalised = _normalise(expr_line)
+
+        # Must contain at least one operator to be worth compressing
+        if not re.search(r"[.+!^]", normalised):
+            return None
+        # Sanity: only boolcalc-legal characters
+        if not re.match(r"^[A-Za-z0-9_.+!^()]+$", normalised):
+            return None
+
+        try:
+            from boolean_algebra_engine import evaluate, synthesize
+
+            table, _  = evaluate(normalised)
+            minimal, m = synthesize(table)
+        except Exception as exc:
+            logger.debug("BooleanCompressor: expression evaluate/synthesize failed: %s", exc)
+            return None
+
+        original_tokens   = len(content.split())
+        compressed_tokens = len(minimal.split())
+        if compressed_tokens >= original_tokens:
+            return None
+
+        var_count  = len(table.variables)
+        compressed = f"[boolean-simplified: {normalised} → {minimal}]\n{minimal}"
+
+        return BooleanCompressionResult(
+            compressed        = compressed,
+            original          = content,
+            original_tokens   = original_tokens,
+            compressed_tokens = len(compressed.split()),
+            variable_count    = var_count,
+            strategy          = "expression",
+        )
+
+
+# ── Anonymous telemetry ───────────────────────────────────────────────────────
+
+_PH_KEY      = "phc_Am4NNyVXotVffz6rcBy8xZVUZeaJCCbbHMu63pWMz3M8"
+_PH_ENDPOINT = "https://us.i.posthog.com/capture/"
+_CONFIG_FILE = (
+    __import__("pathlib").Path(
+        __import__("os").environ.get("XDG_CONFIG_HOME", __import__("pathlib").Path.home() / ".config")
+    ) / "boolcalc" / "telemetry.json"
+)
+
+
+def _fire_telemetry(result: BooleanCompressionResult) -> None:
+    """Fire a PostHog event reporting boolean compression usage from headroom.
+
+    Uses the same install_id as the boolcalc CLI so PostHog can correlate
+    headroom usage with direct CLI usage under one user profile.
+    Runs in a daemon thread — never blocks compression.
+    Respects BOOLCALC_NO_TELEMETRY=1.
+    """
+    if os.environ.get("BOOLCALC_NO_TELEMETRY"):
+        return
+
+    def _send() -> None:
+        try:
+            import json
+            import urllib.request
+
+            install_id = "headroom-anonymous"
+            try:
+                if _CONFIG_FILE.exists():
+                    state      = json.loads(_CONFIG_FILE.read_text())
+                    install_id = state.get("install_id", install_id)
+            except Exception:
+                pass
+
+            payload = json.dumps({
+                "api_key":     _PH_KEY,
+                "event":       "headroom_boolean_compress",
+                "distinct_id": install_id,
+                "properties": {
+                    "tokens_before":  result.original_tokens,
+                    "tokens_after":   result.compressed_tokens,
+                    "tokens_saved":   result.tokens_saved,
+                    "savings_pct":    round(result.savings_pct, 1),
+                    "variable_count": result.variable_count,
+                    "strategy":       result.strategy,
+                    "source":         "headroom",
+                },
+            }).encode()
+
+            req = urllib.request.Request(
+                _PH_ENDPOINT,
+                data    = payload,
+                headers = {"Content-Type": "application/json"},
+                method  = "POST",
+            )
+            urllib.request.urlopen(req, timeout=3)
+        except Exception:
+            pass
+
+    threading.Thread(target=_send, daemon=True).start()
+
+
+# ── NL Boolean Compressor ─────────────────────────────────────────────────────
+
+# Natural-language logic description markers
+_NL_LOGIC_PATTERNS = [
+    re.compile(r"\b(output|signal|result|flag|value|state)\s+(is\s+)?(high|low|true|false|1|0|on|off)\s+(when|if|whenever)\b", re.I),
+    re.compile(r"\b(true|on|active|high|enabled)\s+(only\s+)?(if|when|whenever|iff)\b", re.I),
+    re.compile(r"\b(if|when)\s+\w+\s+(and|or|not|xor|nor|nand)\s+\w+\b", re.I),
+    re.compile(r"\b(lights?|motor|alarm|gate|switch|relay)\s+(turns?\s+)?(on|off)\s+(when|if)\b", re.I),
+]
+
+_NL_OPERATOR_WORDS = re.compile(
+    r"\b(and|or|not|xor|nor|nand|both|neither|either|unless|except|only if|but not)\b", re.I
+)
+
+
+def _looks_like_nl_logic(content: str) -> bool:
+    """Return True if content reads like a natural-language logic description."""
+    for pat in _NL_LOGIC_PATTERNS:
+        if pat.search(content):
+            return True
+    # Heuristic: short prose with at least 2 operator words
+    hits = _NL_OPERATOR_WORDS.findall(content)
+    return len(hits) >= 2 and len(content.split()) < 80
+
+
+def _detect_provider():
+    """Return an NL provider if a supported API key is set, else None."""
+    try:
+        from boolean_algebra_engine.nl.nl import AnthropicProvider, OpenAIProvider
+        if os.environ.get("ANTHROPIC_API_KEY"):
+            return AnthropicProvider()
+        if os.environ.get("OPENAI_API_KEY"):
+            return OpenAIProvider()
+    except ImportError:
+        pass
+    return None
+
+
+class NLBooleanCompressor:
+    """Natural-language → minimal boolean expression compressor.
+
+    Requires:
+      - pip install boolean-algebra-engine[nl-anthropic]  (or nl-openai)
+      - ANTHROPIC_API_KEY or OPENAI_API_KEY in environment
+
+    Uses one LLM call per compression to extract the boolean function from
+    natural-language text; the Quine-McCluskey synthesis step is always
+    deterministic and lossless.
+    """
+
+    def compress(self, content: str) -> "BooleanCompressionResult | None":
+        if not _looks_like_nl_logic(content):
+            return None
+        provider = _detect_provider()
+        if provider is None:
+            logger.debug("NLBooleanCompressor: no API key configured — skipping")
+            return None
+        try:
+            from boolean_algebra_engine.nl.nl import ask
+            result = ask(content.strip(), provider=provider)
+        except Exception as exc:
+            logger.debug("NLBooleanCompressor: ask() failed: %s", exc)
+            return None
+
+        minimal = result.minimal or result.expression
+        if not minimal:
+            return None
+
+        var_map = "  ".join(f"{k}={v}" for k, v in result.variables.items())
+        compressed = f"[nl-boolean: {var_map}]\n{minimal}"
+
+        original_tokens   = len(content.split())
+        compressed_tokens = len(compressed.split())
+        if compressed_tokens >= original_tokens:
+            return None
+
+        return BooleanCompressionResult(
+            compressed        = compressed,
+            original          = content,
+            original_tokens   = original_tokens,
+            compressed_tokens = compressed_tokens,
+            variable_count    = len(result.variables),
+            strategy          = "nl_expression",
+        )

--- a/headroom/transforms/boolean_compressor.py
+++ b/headroom/transforms/boolean_compressor.py
@@ -8,11 +8,12 @@ Two compression paths share this module:
    (symbolic, English operators, mixed). Uses Quine-McCluskey via boolean-algebra-engine
    to produce the minimal SOP form.
 
-2. NLBooleanCompressor  — optional, requires an API key (Anthropic or OpenAI).
+2. NLBooleanCompressor  — optional and probabilistic; requires an API key.
    Handles natural-language logic descriptions such as
    "output is high when door is open AND motion is detected but not both".
    The NL layer (boolean-algebra-engine[nl]) calls an LLM once to extract the
-   boolean function, then synthesizes the minimal SOP — the math is still lossless.
+   boolean function, then synthesizes the minimal SOP. The synthesis is exact for
+   the inferred function, but the LLM extraction is not lossless.
    Activated only when ANTHROPIC_API_KEY or OPENAI_API_KEY is set in the environment.
 
 Compression examples:
@@ -20,9 +21,8 @@ Compression examples:
   - English expression (17 tokens)        → "B.C+A.C+A.B"  (4 tokens,  ~71% savings)
   - NL description (15 tokens)            → "A^B"          (2 tokens,  ~87% savings)
 
-Telemetry: fires an anonymous PostHog event to the boolean-algebra-engine project
-each time a compression occurs, reporting tokens_before, tokens_after, variable_count,
-and strategy. Respects BOOLCALC_NO_TELEMETRY=1.
+This integration does not send telemetry to boolean-algebra-engine or any other
+third-party analytics service.
 """
 
 from __future__ import annotations
@@ -30,7 +30,6 @@ from __future__ import annotations
 import logging
 import os
 import re
-import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -44,10 +43,7 @@ if TYPE_CHECKING:
 
 # Order matters: longer patterns before shorter ones
 _NORMALISE_RULES: list[tuple[re.Pattern[str], str]] = [
-    (re.compile(r"\bXNOR\b", re.I), "^"),  # XNOR → ^ (not standard, but handle)
     (re.compile(r"\bXOR\b", re.I), "^"),
-    (re.compile(r"\bNAND\b", re.I), "!."),  # approximate
-    (re.compile(r"\bNOR\b", re.I), "!+"),  # approximate
     (re.compile(r"\bNOT\s+", re.I), "!"),
     (re.compile(r"\bAND\b", re.I), "."),
     (re.compile(r"\bOR\b", re.I), "+"),
@@ -175,9 +171,6 @@ class BooleanCompressor:
             result = self._compress_truth_table(content)
             if result is None:
                 result = self._compress_expression(content)
-            if result is not None:
-                _fire_engine_loaded()
-                _fire_telemetry(result)
             return result
         except Exception as exc:
             logger.debug("BooleanCompressor: compression failed: %s", exc)
@@ -235,6 +228,10 @@ class BooleanCompressor:
 
     def _compress_expression(self, content: str) -> BooleanCompressionResult | None:
         content_stripped = content.strip()
+        # These operators require grouping-aware rewrites. Never approximate
+        # them with character substitution on a path advertised as exact.
+        if re.search(r"\b(?:NAND|NOR|XNOR)\b", content_stripped, re.I):
+            return None
         # Only compress if it looks like a single expression (not prose)
         if "\n" in content_stripped and not re.search(
             r"\b(AND|OR|NOT|XOR)\b", content_stripped, re.I
@@ -278,123 +275,6 @@ class BooleanCompressor:
             variable_count=var_count,
             strategy="expression",
         )
-
-
-# ── Anonymous telemetry ───────────────────────────────────────────────────────
-
-_PH_KEY = "phc_Am4NNyVXotVffz6rcBy8xZVUZeaJCCbbHMu63pWMz3M8"
-_PH_ENDPOINT = "https://us.i.posthog.com/capture/"
-_CONFIG_FILE = (
-    __import__("pathlib").Path(
-        __import__("os").environ.get(
-            "XDG_CONFIG_HOME", __import__("pathlib").Path.home() / ".config"
-        )
-    )
-    / "boolcalc"
-    / "telemetry.json"
-)
-
-_engine_loaded_fired = False
-
-
-def _fire_engine_loaded() -> None:
-    """Fire a one-time event the first time BooleanCompressor compresses successfully.
-
-    Distinguishes headroom-sourced engine usage from direct CLI installs in PostHog.
-    Respects BOOLCALC_NO_TELEMETRY=1.
-    """
-    global _engine_loaded_fired
-    if _engine_loaded_fired or os.environ.get("BOOLCALC_NO_TELEMETRY"):
-        return
-    _engine_loaded_fired = True
-
-    def _send() -> None:
-        try:
-            import json
-            import urllib.request
-
-            install_id = "headroom-anonymous"
-            try:
-                if _CONFIG_FILE.exists():
-                    state = json.loads(_CONFIG_FILE.read_text())
-                    install_id = state.get("install_id", install_id)
-            except Exception:
-                pass
-
-            payload = json.dumps(
-                {
-                    "api_key": _PH_KEY,
-                    "event": "headroom_boolean_engine_loaded",
-                    "distinct_id": install_id,
-                    "properties": {"source": "headroom"},
-                }
-            ).encode()
-
-            req = urllib.request.Request(
-                _PH_ENDPOINT,
-                data=payload,
-                headers={"Content-Type": "application/json"},
-                method="POST",
-            )
-            urllib.request.urlopen(req, timeout=3)
-        except Exception:
-            pass
-
-    threading.Thread(target=_send, daemon=True).start()
-
-
-def _fire_telemetry(result: BooleanCompressionResult) -> None:
-    """Fire a PostHog event reporting boolean compression usage from headroom.
-
-    Uses the same install_id as the boolcalc CLI so PostHog can correlate
-    headroom usage with direct CLI usage under one user profile.
-    Runs in a daemon thread — never blocks compression.
-    Respects BOOLCALC_NO_TELEMETRY=1.
-    """
-    if os.environ.get("BOOLCALC_NO_TELEMETRY"):
-        return
-
-    def _send() -> None:
-        try:
-            import json
-            import urllib.request
-
-            install_id = "headroom-anonymous"
-            try:
-                if _CONFIG_FILE.exists():
-                    state = json.loads(_CONFIG_FILE.read_text())
-                    install_id = state.get("install_id", install_id)
-            except Exception:
-                pass
-
-            payload = json.dumps(
-                {
-                    "api_key": _PH_KEY,
-                    "event": "headroom_boolean_compress",
-                    "distinct_id": install_id,
-                    "properties": {
-                        "tokens_before": result.original_tokens,
-                        "tokens_after": result.compressed_tokens,
-                        "tokens_saved": result.tokens_saved,
-                        "savings_pct": round(result.savings_pct, 1),
-                        "variable_count": result.variable_count,
-                        "strategy": result.strategy,
-                        "source": "headroom",
-                    },
-                }
-            ).encode()
-
-            req = urllib.request.Request(
-                _PH_ENDPOINT,
-                data=payload,
-                headers={"Content-Type": "application/json"},
-                method="POST",
-            )
-            urllib.request.urlopen(req, timeout=3)
-        except Exception:
-            pass
-
-    threading.Thread(target=_send, daemon=True).start()
 
 
 # ── NL Boolean Compressor ─────────────────────────────────────────────────────
@@ -450,7 +330,8 @@ class NLBooleanCompressor:
 
     Uses one LLM call per compression to extract the boolean function from
     natural-language text; the Quine-McCluskey synthesis step is always
-    deterministic and lossless.
+    deterministic for the inferred function. Because the inference uses an LLM,
+    this path is probabilistic and must not be described as lossless.
     """
 
     def compress(self, content: str) -> BooleanCompressionResult | None:

--- a/headroom/transforms/boolean_compressor.py
+++ b/headroom/transforms/boolean_compressor.py
@@ -24,6 +24,7 @@ Telemetry: fires an anonymous PostHog event to the boolean-algebra-engine projec
 each time a compression occurs, reporting tokens_before, tokens_after, variable_count,
 and strategy. Respects BOOLCALC_NO_TELEMETRY=1.
 """
+
 from __future__ import annotations
 
 import logging
@@ -43,19 +44,19 @@ if TYPE_CHECKING:
 
 # Order matters: longer patterns before shorter ones
 _NORMALISE_RULES: list[tuple[re.Pattern[str], str]] = [
-    (re.compile(r"\bXNOR\b",  re.I), "^"),   # XNOR → ^ (not standard, but handle)
-    (re.compile(r"\bXOR\b",   re.I), "^"),
-    (re.compile(r"\bNAND\b",  re.I), "!."),  # approximate
-    (re.compile(r"\bNOR\b",   re.I), "!+"),  # approximate
-    (re.compile(r"\bNOT\s+",  re.I), "!"),
-    (re.compile(r"\bAND\b",   re.I), "."),
-    (re.compile(r"\bOR\b",    re.I), "+"),
-    (re.compile(r"\|\|"),           "+"),
-    (re.compile(r"&&"),             "."),
-    (re.compile(r"[~¬]"),           "!"),
-    (re.compile(r"\|(?!\|)"),       "+"),
-    (re.compile(r"&(?!&)"),         "."),
-    (re.compile(r"\s+"),            ""),      # strip all whitespace last
+    (re.compile(r"\bXNOR\b", re.I), "^"),  # XNOR → ^ (not standard, but handle)
+    (re.compile(r"\bXOR\b", re.I), "^"),
+    (re.compile(r"\bNAND\b", re.I), "!."),  # approximate
+    (re.compile(r"\bNOR\b", re.I), "!+"),  # approximate
+    (re.compile(r"\bNOT\s+", re.I), "!"),
+    (re.compile(r"\bAND\b", re.I), "."),
+    (re.compile(r"\bOR\b", re.I), "+"),
+    (re.compile(r"\|\|"), "+"),
+    (re.compile(r"&&"), "."),
+    (re.compile(r"[~¬]"), "!"),
+    (re.compile(r"\|(?!\|)"), "+"),
+    (re.compile(r"&(?!&)"), "."),
+    (re.compile(r"\s+"), ""),  # strip all whitespace last
 ]
 
 
@@ -68,36 +69,36 @@ def _normalise(expr: str) -> str:
 
 # ── Truth table parsing ───────────────────────────────────────────────────────
 
-_BINARY_ROW  = re.compile(r"^[\s|]*([01][\s|]+)+[01][\s|]*$")
-_MD_HEADER   = re.compile(r"^\|?\s*([A-Za-z_]\w*\s*\|?\s*)+$")
+_BINARY_ROW = re.compile(r"^[\s|]*([01][\s|]+)+[01][\s|]*$")
+_MD_HEADER = re.compile(r"^\|?\s*([A-Za-z_]\w*\s*\|?\s*)+$")
 _VAR_EXTRACT = re.compile(r"[A-Za-z_]\w*")
 
 
 @dataclass
 class _ParsedTable:
     variables: list[str]
-    minterms:  list[int]
+    minterms: list[int]
 
 
-def _try_parse_truth_table(content: str) -> "_ParsedTable | None":
+def _try_parse_truth_table(content: str) -> _ParsedTable | None:
     """Parse a markdown or space-separated truth table.
 
     Returns _ParsedTable if confident, None otherwise.
     """
-    lines = [l.strip() for l in content.strip().splitlines() if l.strip()]
+    lines = [ln.strip() for ln in content.strip().splitlines() if ln.strip()]
     # Need at least a header + one data row
     if len(lines) < 2:
         return None
 
     # Find header line (contains variable names, no binary data)
     header_line = None
-    data_start   = 0
+    data_start = 0
     for i, line in enumerate(lines):
         clean = re.sub(r"[|\-:+]", " ", line).strip()
         words = clean.split()
         if words and all(re.match(r"^[A-Za-z_]\w*$", w) for w in words):
             header_line = words
-            data_start  = i + 1
+            data_start = i + 1
             # Skip markdown separator row (---|---...)
             if data_start < len(lines) and re.match(r"^[\s|:\-]+$", lines[data_start]):
                 data_start += 1
@@ -106,7 +107,7 @@ def _try_parse_truth_table(content: str) -> "_ParsedTable | None":
     if header_line is None or len(header_line) < 2:
         return None
 
-    variables = header_line[:-1]   # all but last column
+    variables = header_line[:-1]  # all but last column
     # output_col = header_line[-1]  # not used — last column is output
 
     if not (1 <= len(variables) <= 8):
@@ -116,7 +117,7 @@ def _try_parse_truth_table(content: str) -> "_ParsedTable | None":
     minterms: list[int] = []
     row_index = 0
     for line in lines[data_start:]:
-        clean  = re.sub(r"[|\s]+", " ", line).strip()
+        clean = re.sub(r"[|\s]+", " ", line).strip()
         values = clean.split()
         if not values:
             continue
@@ -137,14 +138,15 @@ def _try_parse_truth_table(content: str) -> "_ParsedTable | None":
 
 # ── Compression result ────────────────────────────────────────────────────────
 
+
 @dataclass
 class BooleanCompressionResult:
-    compressed:        str
-    original:          str
-    original_tokens:   int
+    compressed: str
+    original: str
+    original_tokens: int
     compressed_tokens: int
-    variable_count:    int
-    strategy:          str   # "expression" | "truth_table"
+    variable_count: int
+    strategy: str  # "expression" | "truth_table"
 
     @property
     def tokens_saved(self) -> int:
@@ -159,6 +161,7 @@ class BooleanCompressionResult:
 
 # ── Core compressor ───────────────────────────────────────────────────────────
 
+
 class BooleanCompressor:
     """Lossless boolean algebra compressor.
 
@@ -166,18 +169,20 @@ class BooleanCompressor:
     Optional dependency — fails gracefully if not installed.
     """
 
-    def compress(self, content: str) -> "BooleanCompressionResult | None":
+    def compress(self, content: str) -> BooleanCompressionResult | None:
         """Compress boolean content. Returns None on failure (caller should passthrough)."""
         try:
             result = self._compress_truth_table(content)
             if result is None:
                 result = self._compress_expression(content)
+            if result is not None:
+                _fire_engine_loaded()
             return result
         except Exception as exc:
             logger.debug("BooleanCompressor: compression failed: %s", exc)
             return None
 
-    def _compress_truth_table(self, content: str) -> "BooleanCompressionResult | None":
+    def _compress_truth_table(self, content: str) -> BooleanCompressionResult | None:
         parsed = _try_parse_truth_table(content)
         if parsed is None:
             return None
@@ -189,12 +194,12 @@ class BooleanCompressor:
             minimal = "1"
         else:
             try:
-                from boolean_algebra_engine.core.models import TruthTable, TruthTableRow
                 from boolean_algebra_engine import synthesize
+                from boolean_algebra_engine.core.models import TruthTable, TruthTableRow
 
                 rows: list[TruthTableRow] = []
                 n = len(parsed.variables)
-                for i in range(2 ** n):
+                for i in range(2**n):
                     bits = [(i >> (n - 1 - j)) & 1 for j in range(n)]
                     inputs = dict(zip(parsed.variables, bits))
                     output = 1 if i in parsed.minterms else 0
@@ -210,32 +215,32 @@ class BooleanCompressor:
                 logger.debug("BooleanCompressor: synthesize failed: %s", exc)
                 return None
 
-        original_tokens   = len(content.split())
+        original_tokens = len(content.split())
         compressed_tokens = len(minimal.split())
         if compressed_tokens >= original_tokens:
             return None  # no savings
 
-        header = (
-            f"[boolean-simplified: {', '.join(parsed.variables)} → {minimal}]\n"
-        )
+        header = f"[boolean-simplified: {', '.join(parsed.variables)} → {minimal}]\n"
         compressed = header + minimal
 
         return BooleanCompressionResult(
-            compressed        = compressed,
-            original          = content,
-            original_tokens   = original_tokens,
-            compressed_tokens = len(compressed.split()),
-            variable_count    = len(parsed.variables),
-            strategy          = "truth_table",
+            compressed=compressed,
+            original=content,
+            original_tokens=original_tokens,
+            compressed_tokens=len(compressed.split()),
+            variable_count=len(parsed.variables),
+            strategy="truth_table",
         )
 
-    def _compress_expression(self, content: str) -> "BooleanCompressionResult | None":
+    def _compress_expression(self, content: str) -> BooleanCompressionResult | None:
         content_stripped = content.strip()
         # Only compress if it looks like a single expression (not prose)
-        if "\n" in content_stripped and not re.search(r"\b(AND|OR|NOT|XOR)\b", content_stripped, re.I):
+        if "\n" in content_stripped and not re.search(
+            r"\b(AND|OR|NOT|XOR)\b", content_stripped, re.I
+        ):
             return None
         # Collapse multi-line expressions (each line is one expression or one term)
-        lines = [l.strip() for l in content_stripped.splitlines() if l.strip()]
+        lines = [ln.strip() for ln in content_stripped.splitlines() if ln.strip()]
         expr_line = " ".join(lines) if len(lines) > 1 else content_stripped
 
         normalised = _normalise(expr_line)
@@ -250,39 +255,91 @@ class BooleanCompressor:
         try:
             from boolean_algebra_engine import evaluate, synthesize
 
-            table, _  = evaluate(normalised)
+            table, _ = evaluate(normalised)
             minimal, m = synthesize(table)
         except Exception as exc:
             logger.debug("BooleanCompressor: expression evaluate/synthesize failed: %s", exc)
             return None
 
-        original_tokens   = len(content.split())
+        original_tokens = len(content.split())
         compressed_tokens = len(minimal.split())
         if compressed_tokens >= original_tokens:
             return None
 
-        var_count  = len(table.variables)
+        var_count = len(table.variables)
         compressed = f"[boolean-simplified: {normalised} → {minimal}]\n{minimal}"
 
         return BooleanCompressionResult(
-            compressed        = compressed,
-            original          = content,
-            original_tokens   = original_tokens,
-            compressed_tokens = len(compressed.split()),
-            variable_count    = var_count,
-            strategy          = "expression",
+            compressed=compressed,
+            original=content,
+            original_tokens=original_tokens,
+            compressed_tokens=len(compressed.split()),
+            variable_count=var_count,
+            strategy="expression",
         )
 
 
 # ── Anonymous telemetry ───────────────────────────────────────────────────────
 
-_PH_KEY      = "phc_Am4NNyVXotVffz6rcBy8xZVUZeaJCCbbHMu63pWMz3M8"
+_PH_KEY = "phc_Am4NNyVXotVffz6rcBy8xZVUZeaJCCbbHMu63pWMz3M8"
 _PH_ENDPOINT = "https://us.i.posthog.com/capture/"
 _CONFIG_FILE = (
     __import__("pathlib").Path(
-        __import__("os").environ.get("XDG_CONFIG_HOME", __import__("pathlib").Path.home() / ".config")
-    ) / "boolcalc" / "telemetry.json"
+        __import__("os").environ.get(
+            "XDG_CONFIG_HOME", __import__("pathlib").Path.home() / ".config"
+        )
+    )
+    / "boolcalc"
+    / "telemetry.json"
 )
+
+_engine_loaded_fired = False
+
+
+def _fire_engine_loaded() -> None:
+    """Fire a one-time event the first time BooleanCompressor compresses successfully.
+
+    Distinguishes headroom-sourced engine usage from direct CLI installs in PostHog.
+    Respects BOOLCALC_NO_TELEMETRY=1.
+    """
+    global _engine_loaded_fired
+    if _engine_loaded_fired or os.environ.get("BOOLCALC_NO_TELEMETRY"):
+        return
+    _engine_loaded_fired = True
+
+    def _send() -> None:
+        try:
+            import json
+            import urllib.request
+
+            install_id = "headroom-anonymous"
+            try:
+                if _CONFIG_FILE.exists():
+                    state = json.loads(_CONFIG_FILE.read_text())
+                    install_id = state.get("install_id", install_id)
+            except Exception:
+                pass
+
+            payload = json.dumps(
+                {
+                    "api_key": _PH_KEY,
+                    "event": "headroom_boolean_engine_loaded",
+                    "distinct_id": install_id,
+                    "properties": {"source": "headroom"},
+                }
+            ).encode()
+
+            req = urllib.request.Request(
+                _PH_ENDPOINT,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            urllib.request.urlopen(req, timeout=3)
+        except Exception:
+            pass
+
+    threading.Thread(target=_send, daemon=True).start()
 
 
 def _fire_telemetry(result: BooleanCompressionResult) -> None:
@@ -304,31 +361,33 @@ def _fire_telemetry(result: BooleanCompressionResult) -> None:
             install_id = "headroom-anonymous"
             try:
                 if _CONFIG_FILE.exists():
-                    state      = json.loads(_CONFIG_FILE.read_text())
+                    state = json.loads(_CONFIG_FILE.read_text())
                     install_id = state.get("install_id", install_id)
             except Exception:
                 pass
 
-            payload = json.dumps({
-                "api_key":     _PH_KEY,
-                "event":       "headroom_boolean_compress",
-                "distinct_id": install_id,
-                "properties": {
-                    "tokens_before":  result.original_tokens,
-                    "tokens_after":   result.compressed_tokens,
-                    "tokens_saved":   result.tokens_saved,
-                    "savings_pct":    round(result.savings_pct, 1),
-                    "variable_count": result.variable_count,
-                    "strategy":       result.strategy,
-                    "source":         "headroom",
-                },
-            }).encode()
+            payload = json.dumps(
+                {
+                    "api_key": _PH_KEY,
+                    "event": "headroom_boolean_compress",
+                    "distinct_id": install_id,
+                    "properties": {
+                        "tokens_before": result.original_tokens,
+                        "tokens_after": result.compressed_tokens,
+                        "tokens_saved": result.tokens_saved,
+                        "savings_pct": round(result.savings_pct, 1),
+                        "variable_count": result.variable_count,
+                        "strategy": result.strategy,
+                        "source": "headroom",
+                    },
+                }
+            ).encode()
 
             req = urllib.request.Request(
                 _PH_ENDPOINT,
-                data    = payload,
-                headers = {"Content-Type": "application/json"},
-                method  = "POST",
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
             )
             urllib.request.urlopen(req, timeout=3)
         except Exception:
@@ -341,10 +400,15 @@ def _fire_telemetry(result: BooleanCompressionResult) -> None:
 
 # Natural-language logic description markers
 _NL_LOGIC_PATTERNS = [
-    re.compile(r"\b(output|signal|result|flag|value|state)\s+(is\s+)?(high|low|true|false|1|0|on|off)\s+(when|if|whenever)\b", re.I),
+    re.compile(
+        r"\b(output|signal|result|flag|value|state)\s+(is\s+)?(high|low|true|false|1|0|on|off)\s+(when|if|whenever)\b",
+        re.I,
+    ),
     re.compile(r"\b(true|on|active|high|enabled)\s+(only\s+)?(if|when|whenever|iff)\b", re.I),
     re.compile(r"\b(if|when)\s+\w+\s+(and|or|not|xor|nor|nand)\s+\w+\b", re.I),
-    re.compile(r"\b(lights?|motor|alarm|gate|switch|relay)\s+(turns?\s+)?(on|off)\s+(when|if)\b", re.I),
+    re.compile(
+        r"\b(lights?|motor|alarm|gate|switch|relay)\s+(turns?\s+)?(on|off)\s+(when|if)\b", re.I
+    ),
 ]
 
 _NL_OPERATOR_WORDS = re.compile(
@@ -366,6 +430,7 @@ def _detect_provider():
     """Return an NL provider if a supported API key is set, else None."""
     try:
         from boolean_algebra_engine.nl.nl import AnthropicProvider, OpenAIProvider
+
         if os.environ.get("ANTHROPIC_API_KEY"):
             return AnthropicProvider()
         if os.environ.get("OPENAI_API_KEY"):
@@ -387,7 +452,7 @@ class NLBooleanCompressor:
     deterministic and lossless.
     """
 
-    def compress(self, content: str) -> "BooleanCompressionResult | None":
+    def compress(self, content: str) -> BooleanCompressionResult | None:
         if not _looks_like_nl_logic(content):
             return None
         provider = _detect_provider()
@@ -396,6 +461,7 @@ class NLBooleanCompressor:
             return None
         try:
             from boolean_algebra_engine.nl.nl import ask
+
             result = ask(content.strip(), provider=provider)
         except Exception as exc:
             logger.debug("NLBooleanCompressor: ask() failed: %s", exc)
@@ -408,16 +474,16 @@ class NLBooleanCompressor:
         var_map = "  ".join(f"{k}={v}" for k, v in result.variables.items())
         compressed = f"[nl-boolean: {var_map}]\n{minimal}"
 
-        original_tokens   = len(content.split())
+        original_tokens = len(content.split())
         compressed_tokens = len(compressed.split())
         if compressed_tokens >= original_tokens:
             return None
 
         return BooleanCompressionResult(
-            compressed        = compressed,
-            original          = content,
-            original_tokens   = original_tokens,
-            compressed_tokens = compressed_tokens,
-            variable_count    = len(result.variables),
-            strategy          = "nl_expression",
+            compressed=compressed,
+            original=content,
+            original_tokens=original_tokens,
+            compressed_tokens=compressed_tokens,
+            variable_count=len(result.variables),
+            strategy="nl_expression",
         )

--- a/headroom/transforms/boolean_compressor.py
+++ b/headroom/transforms/boolean_compressor.py
@@ -32,7 +32,7 @@ import os
 import re
 import threading
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 logger = logging.getLogger(__name__)
 
@@ -177,6 +177,7 @@ class BooleanCompressor:
                 result = self._compress_expression(content)
             if result is not None:
                 _fire_engine_loaded()
+                _fire_telemetry(result)
             return result
         except Exception as exc:
             logger.debug("BooleanCompressor: compression failed: %s", exc)
@@ -426,7 +427,7 @@ def _looks_like_nl_logic(content: str) -> bool:
     return len(hits) >= 2 and len(content.split()) < 80
 
 
-def _detect_provider():
+def _detect_provider() -> Any | None:
     """Return an NL provider if a supported API key is set, else None."""
     try:
         from boolean_algebra_engine.nl.nl import AnthropicProvider, OpenAIProvider

--- a/headroom/transforms/content_detector.py
+++ b/headroom/transforms/content_detector.py
@@ -33,6 +33,8 @@ class ContentType(Enum):
     HTML = "html"  # Web pages (needs content extraction, not compression)
     TABULAR = "tabular"  # CSV/TSV, markdown tables, fixed-width tables
     STRUCTURED_CONFIG = "structured_config"  # YAML/TOML/INI config files
+    BOOLEAN_LOGIC = "boolean_logic"  # Boolean expressions and truth tables
+    NL_BOOLEAN_LOGIC = "nl_boolean_logic"  # Natural-language logic descriptions
     PLAIN_TEXT = "text"  # Fallback
 
 
@@ -226,7 +228,17 @@ def detect_content_type(content: str) -> DetectionResult:
     if code_result and code_result.confidence >= 0.5:
         return code_result
 
-    # 9. Fallback to plain text
+    # 9. Check for boolean logic (truth tables and boolean expressions)
+    bool_result = _try_detect_boolean(content)
+    if bool_result and bool_result.confidence >= 0.7:
+        return bool_result
+
+    # 10. Check for natural-language logic descriptions
+    nl_bool_result = _try_detect_nl_boolean(content)
+    if nl_bool_result and nl_bool_result.confidence >= 0.7:
+        return nl_bool_result
+
+    # 11. Fallback to plain text
     return DetectionResult(ContentType.PLAIN_TEXT, 0.5, {})
 
 
@@ -805,3 +817,138 @@ def is_json_array_of_dicts(content: str) -> bool:
     return result.content_type == ContentType.JSON_ARRAY and result.metadata.get(
         "is_dict_array", False
     )
+
+
+# ── Boolean logic detection ───────────────────────────────────────────────────
+
+_BOOL_ENGLISH_OPS = re.compile(
+    r"\b(AND|OR|NOT|XOR|NAND|NOR|XNOR)\b", re.I
+)
+_BOOL_SYMBOLIC_OPS = re.compile(
+    r"(?<![a-zA-Z0-9_])[A-Z](?:\s*[.+^|&]\s*!?[A-Z])+",
+)
+_BOOL_VARIABLE = re.compile(r"^[A-Z]$")
+_BOOL_TABLE_HEADER = re.compile(
+    r"^[\|]?\s*([A-Za-z_]\w*\s*[\|]?\s*){2,}$"
+)
+_BOOL_TABLE_ROW = re.compile(
+    r"^[\s|]*([01][\s|]+)+[01][\s|]*$"
+)
+
+
+def _try_detect_boolean(content: str) -> "DetectionResult | None":
+    """Detect boolean logic content: truth tables and boolean expressions.
+
+    Returns a DetectionResult with ContentType.BOOLEAN_LOGIC when confident
+    the content represents boolean algebra. Does not fire for source code
+    that happens to use boolean operators — detection requires single-letter
+    uppercase variables or an explicit truth table structure.
+    """
+    stripped = content.strip()
+    lines    = [l.strip() for l in stripped.splitlines() if l.strip()]
+
+    if not lines:
+        return None
+
+    # ── Truth table detection ─────────────────────────────────────────────
+    # Require: 1 header row of variable names + N binary data rows
+    header_found    = False
+    binary_rows     = 0
+    header_var_count = 0
+
+    for line in lines:
+        clean = re.sub(r"[|\-:+]", " ", line).strip()
+        words = clean.split()
+        if not words:
+            continue
+        if not header_found:
+            # Header: all tokens look like identifiers, none are "0" or "1"
+            if all(re.match(r"^[A-Za-z_]\w*$", w) for w in words) and len(words) >= 2:
+                header_found     = True
+                header_var_count = len(words)
+                continue
+        if header_found:
+            # Skip separator rows
+            if re.match(r"^[-\s|:]+$", line):
+                continue
+            if all(v in ("0", "1") for v in words) and len(words) == header_var_count:
+                binary_rows += 1
+
+    if header_found and binary_rows >= 2:
+        confidence = min(0.95, 0.7 + 0.05 * binary_rows)
+        return DetectionResult(
+            ContentType.BOOLEAN_LOGIC,
+            confidence,
+            {"form": "truth_table", "variable_count": header_var_count - 1},
+        )
+
+    # ── Boolean expression detection ──────────────────────────────────────
+    # Require single-letter uppercase variables + recognised operators
+    # Reject if content has lowercase identifiers (likely prose or code)
+    text = " ".join(lines)
+
+    has_english_ops  = bool(_BOOL_ENGLISH_OPS.search(text))
+    has_symbolic_ops = bool(_BOOL_SYMBOLIC_OPS.search(text))
+
+    # Check uppercase-only variable pattern: single capital letters used as variables
+    single_cap_vars = re.findall(r"\b([A-Z])\b", text)
+    has_single_caps = len(set(single_cap_vars)) >= 2
+
+    # Reject if there's prose (lowercase words longer than 2 chars not in operators)
+    prose_words = re.findall(r"\b[a-z]{3,}\b", text)
+    known_ops   = {"and", "or", "not", "xor", "nand", "nor", "xnor"}
+    prose_noise = [w for w in prose_words if w not in known_ops]
+    if len(prose_noise) > 2:
+        return None
+
+    if has_single_caps and (has_english_ops or has_symbolic_ops):
+        confidence = 0.85 if has_english_ops else 0.75
+        return DetectionResult(
+            ContentType.BOOLEAN_LOGIC,
+            confidence,
+            {"form": "expression", "variable_count": len(set(single_cap_vars))},
+        )
+
+    return None
+
+
+_NL_LOGIC_SIGNALS = [
+    re.compile(r"\b(output|signal|result|flag|state)\s+(is\s+)?(high|low|true|false|on|off)\s+(when|if)\b", re.I),
+    re.compile(r"\b(true|on|active|high|enabled)\s+(only\s+)?(if|when|iff)\b", re.I),
+    re.compile(r"\b(lights?|motor|alarm|gate|relay|switch)\s+(turns?\s+)?(on|off)\s+(when|if)\b", re.I),
+]
+_NL_OP_WORDS = re.compile(r"\b(and|or|not|xor|nor|nand|both|neither|either|unless|but not)\b", re.I)
+
+
+def _try_detect_nl_boolean(content: str) -> "DetectionResult | None":
+    """Detect natural-language descriptions of boolean/digital logic.
+
+    Only fires when the prose clearly describes a logic function, not generic
+    prose that happens to use 'and'/'or'. Requires at least one structural
+    signal phrase plus multiple operator words.
+    """
+    stripped = content.strip()
+    # Reject multi-paragraph content — NL logic descriptions are short
+    if stripped.count("\n\n") > 1 or len(stripped.split()) > 100:
+        return None
+    # Must not already look like structured boolean (caught by _try_detect_boolean)
+    if re.search(r"[A-Z]\.[A-Z]|[A-Z]\+[A-Z]", stripped):
+        return None
+
+    signal_hit = any(pat.search(stripped) for pat in _NL_LOGIC_SIGNALS)
+    op_count   = len(_NL_OP_WORDS.findall(stripped))
+
+    if signal_hit and op_count >= 1:
+        return DetectionResult(
+            ContentType.NL_BOOLEAN_LOGIC,
+            0.80,
+            {"form": "nl_description", "op_count": op_count},
+        )
+    if op_count >= 3 and len(stripped.split()) < 50:
+        return DetectionResult(
+            ContentType.NL_BOOLEAN_LOGIC,
+            0.70,
+            {"form": "nl_description", "op_count": op_count},
+        )
+
+    return None

--- a/headroom/transforms/content_detector.py
+++ b/headroom/transforms/content_detector.py
@@ -821,22 +821,16 @@ def is_json_array_of_dicts(content: str) -> bool:
 
 # ── Boolean logic detection ───────────────────────────────────────────────────
 
-_BOOL_ENGLISH_OPS = re.compile(
-    r"\b(AND|OR|NOT|XOR|NAND|NOR|XNOR)\b", re.I
-)
+_BOOL_ENGLISH_OPS = re.compile(r"\b(AND|OR|NOT|XOR|NAND|NOR|XNOR)\b", re.I)
 _BOOL_SYMBOLIC_OPS = re.compile(
     r"(?<![a-zA-Z0-9_])[A-Z](?:\s*[.+^|&]\s*!?[A-Z])+",
 )
 _BOOL_VARIABLE = re.compile(r"^[A-Z]$")
-_BOOL_TABLE_HEADER = re.compile(
-    r"^[\|]?\s*([A-Za-z_]\w*\s*[\|]?\s*){2,}$"
-)
-_BOOL_TABLE_ROW = re.compile(
-    r"^[\s|]*([01][\s|]+)+[01][\s|]*$"
-)
+_BOOL_TABLE_HEADER = re.compile(r"^[\|]?\s*([A-Za-z_]\w*\s*[\|]?\s*){2,}$")
+_BOOL_TABLE_ROW = re.compile(r"^[\s|]*([01][\s|]+)+[01][\s|]*$")
 
 
-def _try_detect_boolean(content: str) -> "DetectionResult | None":
+def _try_detect_boolean(content: str) -> DetectionResult | None:
     """Detect boolean logic content: truth tables and boolean expressions.
 
     Returns a DetectionResult with ContentType.BOOLEAN_LOGIC when confident
@@ -845,15 +839,15 @@ def _try_detect_boolean(content: str) -> "DetectionResult | None":
     uppercase variables or an explicit truth table structure.
     """
     stripped = content.strip()
-    lines    = [l.strip() for l in stripped.splitlines() if l.strip()]
+    lines = [ln.strip() for ln in stripped.splitlines() if ln.strip()]
 
     if not lines:
         return None
 
     # ── Truth table detection ─────────────────────────────────────────────
     # Require: 1 header row of variable names + N binary data rows
-    header_found    = False
-    binary_rows     = 0
+    header_found = False
+    binary_rows = 0
     header_var_count = 0
 
     for line in lines:
@@ -864,7 +858,7 @@ def _try_detect_boolean(content: str) -> "DetectionResult | None":
         if not header_found:
             # Header: all tokens look like identifiers, none are "0" or "1"
             if all(re.match(r"^[A-Za-z_]\w*$", w) for w in words) and len(words) >= 2:
-                header_found     = True
+                header_found = True
                 header_var_count = len(words)
                 continue
         if header_found:
@@ -887,7 +881,7 @@ def _try_detect_boolean(content: str) -> "DetectionResult | None":
     # Reject if content has lowercase identifiers (likely prose or code)
     text = " ".join(lines)
 
-    has_english_ops  = bool(_BOOL_ENGLISH_OPS.search(text))
+    has_english_ops = bool(_BOOL_ENGLISH_OPS.search(text))
     has_symbolic_ops = bool(_BOOL_SYMBOLIC_OPS.search(text))
 
     # Check uppercase-only variable pattern: single capital letters used as variables
@@ -896,7 +890,7 @@ def _try_detect_boolean(content: str) -> "DetectionResult | None":
 
     # Reject if there's prose (lowercase words longer than 2 chars not in operators)
     prose_words = re.findall(r"\b[a-z]{3,}\b", text)
-    known_ops   = {"and", "or", "not", "xor", "nand", "nor", "xnor"}
+    known_ops = {"and", "or", "not", "xor", "nand", "nor", "xnor"}
     prose_noise = [w for w in prose_words if w not in known_ops]
     if len(prose_noise) > 2:
         return None
@@ -913,14 +907,19 @@ def _try_detect_boolean(content: str) -> "DetectionResult | None":
 
 
 _NL_LOGIC_SIGNALS = [
-    re.compile(r"\b(output|signal|result|flag|state)\s+(is\s+)?(high|low|true|false|on|off)\s+(when|if)\b", re.I),
+    re.compile(
+        r"\b(output|signal|result|flag|state)\s+(is\s+)?(high|low|true|false|on|off)\s+(when|if)\b",
+        re.I,
+    ),
     re.compile(r"\b(true|on|active|high|enabled)\s+(only\s+)?(if|when|iff)\b", re.I),
-    re.compile(r"\b(lights?|motor|alarm|gate|relay|switch)\s+(turns?\s+)?(on|off)\s+(when|if)\b", re.I),
+    re.compile(
+        r"\b(lights?|motor|alarm|gate|relay|switch)\s+(turns?\s+)?(on|off)\s+(when|if)\b", re.I
+    ),
 ]
 _NL_OP_WORDS = re.compile(r"\b(and|or|not|xor|nor|nand|both|neither|either|unless|but not)\b", re.I)
 
 
-def _try_detect_nl_boolean(content: str) -> "DetectionResult | None":
+def _try_detect_nl_boolean(content: str) -> DetectionResult | None:
     """Detect natural-language descriptions of boolean/digital logic.
 
     Only fires when the prose clearly describes a logic function, not generic
@@ -936,7 +935,7 @@ def _try_detect_nl_boolean(content: str) -> "DetectionResult | None":
         return None
 
     signal_hit = any(pat.search(stripped) for pat in _NL_LOGIC_SIGNALS)
-    op_count   = len(_NL_OP_WORDS.findall(stripped))
+    op_count = len(_NL_OP_WORDS.findall(stripped))
 
     if signal_hit and op_count >= 1:
         return DetectionResult(

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -3379,17 +3379,18 @@ class ContentRouter(Transform):
                     compressor_name = type(compressor).__name__
                     bool_result = compressor.compress(content)
                     if bool_result is not None:
-                        compressed        = bool_result.compressed
+                        compressed = bool_result.compressed
                         compressed_tokens = bool_result.compressed_tokens
-                        decision_reason   = f"boolean_{bool_result.strategy}"
+                        decision_reason = f"boolean_{bool_result.strategy}"
                         from .boolean_compressor import _fire_telemetry
+
                         _fire_telemetry(bool_result)
                 if compressed is None:
                     # Fallback to Kompress when boolean-algebra-engine unavailable
                     compressed, compressed_tokens = self._try_ml_compressor(
                         content, context, question
                     )
-                    strategy        = CompressionStrategy.KOMPRESS
+                    strategy = CompressionStrategy.KOMPRESS
                     actual_strategy = strategy
                     compressor_name = "KompressCompressor"
                     decision_reason = "boolean_unavailable_fallback_kompress"
@@ -3401,16 +3402,17 @@ class ContentRouter(Transform):
                     compressor_name = type(compressor).__name__
                     bool_result = compressor.compress(content)
                     if bool_result is not None:
-                        compressed        = bool_result.compressed
+                        compressed = bool_result.compressed
                         compressed_tokens = bool_result.compressed_tokens
-                        decision_reason   = "nl_boolean"
+                        decision_reason = "nl_boolean"
                         from .boolean_compressor import _fire_telemetry
+
                         _fire_telemetry(bool_result)
                 if compressed is None:
                     compressed, compressed_tokens = self._try_ml_compressor(
                         content, context, question
                     )
-                    strategy        = CompressionStrategy.KOMPRESS
+                    strategy = CompressionStrategy.KOMPRESS
                     actual_strategy = strategy
                     compressor_name = "KompressCompressor"
                     decision_reason = "nl_boolean_unavailable_fallback_kompress"
@@ -4098,7 +4100,9 @@ class ContentRouter(Transform):
 
                 self._boolean_compressor = BooleanCompressor()
             except ImportError:
-                logger.debug("BooleanCompressor not available — install boolean-algebra-engine[cli]")
+                logger.debug(
+                    "BooleanCompressor not available — install boolean-algebra-engine[cli]"
+                )
         return self._boolean_compressor
 
     def _get_nl_boolean_compressor(self) -> Any:
@@ -4109,7 +4113,9 @@ class ContentRouter(Transform):
 
                 self._nl_boolean_compressor = NLBooleanCompressor()
             except ImportError:
-                logger.debug("NLBooleanCompressor not available — install boolean-algebra-engine[nl-anthropic]")
+                logger.debug(
+                    "NLBooleanCompressor not available — install boolean-algebra-engine[nl-anthropic]"
+                )
         return self._nl_boolean_compressor
 
     def _get_diff_compressor(self) -> Any:

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -1357,6 +1357,8 @@ class CompressionStrategy(Enum):
     HTML = "html"
     TABULAR = "tabular"
     CONFIG = "config"
+    BOOLEAN = "boolean"
+    NL_BOOLEAN = "nl_boolean"
     MIXED = "mixed"
     PASSTHROUGH = "passthrough"
 
@@ -1797,6 +1799,8 @@ class ContentRouter(Transform):
         self._search_compressor: Any = None
         self._log_compressor: Any = None
         self._diff_compressor: Any = None
+        self._boolean_compressor: Any = None
+        self._nl_boolean_compressor: Any = None
         self._html_extractor: Any = None
         self._tabular_compressor: Any = None
         self._config_compressor: Any = None
@@ -2362,6 +2366,8 @@ class ContentRouter(Transform):
             ContentType.HTML: CompressionStrategy.HTML,
             ContentType.TABULAR: CompressionStrategy.TABULAR,
             ContentType.STRUCTURED_CONFIG: CompressionStrategy.CONFIG,
+            ContentType.BOOLEAN_LOGIC: CompressionStrategy.BOOLEAN,
+            ContentType.NL_BOOLEAN_LOGIC: CompressionStrategy.NL_BOOLEAN,
             ContentType.PLAIN_TEXT: CompressionStrategy.TEXT,
         }
 
@@ -3367,6 +3373,49 @@ class ContentRouter(Transform):
                         compressed_tokens = _estimate_tokens(compressed) if compressed else 0
                         decision_reason = "html_extractor"
 
+            elif strategy == CompressionStrategy.BOOLEAN:
+                compressor = self._get_boolean_compressor()
+                if compressor:
+                    compressor_name = type(compressor).__name__
+                    bool_result = compressor.compress(content)
+                    if bool_result is not None:
+                        compressed        = bool_result.compressed
+                        compressed_tokens = bool_result.compressed_tokens
+                        decision_reason   = f"boolean_{bool_result.strategy}"
+                        from .boolean_compressor import _fire_telemetry
+                        _fire_telemetry(bool_result)
+                if compressed is None:
+                    # Fallback to Kompress when boolean-algebra-engine unavailable
+                    compressed, compressed_tokens = self._try_ml_compressor(
+                        content, context, question
+                    )
+                    strategy        = CompressionStrategy.KOMPRESS
+                    actual_strategy = strategy
+                    compressor_name = "KompressCompressor"
+                    decision_reason = "boolean_unavailable_fallback_kompress"
+                    strategy_chain.append(CompressionStrategy.KOMPRESS.value)
+
+            elif strategy == CompressionStrategy.NL_BOOLEAN:
+                compressor = self._get_nl_boolean_compressor()
+                if compressor:
+                    compressor_name = type(compressor).__name__
+                    bool_result = compressor.compress(content)
+                    if bool_result is not None:
+                        compressed        = bool_result.compressed
+                        compressed_tokens = bool_result.compressed_tokens
+                        decision_reason   = "nl_boolean"
+                        from .boolean_compressor import _fire_telemetry
+                        _fire_telemetry(bool_result)
+                if compressed is None:
+                    compressed, compressed_tokens = self._try_ml_compressor(
+                        content, context, question
+                    )
+                    strategy        = CompressionStrategy.KOMPRESS
+                    actual_strategy = strategy
+                    compressor_name = "KompressCompressor"
+                    decision_reason = "nl_boolean_unavailable_fallback_kompress"
+                    strategy_chain.append(CompressionStrategy.KOMPRESS.value)
+
             elif strategy == CompressionStrategy.KOMPRESS:
                 # Registry-resolved dispatch: the built-in "kompress" adapter
                 # delegates to the SAME ``_try_ml_compressor(content, context,
@@ -3785,6 +3834,8 @@ class ContentRouter(Transform):
             ContentType.HTML: CompressionStrategy.HTML,
             ContentType.TABULAR: CompressionStrategy.TABULAR,
             ContentType.STRUCTURED_CONFIG: CompressionStrategy.CONFIG,
+            ContentType.BOOLEAN_LOGIC: CompressionStrategy.BOOLEAN,
+            ContentType.NL_BOOLEAN_LOGIC: CompressionStrategy.NL_BOOLEAN,
             ContentType.PLAIN_TEXT: CompressionStrategy.TEXT,
         }
         return mapping.get(content_type, self.config.fallback_strategy)
@@ -3800,6 +3851,8 @@ class ContentRouter(Transform):
             CompressionStrategy.HTML: ContentType.HTML,
             CompressionStrategy.TABULAR: ContentType.TABULAR,
             CompressionStrategy.CONFIG: ContentType.STRUCTURED_CONFIG,
+            CompressionStrategy.BOOLEAN: ContentType.BOOLEAN_LOGIC,
+            CompressionStrategy.NL_BOOLEAN: ContentType.NL_BOOLEAN_LOGIC,
             CompressionStrategy.TEXT: ContentType.PLAIN_TEXT,
             CompressionStrategy.KOMPRESS: ContentType.PLAIN_TEXT,
             CompressionStrategy.PASSTHROUGH: ContentType.PLAIN_TEXT,
@@ -4036,6 +4089,28 @@ class ContentRouter(Transform):
             except ImportError:  # pragma: no cover - defensive; module is pure stdlib
                 logger.debug("ConfigCompressor not available")
         return self._config_compressor
+
+    def _get_boolean_compressor(self) -> Any:
+        """Get BooleanCompressor (lazy load). Requires boolean-algebra-engine."""
+        if self._boolean_compressor is None:
+            try:
+                from .boolean_compressor import BooleanCompressor
+
+                self._boolean_compressor = BooleanCompressor()
+            except ImportError:
+                logger.debug("BooleanCompressor not available — install boolean-algebra-engine[cli]")
+        return self._boolean_compressor
+
+    def _get_nl_boolean_compressor(self) -> Any:
+        """Get NLBooleanCompressor (lazy load). Requires boolean-algebra-engine[nl-*] + API key."""
+        if self._nl_boolean_compressor is None:
+            try:
+                from .boolean_compressor import NLBooleanCompressor
+
+                self._nl_boolean_compressor = NLBooleanCompressor()
+            except ImportError:
+                logger.debug("NLBooleanCompressor not available — install boolean-algebra-engine[nl-anthropic]")
+        return self._nl_boolean_compressor
 
     def _get_diff_compressor(self) -> Any:
         """Get DiffCompressor (lazy load). Rust-only — Python implementation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,18 @@ langchain = [
     "langchain-core>=1.3.3,<4.0",
     "langchain-openai>=1.1.14,<2.0",
 ]
+# Boolean algebra compression (lossless, zero-LLM, Quine-McCluskey via boolean-algebra-engine)
+boolean = [
+    "boolean-algebra-engine>=0.3.0",
+]
+# Boolean + NL extraction via Anthropic
+boolean-nl-anthropic = [
+    "boolean-algebra-engine[nl-anthropic]>=0.3.0",
+]
+# Boolean + NL extraction via OpenAI
+boolean-nl-openai = [
+    "boolean-algebra-engine[nl-openai]>=0.3.0",
+]
 # Agno agent framework integration
 agno = [
     "agno>=1.0.0",

--- a/tests/test_transforms_boolean_compressor.py
+++ b/tests/test_transforms_boolean_compressor.py
@@ -322,6 +322,37 @@ def test_telemetry_fires_thread_without_opt_out(monkeypatch: pytest.MonkeyPatch)
 # ── Content router integration ────────────────────────────────────────────────
 
 
+def test_engine_loaded_fires_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    import headroom.transforms.boolean_compressor as mod
+
+    monkeypatch.setattr(mod, "_engine_loaded_fired", False)
+    monkeypatch.delenv("BOOLCALC_NO_TELEMETRY", raising=False)
+    threads_started: list[Any] = []
+    original_thread = __import__("threading").Thread
+
+    def capturing_thread(*args: Any, **kwargs: Any) -> Any:
+        t = original_thread(*args, **kwargs)
+        threads_started.append(t)
+        return t
+
+    with patch("threading.Thread", side_effect=capturing_thread):
+        mod._fire_engine_loaded()
+        mod._fire_engine_loaded()
+
+    assert len(threads_started) == 1, "engine_loaded must fire exactly once per process"
+
+
+def test_engine_loaded_suppressed_by_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    import headroom.transforms.boolean_compressor as mod
+
+    monkeypatch.setattr(mod, "_engine_loaded_fired", False)
+    monkeypatch.setenv("BOOLCALC_NO_TELEMETRY", "1")
+
+    with patch("threading.Thread") as mock_thread:
+        mod._fire_engine_loaded()
+        mock_thread.assert_not_called()
+
+
 def test_router_boolean_strategy_mapped(monkeypatch: pytest.MonkeyPatch) -> None:
     """BOOLEAN and NL_BOOLEAN strategies are wired in ContentRouter without import error."""
     from headroom.transforms.content_router import CompressionStrategy, ContentRouter

--- a/tests/test_transforms_boolean_compressor.py
+++ b/tests/test_transforms_boolean_compressor.py
@@ -8,7 +8,7 @@ Covers the checklist from PR #779:
 - NL description without API key → skips gracefully
 - boolean-algebra-engine not installed → graceful fallback, no import error
 - Prose with and/or → not detected as boolean logic
-- BOOLCALC_NO_TELEMETRY=1 → no PostHog event fired
+- integration performs no third-party telemetry
 """
 
 from __future__ import annotations
@@ -24,7 +24,6 @@ from headroom.transforms.boolean_compressor import (
     BooleanCompressionResult,
     BooleanCompressor,
     NLBooleanCompressor,
-    _fire_telemetry,
     _normalise,
     _try_parse_truth_table,
 )
@@ -194,6 +193,16 @@ def test_boolean_compressor_truth_table(monkeypatch: pytest.MonkeyPatch) -> None
     assert "B.C+A.C+A.B" in result.compressed
 
 
+def test_boolean_compressor_does_not_emit_third_party_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_engine(monkeypatch, minimal="B.C+A.C+A.B")
+    with patch("urllib.request.urlopen") as urlopen:
+        result = BooleanCompressor().compress(_MAJORITY_TABLE)
+    assert result is not None
+    urlopen.assert_not_called()
+
+
 def test_boolean_compressor_english_expression(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_engine(monkeypatch, minimal="A.B")
     result = BooleanCompressor().compress("A AND B OR A AND B")
@@ -208,6 +217,15 @@ def test_boolean_compressor_already_minimal_returns_none(monkeypatch: pytest.Mon
     _install_fake_engine(monkeypatch, minimal="A")
     result = BooleanCompressor().compress("A")
     assert result is None
+
+
+@pytest.mark.parametrize("operator", ["NAND", "NOR", "XNOR"])
+def test_boolean_compressor_never_approximates_grouped_operators(
+    monkeypatch: pytest.MonkeyPatch,
+    operator: str,
+) -> None:
+    _install_fake_engine(monkeypatch, minimal="A")
+    assert BooleanCompressor().compress(f"A {operator} B") is None
 
 
 def test_boolean_compressor_missing_engine_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -272,85 +290,294 @@ def test_nl_compressor_skips_non_logic_content(monkeypatch: pytest.MonkeyPatch) 
     assert result is None
 
 
-# ── Telemetry opt-out ─────────────────────────────────────────────────────────
-
-
-def test_telemetry_suppressed_by_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("BOOLCALC_NO_TELEMETRY", "1")
-
-    with patch("threading.Thread") as mock_thread:
-        _fire_telemetry(
-            BooleanCompressionResult(
-                compressed="A.B",
-                original="A AND B",
-                original_tokens=3,
-                compressed_tokens=1,
-                variable_count=2,
-                strategy="expression",
-            )
-        )
-        mock_thread.assert_not_called()
-
-
-def test_telemetry_fires_thread_without_opt_out(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("BOOLCALC_NO_TELEMETRY", raising=False)
-    threads_started: list[Any] = []
-
-    original_thread = __import__("threading").Thread
-
-    def capturing_thread(*args: Any, **kwargs: Any) -> Any:
-        t = original_thread(*args, **kwargs)
-        threads_started.append(t)
-        return t
-
-    with patch("threading.Thread", side_effect=capturing_thread):
-        _fire_telemetry(
-            BooleanCompressionResult(
-                compressed="A.B",
-                original="A AND B",
-                original_tokens=3,
-                compressed_tokens=1,
-                variable_count=2,
-                strategy="expression",
-            )
-        )
-
-    assert len(threads_started) == 1
-    assert threads_started[0].daemon is True
-
-
 # ── Content router integration ────────────────────────────────────────────────
 
 
-def test_engine_loaded_fires_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    import headroom.transforms.boolean_compressor as mod
-
-    monkeypatch.setattr(mod, "_engine_loaded_fired", False)
-    monkeypatch.delenv("BOOLCALC_NO_TELEMETRY", raising=False)
-    threads_started: list[Any] = []
-    original_thread = __import__("threading").Thread
-
-    def capturing_thread(*args: Any, **kwargs: Any) -> Any:
-        t = original_thread(*args, **kwargs)
-        threads_started.append(t)
-        return t
-
-    with patch("threading.Thread", side_effect=capturing_thread):
-        mod._fire_engine_loaded()
-        mod._fire_engine_loaded()
-
-    assert len(threads_started) == 1, "engine_loaded must fire exactly once per process"
+# ---------------------------------------------------------------------------
+# _try_parse_truth_table edge cases
+# ---------------------------------------------------------------------------
 
 
-def test_engine_loaded_suppressed_by_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    import headroom.transforms.boolean_compressor as mod
+def test_parse_truth_table_rejects_binary_only_no_header() -> None:
+    # Coverage: 96->107, 99->96, 108 — all lines are binary, no identifier header found
+    binary_only = "0 0 0\n0 1 1\n1 0 1\n1 1 1"
+    assert _try_parse_truth_table(binary_only) is None
 
-    monkeypatch.setattr(mod, "_engine_loaded_fired", False)
-    monkeypatch.setenv("BOOLCALC_NO_TELEMETRY", "1")
 
-    with patch("threading.Thread") as mock_thread:
-        mod._fire_engine_loaded()
-        mock_thread.assert_not_called()
+def test_parse_truth_table_rejects_too_many_variables() -> None:
+    # Coverage: 114 — 9 input columns = 9 variables, exceeds the 8-variable limit
+    header = "A B C D E F G H I Out"
+    one_row = "0 " * 9 + "0"
+    assert _try_parse_truth_table(header + "\n" + one_row) is None
+
+
+def test_parse_truth_table_skips_pipe_only_rows_in_data_section() -> None:
+    # Coverage: 123 — a "|" row in the data section becomes empty after re.sub → continue
+    table = "A B Out\n|---|---|---|\n0 0 0\n|\n0 1 1\n1 0 1\n1 1 1"
+    result = _try_parse_truth_table(table)
+    assert result is not None
+    assert result.variables == ["A", "B"]
+
+
+def test_parse_truth_table_rejects_column_count_mismatch() -> None:
+    # Coverage: 127 — a data row has fewer columns than the header
+    bad = "A B Out\n0 0\n0 1 1\n1 0 1\n1 1 1"
+    assert _try_parse_truth_table(bad) is None
+
+
+# ---------------------------------------------------------------------------
+# BooleanCompressionResult edge case
+# ---------------------------------------------------------------------------
+
+
+def test_boolean_result_savings_pct_zero_original_tokens() -> None:
+    # Coverage: 158 — savings_pct guard against division by zero
+    result = BooleanCompressionResult(
+        compressed="A",
+        original="",
+        original_tokens=0,
+        compressed_tokens=0,
+        variable_count=1,
+        strategy="expression",
+    )
+    assert result.savings_pct == 0.0
+
+
+# ---------------------------------------------------------------------------
+# BooleanCompressor.compress outer exception guard
+# ---------------------------------------------------------------------------
+
+
+def test_boolean_compressor_compress_catches_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Coverage: 182-184 — outer try/except in compress() catches non-ImportError exceptions
+    compressor = BooleanCompressor()
+
+    def raise_error(content: str) -> None:
+        raise RuntimeError("unexpected internal error")
+
+    monkeypatch.setattr(compressor, "_compress_truth_table", raise_error)
+    assert compressor.compress("A AND B") is None
+
+
+# ---------------------------------------------------------------------------
+# Contradiction and tautology paths in _compress_truth_table
+# ---------------------------------------------------------------------------
+
+
+def test_compress_truth_table_contradiction_all_zeros() -> None:
+    # Coverage: 192 — all outputs are 0 → minimal set directly to "0"
+    table = "A B Out\n0 0 0\n0 1 0\n1 0 0\n1 1 0"
+    result = BooleanCompressor()._compress_truth_table(table)
+    assert result is not None
+    assert "0" in result.compressed
+    assert result.strategy == "truth_table"
+
+
+def test_compress_truth_table_tautology_all_ones() -> None:
+    # Coverage: 195 — all outputs are 1 → minimal set directly to "1"
+    table = "A B Out\n0 0 1\n0 1 1\n1 0 1\n1 1 1"
+    result = BooleanCompressor()._compress_truth_table(table)
+    assert result is not None
+    assert "1" in result.compressed
+
+
+def test_compress_truth_table_no_savings(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Coverage: 222 — engine minimal has >= tokens than original → return None
+    # Use a 1-variable table (6 tokens) and a 6-word minimal expression
+    _install_fake_engine(monkeypatch, minimal="A B C D E F")
+    table = "A Out\n0 0\n1 1"
+    result = BooleanCompressor()._compress_truth_table(table)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _compress_expression edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_compress_expression_illegal_chars_after_normalisation() -> None:
+    # Coverage: 254 — '$' is not in the boolcalc alphabet → return None
+    result = BooleanCompressor()._compress_expression("A AND $B")
+    assert result is None
+
+
+def test_compress_expression_engine_exception_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Coverage: 261-263 — ImportError from missing engine is caught → return None
+    monkeypatch.setitem(sys.modules, "boolean_algebra_engine", None)  # type: ignore[arg-type]
+    result = BooleanCompressor()._compress_expression("A AND B OR NOT C")
+    assert result is None
+
+
+def test_compress_expression_no_savings(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Coverage: 268 — engine minimal has >= tokens than the original expression
+    _install_fake_engine(monkeypatch, minimal="A B C D")
+    result = BooleanCompressor()._compress_expression("A AND B")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _detect_provider paths
+# ---------------------------------------------------------------------------
+
+
+def test_detect_provider_openai_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Coverage: 438 — OPENAI_API_KEY set (no Anthropic key) → returns OpenAIProvider
+    from headroom.transforms.boolean_compressor import _detect_provider
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    fake_provider = object()
+    nl_mod = ModuleType("boolean_algebra_engine.nl.nl")
+    nl_mod.AnthropicProvider = lambda: None  # type: ignore[attr-defined]
+    nl_mod.OpenAIProvider = lambda: fake_provider  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(
+        sys.modules, "boolean_algebra_engine.nl", ModuleType("boolean_algebra_engine.nl")
+    )
+    monkeypatch.setitem(sys.modules, "boolean_algebra_engine.nl.nl", nl_mod)
+
+    assert _detect_provider() is fake_provider
+
+
+def test_detect_provider_import_error_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Coverage: 439-440 — ImportError from boolean_algebra_engine.nl.nl → pass → return None
+    from headroom.transforms.boolean_compressor import _detect_provider
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setitem(
+        sys.modules,
+        "boolean_algebra_engine.nl.nl",
+        None,  # type: ignore[arg-type]
+    )
+    assert _detect_provider() is None
+
+
+# ---------------------------------------------------------------------------
+# NLBooleanCompressor edge cases
+# ---------------------------------------------------------------------------
+
+
+def _setup_nl_mod(
+    monkeypatch: pytest.MonkeyPatch,
+    ask_fn: Any,
+) -> None:
+    """Wire a fake nl module with the given ask function into sys.modules."""
+    fake_provider = object()
+    nl_mod = ModuleType("boolean_algebra_engine.nl.nl")
+    nl_mod.AnthropicProvider = lambda: fake_provider  # type: ignore[attr-defined]
+    nl_mod.OpenAIProvider = lambda: None  # type: ignore[attr-defined]
+    nl_mod.ask = ask_fn  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(
+        sys.modules, "boolean_algebra_engine.nl", ModuleType("boolean_algebra_engine.nl")
+    )
+    monkeypatch.setitem(sys.modules, "boolean_algebra_engine.nl.nl", nl_mod)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+
+_NL_CONTENT = "The alarm turns on when motion is detected and the door is open."
+
+
+def test_nl_compressor_ask_exception_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Coverage: 467-469 — ask() raises an exception → caught → return None
+    def boom(content: str, provider: Any) -> None:
+        raise RuntimeError("api failure")
+
+    _setup_nl_mod(monkeypatch, boom)
+    assert NLBooleanCompressor().compress(_NL_CONTENT) is None
+
+
+def test_nl_compressor_empty_minimal_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Coverage: 473 — result.minimal is None and result.expression is None → return None
+    _setup_nl_mod(
+        monkeypatch,
+        lambda content, provider: SimpleNamespace(minimal=None, expression=None, variables={}),
+    )
+    assert NLBooleanCompressor().compress(_NL_CONTENT) is None
+
+
+def test_nl_compressor_no_savings_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Coverage: 481 — compressed form is longer than original → return None
+    long_minimal = " ".join(["X"] * 50)
+    _setup_nl_mod(
+        monkeypatch,
+        lambda content, provider: SimpleNamespace(
+            minimal=long_minimal,
+            expression=None,
+            variables={"A": "door_open"},
+        ),
+    )
+    assert NLBooleanCompressor().compress(_NL_CONTENT) is None
+
+
+# ---------------------------------------------------------------------------
+# detect_content_type integration: boolean paths in the main detector
+# ---------------------------------------------------------------------------
+
+
+def test_detect_content_type_routes_truth_table_to_boolean_logic() -> None:
+    # Coverage: content_detector.py lines 170-172 — detect_content_type returns BOOLEAN_LOGIC
+    from headroom.transforms.content_detector import detect_content_type
+
+    table = "A B Out\n0 0 0\n0 1 1\n1 0 1\n1 1 1"
+    result = detect_content_type(table)
+    assert result.content_type is ContentType.BOOLEAN_LOGIC
+
+
+def test_detect_content_type_routes_nl_description_to_nl_boolean_logic() -> None:
+    # Coverage: content_detector.py lines 175-177 — detect_content_type returns NL_BOOLEAN_LOGIC
+    from headroom.transforms.content_detector import detect_content_type
+
+    content = "The alarm turns on when motion is detected and the door is open."
+    result = detect_content_type(content)
+    assert result.content_type is ContentType.NL_BOOLEAN_LOGIC
+
+
+# ---------------------------------------------------------------------------
+# _try_detect_boolean edge cases in content_detector.py
+# ---------------------------------------------------------------------------
+
+
+def test_try_detect_boolean_empty_content_returns_none() -> None:
+    # Coverage: content_detector.py 472-473 — empty content → if not lines: return None
+    assert _try_detect_boolean("") is None
+    assert _try_detect_boolean("   ") is None
+
+
+def test_try_detect_boolean_skips_separator_line_before_header() -> None:
+    # Coverage: content_detector.py 484-485 — "---" becomes empty words → continue
+    content = "---\nA B Out\n0 0 0\n0 1 1\n1 0 1\n1 1 1"
+    result = _try_detect_boolean(content)
+    assert result is not None
+    assert result.content_type is ContentType.BOOLEAN_LOGIC
+
+
+# ---------------------------------------------------------------------------
+# _try_detect_nl_boolean op-count heuristic path
+# ---------------------------------------------------------------------------
+
+
+def test_try_detect_boolean_non_binary_data_row_is_skipped() -> None:
+    # Coverage: content_detector.py 496->481 — data row with non-binary words → False branch
+    content = "A B Out\nskip this row\n0 1 1\n1 0 1\n1 1 1"
+    result = _try_detect_boolean(content)
+    # Non-binary row is skipped; 3 binary rows remain → detected as BOOLEAN_LOGIC
+    assert result is not None
+    assert result.content_type is ContentType.BOOLEAN_LOGIC
+
+
+def test_try_detect_nl_boolean_op_count_heuristic() -> None:
+    # Coverage: content_detector.py 574-579 — no signal phrase but op_count >= 3 → 0.70
+    content = "enable if either A or B but not both"
+    result = _try_detect_nl_boolean(content)
+    assert result is not None
+    assert result.content_type is ContentType.NL_BOOLEAN_LOGIC
+    assert result.confidence == 0.70
 
 
 def test_router_boolean_strategy_mapped(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_transforms_boolean_compressor.py
+++ b/tests/test_transforms_boolean_compressor.py
@@ -1,0 +1,340 @@
+"""Tests for boolean algebra compressor and detector paths.
+
+Covers the checklist from PR #779:
+- Truth table (markdown) → BooleanCompressor returns minimal SOP
+- English expression → normalised, synthesised
+- Already-minimal expression → no regression (passthrough)
+- NL description with API key → NLBooleanCompressor fires
+- NL description without API key → skips gracefully
+- boolean-algebra-engine not installed → graceful fallback, no import error
+- Prose with and/or → not detected as boolean logic
+- BOOLCALC_NO_TELEMETRY=1 → no PostHog event fired
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from headroom.transforms.boolean_compressor import (
+    BooleanCompressionResult,
+    BooleanCompressor,
+    NLBooleanCompressor,
+    _fire_telemetry,
+    _normalise,
+    _try_parse_truth_table,
+)
+from headroom.transforms.content_detector import (
+    ContentType,
+    _try_detect_boolean,
+    _try_detect_nl_boolean,
+)
+
+# ── Notation normaliser ───────────────────────────────────────────────────────
+
+
+def test_normalise_english_operators() -> None:
+    assert _normalise("A AND B OR NOT C") == "A.B+!C"
+
+
+def test_normalise_symbolic_operators() -> None:
+    assert _normalise("A || B && !C") == "A+B.!C"
+
+
+def test_normalise_strips_whitespace() -> None:
+    assert " " not in _normalise("A AND B")
+
+
+# ── Truth table parser ────────────────────────────────────────────────────────
+
+_MAJORITY_TABLE = """\
+| A | B | C | Out |
+|---|---|---|-----|
+| 0 | 0 | 0 |  0  |
+| 0 | 0 | 1 |  0  |
+| 0 | 1 | 0 |  0  |
+| 0 | 1 | 1 |  1  |
+| 1 | 0 | 0 |  0  |
+| 1 | 0 | 1 |  1  |
+| 1 | 1 | 0 |  1  |
+| 1 | 1 | 1 |  1  |
+"""
+
+
+def test_parse_truth_table_3var_markdown() -> None:
+    result = _try_parse_truth_table(_MAJORITY_TABLE)
+    assert result is not None
+    assert result.variables == ["A", "B", "C"]
+    assert set(result.minterms) == {3, 5, 6, 7}
+
+
+def test_parse_truth_table_rejects_incomplete() -> None:
+    incomplete = "A B Out\n0 0 0\n0 1 1\n"  # only 2 of 4 rows
+    assert _try_parse_truth_table(incomplete) is None
+
+
+def test_parse_truth_table_rejects_non_binary_cells() -> None:
+    bad = "A B Out\n0 0 X\n0 1 1\n1 0 0\n1 1 1\n"
+    assert _try_parse_truth_table(bad) is None
+
+
+def test_parse_truth_table_rejects_plain_text() -> None:
+    assert _try_parse_truth_table("just some prose here") is None
+
+
+# ── Boolean content detector ──────────────────────────────────────────────────
+
+
+def test_detect_boolean_truth_table() -> None:
+    result = _try_detect_boolean(_MAJORITY_TABLE)
+    assert result is not None
+    assert result.content_type is ContentType.BOOLEAN_LOGIC
+    assert result.metadata["form"] == "truth_table"
+    assert result.confidence >= 0.7
+
+
+def test_detect_boolean_english_expression() -> None:
+    result = _try_detect_boolean("A AND B OR NOT C")
+    assert result is not None
+    assert result.content_type is ContentType.BOOLEAN_LOGIC
+    assert result.metadata["form"] == "expression"
+    assert result.confidence >= 0.85
+
+
+def test_detect_boolean_symbolic_expression() -> None:
+    result = _try_detect_boolean("A.B + !C")
+    assert result is not None
+    assert result.content_type is ContentType.BOOLEAN_LOGIC
+
+
+def test_detect_boolean_rejects_prose_with_and_or() -> None:
+    prose = "We need to handle errors and log them or retry the operation if needed."
+    assert _try_detect_boolean(prose) is None
+
+
+def test_detect_boolean_rejects_source_code() -> None:
+    code = "if user.is_admin and not user.suspended:\n    grant_access()"
+    assert _try_detect_boolean(code) is None
+
+
+def test_detect_boolean_requires_two_distinct_variables() -> None:
+    assert _try_detect_boolean("A AND A") is None or True  # single unique var, may return None
+
+
+# ── NL boolean content detector ──────────────────────────────────────────────
+
+
+def test_detect_nl_boolean_signal_phrase() -> None:
+    content = "The alarm turns on when motion is detected and door is open."
+    result = _try_detect_nl_boolean(content)
+    assert result is not None
+    assert result.content_type is ContentType.NL_BOOLEAN_LOGIC
+    assert result.confidence >= 0.70
+
+
+def test_detect_nl_boolean_rejects_long_prose() -> None:
+    long_prose = ("and or not " * 40).strip()  # >100 words but operator-only
+    assert _try_detect_nl_boolean(long_prose) is None
+
+
+def test_detect_nl_boolean_rejects_structured_expression() -> None:
+    # Already looks like formal boolean — should be caught by _try_detect_boolean
+    assert _try_detect_nl_boolean("A.B+!C") is None
+
+
+def test_detect_nl_boolean_rejects_generic_prose() -> None:
+    prose = "I went to the store and bought milk or juice."
+    # Only 2 operator words, no signal phrase — should not fire
+    result = _try_detect_nl_boolean(prose)
+    # Either None or low-confidence; must not be above 0.75
+    assert result is None or result.confidence < 0.75
+
+
+# ── BooleanCompressor (with mocked boolean_algebra_engine) ───────────────────
+
+
+def _make_fake_engine(minimal: str = "B.C+A.C+A.B") -> ModuleType:
+    """Build a minimal fake of the boolean_algebra_engine module."""
+
+    def fake_row(inputs: Any, output: Any) -> Any:
+        return SimpleNamespace(inputs=inputs, output=output)
+
+    engine = ModuleType("boolean_algebra_engine")
+    engine.synthesize = lambda table: (minimal, None)
+    engine.evaluate = lambda expr: (SimpleNamespace(variables=["A", "B", "C"]), None)
+
+    core = ModuleType("boolean_algebra_engine.core")
+    models = ModuleType("boolean_algebra_engine.core.models")
+    models.TruthTable = lambda **kw: SimpleNamespace(**kw)
+    models.TruthTableRow = fake_row
+    core.models = models
+
+    engine.core = core
+    return engine
+
+
+def _install_fake_engine(monkeypatch: pytest.MonkeyPatch, minimal: str = "B.C+A.C+A.B") -> None:
+    fake = _make_fake_engine(minimal)
+    monkeypatch.setitem(sys.modules, "boolean_algebra_engine", fake)
+    monkeypatch.setitem(sys.modules, "boolean_algebra_engine.core", fake.core)
+    monkeypatch.setitem(sys.modules, "boolean_algebra_engine.core.models", fake.core.models)
+
+
+def test_boolean_compressor_truth_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_engine(monkeypatch, minimal="B.C+A.C+A.B")
+    result = BooleanCompressor().compress(_MAJORITY_TABLE)
+    assert result is not None
+    assert result.strategy == "truth_table"
+    assert result.variable_count == 3
+    assert result.tokens_saved > 0
+    assert "B.C+A.C+A.B" in result.compressed
+
+
+def test_boolean_compressor_english_expression(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_engine(monkeypatch, minimal="A.B")
+    result = BooleanCompressor().compress("A AND B OR A AND B")
+    assert result is not None
+    assert result.strategy == "expression"
+    assert "A.B" in result.compressed
+
+
+def test_boolean_compressor_already_minimal_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # When minimal == original (single short token), compressed_tokens >= original_tokens
+    # so the compressor should return None (no gain)
+    _install_fake_engine(monkeypatch, minimal="A")
+    result = BooleanCompressor().compress("A")
+    assert result is None
+
+
+def test_boolean_compressor_missing_engine_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "boolean_algebra_engine", None)  # type: ignore[arg-type]
+    result = BooleanCompressor().compress(_MAJORITY_TABLE)
+    assert result is None
+
+
+def test_boolean_compressor_engine_exception_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _make_fake_engine()
+    fake.synthesize = lambda _: (_ for _ in ()).throw(RuntimeError("boom"))  # type: ignore[assignment]
+    monkeypatch.setitem(sys.modules, "boolean_algebra_engine", fake)
+    result = BooleanCompressor().compress(_MAJORITY_TABLE)
+    assert result is None
+
+
+# ── NLBooleanCompressor ───────────────────────────────────────────────────────
+
+
+def _fake_nl_result() -> Any:
+    return SimpleNamespace(
+        minimal="A^B",
+        expression="A XOR B",
+        variables={"A": "door_open", "B": "motion_detected"},
+    )
+
+
+def test_nl_compressor_fires_with_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    fake_provider = object()
+    nl_mod = ModuleType("boolean_algebra_engine.nl.nl")
+    nl_mod.AnthropicProvider = lambda: fake_provider  # type: ignore[attr-defined]
+    nl_mod.OpenAIProvider = lambda: None  # type: ignore[attr-defined]
+    nl_mod.ask = lambda content, provider: _fake_nl_result()  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(
+        sys.modules, "boolean_algebra_engine.nl", ModuleType("boolean_algebra_engine.nl")
+    )
+    monkeypatch.setitem(sys.modules, "boolean_algebra_engine.nl.nl", nl_mod)
+
+    content = "The alarm turns on when motion is detected and the door is open."
+    result = NLBooleanCompressor().compress(content)
+    assert result is not None
+    assert result.strategy == "nl_expression"
+    assert "A^B" in result.compressed
+
+
+def test_nl_compressor_skips_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    content = "The alarm turns on when motion is detected and the door is open."
+    result = NLBooleanCompressor().compress(content)
+    assert result is None
+
+
+def test_nl_compressor_skips_non_logic_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    prose = "I had a great time at the park yesterday with my friends."
+    result = NLBooleanCompressor().compress(prose)
+    assert result is None
+
+
+# ── Telemetry opt-out ─────────────────────────────────────────────────────────
+
+
+def test_telemetry_suppressed_by_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BOOLCALC_NO_TELEMETRY", "1")
+
+    with patch("threading.Thread") as mock_thread:
+        _fire_telemetry(
+            BooleanCompressionResult(
+                compressed="A.B",
+                original="A AND B",
+                original_tokens=3,
+                compressed_tokens=1,
+                variable_count=2,
+                strategy="expression",
+            )
+        )
+        mock_thread.assert_not_called()
+
+
+def test_telemetry_fires_thread_without_opt_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BOOLCALC_NO_TELEMETRY", raising=False)
+    threads_started: list[Any] = []
+
+    original_thread = __import__("threading").Thread
+
+    def capturing_thread(*args: Any, **kwargs: Any) -> Any:
+        t = original_thread(*args, **kwargs)
+        threads_started.append(t)
+        return t
+
+    with patch("threading.Thread", side_effect=capturing_thread):
+        _fire_telemetry(
+            BooleanCompressionResult(
+                compressed="A.B",
+                original="A AND B",
+                original_tokens=3,
+                compressed_tokens=1,
+                variable_count=2,
+                strategy="expression",
+            )
+        )
+
+    assert len(threads_started) == 1
+    assert threads_started[0].daemon is True
+
+
+# ── Content router integration ────────────────────────────────────────────────
+
+
+def test_router_boolean_strategy_mapped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BOOLEAN and NL_BOOLEAN strategies are wired in ContentRouter without import error."""
+    from headroom.transforms.content_router import CompressionStrategy, ContentRouter
+
+    assert hasattr(CompressionStrategy, "BOOLEAN")
+    assert hasattr(CompressionStrategy, "NL_BOOLEAN")
+
+    router = ContentRouter()
+    assert (
+        router._strategy_from_detection_type(ContentType.BOOLEAN_LOGIC)
+        is CompressionStrategy.BOOLEAN
+    )
+    assert (
+        router._strategy_from_detection_type(ContentType.NL_BOOLEAN_LOGIC)
+        is CompressionStrategy.NL_BOOLEAN
+    )

--- a/tests/test_transforms_content_router.py
+++ b/tests/test_transforms_content_router.py
@@ -1755,7 +1755,8 @@ def test_detect_content_overrides_html_misroute_for_grep_and_logs(
         "</section></main></body></html>"
     )
     assert _detect_content(html).content_type is ContentType.HTML
-||||||| parent of c4fb013c (test: cover BOOLEAN and NL_BOOLEAN strategy paths in content_router)
+
+
 # BOOLEAN and NL_BOOLEAN strategy paths (PR #779)
 # ---------------------------------------------------------------------------
 
@@ -1812,9 +1813,6 @@ def test_boolean_strategy_compresses_when_compressor_available(
             return fake_result
 
     monkeypatch.setattr(router, "_get_boolean_compressor", lambda: FakeBoolean())
-    import headroom.transforms.boolean_compressor as bc_mod
-    monkeypatch.setattr(bc_mod, "_fire_telemetry", lambda result: None)
-
     compressed, tokens, chain = router._apply_strategy_to_content(
         content, CompressionStrategy.BOOLEAN, context=""
     )
@@ -1891,9 +1889,6 @@ def test_nl_boolean_strategy_compresses_when_compressor_available(
             return fake_result
 
     monkeypatch.setattr(router, "_get_nl_boolean_compressor", lambda: FakeNLBoolean())
-    import headroom.transforms.boolean_compressor as bc_mod
-    monkeypatch.setattr(bc_mod, "_fire_telemetry", lambda result: None)
-
     compressed, tokens, chain = router._apply_strategy_to_content(
         content, CompressionStrategy.NL_BOOLEAN, context=""
     )

--- a/tests/test_transforms_content_router.py
+++ b/tests/test_transforms_content_router.py
@@ -1755,3 +1755,207 @@ def test_detect_content_overrides_html_misroute_for_grep_and_logs(
         "</section></main></body></html>"
     )
     assert _detect_content(html).content_type is ContentType.HTML
+||||||| parent of c4fb013c (test: cover BOOLEAN and NL_BOOLEAN strategy paths in content_router)
+# BOOLEAN and NL_BOOLEAN strategy paths (PR #779)
+# ---------------------------------------------------------------------------
+
+
+def test_boolean_nl_boolean_strategies_in_enum() -> None:
+    assert CompressionStrategy.BOOLEAN.value == "boolean"
+    assert CompressionStrategy.NL_BOOLEAN.value == "nl_boolean"
+
+
+def test_strategy_from_detection_type_maps_boolean_content_types() -> None:
+    from headroom.transforms.content_detector import ContentType
+
+    router = ContentRouter()
+    assert (
+        router._strategy_from_detection_type(ContentType.BOOLEAN_LOGIC)
+        is CompressionStrategy.BOOLEAN
+    )
+    assert (
+        router._strategy_from_detection_type(ContentType.NL_BOOLEAN_LOGIC)
+        is CompressionStrategy.NL_BOOLEAN
+    )
+
+
+def test_content_type_from_strategy_maps_boolean_strategies() -> None:
+    from headroom.transforms.content_detector import ContentType
+
+    router = ContentRouter()
+    assert (
+        router._content_type_from_strategy(CompressionStrategy.BOOLEAN) is ContentType.BOOLEAN_LOGIC
+    )
+    assert (
+        router._content_type_from_strategy(CompressionStrategy.NL_BOOLEAN)
+        is ContentType.NL_BOOLEAN_LOGIC
+    )
+
+
+def test_boolean_strategy_compresses_when_compressor_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = ContentRouter()
+    content = "A B result\n0 0 0\n0 1 1\n1 0 1\n1 1 1"
+
+    fake_result = SimpleNamespace(
+        compressed="A | B",
+        compressed_tokens=3,
+        strategy="truth_table",
+        original=content,
+        original_tokens=len(content.split()),
+        variable_count=2,
+    )
+
+    class FakeBoolean:
+        def compress(self, c: str) -> object:
+            return fake_result
+
+    monkeypatch.setattr(router, "_get_boolean_compressor", lambda: FakeBoolean())
+    import headroom.transforms.boolean_compressor as bc_mod
+    monkeypatch.setattr(bc_mod, "_fire_telemetry", lambda result: None)
+
+    compressed, tokens, chain = router._apply_strategy_to_content(
+        content, CompressionStrategy.BOOLEAN, context=""
+    )
+
+    assert compressed == "A | B"
+    assert tokens == 3
+    assert chain == ["boolean"]
+
+
+def test_boolean_strategy_falls_back_to_kompress_when_compressor_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = ContentRouter()
+    content = "A B result\n0 0 0\n0 1 1\n1 0 1\n1 1 1"
+
+    monkeypatch.setattr(router, "_get_boolean_compressor", lambda: None)
+
+    def fake_ml(c: str, ctx: str, q: object = None) -> tuple[str, int]:
+        return ("kompress_out", 2)
+
+    monkeypatch.setattr(router, "_try_ml_compressor", fake_ml)
+
+    compressed, tokens, chain = router._apply_strategy_to_content(
+        content, CompressionStrategy.BOOLEAN, context=""
+    )
+
+    assert compressed == "kompress_out"
+    assert tokens == 2
+    assert "kompress" in chain
+
+
+def test_boolean_strategy_falls_back_when_compress_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = ContentRouter()
+    content = "A B result\n0 0 0\n0 1 1\n1 0 1\n1 1 1"
+
+    class FakeBooleanReturnsNone:
+        def compress(self, c: str) -> None:
+            return None
+
+    monkeypatch.setattr(router, "_get_boolean_compressor", lambda: FakeBooleanReturnsNone())
+
+    def fake_ml(c: str, ctx: str, q: object = None) -> tuple[str, int]:
+        return ("kompress_fallback", 5)
+
+    monkeypatch.setattr(router, "_try_ml_compressor", fake_ml)
+
+    compressed, tokens, chain = router._apply_strategy_to_content(
+        content, CompressionStrategy.BOOLEAN, context=""
+    )
+
+    assert compressed == "kompress_fallback"
+    assert "kompress" in chain
+
+
+def test_nl_boolean_strategy_compresses_when_compressor_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = ContentRouter()
+    content = "trigger alert when temperature above 30 and humidity above 80"
+
+    fake_result = SimpleNamespace(
+        compressed="temp>30 AND humid>80",
+        compressed_tokens=4,
+        strategy="nl_boolean",
+        original=content,
+        original_tokens=len(content.split()),
+        variable_count=2,
+    )
+
+    class FakeNLBoolean:
+        def compress(self, c: str) -> object:
+            return fake_result
+
+    monkeypatch.setattr(router, "_get_nl_boolean_compressor", lambda: FakeNLBoolean())
+    import headroom.transforms.boolean_compressor as bc_mod
+    monkeypatch.setattr(bc_mod, "_fire_telemetry", lambda result: None)
+
+    compressed, tokens, chain = router._apply_strategy_to_content(
+        content, CompressionStrategy.NL_BOOLEAN, context=""
+    )
+
+    assert compressed == "temp>30 AND humid>80"
+    assert tokens == 4
+    assert chain == ["nl_boolean"]
+
+
+def test_nl_boolean_strategy_falls_back_to_kompress_when_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = ContentRouter()
+    content = "trigger alert when temperature high and humidity high"
+
+    monkeypatch.setattr(router, "_get_nl_boolean_compressor", lambda: None)
+
+    def fake_ml(c: str, ctx: str, q: object = None) -> tuple[str, int]:
+        return ("kompress_nl_out", 3)
+
+    monkeypatch.setattr(router, "_try_ml_compressor", fake_ml)
+
+    compressed, tokens, chain = router._apply_strategy_to_content(
+        content, CompressionStrategy.NL_BOOLEAN, context=""
+    )
+
+    assert compressed == "kompress_nl_out"
+    assert tokens == 3
+    assert "kompress" in chain
+
+
+def test_get_boolean_compressor_caches_instance() -> None:
+    router = ContentRouter()
+    c1 = router._get_boolean_compressor()
+    c2 = router._get_boolean_compressor()
+    assert c1 is c2
+
+
+def test_get_boolean_compressor_returns_none_on_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+
+    router = ContentRouter()
+    router._boolean_compressor = None
+    monkeypatch.setitem(sys.modules, "headroom.transforms.boolean_compressor", None)
+    assert router._get_boolean_compressor() is None
+
+
+def test_get_nl_boolean_compressor_caches_instance() -> None:
+    router = ContentRouter()
+    c1 = router._get_nl_boolean_compressor()
+    c2 = router._get_nl_boolean_compressor()
+    assert c1 is c2
+
+
+def test_get_nl_boolean_compressor_returns_none_on_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+
+    router = ContentRouter()
+    router._nl_boolean_compressor = None
+    monkeypatch.setitem(sys.modules, "headroom.transforms.boolean_compressor", None)
+    assert router._get_nl_boolean_compressor() is None

--- a/uv.lock
+++ b/uv.lock
@@ -504,6 +504,23 @@ wheels = [
 ]
 
 [[package]]
+name = "boolean-algebra-engine"
+version = "0.3.21"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/10/39770979c896e5e64adc899ca5247c560b6662c591e957af94c54749d82b/boolean_algebra_engine-0.3.21.tar.gz", hash = "sha256:7295e84bdc539c17b9ff3b126deb30f5b6951b34eff21cafe1ab362ec9636917", size = 54233, upload-time = "2026-06-08T15:58:29.407Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/d0/537c57f3ce06e703a2e17ed90874cad764070bb41afe1f35ded6c085ed08/boolean_algebra_engine-0.3.21-py3-none-any.whl", hash = "sha256:2c943115eda4c0aa614986618813b59109fe20c222e87dd4cc424c64683c5ff4", size = 48737, upload-time = "2026-06-08T15:58:28.166Z" },
+]
+
+[package.optional-dependencies]
+nl-anthropic = [
+    { name = "anthropic" },
+]
+nl-openai = [
+    { name = "openai" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.42.38"
 source = { registry = "https://pypi.org/simple/" }
@@ -1748,6 +1765,15 @@ bedrock = [
     { name = "boto3" },
     { name = "botocore", extra = ["crt"] },
 ]
+boolean = [
+    { name = "boolean-algebra-engine" },
+]
+boolean-nl-anthropic = [
+    { name = "boolean-algebra-engine", extra = ["nl-anthropic"] },
+]
+boolean-nl-openai = [
+    { name = "boolean-algebra-engine", extra = ["nl-openai"] },
+]
 code = [
     { name = "tree-sitter" },
     { name = "tree-sitter-language-pack" },
@@ -1938,6 +1964,9 @@ requires-dist = [
     { name = "ast-grep-cli", specifier = ">=0.30.0,!=0.44.1" },
     { name = "autogen-agentchat", marker = "extra == 'autogen'", specifier = ">=0.7" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.41.0" },
+    { name = "boolean-algebra-engine", marker = "extra == 'boolean'", specifier = ">=0.3.0" },
+    { name = "boolean-algebra-engine", extras = ["nl-anthropic"], marker = "extra == 'boolean-nl-anthropic'", specifier = ">=0.3.0" },
+    { name = "boolean-algebra-engine", extras = ["nl-openai"], marker = "extra == 'boolean-nl-openai'", specifier = ">=0.3.0" },
     { name = "botocore", extras = ["crt"], marker = "extra == 'bedrock'", specifier = ">=1.41.0" },
     { name = "click", specifier = ">=8.3.3" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=1.0" },
@@ -2032,7 +2061,7 @@ requires-dist = [
     { name = "xlrd", marker = "extra == 'spreadsheet'", specifier = ">=2.0.1" },
     { name = "zstandard", marker = "extra == 'proxy'", specifier = ">=0.20.0" },
 ]
-provides-extras = ["proxy", "proxy-prod", "code", "ml", "memory", "vector", "memory-stack", "pytorch-mps", "relevance", "image", "reports", "spreadsheet", "otel", "anyllm", "langchain", "agno", "strands", "crewai", "autogen", "mcp", "voice", "voice-train", "evals", "bedrock", "html", "dev", "all", "sandbox"]
+provides-extras = ["proxy", "proxy-prod", "code", "ml", "memory", "vector", "memory-stack", "pytorch-mps", "relevance", "image", "reports", "spreadsheet", "otel", "anyllm", "langchain", "boolean", "boolean-nl-anthropic", "boolean-nl-openai", "agno", "strands", "crewai", "autogen", "mcp", "voice", "voice-train", "evals", "bedrock", "html", "dev", "all", "sandbox"]
 
 [[package]]
 name = "hf-xet"

--- a/wiki/compression.md
+++ b/wiki/compression.md
@@ -402,6 +402,92 @@ print(f"CCR Key: {result.ccr_key}")             # For retrieval
 
 ---
 
+---
+
+## Boolean Compression
+
+Headroom includes a **lossless** boolean algebra compressor that reduces truth tables and boolean expressions to their minimal sum-of-products (SOP) form using the Quine-McCluskey algorithm via [boolean-algebra-engine](https://github.com/Shrivastava-Aditya/bool-LLM-ngn). Unlike Kompress, this path never approximates — the output is proven logically equivalent to the input.
+
+### Content types handled
+
+| Input | Example | Savings |
+|-------|---------|---------|
+| Markdown truth table | 8-row `\| A \| B \| C \| Out \|` table | ~91% |
+| English-operator expression | `A AND B OR NOT C` | ~71% |
+| Natural-language logic (NL path) | "alarm on when door open and motion detected" | ~87% |
+
+### Installation
+
+```bash
+# Algorithmic path only (no API key needed)
+pip install "headroom-ai[boolean]"
+
+# With natural-language extraction (Anthropic)
+pip install "headroom-ai[boolean,nl-anthropic]"
+export ANTHROPIC_API_KEY=sk-...
+
+# With natural-language extraction (OpenAI)
+pip install "headroom-ai[boolean,nl-openai]"
+export OPENAI_API_KEY=sk-...
+```
+
+If `boolean-algebra-engine` is not installed, both compressors are silently unavailable and headroom falls back to Kompress. No import error is raised at startup.
+
+### How detection works
+
+The router detects boolean content before routing:
+
+- **Truth tables**: A header row of variable names followed by rows of `0`/`1` values (markdown `|` pipes supported).
+- **Symbolic expressions**: Single uppercase-letter variables (`A`, `B`, `C`) combined with `AND`/`OR`/`NOT`, `&&`/`||`/`!`, `.`/`+`/`~`, or Unicode `¬`.
+- **Natural-language logic** (NL path, optional): Short prose describing a logic function using signal phrases like *"output is high when … and …"* or *"alarm turns on if … but not …"*.
+
+Source code and general prose that happen to use `and`/`or` are **not** detected — the detector requires single-letter uppercase variables or an explicit truth table structure to avoid false positives.
+
+### Telemetry and opt-out
+
+This path fires two anonymous events to the **boolean-algebra-engine** PostHog project:
+
+**`headroom_boolean_engine_loaded`** — fired once per headroom session the first time a boolean compression succeeds. Used to distinguish headroom-sourced engine usage from direct CLI installs.
+
+| Field | Value |
+|-------|-------|
+| `source` | `"headroom"` |
+
+**`headroom_boolean_compress`** — fired on each compression. Reports:
+
+| Field | Description |
+|-------|-------------|
+| `tokens_before` | Token count before compression |
+| `tokens_after` | Token count after compression |
+| `tokens_saved` | Tokens saved |
+| `savings_pct` | Savings as a percentage |
+| `variable_count` | Number of boolean variables |
+| `strategy` | `"truth_table"`, `"expression"`, or `"nl_expression"` |
+| `source` | Always `"headroom"` |
+
+No prompt content, file paths, or personally identifiable information is sent. The `distinct_id` reuses the `boolean-algebra-engine` install ID (stored in `~/.config/boolcalc/telemetry.json`) so headroom usage can be correlated with direct CLI usage under one anonymous profile.
+
+**To opt out**, set the environment variable before starting headroom:
+
+```bash
+export BOOLCALC_NO_TELEMETRY=1
+```
+
+Or add it to your headroom environment permanently:
+
+```bash
+# docker-compose.yml
+environment:
+  - BOOLCALC_NO_TELEMETRY=1
+
+# .env / shell profile
+BOOLCALC_NO_TELEMETRY=1
+```
+
+When the variable is set, no network request is made and no thread is spawned.
+
+---
+
 ## See Also
 
 - [Transforms Reference](transforms.md) - Other compression transforms

--- a/wiki/compression.md
+++ b/wiki/compression.md
@@ -406,7 +406,7 @@ print(f"CCR Key: {result.ccr_key}")             # For retrieval
 
 ## Boolean Compression
 
-Headroom includes a **lossless** boolean algebra compressor that reduces truth tables and boolean expressions to their minimal sum-of-products (SOP) form using the Quine-McCluskey algorithm via [boolean-algebra-engine](https://github.com/Shrivastava-Aditya/bool-LLM-ngn). Unlike Kompress, this path never approximates — the output is proven logically equivalent to the input.
+Headroom includes a deterministic boolean algebra compressor that reduces truth tables and boolean expressions to their minimal sum-of-products (SOP) form using the Quine-McCluskey algorithm via [boolean-algebra-engine](https://github.com/Shrivastava-Aditya/bool-LLM-ngn). For structured inputs, the output is logically equivalent to the parsed function. The optional natural-language path first uses an LLM to infer a function and is therefore probabilistic, not lossless.
 
 ### Content types handled
 
@@ -443,48 +443,9 @@ The router detects boolean content before routing:
 
 Source code and general prose that happen to use `and`/`or` are **not** detected — the detector requires single-letter uppercase variables or an explicit truth table structure to avoid false positives.
 
-### Telemetry and opt-out
+### Telemetry
 
-This path fires two anonymous events to the **boolean-algebra-engine** PostHog project:
-
-**`headroom_boolean_engine_loaded`** — fired once per headroom session the first time a boolean compression succeeds. Used to distinguish headroom-sourced engine usage from direct CLI installs.
-
-| Field | Value |
-|-------|-------|
-| `source` | `"headroom"` |
-
-**`headroom_boolean_compress`** — fired on each compression. Reports:
-
-| Field | Description |
-|-------|-------------|
-| `tokens_before` | Token count before compression |
-| `tokens_after` | Token count after compression |
-| `tokens_saved` | Tokens saved |
-| `savings_pct` | Savings as a percentage |
-| `variable_count` | Number of boolean variables |
-| `strategy` | `"truth_table"`, `"expression"`, or `"nl_expression"` |
-| `source` | Always `"headroom"` |
-
-No prompt content, file paths, or personally identifiable information is sent. The `distinct_id` reuses the `boolean-algebra-engine` install ID (stored in `~/.config/boolcalc/telemetry.json`) so headroom usage can be correlated with direct CLI usage under one anonymous profile.
-
-**To opt out**, set the environment variable before starting headroom:
-
-```bash
-export BOOLCALC_NO_TELEMETRY=1
-```
-
-Or add it to your headroom environment permanently:
-
-```bash
-# docker-compose.yml
-environment:
-  - BOOLCALC_NO_TELEMETRY=1
-
-# .env / shell profile
-BOOLCALC_NO_TELEMETRY=1
-```
-
-When the variable is set, no network request is made and no thread is spawned.
+The Headroom integration does not send usage events to the boolean-algebra-engine PostHog project or create a second analytics channel. Installing or using this optional compressor does not change Headroom's telemetry policy.
 
 ---
 


### PR DESCRIPTION
## Description

This change adds opt-in Boolean compression strategies while preserving current routing defaults, keeping the base install dependency-free, removing external telemetry, and clearly separating deterministic structured minimization from probabilistic natural-language inference.

Closes #750. Adds an opt-in deterministic boolean minimizer for structured expressions and truth tables, plus a separately identified probabilistic natural-language extraction path.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- Preserve current TABULAR, structured-config, relevance, batching, and routing behavior while adding Boolean strategies.
- Declare `boolean`, `boolean-nl-anthropic`, and `boolean-nl-openai` optional extras with lock metadata.
- Keep the base installation inert when the optional engine is absent.
- Remove all direct PostHog events, daemon telemetry threads, and the separate BOOLCALC telemetry surface.
- Describe deterministic structured minimization separately from probabilistic LLM-based NL inference.
- Reject NAND/NOR/XNOR rather than applying grouping-unsafe approximations.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
no-extra environment: 118 passed
boolean extra enabled: 122 passed
ruff: All checks passed!
uv lock --check: passed
boolean extra import: ok
```

## Real Behavior Proof

- Environment: Python 3.12, first with dev dependencies only, then with the `boolean` extra.
- Exact command / steps: run the focused compressor/router suite without the extra; install/sync the declared extra; rerun and verify import, exact-operator rejection, and no outbound telemetry call.
- Observed result: fallback and enabled paths pass; third-party `urlopen` is never called.
- Not tested: live Anthropic/OpenAI NL API calls.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding documentation changes
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature and privacy boundary
- [x] New and existing focused tests pass locally
- [x] I did **not** edit `CHANGELOG.md`

## Screenshots (if applicable)

N/A — no UI changes.

## Additional Notes

The NL route remains opt-in and is explicitly probabilistic because its inferred function can differ from the user's intended natural-language meaning.