### PR TITLE
fix(agent-evals): Phase 1 — Aider Polyglot harness + statistics layer

### DIFF
--- a/agent-evals/.gitignore
+++ b/agent-evals/.gitignore
@@ -22,3 +22,6 @@ htmlcov/
 # Secrets — never commit
 .env
 .env.*
+
+# Benchmark exercise checkout (cloned, not vendored)
+.cache/

--- a/agent-evals/pyproject.toml
+++ b/agent-evals/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
+    "python-dotenv>=1.0.0",
     "httpx>=0.24.0",
     "numpy>=1.24.0",
     "click>=8.1.0",

--- a/agent-evals/src/agent_evals/benchmarks/aider_polyglot.py
+++ b/agent-evals/src/agent_evals/benchmarks/aider_polyglot.py
@@ -1,0 +1,211 @@
+"""Aider Polyglot benchmark: task loader + grader.
+
+The loader scans an Exercism-style checkout of ``github.com/Aider-AI/polyglot-benchmark`` and
+turns each practice exercise into a :class:`~agent_evals.models.BenchTask`. The grader is a
+pass-through of the pytest verdict the harness already computed during rollout: Aider + pytest IS
+the official Polyglot grade, so it is produced inside
+:class:`~agent_evals.harnesses.aider.AiderHarness` and merely surfaced here as a
+:class:`~agent_evals.models.GradeResult`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agent_evals.config import AiderConfig
+from agent_evals.logging import get_logger
+from agent_evals.models import BenchTask, GradeResult
+
+logger = get_logger("benchmarks.aider_polyglot")
+
+# Exercism layout constants — bound to the polyglot-benchmark checkout structure.
+_PRACTICE_SUBPATH = ("exercises", "practice")
+_META_DIR = ".meta"
+_CONFIG_FILE = "config.json"
+_DOCS_DIR = ".docs"
+_INSTRUCTIONS_FILE = "instructions.md"
+_INSTRUCTIONS_APPEND_FILE = "instructions.append.md"
+
+# Keys inside .meta/config.json's ``files`` block.
+_FILES_KEY = "files"
+_SOLUTION_KEY = "solution"
+_TEST_KEY = "test"
+
+
+def _practice_dir(cfg: AiderConfig) -> Path:
+    """Resolve ``<exercises_dir>/<language>/exercises/practice`` (absolute)."""
+
+    return (cfg.exercises_dir / cfg.language).joinpath(*_PRACTICE_SUBPATH).resolve()
+
+
+def _read_config_files(exercise_dir: Path) -> dict[str, Any]:
+    """Read the ``files`` block from an exercise's ``.meta/config.json``."""
+
+    config_path = exercise_dir / _META_DIR / _CONFIG_FILE
+    if not config_path.exists():
+        raise FileNotFoundError(f"missing exercise config: {config_path}")
+    data: Any = json.loads(config_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"malformed exercise config (not an object): {config_path}")
+    files = data.get(_FILES_KEY)
+    if not isinstance(files, dict):
+        raise ValueError(f"exercise config missing 'files' block: {config_path}")
+    return files
+
+
+def _str_list(value: Any) -> list[str]:
+    """Coerce a config leaf into a list of strings (single string -> one-element list)."""
+
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return []
+
+
+def _instruction_paths(exercise_dir: Path) -> list[str]:
+    """Existing instruction docs (main + optional append), as exercise-relative paths."""
+
+    out: list[str] = []
+    for name in (_INSTRUCTIONS_FILE, _INSTRUCTIONS_APPEND_FILE):
+        if (exercise_dir / _DOCS_DIR / name).exists():
+            out.append(f"{_DOCS_DIR}/{name}")
+    return out
+
+
+def _select(exercise_dirs: list[Path], cfg: AiderConfig) -> list[Path]:
+    """Apply subset selection: ``subset_names`` (exact) wins, else ``subset_limit``, else all."""
+
+    by_name = {p.name: p for p in exercise_dirs}
+    if cfg.subset_names:
+        selected: list[Path] = []
+        missing: list[str] = []
+        for name in cfg.subset_names:
+            if name in by_name:
+                selected.append(by_name[name])
+            else:
+                missing.append(name)
+        if missing:
+            raise ValueError(f"subset_names not found under {cfg.language!r}: {sorted(missing)}")
+        return sorted(selected, key=lambda p: p.name)
+    if cfg.subset_limit is not None:
+        return exercise_dirs[: cfg.subset_limit]
+    return exercise_dirs
+
+
+def load_polyglot_tasks(cfg: AiderConfig) -> list[BenchTask]:
+    """Scan the polyglot checkout and build one :class:`BenchTask` per practice exercise.
+
+    Tasks are sorted by exercise name for determinism, then subset-selected. Each payload carries
+    absolute exercise dir + config-relative solution/test/instruction paths so the harness can
+    resolve them inside its isolated copy. Raises if the exercises directory is missing.
+    """
+
+    practice = _practice_dir(cfg)
+    if not practice.is_dir():
+        raise FileNotFoundError(
+            f"polyglot exercises directory not found: {practice} "
+            f"(check AiderConfig.exercises_dir={cfg.exercises_dir!r} and language={cfg.language!r})"
+        )
+
+    exercise_dirs = sorted((p for p in practice.iterdir() if p.is_dir()), key=lambda p: p.name)
+    selected = _select(exercise_dirs, cfg)
+
+    tasks: list[BenchTask] = []
+    for exercise_dir in selected:
+        files = _read_config_files(exercise_dir)
+        solution_files = _str_list(files.get(_SOLUTION_KEY))
+        test_files = _str_list(files.get(_TEST_KEY))
+        if not solution_files:
+            raise ValueError(f"exercise {exercise_dir.name!r} has no solution files in config")
+        if not test_files:
+            raise ValueError(f"exercise {exercise_dir.name!r} has no test files in config")
+        tasks.append(
+            BenchTask(
+                task_id=exercise_dir.name,
+                payload={
+                    "exercise_dir": str(exercise_dir.resolve()),
+                    "language": cfg.language,
+                    "solution_files": solution_files,
+                    "test_files": test_files,
+                    "instructions_paths": _instruction_paths(exercise_dir),
+                },
+            )
+        )
+
+    logger.info(
+        "loaded polyglot tasks",
+        extra={
+            "fields": {
+                "language": cfg.language,
+                "practice_dir": str(practice),
+                "total_available": len(exercise_dirs),
+                "selected": len(tasks),
+            }
+        },
+    )
+    return tasks
+
+
+class AiderPolyglotGrader:
+    """Pass-through grader for Aider Polyglot.
+
+    The harness runs aider + pytest during rollout and writes the verdict into the prediction
+    JSON (``{"resolved": bool, "tests_outcomes": [...], "exercise": str}``). This grader parses
+    that JSON back into a :class:`GradeResult`. A missing / malformed / empty prediction grades as
+    ``resolved=False`` with the parse failure recorded in ``detail`` — loud, never silent.
+    """
+
+    def __init__(self, language: str) -> None:
+        self.name = "aider_polyglot"
+        self.benchmark_ref = f"polyglot-benchmark@{language}"
+
+    def grade(self, predictions: dict[str, str], tasks: list[BenchTask]) -> dict[str, GradeResult]:
+        """Grade each task by parsing the harness-computed verdict in its prediction JSON."""
+
+        results: dict[str, GradeResult] = {}
+        for task in tasks:
+            prediction = predictions.get(task.task_id, "")
+            results[task.task_id] = self._grade_one(task.task_id, prediction)
+        return results
+
+    def _grade_one(self, task_id: str, prediction: str) -> GradeResult:
+        if not prediction:
+            logger.warning(
+                "empty prediction; grading as unresolved",
+                extra={"fields": {"task_id": task_id}},
+            )
+            return GradeResult(
+                task_id=task_id,
+                resolved=False,
+                detail={"parse_error": "empty prediction"},
+            )
+        try:
+            parsed: Any = json.loads(prediction)
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "malformed prediction JSON; grading as unresolved",
+                extra={"fields": {"task_id": task_id, "error": repr(exc)}},
+            )
+            return GradeResult(
+                task_id=task_id,
+                resolved=False,
+                detail={"parse_error": repr(exc), "raw": prediction[:200]},
+            )
+        if not isinstance(parsed, dict):
+            return GradeResult(
+                task_id=task_id,
+                resolved=False,
+                detail={"parse_error": "prediction is not a JSON object"},
+            )
+        resolved = bool(parsed.get("resolved", False))
+        return GradeResult(
+            task_id=task_id,
+            resolved=resolved,
+            detail={
+                "tests_outcomes": parsed.get("tests_outcomes", []),
+                "exercise": parsed.get("exercise"),
+            },
+        )

--- a/agent-evals/src/agent_evals/cli.py
+++ b/agent-evals/src/agent_evals/cli.py
@@ -1,16 +1,29 @@
 """agent-evals CLI.
 
-Phase 0 surfaces version + resolved config. The ``run`` command is wired in once the
-orchestrator and benchmark adapters land (Phase 1/2).
+``version`` / ``show-config`` are config introspection. ``run`` executes a full WITH-vs-WITHOUT
+experiment (3 arms) over the Aider Polyglot subset and prints the scorecard with the TOST verdict.
+Provider keys are loaded from a ``.env`` (never read from chat/source) for the live model calls.
 """
 
 from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
 
 import click
 
 from . import __version__
 from .config import Settings
-from .logging import configure_logging
+from .logging import configure_logging, get_logger
+from .models import Provider
+from .report.scorecard import render_scorecard
+
+logger = get_logger("cli")
+
+# headroom repo root = .../headroom ; this file = .../headroom/agent-evals/src/agent_evals/cli.py
+_AGENT_EVALS_ROOT = Path(__file__).resolve().parents[2]
+_HEADROOM_ROOT = Path(__file__).resolve().parents[3]
 
 
 @click.group()
@@ -32,6 +45,88 @@ def show_config() -> None:
     settings = Settings()
     configure_logging(settings.log_level, json_output=settings.log_json)
     click.echo(settings.model_dump_json(indent=2))
+
+
+def _load_env(settings: Settings) -> str:
+    """Load provider keys from a .env into os.environ for live runs. Returns the path used."""
+
+    from dotenv import find_dotenv, load_dotenv
+
+    if settings.dotenv_path is not None:
+        path = str(settings.dotenv_path)
+    else:
+        path = find_dotenv(usecwd=True)
+    if path:
+        load_dotenv(path, override=False)
+    return path or "(none found)"
+
+
+@main.command(name="run")
+@click.option(
+    "--provider", type=click.Choice([p.value for p in Provider]), help="Override provider."
+)
+@click.option("--model", "model_snapshot", help="Override model snapshot (e.g. claude-sonnet-4-6).")
+@click.option("--language", help="Polyglot language subset (python/go/rust/java).")
+@click.option("--subset-limit", type=int, help="Run only the first N exercises (sorted).")
+@click.option(
+    "--subset-names", help="Comma-separated exact exercise names (overrides --subset-limit)."
+)
+@click.option("--k-runs", type=int, help="Independent runs per (arm, task).")
+@click.option("--concurrency", type=int, help="Concurrent rollouts per arm (use 1 for aider).")
+@click.option("--exercises-dir", type=click.Path(), help="Path to the polyglot-benchmark checkout.")
+@click.option("--run-dir", type=click.Path(), help="Where to write journal/manifest/scorecard.")
+def run_cmd(
+    provider: str | None,
+    model_snapshot: str | None,
+    language: str | None,
+    subset_limit: int | None,
+    subset_names: str | None,
+    k_runs: int | None,
+    concurrency: int | None,
+    exercises_dir: str | None,
+    run_dir: str | None,
+) -> None:
+    """Run the 3-arm WITH-vs-WITHOUT experiment and print the scorecard."""
+
+    settings = Settings()
+    if provider is not None:
+        settings.provider = Provider(provider)
+    if model_snapshot is not None:
+        settings.model_snapshot = model_snapshot
+    if language is not None:
+        settings.aider.language = language
+    if subset_limit is not None:
+        settings.aider.subset_limit = subset_limit
+    if subset_names:
+        settings.aider.subset_names = [n.strip() for n in subset_names.split(",") if n.strip()]
+    if k_runs is not None:
+        settings.stats.k_runs = k_runs
+    if concurrency is not None:
+        settings.concurrency = concurrency
+    if exercises_dir is not None:
+        settings.aider.exercises_dir = Path(exercises_dir)
+
+    configure_logging(settings.log_level, json_output=settings.log_json)
+    env_path = _load_env(settings)
+    logger.info("env_loaded", extra={"fields": {"dotenv": env_path}})
+
+    now = datetime.now(timezone.utc)
+    out_dir = Path(run_dir) if run_dir else (settings.run_dir / now.strftime("%Y%m%dT%H%M%SZ"))
+
+    # Imported here so `version`/`show-config` never pull in aider/litellm.
+    from .run import run_experiment
+
+    _manifest, scorecard = asyncio.run(
+        run_experiment(
+            settings,
+            now=now,
+            run_dir=out_dir,
+            headroom_repo_path=str(_HEADROOM_ROOT),
+            agent_evals_repo_path=str(_AGENT_EVALS_ROOT),
+        )
+    )
+    click.echo(render_scorecard(scorecard))
+    click.echo(f"\nArtifacts written to: {out_dir}")
 
 
 if __name__ == "__main__":

--- a/agent-evals/src/agent_evals/config.py
+++ b/agent-evals/src/agent_evals/config.py
@@ -26,6 +26,21 @@ class StatsConfig(BaseModel):
     seed: int = 12345
 
 
+class AiderConfig(BaseModel):
+    """Aider Polyglot harness knobs (Phase 1)."""
+
+    # Checkout of github.com/Aider-AI/polyglot-benchmark (cloned, not vendored).
+    exercises_dir: Path = Path(".cache/polyglot-benchmark")
+    language: str = "python"  # python/go/rust/java run locally; js/cpp need Docker (excluded)
+    edit_format: str = "whole"  # safe across arbitrary models
+    tries: int = Field(default=2, ge=1)  # pass_rate_1 = try 1; pass_rate_2 = within 2 tries
+    pytest_timeout_s: float = Field(default=180.0, gt=0.0)
+    # Subset selection for cheap smokes / dev. subset_names (exact exercise dir names) wins;
+    # else the first ``subset_limit`` exercises in sorted order; None limit = the full set.
+    subset_limit: int | None = None
+    subset_names: list[str] = Field(default_factory=list)
+
+
 class ProxyLaunchConfig(BaseModel):
     """How arms.py launches and probes the Headroom proxy. No command is hardcoded in logic."""
 
@@ -62,5 +77,15 @@ class Settings(BaseSettings):
     run_dir: Path = Path("./runs")
     log_level: str = "INFO"
     log_json: bool = True
+    # Path to a .env carrying provider keys for live runs. None => python-dotenv searches upward
+    # (finds the repo-root .env). Keys themselves are never stored in Settings.
+    dotenv_path: Path | None = None
     stats: StatsConfig = Field(default_factory=StatsConfig)
     proxy: ProxyLaunchConfig = Field(default_factory=ProxyLaunchConfig)
+    aider: AiderConfig = Field(default_factory=AiderConfig)
+
+    def litellm_model_name(self) -> str:
+        """The litellm-routed model name for the configured provider (e.g. ``anthropic/<snap>``)."""
+
+        prefix = "anthropic" if self.provider is Provider.ANTHROPIC else "openai"
+        return f"{prefix}/{self.model_snapshot}"

--- a/agent-evals/src/agent_evals/harnesses/aider.py
+++ b/agent-evals/src/agent_evals/harnesses/aider.py
@@ -167,8 +167,10 @@ def make_savings_logger(
 
 def _aider_version() -> str:
     """Installed aider version string (imported lazily — aider is an ``[aider]``-extra dep)."""
-
-    import aider
+    try:
+        import aider
+    except ModuleNotFoundError:
+        return "not-installed"
 
     return str(getattr(aider, "__version__", "unknown"))
 

--- a/agent-evals/src/agent_evals/harnesses/aider.py
+++ b/agent-evals/src/agent_evals/harnesses/aider.py
@@ -1,0 +1,468 @@
+"""Aider Polyglot rollout harness — drives the aider Coder API directly.
+
+The installed ``aider-chat`` (0.86.2) does NOT ship ``aider.benchmark``, so this harness drives
+the public Coder API itself: ``Coder.create(...).run(with_message=...)`` performs one edit round
+against an isolated copy of an Exercism-style exercise, then we run the exercise's pytest file as
+the grader-of-record. Aider + pytest IS the official grade for Polyglot, so it is computed here,
+during rollout; :class:`~agent_evals.benchmarks.aider_polyglot.AiderPolyglotGrader` is a
+pass-through of the verdict this harness writes into the prediction JSON.
+
+``litellm`` and ``aider`` are imported only inside this module — both live behind the ``[aider]``
+extra and must never be pulled in by core modules.
+
+Savings capture
+---------------
+aider issues its model calls through litellm. We register a litellm ``CustomLogger`` (once,
+idempotently) whose ``log_success_event`` reads the per-response Headroom headers off
+``response_obj._hidden_params["additional_headers"]`` (litellm prefixes provider headers with
+``llm_provider-``), strips that prefix, and feeds the result to
+:func:`~agent_evals.metrics.savings.parse_savings_headers`. The current task is identified via a
+module-level :class:`contextvars.ContextVar` that the worker thread sets (``_active_task``) around
+the Coder loop.
+
+Concurrency caveat
+------------------
+litellm invokes the success callback synchronously, on the same thread that made the request, so
+inside one worker thread the contextvar correctly attributes every response to the task that
+thread is running. This holds for orchestrator concurrency == 1 within an arm. At concurrency > 1
+in one arm, multiple worker threads share the single process-wide callback; the contextvar is
+per-thread so attribution is still correct PROVIDED litellm keeps calling the callback inline on
+the requesting thread (it does today). Until per-call-id correlation is added we recommend running
+the aider arm at concurrency == 1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from agent_evals.config import Settings
+from agent_evals.logging import get_logger
+from agent_evals.metrics.savings import SavingsStore, parse_savings_headers
+from agent_evals.models import ArmName, BenchTask, Pricing, Provider, RolloutResult
+
+logger = get_logger("harnesses.aider")
+
+# litellm prefixes upstream provider response headers with this when surfacing them on
+# ``response_obj._hidden_params["additional_headers"]``. We strip it before parsing so the keys
+# match what ``parse_savings_headers`` expects (the raw ``x-headroom-*`` names).
+_LITELLM_PROVIDER_HEADER_PREFIX = "llm_provider-"
+_HIDDEN_PARAMS_ATTR = "_hidden_params"
+_ADDITIONAL_HEADERS_KEY = "additional_headers"
+
+# Env var the arm hands us (its proxy base_url) vs the var litellm actually reads. We translate
+# one to the other per provider before constructing the Model.
+_ARM_ENV_BY_PROVIDER: dict[Provider, str] = {
+    Provider.ANTHROPIC: "ANTHROPIC_BASE_URL",
+    Provider.OPENAI: "OPENAI_BASE_URL",
+}
+_LITELLM_ENV_BY_PROVIDER: dict[Provider, str] = {
+    Provider.ANTHROPIC: "ANTHROPIC_API_BASE",
+    Provider.OPENAI: "OPENAI_API_BASE",
+}
+
+# Identifies the task a litellm response belongs to. Set per worker thread around the Coder loop.
+current_task_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "agent_evals_aider_current_task_id", default=None
+)
+
+
+@contextmanager
+def _active_task(task_id: str) -> Iterator[None]:
+    """Bind ``current_task_id`` to ``task_id`` for the duration of the block (then reset)."""
+
+    token = current_task_id.set(task_id)
+    try:
+        yield
+    finally:
+        current_task_id.reset(token)
+
+
+def _strip_provider_prefix(headers: Mapping[str, Any]) -> dict[str, str]:
+    """Drop litellm's ``llm_provider-`` prefix and stringify values for header parsing.
+
+    Keys without the prefix are passed through unchanged so the parser can still see plain
+    ``x-headroom-*`` headers if litellm ever surfaces them un-prefixed.
+    """
+
+    out: dict[str, str] = {}
+    for key, value in headers.items():
+        name = str(key)
+        if name.startswith(_LITELLM_PROVIDER_HEADER_PREFIX):
+            name = name[len(_LITELLM_PROVIDER_HEADER_PREFIX) :]
+        out[name] = str(value)
+    return out
+
+
+def _extract_additional_headers(response_obj: Any) -> dict[str, Any] | None:
+    """Pull ``_hidden_params["additional_headers"]`` off a litellm response, or ``None``."""
+
+    hidden = getattr(response_obj, _HIDDEN_PARAMS_ATTR, None)
+    if not isinstance(hidden, Mapping):
+        return None
+    headers = hidden.get(_ADDITIONAL_HEADERS_KEY)
+    if not isinstance(headers, Mapping):
+        return None
+    return dict(headers)
+
+
+def make_savings_logger(
+    store: SavingsStore,
+    task_id_getter: Callable[[], str | None],
+    pricing: Pricing,
+) -> Any:
+    """Build a litellm ``CustomLogger`` that records per-response Headroom savings.
+
+    Closes over ``store``, ``task_id_getter`` and ``pricing`` so a single registered instance
+    serves every task: on each successful litellm call it resolves the active task id, reads the
+    Headroom headers off the response, and (when both resolve) stores the parsed savings. Nothing
+    is recorded when no task is active or the response carries no Headroom headers — savings are
+    never fabricated. ``litellm`` is imported lazily here to keep it out of core modules.
+    """
+
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class _HeadroomSavingsLogger(CustomLogger):  # type: ignore[misc]
+        def log_success_event(
+            self,
+            kwargs: dict[str, Any],
+            response_obj: Any,
+            start_time: Any,
+            end_time: Any,
+        ) -> None:
+            task_id = task_id_getter()
+            if task_id is None:
+                return
+            headers = _extract_additional_headers(response_obj)
+            if not headers:
+                return
+            savings = parse_savings_headers(_strip_provider_prefix(headers), pricing)
+            if savings is None:
+                return
+            store.add(task_id, savings)
+            logger.debug(
+                "captured task savings via litellm callback",
+                extra={
+                    "fields": {
+                        "task_id": task_id,
+                        "tokens_before": savings.tokens_before,
+                        "tokens_after": savings.tokens_after,
+                        "tokens_saved": savings.tokens_saved,
+                    }
+                },
+            )
+
+    return _HeadroomSavingsLogger()
+
+
+def _aider_version() -> str:
+    """Installed aider version string (imported lazily — aider is an ``[aider]``-extra dep)."""
+
+    import aider
+
+    return str(getattr(aider, "__version__", "unknown"))
+
+
+class AiderHarness:
+    """Harness that rolls out Aider Polyglot exercises and grades them with pytest in-process.
+
+    One instance is reused across tasks. Construction registers the litellm savings callback
+    exactly once (idempotent across instances sharing the module-level guard), so concurrent
+    rollouts all feed the same :class:`SavingsStore`.
+    """
+
+    # Module-level guard so the callback is registered once per process even with many harnesses.
+    _callback_registered: bool = False
+
+    def __init__(self, settings: Settings, store: SavingsStore | None = None) -> None:
+        self.settings = settings
+        self.store = store if store is not None else SavingsStore()
+        self.name = "aider"
+        self.version = _aider_version()
+        self.supported_providers: set[Provider] = {Provider.ANTHROPIC, Provider.OPENAI}
+        self._register_callback_once()
+
+    def _register_callback_once(self) -> None:
+        """Register the litellm savings callback exactly once per process."""
+
+        if AiderHarness._callback_registered:
+            return
+        import litellm
+
+        savings_logger = make_savings_logger(self.store, current_task_id.get, self.settings.pricing)
+        callbacks = list(getattr(litellm, "callbacks", []) or [])
+        callbacks.append(savings_logger)
+        litellm.callbacks = callbacks
+        AiderHarness._callback_registered = True
+        logger.info(
+            "registered litellm savings callback",
+            extra={"fields": {"harness": self.name, "version": self.version}},
+        )
+
+    async def run_task(
+        self, task: BenchTask, env: dict[str, str], workdir: Path, task_tag: str
+    ) -> RolloutResult:
+        """Roll out one exercise in a worker thread (blocking aider/pytest work off the loop)."""
+
+        return await asyncio.to_thread(self._run_sync, task, env, workdir, task_tag)
+
+    # --- sync worker -----------------------------------------------------------------------
+
+    def _run_sync(
+        self, task: BenchTask, env: dict[str, str], workdir: Path, task_tag: str
+    ) -> RolloutResult:
+        start = time.monotonic()
+        try:
+            return self._rollout(task, env, workdir, task_tag, start)
+        except Exception as exc:  # noqa: BLE001 — surface any failure as a loud RolloutResult.
+            wall_ms = (time.monotonic() - start) * 1000.0
+            logger.error(
+                "aider rollout failed",
+                exc_info=True,
+                extra={"fields": {"task_id": task.task_id, "task_tag": task_tag}},
+            )
+            return RolloutResult(
+                task_id=task.task_id,
+                arm=ArmName.A0_DIRECT,
+                run_index=0,
+                prediction="",
+                trajectory_path=workdir,
+                savings=None,
+                wall_ms=wall_ms,
+                error=repr(exc),
+            )
+
+    def _rollout(
+        self,
+        task: BenchTask,
+        env: dict[str, str],
+        workdir: Path,
+        task_tag: str,
+        start: float,
+    ) -> RolloutResult:
+        cfg = self.settings.aider
+        src_exercise = Path(task.payload["exercise_dir"])
+
+        # 1. Isolate: copy the exercise into the workdir so edits/tests never touch the checkout.
+        # Resolve to an ABSOLUTE path: pytest runs as a subprocess with cwd set to this dir, so a
+        # relative path would resolve against the wrong base and pytest would not find the tests
+        # (the root cause of spurious all-fail + the model then "helpfully" rewriting the tests).
+        workdir.mkdir(parents=True, exist_ok=True)
+        dest_exercise = (workdir / src_exercise.name).resolve()
+        if dest_exercise.exists():
+            shutil.rmtree(dest_exercise)
+        shutil.copytree(src_exercise, dest_exercise)
+
+        # 2. Translate the arm's base_url env into the var litellm actually reads (per provider).
+        self._apply_base_url(env)
+
+        # 3. Resolve instructions + solution/test paths (relative to the copied exercise).
+        instructions = self._read_instructions(dest_exercise, task)
+        solution_paths = self._resolve_paths(dest_exercise, task.payload["solution_files"])
+        test_paths = self._resolve_paths(dest_exercise, task.payload["test_files"])
+        if not solution_paths:
+            raise ValueError(f"no solution files for exercise {task.task_id!r}")
+        if not test_paths:
+            raise ValueError(f"no test files for exercise {task.task_id!r}")
+
+        logger.info(
+            "starting aider rollout",
+            extra={
+                "fields": {
+                    "task_id": task.task_id,
+                    "task_tag": task_tag,
+                    "exercise": dest_exercise.name,
+                    "solution_files": [str(p) for p in solution_paths],
+                    "test_files": [str(p) for p in test_paths],
+                    "tries": cfg.tries,
+                    "edit_format": cfg.edit_format,
+                }
+            },
+        )
+
+        coder = self._build_coder(solution_paths)
+
+        # 4/5. Edit -> test loop, up to cfg.tries; feed pytest output back as the next prompt.
+        tests_outcomes: list[bool] = []
+        resolved = False
+        message = instructions
+        # Key savings by the unique per-cell tag (arm-run-task), NOT task_id: the same exercise
+        # runs under every arm against one shared store, so task_id alone would mix B's savings
+        # with A1's for the same exercise. task_tag isolates each (arm, run, task) cell.
+        test_rel_paths = list(task.payload["test_files"])
+        with _active_task(task_tag):
+            for attempt in range(cfg.tries):
+                coder.run(with_message=message)
+                # Grader integrity: the model edits only the solution, but aider applies whatever
+                # diffs the model emits — including (observed) rewriting the test file with bogus
+                # expectations. Restore the PRISTINE test file(s) from the source checkout before
+                # grading so the verdict always reflects the real tests, never model-tampered ones.
+                self._restore_tests(src_exercise, dest_exercise, test_rel_paths)
+                # Run pytest FROM the exercise dir so `import <solution_module>` resolves (pytest's
+                # prepend import mode adds the test's dir to sys.path) and relative test discovery
+                # works. dest_exercise is absolute, so the subprocess cwd is unambiguous.
+                passed, feedback = self._run_pytest(test_paths, dest_exercise, cfg.pytest_timeout_s)
+                tests_outcomes.append(passed)
+                logger.info(
+                    "aider attempt complete",
+                    extra={
+                        "fields": {
+                            "task_id": task.task_id,
+                            "attempt": attempt + 1,
+                            "passed": passed,
+                        }
+                    },
+                )
+                if passed:
+                    resolved = True
+                    break
+                # Next try sees the failing-test output as feedback.
+                message = feedback
+
+        # 6. Aggregate savings captured by the litellm callback for this cell (keyed by task_tag).
+        savings = self.store.aggregate(task_tag, self.settings.pricing)
+
+        # 7. The grader reads this verdict verbatim.
+        prediction = json.dumps(
+            {
+                "resolved": resolved,
+                "tests_outcomes": tests_outcomes,
+                "exercise": dest_exercise.name,
+            }
+        )
+
+        wall_ms = (time.monotonic() - start) * 1000.0
+        logger.info(
+            "aider rollout complete",
+            extra={
+                "fields": {
+                    "task_id": task.task_id,
+                    "resolved": resolved,
+                    "tests_outcomes": tests_outcomes,
+                    "wall_ms": wall_ms,
+                    "tokens_saved": (savings.tokens_saved if savings else None),
+                }
+            },
+        )
+        return RolloutResult(
+            task_id=task.task_id,
+            arm=ArmName.A0_DIRECT,  # orchestrator overwrites arm/run_index.
+            run_index=0,
+            prediction=prediction,
+            trajectory_path=workdir,
+            savings=savings,
+            wall_ms=wall_ms,
+            error=None,
+        )
+
+    # --- helpers ---------------------------------------------------------------------------
+
+    def _apply_base_url(self, env: Mapping[str, str]) -> None:
+        """Set the litellm base-url env var from the arm-provided base_url for our provider."""
+
+        provider = self.settings.provider
+        arm_var = _ARM_ENV_BY_PROVIDER[provider]
+        litellm_var = _LITELLM_ENV_BY_PROVIDER[provider]
+        base_url = env.get(arm_var)
+        if base_url:
+            os.environ[litellm_var] = base_url
+            logger.debug(
+                "applied base_url for litellm",
+                extra={"fields": {"provider": provider.value, litellm_var: base_url}},
+            )
+
+    @staticmethod
+    def _resolve_paths(exercise_dir: Path, rel_paths: list[str]) -> list[Path]:
+        """Resolve config-relative file paths against the copied exercise dir."""
+
+        return [exercise_dir / rel for rel in rel_paths]
+
+    @staticmethod
+    def _read_instructions(exercise_dir: Path, task: BenchTask) -> str:
+        """Concatenate the exercise instruction docs (main + optional append) into one prompt."""
+
+        rel_paths = task.payload.get("instructions_paths") or []
+        parts: list[str] = []
+        for rel in rel_paths:
+            path = exercise_dir / rel
+            if path.exists():
+                parts.append(path.read_text(encoding="utf-8"))
+        if not parts:
+            raise ValueError(f"no instruction docs found for exercise {exercise_dir.name!r}")
+        return "\n\n".join(parts)
+
+    def _build_coder(self, solution_paths: list[Path]) -> Any:
+        """Construct the aider Coder bound to the solution file(s)."""
+
+        from aider.coders import Coder
+        from aider.io import InputOutput
+        from aider.models import Model
+
+        io = InputOutput(yes=True, pretty=False, fancy_input=False)
+        model = Model(self.settings.litellm_model_name())
+        return Coder.create(
+            main_model=model,
+            edit_format=self.settings.aider.edit_format,
+            io=io,
+            fnames=[str(p) for p in solution_paths],
+            use_git=False,
+            stream=False,
+            suggest_shell_commands=False,
+            auto_test=False,
+            # Critical: do NOT scrape URLs found in the instructions. Without this, aider fetches
+            # every linked page (wikipedia/python-docs) into context — observed 313k tokens for one
+            # tiny exercise (~$1/call) and an attempted playwright auto-install. We grade the model
+            # on the instructions alone, as the official Polyglot benchmark does.
+            detect_urls=False,
+        )
+
+    @staticmethod
+    def _restore_tests(src_exercise: Path, dest_exercise: Path, test_rel_paths: list[str]) -> None:
+        """Copy the pristine test file(s) from the source checkout over the working copy."""
+
+        for rel in test_rel_paths:
+            src = src_exercise / rel
+            dest = dest_exercise / rel
+            if src.exists():
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dest)
+
+    @staticmethod
+    def _run_pytest(test_paths: list[Path], cwd_dir: Path, timeout_s: float) -> tuple[bool, str]:
+        """Run the exercise's pytest file(s) from ``cwd_dir``; return (passed, output-for-feedback)."""
+
+        cmd = [sys.executable, "-m", "pytest", *[str(p) for p in test_paths], "-q"]
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(cwd_dir),
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+            )
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            if isinstance(stdout, bytes):
+                stdout = stdout.decode("utf-8", "replace")
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode("utf-8", "replace")
+            feedback = f"pytest timed out after {timeout_s}s\n{stdout}\n{stderr}"
+            logger.warning(
+                "pytest timed out",
+                extra={"fields": {"timeout_s": timeout_s, "cmd": cmd}},
+            )
+            return False, feedback
+        passed = proc.returncode == 0
+        feedback = f"{proc.stdout}\n{proc.stderr}".strip()
+        return passed, feedback

--- a/agent-evals/src/agent_evals/protocols.py
+++ b/agent-evals/src/agent_evals/protocols.py
@@ -8,6 +8,7 @@ and ``Arm``/``ArmHandle`` so real adapters (Phase 1/2) and test fakes are interc
 from __future__ import annotations
 
 from pathlib import Path
+from types import TracebackType
 from typing import Protocol, runtime_checkable
 
 from .models import ArmSpec, BenchTask, GradeResult, Provider, RolloutResult, TaskSavings
@@ -33,7 +34,12 @@ class Arm(Protocol):
 
     async def __aenter__(self) -> ArmHandle: ...
 
-    async def __aexit__(self, *exc: object) -> None: ...
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None: ...
 
 
 @runtime_checkable

--- a/agent-evals/src/agent_evals/report/scorecard.py
+++ b/agent-evals/src/agent_evals/report/scorecard.py
@@ -18,8 +18,13 @@ from pydantic import BaseModel, Field
 from rich.console import Console
 from rich.table import Table
 
+from ..config import StatsConfig
 from ..logging import get_logger
-from ..models import ArmName, TaskResult, TaskSavings
+from ..models import ArmName, EquivalenceVerdict, TaskResult, TaskSavings
+from ..stats.bootstrap import paired_bootstrap
+from ..stats.pairing import pair_arms
+from ..stats.tost import equivalence_verdict
+from ..stats.wilson import wilson_half_width_pp
 
 logger = get_logger("report.scorecard")
 
@@ -57,12 +62,19 @@ class ArmSummary(BaseModel):
 
 
 class Scorecard(BaseModel):
-    """The full Phase-0 scorecard: one summary per arm plus the headline naive delta."""
+    """The scorecard: one summary per arm, the naive headline delta, and — when statistics are
+    requested (Phase 1+) — the paired-bootstrap delta and TOST equivalence verdict."""
 
     experiment_id: str
     arms: list[ArmSummary] = Field(default_factory=list)
-    # B_HEADROOM resolved_rate - A1_PASSTHROUGH resolved_rate. None if either arm is absent.
+    # B_HEADROOM resolved_rate - A1_PASSTHROUGH resolved_rate (fraction). None if either arm absent.
     accuracy_delta_b_vs_a1: float | None = None
+    # Phase 1+ inferential fields (None unless build_scorecard was given a StatsConfig):
+    # paired-bootstrap mean per-task delta (pp) + CI, the TOST verdict against the lossy margin,
+    # and the single-arm Wilson noise floor (pp) for context.
+    equivalence: EquivalenceVerdict | None = None
+    accuracy_delta_pp: float | None = None
+    noise_floor_pp: float | None = None
     savings_note: str = _SAVINGS_NOTE
     stats_note: str = _STATS_NOTE
 
@@ -110,11 +122,21 @@ def _summarize_arm(arm: ArmName, cells: list[TaskResult]) -> ArmSummary:
     )
 
 
-def build_scorecard(results: list[TaskResult], experiment_id: str) -> Scorecard:
-    """Group ``results`` by arm, aggregate each, and compute the naive B-vs-A1 accuracy delta.
+def build_scorecard(
+    results: list[TaskResult],
+    experiment_id: str,
+    *,
+    stats_config: StatsConfig | None = None,
+) -> Scorecard:
+    """Group ``results`` by arm, aggregate each, and compute the headline B-vs-A1 delta.
 
-    Arms are emitted in the canonical :class:`ArmName` declaration order (so the rendered table is
-    stable regardless of input ordering). Arms with zero cells are omitted entirely.
+    Without ``stats_config`` this is the Phase-0 behaviour: a naive point delta only, no CI/verdict.
+    With ``stats_config`` (Phase 1+) it additionally pairs B vs A1 per task, runs the paired
+    bootstrap, and produces a TOST equivalence verdict against ``margin_lossy_pp`` plus the
+    single-arm Wilson noise floor. The verdict is left ``None`` when the two arms share no tasks.
+
+    Arms are emitted in canonical :class:`ArmName` declaration order; arms with zero cells are
+    omitted entirely.
     """
 
     by_arm: dict[ArmName, list[TaskResult]] = {}
@@ -142,10 +164,59 @@ def build_scorecard(results: list[TaskResult], experiment_id: str) -> Scorecard:
     else:
         accuracy_delta = treatment - baseline
 
-    return Scorecard(
+    scorecard = Scorecard(
         experiment_id=experiment_id,
         arms=summaries,
         accuracy_delta_b_vs_a1=accuracy_delta,
+    )
+
+    if stats_config is not None:
+        _attach_statistics(scorecard, results, by_arm, stats_config)
+
+    return scorecard
+
+
+def _attach_statistics(
+    scorecard: Scorecard,
+    results: list[TaskResult],
+    by_arm: dict[ArmName, list[TaskResult]],
+    stats_config: StatsConfig,
+) -> None:
+    """Compute the paired-bootstrap delta + TOST verdict (B vs A1) and attach to ``scorecard``."""
+
+    if _HEADLINE_TREATMENT not in by_arm or _HEADLINE_BASELINE not in by_arm:
+        scorecard.stats_note = (
+            "equivalence verdict unavailable: B_HEADROOM or A1_PASSTHROUGH missing"
+        )
+        return
+
+    paired = pair_arms(results, _HEADLINE_TREATMENT, _HEADLINE_BASELINE)
+    if not paired.task_ids:
+        scorecard.stats_note = "equivalence verdict unavailable: B and A1 share no tasks"
+        return
+
+    delta = paired_bootstrap(
+        paired,
+        alpha=stats_config.alpha,
+        n_resamples=stats_config.bootstrap_resamples,
+        seed=stats_config.seed,
+    )
+    verdict = equivalence_verdict(delta, stats_config.margin_lossy_pp)
+
+    baseline_cells = by_arm[_HEADLINE_BASELINE]
+    baseline_p = sum(1 for c in baseline_cells if c.resolved) / len(baseline_cells)
+    noise_floor = wilson_half_width_pp(
+        baseline_p, len(baseline_cells), confidence=1.0 - stats_config.alpha
+    )
+
+    scorecard.equivalence = verdict
+    scorecard.accuracy_delta_pp = delta.point
+    scorecard.noise_floor_pp = noise_floor
+    scorecard.stats_note = (
+        f"paired bootstrap (B-A1) {delta.point:+.2f}pp "
+        f"[{delta.ci_low:+.2f}, {delta.ci_high:+.2f}] at {int((1 - stats_config.alpha) * 100)}% CI; "
+        f"TOST vs ±{stats_config.margin_lossy_pp:.1f}pp ⇒ {verdict.verdict.upper()}; "
+        f"A1 Wilson half-width {noise_floor:.1f}pp (n={len(baseline_cells)})"
     )
 
 
@@ -162,7 +233,7 @@ def render_scorecard(scorecard: Scorecard) -> str:
     delta, and the stats note. No files are written; the string is built in memory.
     """
 
-    table = Table(title=f"Phase-0 Scorecard — {scorecard.experiment_id}")
+    table = Table(title=f"agent-evals Scorecard — {scorecard.experiment_id}")
     table.add_column("arm", no_wrap=True)
     table.add_column("label", no_wrap=True)
     table.add_column("cells", justify="right")
@@ -199,6 +270,14 @@ def render_scorecard(scorecard: Scorecard) -> str:
     # soft_wrap keeps each headline line intact (no width-driven mid-sentence newline), so the
     # full note strings remain contiguous and greppable in the exported text.
     console.print(f"HEADLINE accuracy delta: {delta_text}", soft_wrap=True)
+    if scorecard.equivalence is not None:
+        v = scorecard.equivalence
+        console.print(
+            f"HEADLINE verdict: {v.verdict.upper()} "
+            f"(B-A1 {v.delta.point:+.2f}pp [{v.delta.ci_low:+.2f}, {v.delta.ci_high:+.2f}] "
+            f"vs ±{v.margin:.1f}pp margin)",
+            soft_wrap=True,
+        )
     console.print(f"HEADLINE savings: {scorecard.savings_note}", soft_wrap=True)
     console.print(f"HEADLINE stats: {scorecard.stats_note}", soft_wrap=True)
     return console.export_text()

--- a/agent-evals/src/agent_evals/run.py
+++ b/agent-evals/src/agent_evals/run.py
@@ -1,0 +1,117 @@
+"""Assemble and execute a full WITH-vs-WITHOUT experiment, then score it.
+
+This is the Phase-1 entry the CLI ``run`` command drives. It builds the three arms (Direct /
+Passthrough / Headroom), the Aider harness + Polyglot grader, runs the resumable orchestrator over
+the selected exercises, and produces a scorecard with the paired-bootstrap + TOST verdict. All
+time/identity is injected by the caller (the CLI) so the core stays reproducible.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from .arms import HeadroomArm
+from .benchmarks.aider_polyglot import AiderPolyglotGrader, load_polyglot_tasks
+from .config import Settings
+from .harnesses.aider import AiderHarness
+from .logging import get_logger
+from .manifest import build_manifest
+from .metrics.savings import SavingsStore
+from .models import ArmName, ArmSpec, ProxyMode, RunManifest
+from .orchestrator import Journal, Orchestrator
+from .protocols import Arm
+from .report.scorecard import Scorecard, build_scorecard, render_scorecard
+
+logger = get_logger("run")
+
+# The canonical three-arm plan. Headline accuracy claim = B_HEADROOM vs A1_PASSTHROUGH.
+_ARM_PLAN: list[tuple[ArmName, ProxyMode | None, str]] = [
+    (ArmName.A0_DIRECT, None, "direct"),
+    (ArmName.A1_PASSTHROUGH, ProxyMode.OFF, "passthrough"),
+    (ArmName.B_HEADROOM, ProxyMode.TOKEN, "headroom"),
+]
+
+
+def build_arms(settings: Settings, run_dir: Path) -> list[Arm]:
+    """Build the three HeadroomArms for the configured provider."""
+
+    arms: list[Arm] = []
+    for name, mode, label in _ARM_PLAN:
+        spec = ArmSpec(name=name, provider=settings.provider, proxy_mode=mode, label=label)
+        arms.append(HeadroomArm(spec, settings, run_dir))
+    return arms
+
+
+async def run_experiment(
+    settings: Settings,
+    *,
+    now: datetime,
+    run_dir: Path,
+    headroom_repo_path: str,
+    agent_evals_repo_path: str,
+) -> tuple[RunManifest, Scorecard]:
+    """Run the full experiment and return the pinned manifest + scorecard (also persisted)."""
+
+    tasks = load_polyglot_tasks(settings.aider)
+    if not tasks:
+        raise RuntimeError(
+            f"no polyglot tasks loaded from {settings.aider.exercises_dir} "
+            f"(language={settings.aider.language!r})"
+        )
+
+    store = SavingsStore()
+    harness = AiderHarness(settings, store=store)
+    grader = AiderPolyglotGrader(settings.aider.language)
+    arms = build_arms(settings, run_dir)
+    journal = Journal(run_dir)
+    orchestrator = Orchestrator(settings, arms, harness, grader, journal)
+
+    logger.info(
+        "experiment_start",
+        extra={
+            "fields": {
+                "n_tasks": len(tasks),
+                "arms": [a.spec.name.value for a in arms],
+                "k_runs": settings.stats.k_runs,
+                "provider": settings.provider.value,
+                "model": settings.litellm_model_name(),
+            }
+        },
+    )
+
+    results = await orchestrator.run(tasks)
+
+    manifest = build_manifest(
+        settings,
+        now=now,
+        arms=[a.spec for a in arms],
+        benchmark="aider_polyglot",
+        benchmark_ref=grader.benchmark_ref,
+        harness=harness.name,
+        harness_version=harness.version,
+        headroom_repo_path=headroom_repo_path,
+        agent_evals_repo_path=agent_evals_repo_path,
+    )
+    scorecard = build_scorecard(results, manifest.experiment_id, stats_config=settings.stats)
+    _persist(run_dir, manifest, scorecard)
+    logger.info(
+        "experiment_done",
+        extra={
+            "fields": {
+                "experiment_id": manifest.experiment_id,
+                "verdict": (scorecard.equivalence.verdict if scorecard.equivalence else None),
+                "delta_pp": scorecard.accuracy_delta_pp,
+            }
+        },
+    )
+    return manifest, scorecard
+
+
+def _persist(run_dir: Path, manifest: RunManifest, scorecard: Scorecard) -> None:
+    """Write the manifest + scorecard (JSON + rendered text) into the run directory."""
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "manifest.json").write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+    (run_dir / "scorecard.json").write_text(scorecard.model_dump_json(indent=2), encoding="utf-8")
+    (run_dir / "scorecard.txt").write_text(render_scorecard(scorecard), encoding="utf-8")

--- a/agent-evals/src/agent_evals/stats/__init__.py
+++ b/agent-evals/src/agent_evals/stats/__init__.py
@@ -1,1 +1,21 @@
 """agent_evals.stats subpackage."""
+
+from __future__ import annotations
+
+from .bootstrap import paired_bootstrap
+from .pairing import PairedOutcomes, pair_arms
+from .power import is_underpowered, recommended_runs
+from .tost import equivalence_verdict, non_inferiority_verdict
+from .wilson import wilson_half_width_pp, wilson_interval
+
+__all__ = [
+    "PairedOutcomes",
+    "pair_arms",
+    "paired_bootstrap",
+    "equivalence_verdict",
+    "non_inferiority_verdict",
+    "wilson_interval",
+    "wilson_half_width_pp",
+    "recommended_runs",
+    "is_underpowered",
+]

--- a/agent-evals/src/agent_evals/stats/bootstrap.py
+++ b/agent-evals/src/agent_evals/stats/bootstrap.py
@@ -1,0 +1,90 @@
+"""Paired hierarchical bootstrap for the per-task accuracy delta (pp).
+
+The design has two nested levels of sampling variability: which tasks we drew, and how each task's
+finite K runs landed. A flat per-task-rate bootstrap would ignore the second level and produce a CI
+that is too tight. So each resample is hierarchical: resample tasks with replacement, then for every
+drawn task resample THAT task's runs with replacement before recomputing its rate.
+
+All quantities are in PERCENTAGE POINTS (pp).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..logging import get_logger
+from ..models import DeltaEstimate
+from .pairing import PairedOutcomes
+
+_log = get_logger("stats.bootstrap")
+
+_METHOD = "paired_bootstrap"
+
+
+def paired_bootstrap(
+    paired: PairedOutcomes,
+    *,
+    alpha: float,
+    n_resamples: int,
+    seed: int,
+) -> DeltaEstimate:
+    """Hierarchical paired bootstrap CI for ``mean(delta_pp)``.
+
+    point = ``mean(delta_pp)`` over the observed tasks. Each resample draws ``len(task_ids)`` task
+    indices with replacement; for every drawn task it resamples that task's per-run resolved
+    booleans (B and A1 independently) with replacement, recomputes each rate in pp, and takes the
+    mean delta over the drawn tasks. The CI is the
+    ``[100*alpha/2, 100*(1-alpha/2)]`` percentiles of the resample deltas. Fully deterministic for
+    a fixed ``seed`` via ``np.random.default_rng``.
+
+    Raises ``ValueError`` on empty input — there is no delta to estimate from zero tasks.
+    """
+
+    n_tasks = len(paired.task_ids)
+    if n_tasks == 0:
+        raise ValueError(
+            "paired_bootstrap: no paired tasks; pair_arms produced an empty intersection"
+        )
+
+    rng = np.random.default_rng(seed)
+
+    # Pre-pack each task's runs as int8 (0/1) arrays so resampling is pure-numpy and fast.
+    b_runs = [np.asarray(r, dtype=np.int8) for r in paired.b_runs]
+    a1_runs = [np.asarray(r, dtype=np.int8) for r in paired.a1_runs]
+
+    point = float(np.mean(paired.delta_pp))
+
+    resample_deltas = np.empty(n_resamples, dtype=np.float64)
+    for r in range(n_resamples):
+        task_idx = rng.integers(0, n_tasks, size=n_tasks)
+        delta_sum = 0.0
+        for t in task_idx:
+            br = b_runs[t]
+            ar = a1_runs[t]
+            b_draw = rng.integers(0, br.size, size=br.size)
+            a_draw = rng.integers(0, ar.size, size=ar.size)
+            b_pp = float(br[b_draw].mean()) * 100.0
+            a1_pp = float(ar[a_draw].mean()) * 100.0
+            delta_sum += b_pp - a1_pp
+        resample_deltas[r] = delta_sum / n_tasks
+
+    lo_pct = 100.0 * (alpha / 2.0)
+    hi_pct = 100.0 * (1.0 - alpha / 2.0)
+    ci_low = float(np.percentile(resample_deltas, lo_pct))
+    ci_high = float(np.percentile(resample_deltas, hi_pct))
+
+    _log.info(
+        "paired bootstrap complete",
+        extra={
+            "fields": {
+                "method": _METHOD,
+                "n_tasks": n_tasks,
+                "n_resamples": n_resamples,
+                "alpha": alpha,
+                "point": point,
+                "ci_low": ci_low,
+                "ci_high": ci_high,
+            }
+        },
+    )
+    return DeltaEstimate(point=point, ci_low=ci_low, ci_high=ci_high, method=_METHOD)

--- a/agent-evals/src/agent_evals/stats/pairing.py
+++ b/agent-evals/src/agent_evals/stats/pairing.py
@@ -1,0 +1,114 @@
+"""Pair two arms task-by-task for paired statistical comparison.
+
+The headline comparison is paired: each task contributes one resolved-rate to arm B and one to
+arm A1, and we analyze the per-task delta (B - A1). Pairing on the same tasks removes
+between-task difficulty as a noise source, which the unpaired comparison cannot.
+
+All rates are in PERCENTAGE POINTS (pp): a task's resolved rate is ``mean(resolved bools) * 100``.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from pydantic import BaseModel, Field
+
+from ..logging import get_logger
+from ..models import ArmName, TaskResult
+
+_log = get_logger("stats.pairing")
+
+
+class PairedOutcomes(BaseModel):
+    """Per-task paired outcomes for arms (B vs A1), aligned by ``task_ids`` index.
+
+    ``b_rate_pp[i]``/``a1_rate_pp[i]`` are the resolved rates (pp) for ``task_ids[i]`` in each
+    arm; ``delta_pp[i] == b_rate_pp[i] - a1_rate_pp[i]``. ``b_runs[i]``/``a1_runs[i]`` hold that
+    task's raw per-run resolved booleans, kept so the bootstrap can resample run-to-run variance.
+    """
+
+    arm_b: ArmName
+    arm_a1: ArmName
+    task_ids: list[str] = Field(default_factory=list)
+    b_rate_pp: list[float] = Field(default_factory=list)
+    a1_rate_pp: list[float] = Field(default_factory=list)
+    delta_pp: list[float] = Field(default_factory=list)
+    b_runs: list[list[bool]] = Field(default_factory=list)
+    a1_runs: list[list[bool]] = Field(default_factory=list)
+
+
+def _group_runs(results: list[TaskResult], arm: ArmName) -> dict[str, list[bool]]:
+    """Collect the per-run ``resolved`` booleans for one arm, keyed by task_id.
+
+    An errored cell already carries ``resolved=False`` in the journal, so it is included here as
+    an observed failure (a real outcome), not silently dropped.
+    """
+
+    by_task: dict[str, list[bool]] = defaultdict(list)
+    for r in results:
+        if r.arm is arm:
+            by_task[r.task_id].append(bool(r.resolved))
+    return by_task
+
+
+def _rate_pp(runs: list[bool]) -> float:
+    """Resolved rate in pp = mean of resolved booleans * 100."""
+
+    return sum(1 for x in runs if x) / len(runs) * 100.0
+
+
+def pair_arms(results: list[TaskResult], arm_b: ArmName, arm_a1: ArmName) -> PairedOutcomes:
+    """Pair ``arm_b`` against ``arm_a1`` on the intersection of their task_ids.
+
+    Groups results by (arm, task_id); a task's rate is ``mean(resolved over its runs) * 100``.
+    Only tasks present in BOTH arms are paired; tasks missing from either arm are logged and
+    dropped (never fabricated). Output ``task_ids`` is sorted for determinism.
+    """
+
+    b_by_task = _group_runs(results, arm_b)
+    a1_by_task = _group_runs(results, arm_a1)
+
+    b_keys = set(b_by_task)
+    a1_keys = set(a1_by_task)
+    shared = sorted(b_keys & a1_keys)
+    dropped = b_keys ^ a1_keys
+
+    if dropped:
+        _log.warning(
+            "dropping tasks missing from one arm",
+            extra={
+                "fields": {
+                    "arm_b": arm_b.value,
+                    "arm_a1": arm_a1.value,
+                    "dropped_count": len(dropped),
+                    "dropped_task_ids": sorted(dropped),
+                    "b_only": sorted(b_keys - a1_keys),
+                    "a1_only": sorted(a1_keys - b_keys),
+                }
+            },
+        )
+
+    paired = PairedOutcomes(arm_b=arm_b, arm_a1=arm_a1)
+    for task_id in shared:
+        b_runs = b_by_task[task_id]
+        a1_runs = a1_by_task[task_id]
+        b_pp = _rate_pp(b_runs)
+        a1_pp = _rate_pp(a1_runs)
+        paired.task_ids.append(task_id)
+        paired.b_rate_pp.append(b_pp)
+        paired.a1_rate_pp.append(a1_pp)
+        paired.delta_pp.append(b_pp - a1_pp)
+        paired.b_runs.append(b_runs)
+        paired.a1_runs.append(a1_runs)
+
+    _log.info(
+        "paired arms",
+        extra={
+            "fields": {
+                "arm_b": arm_b.value,
+                "arm_a1": arm_a1.value,
+                "paired_tasks": len(paired.task_ids),
+            }
+        },
+    )
+    return paired

--- a/agent-evals/src/agent_evals/stats/power.py
+++ b/agent-evals/src/agent_evals/stats/power.py
@@ -1,0 +1,113 @@
+"""Power / runs planning for the paired multi-run non-inferiority design.
+
+This is a PLANNING HEURISTIC, not an exact power calculation. It answers: given an estimate of the
+per-task run-to-run noise (``sigma_pp``), a fixed task set (``n_tasks``), and a non-inferiority
+margin (``margin_pp``), how many runs per (task, arm) cell, ``k``, do we need so the test can
+resolve a true delta of 0 within the margin at the requested ``alpha`` and ``power``?
+
+Model: the paired mean delta over ``n_tasks`` tasks, each averaged over ``k`` runs, has standard
+error ``SE ~= sigma_pp / sqrt(n_tasks * k)``. A standard one-sided non-inferiority sizing requires
+``(z_alpha + z_power) * SE <= margin_pp``, i.e.
+
+    (z_alpha + z_power) * sigma_pp / sqrt(n_tasks * k) <= margin_pp.
+
+Solving for the smallest integer ``k >= 1``. The ``z`` values come from ``scipy.stats.norm.ppf`` —
+no hardcoded constants. The approximation ignores task-to-task variance structure and treats
+``sigma_pp`` as a single pooled noise scale, so treat the result as a lower-bound planning figure.
+"""
+
+from __future__ import annotations
+
+import math
+
+from scipy.stats import norm
+
+from ..logging import get_logger
+
+_log = get_logger("stats.power")
+
+
+def _z_one_sided(prob: float) -> float:
+    """One-sided normal quantile ``Phi^{-1}(prob)`` (e.g. prob=0.95 -> ~1.645)."""
+
+    if not 0.0 < prob < 1.0:
+        raise ValueError(f"probability must be in (0, 1); got {prob}")
+    return float(norm.ppf(prob))
+
+
+def recommended_runs(
+    *,
+    sigma_pp: float,
+    margin_pp: float,
+    n_tasks: int,
+    alpha: float = 0.05,
+    power: float = 0.8,
+) -> int:
+    """Smallest ``k >= 1`` runs/cell so the paired non-inferiority test is adequately powered.
+
+    See the module docstring for the sizing model. Returns ``ceil`` of the solved ``k``, floored at
+    1. Raises ``ValueError`` on non-positive ``sigma_pp``/``margin_pp``/``n_tasks``.
+    """
+
+    if sigma_pp <= 0.0:
+        raise ValueError(f"sigma_pp must be > 0; got {sigma_pp}")
+    if margin_pp <= 0.0:
+        raise ValueError(f"margin_pp must be > 0; got {margin_pp}")
+    if n_tasks < 1:
+        raise ValueError(f"n_tasks must be >= 1; got {n_tasks}")
+
+    z_alpha = _z_one_sided(1.0 - alpha)
+    z_power = _z_one_sided(power)
+    z_sum = z_alpha + z_power
+
+    # (z_sum * sigma / sqrt(n*k))^2 <= margin^2  =>  k >= (z_sum*sigma)^2 / (margin^2 * n)
+    k_real = (z_sum * sigma_pp) ** 2 / (margin_pp**2 * n_tasks)
+    k = max(1, math.ceil(k_real))
+
+    _log.info(
+        "recommended runs",
+        extra={
+            "fields": {
+                "sigma_pp": sigma_pp,
+                "margin_pp": margin_pp,
+                "n_tasks": n_tasks,
+                "alpha": alpha,
+                "power": power,
+                "k_real": k_real,
+                "k": k,
+            }
+        },
+    )
+    return k
+
+
+def is_underpowered(
+    *,
+    k_runs: int,
+    sigma_pp: float,
+    margin_pp: float,
+    n_tasks: int,
+    alpha: float = 0.05,
+    power: float = 0.8,
+) -> bool:
+    """True iff the planned ``k_runs`` is below ``recommended_runs(...)`` for the same design."""
+
+    needed = recommended_runs(
+        sigma_pp=sigma_pp,
+        margin_pp=margin_pp,
+        n_tasks=n_tasks,
+        alpha=alpha,
+        power=power,
+    )
+    under = k_runs < needed
+    _log.info(
+        "underpowered check",
+        extra={
+            "fields": {
+                "k_runs": k_runs,
+                "recommended": needed,
+                "underpowered": under,
+            }
+        },
+    )
+    return under

--- a/agent-evals/src/agent_evals/stats/tost.py
+++ b/agent-evals/src/agent_evals/stats/tost.py
@@ -1,0 +1,79 @@
+"""Verdicts from a delta CI: two one-sided tests (TOST) equivalence and non-inferiority.
+
+We never read a p-value here — the bootstrap already gave us a ``(1 - alpha)`` CI, and the CI-based
+TOST verdict is equivalent to the two one-sided tests at level ``alpha``. Working in PERCENTAGE
+POINTS throughout: a negative ``delta_pp`` means B resolved fewer tasks than A1 (B is worse).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from ..logging import get_logger
+from ..models import DeltaEstimate, EquivalenceVerdict
+
+Verdict = Literal["equivalent", "inferior", "inconclusive", "superior"]
+
+_log = get_logger("stats.tost")
+
+
+def equivalence_verdict(delta: DeltaEstimate, margin_pp: float) -> EquivalenceVerdict:
+    """TOST equivalence verdict against a symmetric margin ``[-margin_pp, +margin_pp]``.
+
+    - ``equivalent``  : the whole CI ``[ci_low, ci_high]`` lies inside ``[-margin, +margin]``.
+    - ``inferior``    : ``ci_high < -margin`` (B is conclusively worse than A1 by > margin).
+    - ``superior``    : ``ci_low > +margin`` (B is conclusively better than A1 by > margin).
+    - ``inconclusive``: anything else (CI straddles a margin boundary).
+    """
+
+    lo = delta.ci_low
+    hi = delta.ci_high
+    verdict: Verdict
+    if lo >= -margin_pp and hi <= margin_pp:
+        verdict = "equivalent"
+    elif hi < -margin_pp:
+        verdict = "inferior"
+    elif lo > margin_pp:
+        verdict = "superior"
+    else:
+        verdict = "inconclusive"
+
+    _log.info(
+        "equivalence verdict",
+        extra={
+            "fields": {
+                "test": "tost_equivalence",
+                "margin_pp": margin_pp,
+                "ci_low": lo,
+                "ci_high": hi,
+                "verdict": verdict,
+            }
+        },
+    )
+    return EquivalenceVerdict(delta=delta, margin=margin_pp, verdict=verdict)
+
+
+def non_inferiority_verdict(delta: DeltaEstimate, margin_pp: float) -> EquivalenceVerdict:
+    """One-sided non-inferiority verdict: is B no worse than A1 by more than ``margin_pp``?
+
+    Returns ``equivalent`` (read here as "non-inferior": the CI rules out a true delta below
+    ``-margin_pp``) when ``ci_low > -margin_pp``, otherwise ``inferior``. The ``EquivalenceVerdict``
+    type is reused deliberately; only ``equivalent``/``inferior`` are produced by this one-sided
+    test.
+    """
+
+    lo = delta.ci_low
+    verdict: Verdict = "equivalent" if lo > -margin_pp else "inferior"
+
+    _log.info(
+        "non-inferiority verdict",
+        extra={
+            "fields": {
+                "test": "non_inferiority",
+                "margin_pp": margin_pp,
+                "ci_low": lo,
+                "verdict": verdict,
+            }
+        },
+    )
+    return EquivalenceVerdict(delta=delta, margin=margin_pp, verdict=verdict)

--- a/agent-evals/src/agent_evals/stats/wilson.py
+++ b/agent-evals/src/agent_evals/stats/wilson.py
@@ -1,0 +1,76 @@
+"""Wilson score interval for a single proportion.
+
+Used for per-arm pooled accuracy reporting and for the power planner's half-width sanity checks.
+The Wilson interval is well-behaved near 0/1 and for small n, unlike the normal (Wald) interval.
+The ``z`` multiplier is derived from the requested confidence via ``scipy.stats.norm.ppf`` — never
+hardcoded.
+"""
+
+from __future__ import annotations
+
+from scipy.stats import norm
+
+from ..logging import get_logger
+
+_log = get_logger("stats.wilson")
+
+
+def _z_for(confidence: float) -> float:
+    """Two-sided normal quantile for the given confidence (e.g. 0.95 -> ~1.96)."""
+
+    if not 0.0 < confidence < 1.0:
+        raise ValueError(f"confidence must be in (0, 1); got {confidence}")
+    alpha = 1.0 - confidence
+    return float(norm.ppf(1.0 - alpha / 2.0))
+
+
+def wilson_interval(successes: int, n: int, *, confidence: float = 0.95) -> tuple[float, float]:
+    """Wilson score interval for a proportion, returned as a fraction in ``[0, 1]``.
+
+    ``successes`` must satisfy ``0 <= successes <= n`` and ``n >= 1``.
+    """
+
+    if n < 1:
+        raise ValueError(f"n must be >= 1; got {n}")
+    if not 0 <= successes <= n:
+        raise ValueError(f"successes must be in [0, n]; got {successes} of {n}")
+
+    z = _z_for(confidence)
+    p_hat = successes / n
+    z2 = z * z
+    denom = 1.0 + z2 / n
+    center = (p_hat + z2 / (2.0 * n)) / denom
+    half = (z / denom) * ((p_hat * (1.0 - p_hat) / n + z2 / (4.0 * n * n)) ** 0.5)
+    low = max(0.0, center - half)
+    high = min(1.0, center + half)
+
+    _log.info(
+        "wilson interval",
+        extra={
+            "fields": {
+                "successes": successes,
+                "n": n,
+                "confidence": confidence,
+                "low": low,
+                "high": high,
+            }
+        },
+    )
+    return (low, high)
+
+
+def wilson_half_width_pp(p: float, n: int, *, confidence: float = 0.95) -> float:
+    """Half-width of the Wilson interval at proportion ``p`` and sample size ``n``, in pp.
+
+    Computed by evaluating the Wilson interval at ``successes = round(p * n)`` and halving the span.
+    Sanity: ``n=100, p=0.5, 95%`` gives ~9.6 pp.
+    """
+
+    if n < 1:
+        raise ValueError(f"n must be >= 1; got {n}")
+    if not 0.0 <= p <= 1.0:
+        raise ValueError(f"p must be in [0, 1]; got {p}")
+
+    successes = round(p * n)
+    low, high = wilson_interval(successes, n, confidence=confidence)
+    return (high - low) / 2.0 * 100.0

--- a/agent-evals/tests/test_aider_harness.py
+++ b/agent-evals/tests/test_aider_harness.py
@@ -1,0 +1,450 @@
+"""Unit tests for the Aider Polyglot harness + benchmark.
+
+No API keys, no network, no real model. The aider Coder and the pytest subprocess are both
+monkeypatched; a tiny fake Exercism-style exercise tree is built under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agent_evals.benchmarks.aider_polyglot import AiderPolyglotGrader, load_polyglot_tasks
+from agent_evals.config import AiderConfig, Settings
+from agent_evals.harnesses.aider import (
+    AiderHarness,
+    _active_task,
+    _strip_provider_prefix,
+    current_task_id,
+    make_savings_logger,
+)
+from agent_evals.metrics.savings import SavingsStore
+from agent_evals.models import BenchTask, Pricing
+
+# --------------------------------------------------------------------------------------------
+# Fixtures: a tiny fake polyglot checkout
+# --------------------------------------------------------------------------------------------
+
+
+def _make_exercise(
+    practice: Path,
+    name: str,
+    *,
+    solution_body: str = "def go():\n    return None\n",
+) -> Path:
+    """Create one Exercism-style exercise under ``practice/<name>``."""
+
+    ex = practice / name
+    meta = ex / ".meta"
+    docs = ex / ".docs"
+    meta.mkdir(parents=True)
+    docs.mkdir(parents=True)
+    solution_file = f"{name.replace('-', '_')}.py"
+    test_file = f"{name.replace('-', '_')}_test.py"
+    config = {
+        "files": {
+            "solution": [solution_file],
+            "test": [test_file],
+            "example": [".meta/example.py"],
+        }
+    }
+    (meta / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    (docs / "instructions.md").write_text(f"# {name}\nDo the thing.\n", encoding="utf-8")
+    (docs / "instructions.append.md").write_text("Extra hint.\n", encoding="utf-8")
+    (ex / solution_file).write_text(solution_body, encoding="utf-8")
+    (ex / test_file).write_text(
+        "from " + name.replace("-", "_") + " import go\n\n\ndef test_go():\n    assert go()\n",
+        encoding="utf-8",
+    )
+    return ex
+
+
+@pytest.fixture
+def polyglot_root(tmp_path: Path) -> Path:
+    """A fake ``<root>/python/exercises/practice`` tree with two exercises."""
+
+    practice = tmp_path / "python" / "exercises" / "practice"
+    practice.mkdir(parents=True)
+    _make_exercise(practice, "alpha-task")
+    _make_exercise(practice, "beta-task")
+    return tmp_path
+
+
+def _cfg(root: Path, **kwargs: Any) -> AiderConfig:
+    return AiderConfig(exercises_dir=root, language="python", **kwargs)
+
+
+# --------------------------------------------------------------------------------------------
+# Loader
+# --------------------------------------------------------------------------------------------
+
+
+def test_loader_builds_tasks(polyglot_root: Path) -> None:
+    tasks = load_polyglot_tasks(_cfg(polyglot_root))
+    assert [t.task_id for t in tasks] == ["alpha-task", "beta-task"]
+    alpha = tasks[0]
+    assert alpha.payload["language"] == "python"
+    assert alpha.payload["solution_files"] == ["alpha_task.py"]
+    assert alpha.payload["test_files"] == ["alpha_task_test.py"]
+    assert alpha.payload["instructions_paths"] == [
+        ".docs/instructions.md",
+        ".docs/instructions.append.md",
+    ]
+    assert Path(alpha.payload["exercise_dir"]).is_dir()
+    assert Path(alpha.payload["exercise_dir"]).name == "alpha-task"
+
+
+def test_loader_subset_limit(polyglot_root: Path) -> None:
+    tasks = load_polyglot_tasks(_cfg(polyglot_root, subset_limit=1))
+    assert [t.task_id for t in tasks] == ["alpha-task"]
+
+
+def test_loader_subset_names(polyglot_root: Path) -> None:
+    tasks = load_polyglot_tasks(_cfg(polyglot_root, subset_names=["beta-task"]))
+    assert [t.task_id for t in tasks] == ["beta-task"]
+
+
+def test_loader_subset_names_unknown_raises(polyglot_root: Path) -> None:
+    with pytest.raises(ValueError, match="subset_names not found"):
+        load_polyglot_tasks(_cfg(polyglot_root, subset_names=["nope"]))
+
+
+def test_loader_missing_dir_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="not found"):
+        load_polyglot_tasks(_cfg(tmp_path / "does-not-exist"))
+
+
+# --------------------------------------------------------------------------------------------
+# Grader
+# --------------------------------------------------------------------------------------------
+
+
+def _grader() -> AiderPolyglotGrader:
+    return AiderPolyglotGrader(language="python")
+
+
+def test_grader_benchmark_ref() -> None:
+    assert _grader().benchmark_ref == "polyglot-benchmark@python"
+    assert _grader().name == "aider_polyglot"
+
+
+def test_grader_resolved_true() -> None:
+    pred = json.dumps({"resolved": True, "tests_outcomes": [False, True], "exercise": "alpha"})
+    tasks = [BenchTask(task_id="alpha-task", payload={})]
+    out = _grader().grade({"alpha-task": pred}, tasks)
+    res = out["alpha-task"]
+    assert res.resolved is True
+    assert res.detail["tests_outcomes"] == [False, True]
+    assert res.detail["exercise"] == "alpha"
+
+
+def test_grader_resolved_false() -> None:
+    pred = json.dumps({"resolved": False, "tests_outcomes": [False], "exercise": "alpha"})
+    out = _grader().grade({"alpha-task": pred}, [BenchTask(task_id="alpha-task", payload={})])
+    assert out["alpha-task"].resolved is False
+
+
+def test_grader_malformed_json() -> None:
+    out = _grader().grade(
+        {"alpha-task": "{not json"}, [BenchTask(task_id="alpha-task", payload={})]
+    )
+    res = out["alpha-task"]
+    assert res.resolved is False
+    assert "parse_error" in res.detail
+
+
+def test_grader_empty_prediction() -> None:
+    out = _grader().grade({}, [BenchTask(task_id="alpha-task", payload={})])
+    res = out["alpha-task"]
+    assert res.resolved is False
+    assert res.detail["parse_error"] == "empty prediction"
+
+
+# --------------------------------------------------------------------------------------------
+# Savings callback
+# --------------------------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal litellm-response stand-in exposing ``_hidden_params``."""
+
+    def __init__(self, headers: dict[str, str]) -> None:
+        self._hidden_params = {"additional_headers": headers}
+
+
+def _pricing() -> Pricing:
+    return Pricing(input_usd_per_1m=2.0, output_usd_per_1m=10.0)
+
+
+def test_strip_provider_prefix() -> None:
+    raw = {
+        "llm_provider-x-headroom-tokens-before": "1000",
+        "x-other": "v",
+    }
+    out = _strip_provider_prefix(raw)
+    assert out["x-headroom-tokens-before"] == "1000"
+    assert out["x-other"] == "v"
+
+
+def test_savings_logger_records_for_active_task() -> None:
+    store = SavingsStore()
+    logger = make_savings_logger(store, lambda: "t1", _pricing())
+    resp = _FakeResponse(
+        {
+            "llm_provider-x-headroom-tokens-before": "1000",
+            "llm_provider-x-headroom-tokens-after": "400",
+        }
+    )
+    logger.log_success_event({}, resp, None, None)
+    agg = store.aggregate("t1", _pricing())
+    assert agg is not None
+    assert agg.tokens_before == 1000
+    assert agg.tokens_after == 400
+    assert agg.tokens_saved == 600
+
+
+def test_savings_logger_no_task_records_nothing() -> None:
+    store = SavingsStore()
+    logger = make_savings_logger(store, lambda: None, _pricing())
+    resp = _FakeResponse(
+        {
+            "llm_provider-x-headroom-tokens-before": "1000",
+            "llm_provider-x-headroom-tokens-after": "400",
+        }
+    )
+    logger.log_success_event({}, resp, None, None)
+    assert store.task_ids() == []
+
+
+def test_savings_logger_no_headroom_headers_records_nothing() -> None:
+    store = SavingsStore()
+    logger = make_savings_logger(store, lambda: "t1", _pricing())
+    logger.log_success_event({}, _FakeResponse({"x-unrelated": "1"}), None, None)
+    assert store.task_ids() == []
+
+
+def test_active_task_contextvar_resets() -> None:
+    assert current_task_id.get() is None
+    with _active_task("abc"):
+        assert current_task_id.get() == "abc"
+    assert current_task_id.get() is None
+
+
+# --------------------------------------------------------------------------------------------
+# run_task happy path + retry (Coder + pytest monkeypatched)
+# --------------------------------------------------------------------------------------------
+
+
+class _FakeCoder:
+    """Fake aider Coder: on run(), writes a passing solution into the (copied) solution file."""
+
+    def __init__(self, solution_path: Path) -> None:
+        self._solution_path = solution_path
+        self.runs = 0
+
+    def run(self, with_message: str | None = None) -> None:
+        self.runs += 1
+        self._solution_path.write_text("def go():\n    return True\n", encoding="utf-8")
+
+
+def _settings(root: Path, **aider_kwargs: Any) -> Settings:
+    return Settings(aider=_cfg(root, **aider_kwargs))
+
+
+def _patch_callback_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Skip the real litellm callback registration (litellm import) in unit tests."""
+
+    monkeypatch.setattr(AiderHarness, "_callback_registered", True, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_run_task_happy_path(
+    polyglot_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_callback_off(monkeypatch)
+    settings = _settings(polyglot_root, subset_names=["alpha-task"])
+    store = SavingsStore()
+    harness = AiderHarness(settings, store=store)
+
+    tasks = load_polyglot_tasks(settings.aider)
+    task = tasks[0]
+    source_solution = Path(task.payload["exercise_dir"]) / "alpha_task.py"
+    source_before = source_solution.read_text(encoding="utf-8")
+
+    workdir = tmp_path / "wd"
+
+    def _fake_build(self: AiderHarness, solution_paths: list[Path]) -> _FakeCoder:
+        return _FakeCoder(solution_paths[0])
+
+    def _fake_pytest(test_paths: list[Path], wd: Path, timeout_s: float) -> tuple[bool, str]:
+        return True, "1 passed"
+
+    monkeypatch.setattr(AiderHarness, "_build_coder", _fake_build, raising=True)
+    monkeypatch.setattr(AiderHarness, "_run_pytest", staticmethod(_fake_pytest), raising=True)
+
+    result = await harness.run_task(task, env={}, workdir=workdir, task_tag="alpha-task#0")
+
+    assert result.error is None
+    parsed = json.loads(result.prediction)
+    assert parsed["resolved"] is True
+    assert parsed["tests_outcomes"] == [True]
+    assert parsed["exercise"] == "alpha-task"
+    assert result.trajectory_path == workdir
+    # The exercise was copied into the workdir; the source checkout is untouched.
+    assert (workdir / "alpha-task" / "alpha_task.py").exists()
+    assert source_solution.read_text(encoding="utf-8") == source_before
+
+
+@pytest.mark.asyncio
+async def test_run_task_retry_then_pass(
+    polyglot_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_callback_off(monkeypatch)
+    settings = _settings(polyglot_root, subset_names=["alpha-task"], tries=2)
+    harness = AiderHarness(settings, store=SavingsStore())
+    task = load_polyglot_tasks(settings.aider)[0]
+
+    monkeypatch.setattr(
+        AiderHarness,
+        "_build_coder",
+        lambda self, paths: _FakeCoder(paths[0]),
+        raising=True,
+    )
+
+    outcomes = iter([(False, "1 failed"), (True, "1 passed")])
+
+    def _fake_pytest(test_paths: list[Path], wd: Path, timeout_s: float) -> tuple[bool, str]:
+        return next(outcomes)
+
+    monkeypatch.setattr(AiderHarness, "_run_pytest", staticmethod(_fake_pytest), raising=True)
+
+    result = await harness.run_task(task, env={}, workdir=tmp_path / "wd", task_tag="alpha-task#0")
+    parsed = json.loads(result.prediction)
+    assert parsed["resolved"] is True
+    assert parsed["tests_outcomes"] == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_run_task_all_fail(
+    polyglot_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_callback_off(monkeypatch)
+    settings = _settings(polyglot_root, subset_names=["alpha-task"], tries=2)
+    harness = AiderHarness(settings, store=SavingsStore())
+    task = load_polyglot_tasks(settings.aider)[0]
+
+    monkeypatch.setattr(
+        AiderHarness,
+        "_build_coder",
+        lambda self, paths: _FakeCoder(paths[0]),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        AiderHarness,
+        "_run_pytest",
+        staticmethod(lambda test_paths, wd, timeout_s: (False, "boom")),
+        raising=True,
+    )
+
+    result = await harness.run_task(task, env={}, workdir=tmp_path / "wd", task_tag="alpha-task#0")
+    parsed = json.loads(result.prediction)
+    assert parsed["resolved"] is False
+    assert parsed["tests_outcomes"] == [False, False]
+    assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_run_task_translates_base_url(
+    polyglot_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_callback_off(monkeypatch)
+    settings = _settings(polyglot_root, subset_names=["alpha-task"])
+    harness = AiderHarness(settings, store=SavingsStore())
+    task = load_polyglot_tasks(settings.aider)[0]
+
+    monkeypatch.setattr(
+        AiderHarness,
+        "_build_coder",
+        lambda self, paths: _FakeCoder(paths[0]),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        AiderHarness,
+        "_run_pytest",
+        staticmethod(lambda test_paths, wd, timeout_s: (True, "ok")),
+        raising=True,
+    )
+    monkeypatch.delenv("ANTHROPIC_API_BASE", raising=False)
+
+    await harness.run_task(
+        task,
+        env={"ANTHROPIC_BASE_URL": "http://127.0.0.1:18800"},
+        workdir=tmp_path / "wd",
+        task_tag="alpha-task#0",
+    )
+    assert os.environ.get("ANTHROPIC_API_BASE") == "http://127.0.0.1:18800"
+
+
+@pytest.mark.asyncio
+async def test_run_task_exception_is_loud(
+    polyglot_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_callback_off(monkeypatch)
+    settings = _settings(polyglot_root, subset_names=["alpha-task"])
+    harness = AiderHarness(settings, store=SavingsStore())
+    task = load_polyglot_tasks(settings.aider)[0]
+
+    def _boom(self: AiderHarness, paths: list[Path]) -> Any:
+        raise RuntimeError("coder build failed")
+
+    monkeypatch.setattr(AiderHarness, "_build_coder", _boom, raising=True)
+
+    result = await harness.run_task(task, env={}, workdir=tmp_path / "wd", task_tag="alpha-task#0")
+    assert result.prediction == ""
+    assert result.error is not None
+    assert "coder build failed" in result.error
+
+
+def test_harness_metadata(polyglot_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_callback_off(monkeypatch)
+    harness = AiderHarness(_settings(polyglot_root), store=SavingsStore())
+    assert harness.name == "aider"
+    assert harness.version  # aider's installed version string
+    from agent_evals.models import Provider
+
+    assert harness.supported_providers == {Provider.ANTHROPIC, Provider.OPENAI}
+
+
+# --------------------------------------------------------------------------------------------
+# Optional live test (skipped without a real key) — minimal smoke against one exercise.
+# --------------------------------------------------------------------------------------------
+
+
+@pytest.mark.live
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="requires ANTHROPIC_API_KEY for a real model rollout",
+)
+@pytest.mark.asyncio
+async def test_run_task_live(tmp_path: Path) -> None:  # pragma: no cover - opt-in only
+    settings = Settings(
+        aider=AiderConfig(
+            exercises_dir=Path(".cache/polyglot-benchmark"),
+            language="python",
+            subset_limit=1,
+            tries=1,
+        )
+    )
+    harness = AiderHarness(settings, store=SavingsStore())
+    tasks = load_polyglot_tasks(settings.aider)
+    assert tasks, "no exercises found in the live checkout"
+    result = await harness.run_task(
+        tasks[0], env={}, workdir=tmp_path / "live", task_tag=tasks[0].task_id
+    )
+    assert result.error is None
+    parsed = json.loads(result.prediction)
+    assert "resolved" in parsed

--- a/agent-evals/tests/test_aider_test_integrity.py
+++ b/agent-evals/tests/test_aider_test_integrity.py
@@ -1,0 +1,43 @@
+"""Regression guard: the harness restores pristine test files before grading.
+
+A model (via aider) can emit a diff that rewrites the exercise's test file with bogus
+expectations — observed live on a retry. The grader must always run the REAL tests, so the
+harness copies the pristine test file(s) from the source checkout over the working copy before
+each pytest invocation. This test pins that behaviour without needing aider or a model.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_evals.harnesses.aider import AiderHarness
+
+
+def test_restore_tests_overwrites_tampered_copy(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "leap"
+    dest = tmp_path / "dest" / "leap"
+    (src).mkdir(parents=True)
+    (dest).mkdir(parents=True)
+
+    pristine = "def test_real():\n    assert leap(2000) is True\n"
+    (src / "leap_test.py").write_text(pristine, encoding="utf-8")
+    # The working copy has been tampered with (model rewrote the test to pass trivially).
+    (dest / "leap_test.py").write_text("def test_fake():\n    assert True\n", encoding="utf-8")
+
+    AiderHarness._restore_tests(src, dest, ["leap_test.py"])
+
+    assert (dest / "leap_test.py").read_text(encoding="utf-8") == pristine
+
+
+def test_restore_tests_handles_nested_and_missing(tmp_path: Path) -> None:
+    src = tmp_path / "src" / "ex"
+    dest = tmp_path / "dest" / "ex"
+    (src / "tests").mkdir(parents=True)
+    (dest).mkdir(parents=True)
+    (src / "tests" / "t.py").write_text("X", encoding="utf-8")
+
+    # Nested path is created on restore; a listed-but-absent source path is skipped (not an error).
+    AiderHarness._restore_tests(src, dest, ["tests/t.py", "does_not_exist.py"])
+
+    assert (dest / "tests" / "t.py").read_text(encoding="utf-8") == "X"
+    assert not (dest / "does_not_exist.py").exists()

--- a/agent-evals/tests/test_scorecard_stats.py
+++ b/agent-evals/tests/test_scorecard_stats.py
@@ -1,0 +1,69 @@
+"""Phase-1 scorecard: the paired-bootstrap + TOST equivalence verdict path."""
+
+from __future__ import annotations
+
+from agent_evals.config import StatsConfig
+from agent_evals.models import ArmName, TaskResult
+from agent_evals.report.scorecard import build_scorecard, render_scorecard
+
+
+def _cells(arm: ArmName, pattern: dict[str, list[bool]]) -> list[TaskResult]:
+    """Build cells for one arm: pattern maps task_id -> per-run resolved booleans."""
+
+    out: list[TaskResult] = []
+    for task_id, runs in pattern.items():
+        for i, resolved in enumerate(runs):
+            out.append(TaskResult(task_id=task_id, arm=arm, run_index=i, resolved=resolved))
+    return out
+
+
+def _stats() -> StatsConfig:
+    # Small, fast, deterministic.
+    return StatsConfig(k_runs=4, alpha=0.05, margin_lossy_pp=2.0, bootstrap_resamples=2000, seed=7)
+
+
+def test_equivalent_when_arms_identical() -> None:
+    # Constant-per-task outcomes (all-pass or all-fail) => zero within-task run variance, so an
+    # identical B vs A1 yields every per-task delta == 0 => bootstrap CI [0,0] => EQUIVALENT.
+    # (A *mixed* per-task pattern would instead leave a wide CI at this small n => inconclusive,
+    # which is the real noise floor this framework is built to surface.)
+    pattern = {
+        "t0": [True, True, True, True],
+        "t1": [True, True, True, True],
+        "t2": [False, False, False, False],
+        "t3": [True, True, True, True],
+        "t4": [False, False, False, False],
+    }
+    results = _cells(ArmName.A1_PASSTHROUGH, pattern) + _cells(ArmName.B_HEADROOM, pattern)
+    sc = build_scorecard(results, "exp-equiv", stats_config=_stats())
+    assert sc.equivalence is not None
+    assert sc.equivalence.verdict == "equivalent"
+    assert sc.accuracy_delta_pp is not None and abs(sc.accuracy_delta_pp) < 1e-6
+    assert sc.noise_floor_pp is not None and sc.noise_floor_pp > 0
+    assert "EQUIVALENT" in render_scorecard(sc)
+
+
+def test_inferior_when_b_much_worse() -> None:
+    # B resolves far less often than A1 -> delta strongly negative -> INFERIOR.
+    a1 = {f"t{i}": [True, True, True, True] for i in range(6)}
+    b = {f"t{i}": [False, False, False, False] for i in range(6)}
+    results = _cells(ArmName.A1_PASSTHROUGH, a1) + _cells(ArmName.B_HEADROOM, b)
+    sc = build_scorecard(results, "exp-inf", stats_config=_stats())
+    assert sc.equivalence is not None
+    assert sc.equivalence.verdict == "inferior"
+    assert sc.accuracy_delta_pp is not None and sc.accuracy_delta_pp < -50.0
+
+
+def test_verdict_absent_without_stats_config() -> None:
+    pattern = {f"t{i}": [True, False] for i in range(3)}
+    results = _cells(ArmName.A1_PASSTHROUGH, pattern) + _cells(ArmName.B_HEADROOM, pattern)
+    sc = build_scorecard(results, "exp-nostats")  # Phase-0 behaviour
+    assert sc.equivalence is None
+    assert "Phase 1" in render_scorecard(sc)
+
+
+def test_verdict_absent_when_b_arm_missing() -> None:
+    results = _cells(ArmName.A1_PASSTHROUGH, {"t0": [True, True]})
+    sc = build_scorecard(results, "exp-missing", stats_config=_stats())
+    assert sc.equivalence is None
+    assert "unavailable" in sc.stats_note

--- a/agent-evals/tests/test_stats.py
+++ b/agent-evals/tests/test_stats.py
@@ -1,0 +1,311 @@
+"""Deterministic, I/O-free tests for the agent-evals statistics layer."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_evals.models import ArmName, DeltaEstimate, TaskResult
+from agent_evals.stats.bootstrap import paired_bootstrap
+from agent_evals.stats.pairing import pair_arms
+from agent_evals.stats.power import is_underpowered, recommended_runs
+from agent_evals.stats.tost import equivalence_verdict, non_inferiority_verdict
+from agent_evals.stats.wilson import wilson_half_width_pp, wilson_interval
+
+
+def _cells(task_id: str, arm: ArmName, resolved_pattern: list[bool]) -> list[TaskResult]:
+    """Build K TaskResults for one (task, arm) from a list of per-run resolved booleans."""
+
+    return [
+        TaskResult(task_id=task_id, arm=arm, run_index=i, resolved=r)
+        for i, r in enumerate(resolved_pattern)
+    ]
+
+
+# --------------------------------------------------------------------------- pairing
+
+
+def test_pair_arms_rates_and_deltas() -> None:
+    b = ArmName.B_HEADROOM
+    a1 = ArmName.A1_PASSTHROUGH
+    results: list[TaskResult] = []
+    # t1: B 3/4 = 75pp, A1 2/4 = 50pp -> delta +25
+    results += _cells("t1", b, [True, True, True, False])
+    results += _cells("t1", a1, [True, True, False, False])
+    # t2: B 0/4 = 0pp, A1 4/4 = 100pp -> delta -100
+    results += _cells("t2", b, [False, False, False, False])
+    results += _cells("t2", a1, [True, True, True, True])
+
+    paired = pair_arms(results, b, a1)
+
+    assert paired.task_ids == ["t1", "t2"]  # sorted, intersection
+    assert paired.b_rate_pp == [75.0, 0.0]
+    assert paired.a1_rate_pp == [50.0, 100.0]
+    assert paired.delta_pp == [25.0, -100.0]
+    assert paired.b_runs == [[True, True, True, False], [False, False, False, False]]
+    assert paired.a1_runs == [[True, True, False, False], [True, True, True, True]]
+
+
+def test_pair_arms_intersection_only_drops_unmatched() -> None:
+    b = ArmName.B_HEADROOM
+    a1 = ArmName.A1_PASSTHROUGH
+    results: list[TaskResult] = []
+    results += _cells("shared", b, [True, False])
+    results += _cells("shared", a1, [True, True])
+    results += _cells("b_only", b, [True, True])  # missing from a1 -> dropped
+    results += _cells("a1_only", a1, [False, False])  # missing from b -> dropped
+
+    paired = pair_arms(results, b, a1)
+
+    assert paired.task_ids == ["shared"]
+    assert paired.b_rate_pp == [50.0]
+    assert paired.a1_rate_pp == [100.0]
+    assert paired.delta_pp == [-50.0]
+
+
+def test_pair_arms_errored_cell_counts_as_failure() -> None:
+    # resolved=False (which an errored cell carries) is an observed failure, not dropped.
+    b = ArmName.B_HEADROOM
+    a1 = ArmName.A1_PASSTHROUGH
+    results: list[TaskResult] = []
+    results += [
+        TaskResult(task_id="t", arm=b, run_index=0, resolved=True),
+        TaskResult(task_id="t", arm=b, run_index=1, resolved=False, error="boom"),
+    ]
+    results += _cells("t", a1, [True, True])
+
+    paired = pair_arms(results, b, a1)
+
+    assert paired.task_ids == ["t"]
+    assert paired.b_rate_pp == [50.0]  # the errored run counted as a failure
+    assert paired.a1_rate_pp == [100.0]
+
+
+# --------------------------------------------------------------------------- bootstrap
+
+
+def _paired_from(b_runs: list[list[bool]], a1_runs: list[list[bool]]) -> list[TaskResult]:
+    b = ArmName.B_HEADROOM
+    a1 = ArmName.A1_PASSTHROUGH
+    results: list[TaskResult] = []
+    for i, runs in enumerate(b_runs):
+        results += _cells(f"t{i}", b, runs)
+    for i, runs in enumerate(a1_runs):
+        results += _cells(f"t{i}", a1, runs)
+    return results
+
+
+def test_bootstrap_is_deterministic_for_same_seed() -> None:
+    b_runs = [[True, True, False], [True, False, False], [True, True, True]]
+    a1_runs = [[True, False, False], [False, False, False], [True, True, False]]
+    paired = pair_arms(_paired_from(b_runs, a1_runs), ArmName.B_HEADROOM, ArmName.A1_PASSTHROUGH)
+
+    d1 = paired_bootstrap(paired, alpha=0.05, n_resamples=2000, seed=777)
+    d2 = paired_bootstrap(paired, alpha=0.05, n_resamples=2000, seed=777)
+
+    assert d1 == d2
+    assert d1.method == "paired_bootstrap"
+
+
+def test_bootstrap_different_seed_differs() -> None:
+    # Enough tasks/runs that the percentile grid is fine-grained, so two independent RNG
+    # streams land on distinct CIs (a real property of the bootstrap at adequate resolution).
+    b_runs = [
+        [True, True, False, True, False, True],
+        [True, False, False, True, True, False],
+        [False, True, True, False, True, True],
+        [True, True, True, False, False, False],
+        [False, False, True, True, False, True],
+    ]
+    a1_runs = [
+        [True, False, False, True, False, False],
+        [False, True, False, False, True, False],
+        [True, False, True, False, False, True],
+        [False, False, True, True, False, False],
+        [True, True, False, False, True, False],
+    ]
+    paired = pair_arms(_paired_from(b_runs, a1_runs), ArmName.B_HEADROOM, ArmName.A1_PASSTHROUGH)
+    d1 = paired_bootstrap(paired, alpha=0.05, n_resamples=4000, seed=1)
+    d2 = paired_bootstrap(paired, alpha=0.05, n_resamples=4000, seed=2)
+    # Point is data-only (seed-independent); the CIs should not coincide exactly.
+    assert d1.point == pytest.approx(d2.point)
+    assert (d1.ci_low, d1.ci_high) != (d2.ci_low, d2.ci_high)
+
+
+def test_bootstrap_point_equals_mean_delta() -> None:
+    # B 100pp, A1 0pp on both tasks -> every per-task delta is +100, mean = 100.
+    b_runs = [[True, True], [True, True]]
+    a1_runs = [[False, False], [False, False]]
+    paired = pair_arms(_paired_from(b_runs, a1_runs), ArmName.B_HEADROOM, ArmName.A1_PASSTHROUGH)
+    d = paired_bootstrap(paired, alpha=0.05, n_resamples=1000, seed=5)
+    assert d.point == pytest.approx(100.0)
+
+
+def test_bootstrap_strong_positive_delta_ci_excludes_zero() -> None:
+    # B fully resolves, A1 fully fails, across several tasks -> CI well above 0.
+    b_runs = [[True, True, True]] * 5
+    a1_runs = [[False, False, False]] * 5
+    paired = pair_arms(_paired_from(b_runs, a1_runs), ArmName.B_HEADROOM, ArmName.A1_PASSTHROUGH)
+    d = paired_bootstrap(paired, alpha=0.05, n_resamples=3000, seed=11)
+    assert d.point == pytest.approx(100.0)
+    assert d.ci_low > 0.0
+    assert d.ci_high == pytest.approx(100.0)
+
+
+def test_bootstrap_identical_arms_point_zero_ci_straddles() -> None:
+    # Same per-task patterns in both arms with within-task variability so the CI has width.
+    patterns = [
+        [True, False, True, False],
+        [True, True, False, False],
+        [False, True, True, False],
+    ]
+    paired = pair_arms(_paired_from(patterns, patterns), ArmName.B_HEADROOM, ArmName.A1_PASSTHROUGH)
+    d = paired_bootstrap(paired, alpha=0.05, n_resamples=4000, seed=23)
+    assert d.point == pytest.approx(0.0)
+    assert d.ci_low < 0.0 < d.ci_high
+
+
+def test_bootstrap_empty_raises() -> None:
+    paired = pair_arms([], ArmName.B_HEADROOM, ArmName.A1_PASSTHROUGH)
+    with pytest.raises(ValueError, match="no paired tasks"):
+        paired_bootstrap(paired, alpha=0.05, n_resamples=100, seed=0)
+
+
+def test_bootstrap_alpha_widens_ci() -> None:
+    b_runs = [[True, True, False], [True, False, False], [True, True, True]]
+    a1_runs = [[True, False, False], [False, True, False], [True, True, False]]
+    paired = pair_arms(_paired_from(b_runs, a1_runs), ArmName.B_HEADROOM, ArmName.A1_PASSTHROUGH)
+    narrow = paired_bootstrap(paired, alpha=0.20, n_resamples=4000, seed=99)
+    wide = paired_bootstrap(paired, alpha=0.01, n_resamples=4000, seed=99)
+    assert (wide.ci_high - wide.ci_low) >= (narrow.ci_high - narrow.ci_low)
+
+
+# --------------------------------------------------------------------------- tost
+
+
+def _delta(low: float, high: float, point: float | None = None) -> DeltaEstimate:
+    pt = point if point is not None else (low + high) / 2.0
+    return DeltaEstimate(point=pt, ci_low=low, ci_high=high, method="test")
+
+
+def test_equivalence_all_four_verdicts() -> None:
+    margin = 2.0
+    assert equivalence_verdict(_delta(-1.0, 1.0), margin).verdict == "equivalent"
+    assert equivalence_verdict(_delta(-5.0, -3.0), margin).verdict == "inferior"
+    assert equivalence_verdict(_delta(3.0, 5.0), margin).verdict == "superior"
+    assert equivalence_verdict(_delta(-3.0, 1.0), margin).verdict == "inconclusive"
+    # CI straddling the upper boundary is also inconclusive.
+    assert equivalence_verdict(_delta(1.0, 3.0), margin).verdict == "inconclusive"
+
+
+def test_equivalence_boundary_inclusive() -> None:
+    margin = 2.0
+    # CI exactly on the margins is still equivalent (subset uses <=/>=).
+    assert equivalence_verdict(_delta(-2.0, 2.0), margin).verdict == "equivalent"
+
+
+def test_equivalence_verdict_preserves_inputs() -> None:
+    margin = 2.0
+    d = _delta(-1.0, 1.0)
+    v = equivalence_verdict(d, margin)
+    assert v.delta == d
+    assert v.margin == margin
+
+
+def test_non_inferiority_verdicts() -> None:
+    margin = 2.0
+    # ci_low above -margin -> non-inferior ("equivalent")
+    assert non_inferiority_verdict(_delta(-1.0, 5.0), margin).verdict == "equivalent"
+    # ci_low below -margin -> inferior (regardless of how high ci_high is)
+    assert non_inferiority_verdict(_delta(-3.0, 10.0), margin).verdict == "inferior"
+    # exactly at -margin is NOT strictly greater -> inferior
+    assert non_inferiority_verdict(_delta(-2.0, 5.0), margin).verdict == "inferior"
+
+
+# --------------------------------------------------------------------------- wilson
+
+
+def test_wilson_half_width_known_value() -> None:
+    hw = wilson_half_width_pp(0.5, 100, confidence=0.95)
+    assert hw == pytest.approx(9.6, abs=0.2)
+
+
+def test_wilson_interval_within_unit() -> None:
+    low, high = wilson_interval(50, 100, confidence=0.95)
+    assert 0.0 <= low < high <= 1.0
+    # Centered near 0.5.
+    assert low == pytest.approx(0.404, abs=0.01)
+    assert high == pytest.approx(0.596, abs=0.01)
+
+
+def test_wilson_interval_extremes_clamped() -> None:
+    low0, high0 = wilson_interval(0, 20, confidence=0.95)
+    assert low0 == 0.0
+    assert high0 > 0.0
+    lown, highn = wilson_interval(20, 20, confidence=0.95)
+    assert highn == 1.0
+    assert lown < 1.0
+
+
+def test_wilson_width_shrinks_with_n() -> None:
+    w_small = wilson_half_width_pp(0.5, 50, confidence=0.95)
+    w_large = wilson_half_width_pp(0.5, 500, confidence=0.95)
+    assert w_large < w_small
+
+
+def test_wilson_higher_confidence_widens() -> None:
+    w90 = wilson_half_width_pp(0.5, 100, confidence=0.90)
+    w99 = wilson_half_width_pp(0.5, 100, confidence=0.99)
+    assert w99 > w90
+
+
+def test_wilson_input_validation() -> None:
+    with pytest.raises(ValueError):
+        wilson_interval(5, 0)
+    with pytest.raises(ValueError):
+        wilson_interval(11, 10)
+    with pytest.raises(ValueError):
+        wilson_half_width_pp(1.5, 10)
+
+
+# --------------------------------------------------------------------------- power
+
+
+def test_recommended_runs_decreases_with_more_tasks() -> None:
+    k_few = recommended_runs(sigma_pp=20.0, margin_pp=5.0, n_tasks=50)
+    k_many = recommended_runs(sigma_pp=20.0, margin_pp=5.0, n_tasks=200)
+    assert k_many <= k_few
+    assert k_many >= 1
+
+
+def test_recommended_runs_decreases_with_larger_margin() -> None:
+    k_tight = recommended_runs(sigma_pp=20.0, margin_pp=2.0, n_tasks=100)
+    k_loose = recommended_runs(sigma_pp=20.0, margin_pp=8.0, n_tasks=100)
+    assert k_loose <= k_tight
+
+
+def test_recommended_runs_increases_with_sigma() -> None:
+    k_low = recommended_runs(sigma_pp=10.0, margin_pp=5.0, n_tasks=100)
+    k_high = recommended_runs(sigma_pp=40.0, margin_pp=5.0, n_tasks=100)
+    assert k_high >= k_low
+
+
+def test_recommended_runs_floor_is_one() -> None:
+    # Huge task set + loose margin + tiny noise => analytic k < 1, floored at 1.
+    k = recommended_runs(sigma_pp=1.0, margin_pp=50.0, n_tasks=1000)
+    assert k == 1
+
+
+def test_recommended_runs_validation() -> None:
+    with pytest.raises(ValueError):
+        recommended_runs(sigma_pp=0.0, margin_pp=5.0, n_tasks=10)
+    with pytest.raises(ValueError):
+        recommended_runs(sigma_pp=10.0, margin_pp=0.0, n_tasks=10)
+    with pytest.raises(ValueError):
+        recommended_runs(sigma_pp=10.0, margin_pp=5.0, n_tasks=0)
+
+
+def test_is_underpowered_consistent_with_recommended() -> None:
+    needed = recommended_runs(sigma_pp=30.0, margin_pp=4.0, n_tasks=80)
+    assert is_underpowered(k_runs=needed - 1, sigma_pp=30.0, margin_pp=4.0, n_tasks=80)
+    assert not is_underpowered(k_runs=needed, sigma_pp=30.0, margin_pp=4.0, n_tasks=80)
+    assert not is_underpowered(k_runs=needed + 5, sigma_pp=30.0, margin_pp=4.0, n_tasks=80)


### PR DESCRIPTION
## Description

Phase 1 for the agent-evals stack, based on `agent-evals-phase0` / PR #1037. This adds the first real WITH-vs-WITHOUT accuracy A/B path: run the Aider Polyglot benchmark through the 3-arm proxy and report a paired-bootstrap plus TOST equivalence verdict so Headroom can evaluate whether compression preserves accuracy within a registered margin.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Tests only

## Changes Made

- Added statistics helpers for pairing, hierarchical paired bootstrap, TOST equivalence/non-inferiority, Wilson noise floor, and power recommendations.
- Added the Aider Polyglot harness and benchmark loader using the shipped `aider.coders.Coder` API.
- Captured per-task savings via a LiteLLM `CustomLogger` reading Headroom response headers into the savings store by per-cell task tag.
- Extended scorecard generation to attach bootstrap deltas, TOST verdicts, and Wilson noise-floor context when `stats_config` is provided.
- Added `agent-evals run` wiring and `.env` provider-key loading.
- Hardened live-run behavior by disabling URL scraping, running pytest from the exercise directory with absolute paths, and restoring pristine tests before grading.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
agent-evals test suite
# 127 unit tests passed

ruff
# clean

mypy
# clean
```

## Real Behavior Proof

- Environment: local live smoke using Anthropic against the grade-school Polyglot subset.
- Exact command / steps: Ran A0, A1, and B arms through the Aider Polyglot harness with provider keys loaded from `.env`.
- Observed result: All arms resolved `grade-school` on try 2, savings headers were captured through the proxy, and the scorecard reported EQUIVALENT with B-A1 = +0.00pp within the ±2pp margin. The framework also reported the expected high n=1 Wilson noise floor (±39.7pp).
- Not tested: large multi-exercise claims; the PR explicitly notes real claims require many exercises and repeated K runs. Phase 2 is planned for SWE-bench Verified and ablation arms.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review