### PR TITLE
fix(ci): make PR governance advisory

### DIFF
--- a/.github/workflows/pr-health.yml
+++ b/.github/workflows/pr-health.yml
@@ -131,11 +131,10 @@ jobs:
               }
             }
 
-      - name: Fail when the PR body is incomplete
+      - name: Report incomplete PR body
         if: steps.validate.outputs.valid != 'true'
         run: |
-          echo "PR template validation failed. Update the PR body or move the PR back to draft."
-          exit 1
+          echo "PR template validation found missing fields. The governance comment and labels identify the required author updates."
 
   label:
     runs-on: ubuntu-latest

--- a/scripts/tests/test_pr_health_workflow.py
+++ b/scripts/tests/test_pr_health_workflow.py
@@ -1,0 +1,14 @@
+"""Tests for the PR governance workflow contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_incomplete_pr_template_is_reported_without_failing_job() -> None:
+    workflow = Path(".github/workflows/pr-health.yml").read_text(encoding="utf-8")
+
+    assert "Report incomplete PR body" in workflow
+    assert "PR template validation found missing fields" in workflow
+    assert "Fail when the PR body is incomplete" not in workflow
+    assert 'echo "PR template validation failed' not in workflow


### PR DESCRIPTION
## Description

Make the PR Governance workflow advisory for incomplete pull request bodies. The workflow still validates the template, writes the run summary, comments on the PR, and syncs governance labels, but it no longer marks the check red for expected author follow-up.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Replaced the failing incomplete-template step with a reporting step that exits successfully.
- Added a regression test that guards against reintroducing the hard failure path.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Manual testing performed

### Test Output

```text
pytest scripts/tests/test_pr_governance.py scripts/tests/test_pr_health_labels.py scripts/tests/test_pr_health_workflow.py -q
# 7 passed

act pull_request_target -W .github/workflows/pr-health.yml -e .github/act/pr-governance-invalid.json -n
# Job succeeded

act pull_request_target -W .github/workflows/pr-health.yml -e .github/act/pr-governance-valid.json -n
# Job succeeded
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.13.13, act 0.2.87, Docker Desktop via npipe.
- Exact command / steps: Ran the focused governance/label tests and `act` dry-runs for the valid and invalid PR governance payloads.
- Observed result: Tests passed, the invalid payload's reporting step completed successfully, and both PR Governance dry-runs ended with job success.
- Not tested: Full non-dry-run `act` execution against GitHub API side-effect steps, to avoid mutating real labels/comments from a local run.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review