### PR TITLE
ci: align codecov-action to v5 in native e2e workflows

### DIFF
--- a/.github/workflows/install-native-e2e.yml
+++ b/.github/workflows/install-native-e2e.yml
@@ -58,9 +58,9 @@ jobs:
           pytest tests/test_cli/test_install_cli.py tests/test_install/test_paths.py --cov=headroom --cov-report=xml:coverage-install-native.xml --cov-report=term-missing -q
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage-install-native.xml
+          files: ./coverage-install-native.xml
           flags: install-native
           name: install-native-${{ matrix.os }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/wrap-native-e2e.yml
+++ b/.github/workflows/wrap-native-e2e.yml
@@ -63,9 +63,9 @@ jobs:
           pytest tests/test_cli/test_wrap_bridge.py --cov=headroom --cov-report=xml:coverage-wrap-native.xml --cov-report=term-missing -q
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage-wrap-native.xml
+          files: ./coverage-wrap-native.xml
           flags: wrap-native
           name: wrap-native-${{ matrix.os }}
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

Bump `codecov/codecov-action` from `@v4` to `@v5` in the two native e2e workflows, and rename the `file:` input to `files:` to match the v5 API. The main `ci.yml` already uses `@v5` with `files:`; this aligns the remaining Codecov uploads.

Follow-up to #968.

## Type of Change

- [x] Code refactoring (no functional changes)

## Changes Made

- `.github/workflows/install-native-e2e.yml`: `codecov/codecov-action@v4` to `@v5`, and `file:` to `files:`.
- `.github/workflows/wrap-native-e2e.yml`: `codecov/codecov-action@v4` to `@v5`, and `file:` to `files:`.
- All three Codecov uploads now use `@v5` with the `files:` input.

## Testing

- [x] Manual testing performed

### Test Output

```text
python -c "import yaml; [yaml.safe_load(open(f, encoding='utf-8')) for f in ['.github/workflows/install-native-e2e.yml','.github/workflows/wrap-native-e2e.yml','.github/workflows/ci.yml']]; print('all workflows parse as valid YAML')"
all workflows parse as valid YAML

rg -n "codecov/codecov-action@|^\s+file:|^\s+files:" .github/workflows/install-native-e2e.yml .github/workflows/wrap-native-e2e.yml .github/workflows/ci.yml
.github/workflows/install-native-e2e.yml:61:        uses: codecov/codecov-action@v5
.github/workflows/install-native-e2e.yml:63:          files: ./coverage-install-native.xml
.github/workflows/wrap-native-e2e.yml:66:        uses: codecov/codecov-action@v5
.github/workflows/wrap-native-e2e.yml:68:          files: ./coverage-wrap-native.xml
.github/workflows/ci.yml:209:        uses: codecov/codecov-action@v5
.github/workflows/ci.yml:211:          files: coverage-${{ matrix.shard }}.xml

git diff --check upstream/main...HEAD
# no output
```

## Real Behavior Proof

- Environment: local Windows 11 checkout, Python 3.13.13 with PyYAML, ripgrep.
- Exact command / steps: rebased onto current `main`, parsed the three workflow YAML files, confirmed all Codecov action references use `@v5`, confirmed upload inputs use `files:`, and checked the diff for whitespace errors.
- Observed result: workflow YAML parses; native e2e and CI Codecov upload steps are aligned on `@v5`/`files:`; no whitespace errors.
- Not tested: live Codecov upload, because it requires Actions secrets and GitHub-hosted runners. The PR workflows exercise the changed steps.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review