### PR TITLE
fix: --disable-kompress should not override fallback_strategy to PASSTHROUGH

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -167,7 +167,6 @@ from headroom.transforms import (
     CacheAligner,
     CodeAwareCompressor,
     CodeCompressorConfig,
-    CompressionStrategy,
     ContentRouter,
     ContentRouterConfig,
     TransformPipeline,
@@ -618,7 +617,6 @@ class HeadroomProxy(
         )
         if config.disable_kompress:
             router_config.enable_kompress = False
-            router_config.fallback_strategy = CompressionStrategy.PASSTHROUGH
         # A non-None exclude_tools replaces DEFAULT_EXCLUDE_TOOLS in
         # ContentRouter, so merge rather than assign.
         if config.exclude_tools:

--- a/tests/test_proxy_disable_kompress.py
+++ b/tests/test_proxy_disable_kompress.py
@@ -33,7 +33,7 @@ def test_disable_kompress_config_keeps_optimization_but_disables_ml_fallback() -
     )
 
     assert router.config.enable_kompress is False
-    assert router.config.fallback_strategy == CompressionStrategy.PASSTHROUGH
+    assert router.config.fallback_strategy == CompressionStrategy.KOMPRESS
 
 
 def test_disable_kompress_defaults_to_existing_kompress_behavior() -> None:


### PR DESCRIPTION
## Description

`--disable-kompress` correctly disabled the ML model via `enable_kompress = False`, but it
also forced `router_config.fallback_strategy = CompressionStrategy.PASSTHROUGH`. That
override suppressed ContentRouter's rule-based passes — including the `exclude_tools` gate —
for content that falls through to the fallback, so `HEADROOM_EXCLUDE_TOOLS` had no effect
when `--disable-kompress` was set. Removing the override leaves `fallback_strategy` at its
default (`KOMPRESS`); ContentRouter keeps running its rule-based passes and only Kompress
inference is disabled.

Closes #955

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/server.py`: removed the `router_config.fallback_strategy = CompressionStrategy.PASSTHROUGH` line inside the `if config.disable_kompress:` block; `enable_kompress = False` is kept.
- `headroom/proxy/server.py`: dropped the now-unused `CompressionStrategy` import (it was only referenced by the removed line).
- `tests/test_proxy_disable_kompress.py`: updated the assertion to expect `fallback_strategy == CompressionStrategy.KOMPRESS` (the default), matching the corrected behaviour.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ pytest tests/test_proxy_disable_kompress.py -v
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-9.1.0, pluggy-1.6.0
rootdir: /.../headroom
configfile: pyproject.toml
plugins: anyio-4.14.0, asyncio-1.4.0
collected 2 items

tests/test_proxy_disable_kompress.py::test_disable_kompress_config_keeps_optimization_but_disables_ml_fallback PASSED [ 50%]
tests/test_proxy_disable_kompress.py::test_disable_kompress_defaults_to_existing_kompress_behavior PASSED [100%]

============================== 2 passed in 1.37s ==============================

$ ruff check headroom/proxy/server.py tests/test_proxy_disable_kompress.py
All checks passed!
```

## Real Behavior Proof

- Environment: local clone, Python 3.13.7 venv, headroom core deps + fastapi/uvicorn/httpx.
- Exact command / steps: built the proxy router via `create_app(ProxyConfig(optimize=True, ...))` with `disable_kompress` set and inspected the resulting `ContentRouter` config; ran `pytest tests/test_proxy_disable_kompress.py -v` and `ruff check` on the changed files.
- Observed result: with `--disable-kompress`, `enable_kompress` is `False` and `fallback_strategy` is `KOMPRESS` (the default) instead of `PASSTHROUGH`; ContentRouter stays in the pipeline. Both config tests pass and lint is clean.
- Not tested: full live-proxy `/stats` run against an LLM backend. The issue reporter observed `router_content_router_activations` 0→22 and exclude-tool hits 0→10 after this change (see #955).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

This removes the override line plus its now-unused import, and updates the existing test that
asserted the old behaviour; no new test was added because the corrected behaviour is covered
by that existing test. The live `/stats` reproduction is described in #955.
