### PR TITLE
fix(ci): check out repo in PR Governance label job

### DIFF
--- a/.github/workflows/pr-health.yml
+++ b/.github/workflows/pr-health.yml
@@ -144,6 +144,10 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
       - name: Ensure maintenance labels exist
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Problem

The `label` job in `.github/workflows/pr-health.yml` (PR Governance) fails on **every** PR:

```
python3: can't open file '.../.github/scripts/pr-health-labels.py': [Errno 2] No such file or directory
##[error]Process completed with exit code 2.
```

#986 extracted check-state logic into `.github/scripts/pr-health-labels.py`, but the `label` job never checks out the repo, so the script isn't present on the runner. The `template` job already checks out; `label` does not.

This is self-perpetuating: the failing `label` check is itself the signal that makes governance flag PRs `status: ci failing` and strip `status: ready for review`.

## Fix

Add the same `actions/checkout@v6` (pinned to `base.sha`) the `template` job already uses. On `schedule`/`workflow_dispatch` runs there's no PR context, so `base.sha` is empty and checkout falls back to the default branch — correct in both cases.

Surfaced while triaging the failing governance check on #1008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)