### PR TITLE
fix(mcp): return empty query results for known hashes

### DIFF
--- a/headroom/ccr/mcp_server.py
+++ b/headroom/ccr/mcp_server.py
@@ -414,8 +414,9 @@ class HeadroomMCPServer:
         # Check local store first
         store = self._get_local_store()
         if query:
-            results = store.search(hash_key, query)
-            if results:
+            entry = store.get_metadata(hash_key)
+            if entry is not None:
+                results = store.search(hash_key, query)
                 self._stats.record_retrieval(hash_key)
                 return {
                     "hash": hash_key,

--- a/tests/test_ccr_mcp_server.py
+++ b/tests/test_ccr_mcp_server.py
@@ -65,3 +65,31 @@ def test_mcp_retrieves_proxy_stored_content(fresh_store) -> None:
 
     assert result.get("source") == "local"
     assert result["original_content"] == original
+
+
+def test_mcp_query_retrieve_returns_empty_results_for_known_hash(fresh_store) -> None:
+    """A query miss inside a known hash is not the same as an expired hash."""
+    pytest.importorskip("mcp", reason="MCP SDK required")
+    original = "alpha\nbeta\ngamma"
+    hash_key = get_compression_store().store(original, "alpha beta")
+
+    server = mcp_server.HeadroomMCPServer(check_proxy=False)
+    result = asyncio.run(server._retrieve_content(hash_key, query="needle"))
+
+    assert result == {
+        "hash": hash_key,
+        "source": "local",
+        "query": "needle",
+        "results": [],
+        "count": 0,
+    }
+
+
+def test_mcp_query_retrieve_unknown_hash_still_errors(fresh_store) -> None:
+    pytest.importorskip("mcp", reason="MCP SDK required")
+    server = mcp_server.HeadroomMCPServer(check_proxy=False)
+
+    result = asyncio.run(server._retrieve_content("deadbeef", query="needle"))
+
+    assert result["hash"] == "deadbeef"
+    assert "error" in result


### PR DESCRIPTION
## Summary

Fix `headroom_retrieve(hash, query)` so a known local hash with zero BM25 matches returns an empty result set instead of falling through to the generic "Content not found" error.

## Why

The MCP docs describe `query` as an optional search within cached content. A query miss means "no matching items", not "the hash expired or is wrong". The previous behavior made plain-text/query misses look like CCR loss.

## Changes

- Check local hash metadata before running query search.
- Return `{ results: [], count: 0 }` for known hashes with no query matches.
- Keep unknown hashes returning the existing error.
- Add focused MCP server regression tests.

## Validation

- `PYTHONPATH=/tmp/headroom uvx --with pytest --with pytest-asyncio --with mcp --with httpx --with pydantic --with rich --with tiktoken --with zstandard --with opentelemetry-api pytest tests/test_ccr_mcp_server.py -q` → `5 passed`
- `uvx ruff check headroom/ccr/mcp_server.py tests/test_ccr_mcp_server.py` → `All checks passed`
- Direct self-check against the MCP retrieval path passed.

Note: `uv run pytest tests/test_ccr_mcp_server.py -q` could not run locally because editable build failed while downloading a build-backend asset (`Connection reset by peer`). The isolated pytest command above avoids the project build and exercises the patched checkout via `PYTHONPATH`.
