### PR TITLE
Normalize headroom_stats MCP input schema

### DIFF
--- a/headroom/ccr/mcp_server.py
+++ b/headroom/ccr/mcp_server.py
@@ -540,6 +540,7 @@ class HeadroomMCPServer:
                     inputSchema={
                         "type": "object",
                         "properties": {},
+                        "required": [],
                     },
                 ),
             ]


### PR DESCRIPTION

## Description

Normalize the `headroom_stats` MCP tool input schema to match other no-argument MCP tools in the repository.

The `headroom_stats` tool previously advertised the following schema:

```json
{
  "type": "object",
  "properties": {}
}
```

This change updates it to:

```json
{
  "type": "object",
  "properties": {},
  "required": []
}
```

This makes the schema consistent with other MCP tool definitions in the codebase that do not require input parameters.

Related to #736. While this change does not conclusively fix the Copilot ACP tool discovery issue, it removes an inconsistency in the advertised MCP tool schema and may improve compatibility with MCP clients that perform stricter schema validation.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

* Added `"required": []` to the `headroom_stats` MCP tool schema.
* Normalized `headroom_stats` to match other no-argument MCP tool definitions in the repository.
* Improved MCP schema consistency across tool registrations.

## Testing

Describe the tests you ran to verify your changes:

* [ ] Unit tests pass (`pytest`)
* [ ] Linting passes (`ruff check .`)
* [ ] Type checking passes (`mypy headroom`)
* [ ] New tests added for new functionality
* [x] Manual testing performed

## Test Output

Not run. This change is limited to MCP tool schema metadata and does not modify runtime tool behavior.

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

The repository already uses `"required": []` for other MCP tool schemas with no required parameters (for example in the memory MCP implementation). This change aligns `headroom_stats` with that existing pattern.
<!-- maintainer-validation-2026-06-13 -->

## Testing

Describe the tests you ran to verify your changes:

- [x] Commit message validation passes (`commitlint --last --config .commitlintrc.json`)
- [x] Manual review performed

## Test Output

```text
npx --yes -p @commitlint/cli -p @commitlint/config-conventional commitlint --last --config .commitlintrc.json
# passed with no output
```

## Real Behavior Proof

- Environment: Windows local maintainer checkout, PowerShell, GitHub CLI authenticated as maintainer.
- Exact command / steps: Amended the single PR commit subject to `fix(mcp): normalize headroom_stats input schema` with original author `Praneet <praneetware@gmail.com>`, then validated with commitlint.
- Observed result: Commitlint passed locally; branch pushed with `--force-with-lease` after confirming the remote still pointed at `26ad25dcc0a3fd5bf37a6f10f1bbd782d034ba9a`.
- Not tested: Full project test suite was not rerun for this commit-message-only maintenance update.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
<!-- maintainer-template-normalization-2026-06-13 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added an explicit empty `required` list to the `headroom_stats` MCP input schema.
- Matched `headroom_stats` to the repository pattern for no-argument MCP tool schemas.
- Rewrote the PR commit subject to satisfy the repository commitlint rules while preserving the original author.

## Testing

- [x] Commit message validation passes (`commitlint --last --config .commitlintrc.json`)
- [x] Manual review performed

```text
npx --yes -p @commitlint/cli -p @commitlint/config-conventional commitlint --last --config .commitlintrc.json
# passed with no output
```
