### PR TITLE
Fix Codex ChatGPT /v1/models compatibility metadata

### DIFF
--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -79,8 +79,71 @@ def _codex_client_version(requested_client_version: str | None = None) -> str:
     return "0.130.0"
 
 
-def _models_list_response(model_ids: tuple[str, ...]) -> Response:
-    """Build an OpenAI-compatible model-list response for Codex metadata callers."""
+_CODEX_REASONING_LEVELS: tuple[dict[str, str], ...] = (
+    {"effort": "low", "description": "Fast responses with lighter reasoning"},
+    {
+        "effort": "medium",
+        "description": "Balances speed and reasoning depth for everyday tasks",
+    },
+    {"effort": "high", "description": "Greater reasoning depth for complex problems"},
+    {"effort": "xhigh", "description": "Extra high reasoning depth for complex problems"},
+)
+
+
+def _display_name_from_model_id(model_id: str) -> str:
+    return "-".join(
+        part.upper() if part == "gpt" else part.capitalize() for part in model_id.split("-")
+    )
+
+
+def _codex_model_registry_entry(
+    model_id: str,
+    upstream_entry: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return Codex app-server model metadata with required registry fields."""
+    entry = dict(upstream_entry or {})
+    entry["slug"] = model_id
+    entry.setdefault("display_name", _display_name_from_model_id(model_id))
+    entry.setdefault("description", "Codex model available through ChatGPT subscription auth.")
+    entry.setdefault("default_reasoning_level", "medium")
+    entry.setdefault("supported_reasoning_levels", list(_CODEX_REASONING_LEVELS))
+    entry.setdefault("shell_type", "shell_command")
+    entry.setdefault("visibility", "list")
+    entry.setdefault("supported_in_api", True)
+    entry.setdefault("priority", 50)
+    entry.setdefault("additional_speed_tiers", ["fast"])
+    entry.setdefault(
+        "service_tiers",
+        [{"id": "priority", "name": "Fast", "description": "1.5x speed, increased usage"}],
+    )
+    entry.setdefault("availability_nux", None)
+    entry.setdefault("upgrade", None)
+    entry.setdefault("context_window", 272000)
+    entry.setdefault("max_context_window", 272000)
+    entry.setdefault("effective_context_window_percent", 95)
+    entry.setdefault("experimental_supported_tools", [])
+    entry.setdefault("input_modalities", ["text", "image"])
+    entry.setdefault("supports_search_tool", True)
+    entry.setdefault("use_responses_lite", False)
+    entry.setdefault("support_verbosity", True)
+    entry.setdefault("default_verbosity", "low")
+    entry.setdefault("apply_patch_tool_type", "freeform")
+    entry.setdefault("web_search_tool_type", "text_and_image")
+    entry.setdefault("truncation_policy", {"mode": "tokens", "limit": 10000})
+    entry.setdefault("supports_image_detail_original", True)
+    entry.setdefault("supports_parallel_tool_calls", True)
+    entry.setdefault("supports_reasoning_summaries", True)
+    entry.setdefault("default_reasoning_summary", "none")
+    return entry
+
+
+def _models_list_response_from_entries(model_entries: tuple[dict[str, Any], ...]) -> Response:
+    model_ids = tuple(
+        slug
+        for entry in model_entries
+        for slug in (entry.get("slug"),)
+        if isinstance(slug, str) and slug
+    )
     payload = {
         "object": "list",
         "data": [
@@ -92,6 +155,7 @@ def _models_list_response(model_ids: tuple[str, ...]) -> Response:
             }
             for model_id in model_ids
         ],
+        "models": list(model_entries),
     }
     return Response(
         content=json.dumps(payload),
@@ -102,7 +166,9 @@ def _models_list_response(model_ids: tuple[str, ...]) -> Response:
 
 def _synthetic_models_list_response() -> Response:
     """OpenAI-compatible `/v1/models` payload for Codex ChatGPT auth."""
-    return _models_list_response(_CHATGPT_AUTH_CODEX_MODELS)
+    return _models_list_response_from_entries(
+        tuple(_codex_model_registry_entry(model_id) for model_id in _CHATGPT_AUTH_CODEX_MODELS)
+    )
 
 
 def _synthetic_model_get_response(model_id: str) -> Response:
@@ -152,12 +218,12 @@ def _normalize_codex_registry_headers(headers: dict[str, str]) -> dict[str, str]
     return upstream_headers
 
 
-async def _fetch_chatgpt_codex_model_ids(
+async def _fetch_chatgpt_codex_model_entries(
     proxy: Any,
     headers: dict[str, str],
     requested_client_version: str | None,
-) -> tuple[str, ...] | None:
-    """Fetch Codex model slugs from ChatGPT, returning None when fallback should apply."""
+) -> tuple[dict[str, Any], ...] | None:
+    """Fetch Codex model metadata from ChatGPT, returning None when fallback should apply."""
     client_version = _codex_client_version(requested_client_version)
     upstream_headers = _normalize_codex_registry_headers(headers)
     url = (
@@ -185,20 +251,21 @@ async def _fetch_chatgpt_codex_model_ids(
             logger.warning("Codex model registry response did not contain models[]")
             return None
 
-        model_ids = tuple(
-            slug
+        model_entries = tuple(
+            _codex_model_registry_entry(slug, entry)
             for entry in models_raw
             if isinstance(entry, dict)
             for slug in (entry.get("slug"),)
             if isinstance(slug, str) and slug
         )
-        if not model_ids:
+        if not model_entries:
             logger.warning("Codex model registry returned no model slugs")
             return None
 
-        logger.info("Fetched %d Codex models from upstream model registry", len(model_ids))
-        logger.debug("Fetched Codex model IDs from upstream model registry: %s", list(model_ids))
-        return model_ids
+        model_ids = [entry["slug"] for entry in model_entries]
+        logger.info("Fetched %d Codex models from upstream model registry", len(model_entries))
+        logger.debug("Fetched Codex model IDs from upstream model registry: %s", model_ids)
+        return model_entries
     except Exception:
         logger.exception("Codex model registry fetch failed")
         return None
@@ -210,10 +277,12 @@ async def _fetch_chatgpt_codex_models_response(
     requested_client_version: str | None,
 ) -> Response | None:
     """Build a dynamic `/v1/models` response from the Codex registry when available."""
-    model_ids = await _fetch_chatgpt_codex_model_ids(proxy, headers, requested_client_version)
-    if model_ids is None:
+    model_entries = await _fetch_chatgpt_codex_model_entries(
+        proxy, headers, requested_client_version
+    )
+    if model_entries is None:
         return None
-    return _models_list_response(model_ids)
+    return _models_list_response_from_entries(model_entries)
 
 
 async def _fetch_chatgpt_codex_model_get_response(
@@ -223,9 +292,17 @@ async def _fetch_chatgpt_codex_model_get_response(
     requested_client_version: str | None,
 ) -> Response | None:
     """Build a dynamic `/v1/models/{id}` response from the Codex registry when available."""
-    model_ids = await _fetch_chatgpt_codex_model_ids(proxy, headers, requested_client_version)
-    if model_ids is None:
+    model_entries = await _fetch_chatgpt_codex_model_entries(
+        proxy, headers, requested_client_version
+    )
+    if model_entries is None:
         return None
+    model_ids = tuple(
+        slug
+        for entry in model_entries
+        for slug in (entry.get("slug"),)
+        if isinstance(slug, str) and slug
+    )
     if model_id in model_ids:
         return Response(
             content=json.dumps(

--- a/tests/test_provider_proxy_routes.py
+++ b/tests/test_provider_proxy_routes.py
@@ -511,23 +511,33 @@ def test_v1_models_fetches_codex_registry_under_chatgpt_auth(monkeypatch) -> Non
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload == {
-        "object": "list",
-        "data": [
-            {
-                "id": "gpt-5.5",
-                "object": "model",
-                "created": 0,
-                "owned_by": "openai",
-            },
-            {
-                "id": "gpt-5.3-codex-spark",
-                "object": "model",
-                "created": 0,
-                "owned_by": "openai",
-            },
-        ],
-    }
+    assert payload["object"] == "list"
+    assert payload["data"] == [
+        {
+            "id": "gpt-5.5",
+            "object": "model",
+            "created": 0,
+            "owned_by": "openai",
+        },
+        {
+            "id": "gpt-5.3-codex-spark",
+            "object": "model",
+            "created": 0,
+            "owned_by": "openai",
+        },
+    ]
+    assert [entry["slug"] for entry in payload["models"]] == [
+        "gpt-5.5",
+        "gpt-5.3-codex-spark",
+    ]
+    assert [entry["display_name"] for entry in payload["models"]] == [
+        "GPT-5.5",
+        "GPT-5.3-Codex-Spark",
+    ]
+    for entry in payload["models"]:
+        assert entry["default_reasoning_level"] == "medium"
+        assert entry["context_window"] == 272000
+        assert entry["supports_parallel_tool_calls"] is True
     assert len(fake_http_client.calls) == 1
     method, url, headers = fake_http_client.calls[0]
     assert method == "GET"
@@ -578,8 +588,14 @@ def test_v1_models_falls_back_to_synthetic_list_under_chatgpt_auth(monkeypatch) 
     assert isinstance(payload["data"], list)
     assert len(payload["data"]) > 0
     model_ids = {entry["id"] for entry in payload["data"]}
+    model_slugs = {entry["slug"] for entry in payload["models"]}
     # Spot-check: the model from issue #478's repro log must be present.
     assert "gpt-5.5" in model_ids
+    assert "gpt-5.5" in model_slugs
+    gpt_55 = next(entry for entry in payload["models"] if entry["slug"] == "gpt-5.5")
+    assert gpt_55["display_name"] == "GPT-5.5"
+    assert gpt_55["supported_in_api"] is True
+    assert gpt_55["default_reasoning_level"] == "medium"
     for entry in payload["data"]:
         assert entry["object"] == "model"
         assert entry["owned_by"] == "openai"

--- a/tests/test_proxy_codex_route_aliases.py
+++ b/tests/test_proxy_codex_route_aliases.py
@@ -227,6 +227,14 @@ def test_codex_model_metadata_fetches_codex_registry_for_chatgpt_auth(monkeypatc
         "gpt-5.5",
         "gpt-5.3-codex-spark",
     }
+    assert {entry["slug"] for entry in list_payload["models"]} == {
+        "gpt-5.5",
+        "gpt-5.3-codex-spark",
+    }
+    for entry in list_payload["models"]:
+        assert entry["display_name"]
+        assert entry["default_reasoning_level"] == "medium"
+        assert entry["supports_parallel_tool_calls"] is True
 
     # Single-model GET returns a model object when known.
     assert known_response.status_code == 200


### PR DESCRIPTION
## Description

Fixes Codex ChatGPT/OAuth `/v1/models` metadata compatibility while keeping Headroom's existing OpenAI-compatible response shape.

Headroom's ChatGPT/OAuth model-list route already returned:

- `object: "list"`
- `data[]`

Newer Codex clients also inspect a top-level `models[]` registry metadata array. Without that shape, completions can still work, but clients may emit non-fatal model metadata decode or missing-field warnings before the follow-up `/v1/responses` call.

This PR keeps `object`/`data[]` unchanged and adds a Codex-compatible `models[]` array. Upstream registry metadata is preserved where available, and only missing fields are filled with defaults.

Closes: N/A

## Type of Change

- [x] Bug fix (non-breaking change fixes issue)
- [ ] New feature (non-breaking change adds functionality)
- [ ] Breaking change (fix or feature would cause existing functionality change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add Codex registry metadata generation for the ChatGPT/OAuth `/v1/models` response.
- Preserve dynamic upstream registry entries instead of reducing them to slug-only IDs.
- Add fallback metadata for known Codex models if upstream registry data is unavailable.
- Fill required/default Codex fields when absent, including:
  - `display_name`
  - `default_reasoning_level`
  - `supported_reasoning_levels`
  - `context_window`
  - tool/runtime capability flags
- Keep the existing OpenAI-compatible `data[]` response shape.
- Add tests that assert both OpenAI-compatible `data[]` and Codex-compatible `models[]` shapes.

Changed files:

- `headroom/providers/proxy_routes.py`
- `tests/test_provider_proxy_routes.py`
- `tests/test_proxy_codex_route_aliases.py`

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
ruff check headroom/providers/proxy_routes.py tests/test_provider_proxy_routes.py tests/test_proxy_codex_route_aliases.py
# pass

pytest tests/test_provider_proxy_routes.py::test_v1_models_fetches_codex_registry_under_chatgpt_auth
# pass

pytest tests/test_proxy_codex_route_aliases.py
# pass

pytest tests/test_provider_proxy_routes.py
# pass
```

## Real Behavior Proof

- Environment: isolated local Headroom proxy using the patched source.
- Exact command / steps:
  - call `/v1/models`
  - run one small Codex `/v1/responses` request through the proxy
  - compare Headroom `/stats`
  - check logs for Codex model metadata decode or missing-field warnings
- Observed result:
  - `/v1/models` succeeded
  - `/v1/responses` succeeded
  - `requests.failed` stayed flat
  - provider stats and proxy compression accounting increased
  - no Codex model metadata decode or missing-field warnings observed
- Not tested:
  - full repository `mypy headroom` pass was not run for this submission

## Review Readiness

- [x] I have performed a self-review before requesting human review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows project's style guidelines
- [x] I performed self-review my code
- [ ] I commented my code, particularly in hard-to-understand areas
- [ ] I made corresponding changes documentation
- [x] My changes generate no new warnings
- [x] I added tests prove fix is effective or feature works
- [x] New and existing unit tests pass locally my changes
- [ ] I updated CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A.

## Additional Notes

Checklist items left unchecked are intentionally not applicable or not run for this focused compatibility PR:

- no new comments were needed in the implementation
- no documentation or changelog update is included for this compatibility fix to an existing route
- full-suite `mypy headroom` was not run in the submission pass

