### PR TITLE
fix(anthropic): add claude-opus-4-8 1M context window + pricing

### DIFF
--- a/headroom/providers/anthropic.py
+++ b/headroom/providers/anthropic.py
@@ -83,6 +83,9 @@ def sanitize_anthropic_model_metadata(value: Any) -> Any:
 # Anthropic model context limits
 # All Claude 3+ models have 200K context
 ANTHROPIC_CONTEXT_LIMITS: dict[str, int] = {
+    # Claude 4.8 (Opus 4.8) - 1M context. The bare key also matches the
+    # "[1m]" tier-suffixed form Claude Code sends, via partial-match lookup.
+    "claude-opus-4-8": 1000000,
     # Claude 4.7 (Opus 4.7) - 1M context
     "claude-opus-4-7": 1000000,
     # Claude 4.6 (Opus 4.6) - 1M context
@@ -112,6 +115,8 @@ ANTHROPIC_CONTEXT_LIMITS: dict[str, int] = {
 # NOTE: These are ESTIMATES. Always verify against actual Anthropic billing.
 # Last updated: 2025-01-14
 ANTHROPIC_PRICING: dict[str, dict[str, float]] = {
+    # Claude 4.8 (Opus tier pricing)
+    "claude-opus-4-8": {"input": 15.00, "output": 75.00, "cached_input": 1.50},
     # Claude 4.7 (Opus tier pricing)
     "claude-opus-4-7": {"input": 15.00, "output": 75.00, "cached_input": 1.50},
     # Claude 4.6 (Opus tier pricing)


### PR DESCRIPTION
## Problem
`claude-opus-4-8` is missing from `ANTHROPIC_CONTEXT_LIMITS` in `headroom/providers/anthropic.py`. Prior Opus models (4-6, 4-7) are listed at `1000000`, but 4-8 falls through to the opus *pattern default* of `200000` — so headroom sizes Opus 4.8's window at 200K instead of its real 1M, which over-aggressively trims context for that model.

## Fix
- Add `"claude-opus-4-8": 1000000` to `ANTHROPIC_CONTEXT_LIMITS` (mirrors the 4-7/4-6 entries). The bare key also resolves the `[1m]` tier-suffixed model id Claude Code sends, via the existing partial-match lookup.
- Add the matching opus-tier entry to `ANTHROPIC_PRICING`.

## Verification
```
get_context_limit(claude-opus-4-8)      -> 1,000,000
get_context_limit(claude-opus-4-8[1m])  -> 1,000,000
get_context_limit(claude-opus-4-5-...)  ->   200,000   # unchanged
```

Signed-off-by included (DCO).