### PR TITLE
feat: add headroom wrap opencode command

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -2552,6 +2552,7 @@ def wrap() -> None:
     Supported tools (one Click subcommand per tool):
         headroom wrap claude              # Claude Code (Anthropic)
         headroom wrap codex               # OpenAI Codex CLI
+        headroom wrap opencode            # OpenCode (OpenAI-compatible)
         headroom wrap copilot -- --model claude-sonnet-4-20250514
         headroom wrap aider               # Aider
         headroom wrap cursor              # Cursor (prints config instructions)
@@ -2568,11 +2569,6 @@ def wrap() -> None:
         - `headroom proxy` — just the proxy. Use this with any
           OpenAI/Anthropic-compatible client by setting
           ANTHROPIC_BASE_URL / OPENAI_BASE_URL yourself.
-
-    \b
-    Note: `headroom wrap opencode` does NOT exist. For opencode, run
-    `headroom proxy` and point opencode at it via OPENAI_BASE_URL.
-    `openclaw` is a separate tool — different from opencode.
     """
 
 
@@ -3358,6 +3354,256 @@ def codex(
         anyllm_provider=anyllm_provider,
         region=region,
     )
+
+
+# =============================================================================
+# OpenCode
+# =============================================================================
+
+
+@wrap.command(context_settings={"ignore_unknown_options": True})
+@click.option("--port", "-p", default=8787, type=int, help="Proxy port (default: 8787)")
+@click.option(
+    "--no-context-tool",
+    "--no-rtk",
+    "no_rtk",
+    is_flag=True,
+    help="Skip CLI context-tool setup",
+)
+@click.option(
+    "--no-mcp",
+    is_flag=True,
+    help="Skip headroom MCP server registration (compression markers will be unactionable)",
+)
+@click.option("--no-serena", is_flag=True, help="Skip Serena MCP server registration")
+@click.option(
+    "--code-graph",
+    is_flag=True,
+    help="Enable code graph indexing via codebase-memory-mcp (optional)",
+)
+@click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option(
+    "--learn", is_flag=True, help="Enable live traffic learning (patterns saved to AGENTS.md)"
+)
+@click.option(
+    "--backend",
+    default=None,
+    help="API backend for the proxy: 'anthropic', 'anyllm', 'litellm-vertex', etc. (env: HEADROOM_BACKEND)",
+)
+@click.option(
+    "--anyllm-provider",
+    default=None,
+    help="Provider for any-llm backend: openai, mistral, groq, etc. (env: HEADROOM_ANYLLM_PROVIDER)",
+)
+@click.option("--region", default=None, help="Cloud region for Bedrock/Vertex (env: HEADROOM_REGION)")
+@click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option("--verbose", "-v", is_flag=True, help="Verbose output")
+@click.option("--prepare-only", is_flag=True, hidden=True)
+@click.argument("opencode_args", nargs=-1, type=click.UNPROCESSED)
+def opencode(
+    port: int,
+    no_rtk: bool,
+    no_mcp: bool,
+    no_serena: bool,
+    code_graph: bool,
+    no_proxy: bool,
+    learn: bool,
+    memory: bool,
+    backend: str | None,
+    anyllm_provider: str | None,
+    region: str | None,
+    verbose: bool,
+    prepare_only: bool,
+    opencode_args: tuple,
+) -> None:
+    """Launch OpenCode through Headroom proxy.
+
+    \b
+    Sets OPENAI_BASE_URL to route all OpenAI API calls through Headroom.
+    Sets up the selected CLI context tool so OpenCode uses token-optimized
+    commands (60-90% savings on shell output). Also
+    registers the headroom MCP server in the OpenCode config file
+    so OpenCode can call ``headroom_retrieve`` on compression markers.
+
+    \b
+    Examples:
+        headroom wrap opencode                         # Start proxy + context tool + mcp + opencode
+        headroom wrap opencode -- "fix the bug"        # Pass prompt to opencode
+        headroom wrap opencode --no-context-tool       # Skip CLI context-tool setup
+        headroom wrap opencode --no-mcp                # Skip MCP retrieve tool registration
+        headroom wrap opencode --no-serena             # Skip Serena MCP registration
+        headroom wrap opencode --port 9999             # Custom proxy port
+        headroom wrap opencode --backend anyllm --anyllm-provider groq
+    """
+    # Snapshot OpenCode config BEFORE any wrap-time mutation so
+    # `headroom unwrap opencode` can restore the user's pre-wrap state.
+    from headroom.mcp_registry.opencode import OpenCodeRegistrar
+
+    registrar = OpenCodeRegistrar()
+    if registrar.detect():
+        registrar.snapshot_config()
+
+    # Setup CLI context tool for OpenCode.
+    if not no_rtk:
+        if _selected_context_tool() == _CONTEXT_TOOL_LEAN_CTX:
+            click.echo("  Setting up lean-ctx for OpenCode...")
+            _setup_lean_ctx_agent("opencode", verbose=verbose)
+        else:
+            click.echo("  Setting up rtk for OpenCode...")
+            rtk_path = _ensure_rtk_binary(verbose=verbose)
+            if rtk_path:
+                # Inject RTK instructions into OpenCode's config
+                rtk_instructions_path = str(Path.home() / ".config" / "opencode" / "instructions" / "rtk.md")
+                _inject_rtk_instructions(Path(rtk_instructions_path), verbose=verbose)
+                # Also add the instruction path to OpenCode's config
+                registrar.add_instruction(rtk_instructions_path)
+
+    # Register headroom MCP server in OpenCode config so OpenCode can
+    # call headroom_retrieve on compression markers from the proxy.
+    if not no_mcp:
+        _setup_headroom_mcp(registrar, port, verbose=verbose, force=True)
+    elif verbose:
+        click.echo("  Skipping MCP retrieve tool (--no-mcp)")
+
+    if not no_serena:
+        _setup_serena_mcp(registrar, context="opencode", verbose=verbose, force=True)
+    elif verbose:
+        click.echo("  Skipping Serena MCP (--no-serena)")
+
+    # Setup memory MCP server for OpenCode
+    if memory:
+        click.echo("  Setting up memory for OpenCode...")
+        mem_dir = Path.cwd() / ".headroom"
+        mem_dir.mkdir(parents=True, exist_ok=True)
+        db_path = str(mem_dir / "memory.db")
+        mem_user = os.environ.get("USER", os.environ.get("USERNAME", "default"))
+
+        # Register MCP server in OpenCode config
+        _inject_memory_mcp_opencode(registrar, db_path, mem_user)
+
+        # Inject memory guidance into project AGENTS.md
+        agents_md = Path.cwd() / "AGENTS.md"
+        _inject_memory_agents_md(agents_md)
+
+        # Sync Claude's memories → DB so MCP search finds them
+        try:
+            import asyncio
+
+            from headroom.memory.backends.local import LocalBackend, LocalBackendConfig
+            from headroom.memory.sync import sync_import
+            from headroom.memory.sync_adapters.claude_code import (
+                ClaudeCodeAdapter,
+                get_claude_memory_dir,
+            )
+
+            claude_memory_dir = get_claude_memory_dir()
+
+            async def _import_claude_memories() -> int:
+                config = LocalBackendConfig(db_path=db_path)
+                backend = LocalBackend(config)
+                await backend._ensure_initialized()
+                adapter = ClaudeCodeAdapter(claude_memory_dir)
+                count = await sync_import(backend, adapter, mem_user)
+                await backend.close()
+                return count
+
+            imported = asyncio.run(_import_claude_memories())
+            if imported:
+                click.echo(f"  Memory: imported {imported} memories from Claude")
+        except Exception as e:
+            click.echo(f"  Warning: Claude memory import failed: {e}")
+
+    if prepare_only:
+        _inject_opencode_provider_config(registrar, port)
+        return
+
+    opencode_bin = shutil.which("opencode")
+    if not opencode_bin:
+        click.echo("Error: 'opencode' not found in PATH.")
+        click.echo("Install OpenCode: npm install -g @opencode-ai/opencode")
+        raise SystemExit(1)
+
+    env, env_vars_display = _build_opencode_launch_env(port, os.environ)
+
+    # Per-project savings attribution
+    _opencode_project = _project_name_from_cwd()
+    if _opencode_project and "HEADROOM_PROJECT" not in env:
+        env["HEADROOM_PROJECT"] = _opencode_project
+
+    # Inject Headroom provider into OpenCode config
+    _inject_opencode_provider_config(registrar, port)
+    if memory:
+        mem_dir = Path.cwd() / ".headroom"
+        _inject_memory_mcp_opencode(
+            registrar,
+            str(mem_dir / "memory.db"),
+            os.environ.get("USER", os.environ.get("USERNAME", "default")),
+        )
+
+    _launch_tool(
+        binary=opencode_bin,
+        args=opencode_args,
+        env=env,
+        port=port,
+        no_proxy=no_proxy,
+        tool_label="OPENCODE",
+        env_vars_display=env_vars_display,
+        learn=learn,
+        memory=memory,
+        agent_type="opencode",
+        code_graph=code_graph,
+        backend=backend,
+        anyllm_provider=anyllm_provider,
+        region=region,
+    )
+
+
+def _inject_opencode_provider_config(registrar: Any, port: int) -> None:
+    """Override the built-in Deepseek provider's baseURL to route through the proxy.
+
+    Unlike Claude and Codex, OpenCode's built-in providers take precedence
+    over custom providers. The only reliable way to route traffic through
+    the proxy is to override the built-in provider's baseURL.
+    """
+    from headroom.providers.opencode import proxy_base_url
+
+    base_url = proxy_base_url(port)
+    registrar.override_provider_base_url("deepseek", base_url)
+    if registrar._config_file.exists():
+        click.echo(f"  Deepseek provider baseURL overridden to {base_url}")
+
+
+def _build_opencode_launch_env(
+    port: int, environ: dict[str, str]
+) -> tuple[dict[str, str], list[str]]:
+    """Build environment variables for OpenCode through the local proxy."""
+    env = dict(environ)
+    from headroom.providers.opencode import proxy_base_url
+
+    base_url = proxy_base_url(port)
+    env["OPENAI_BASE_URL"] = base_url
+    return env, [f"OPENAI_BASE_URL={base_url}"]
+
+
+def _inject_memory_mcp_opencode(registrar: Any, db_path: str, user_id: str) -> None:
+    """Register headroom memory as an MCP server in OpenCode's config.
+
+    Idempotent — replaces existing entry if present.
+    """
+    import sys
+
+    from headroom.mcp_registry.base import ServerSpec
+
+    python_bin = sys.executable.replace("\\", "/")
+    db_path_clean = db_path.replace("\\", "/")
+
+    spec = ServerSpec(
+        name="headroom_memory",
+        command=python_bin,
+        args=("-m", "headroom.memory.mcp_server", "--db", db_path_clean, "--user", user_id),
+    )
+    registrar.register_server(spec, force=True)
+    click.echo(f"  Memory MCP: registered in {registrar._config_file}")
 
 
 # =============================================================================
@@ -4402,3 +4648,125 @@ def unwrap_codex(port: int, no_stop_proxy: bool) -> None:
     if not no_stop_proxy and status != "noop":
         _echo_unwrap_proxy_stop_status(_stop_local_proxy_for_unwrap(port), port)
     click.echo()
+
+
+# =============================================================================
+# OpenCode (unwrap)
+# =============================================================================
+
+
+@unwrap.command("opencode")
+@click.option("--port", "-p", default=8787, type=int, help="Proxy port (default: 8787)")
+@click.option("--no-stop-proxy", is_flag=True, help="Do not stop the local Headroom proxy")
+def unwrap_opencode(port: int, no_stop_proxy: bool) -> None:
+    """Undo ``headroom wrap opencode`` edits to the OpenCode config file.
+
+    Behaviour:
+
+    * If a pre-wrap backup (``opencode.jsonc.headroom-backup``) exists, the
+      original file is restored byte-for-byte and the backup is removed.
+    * Otherwise, if the config file still contains Headroom-managed entries
+      (provider, MCP servers), those are removed and the rest is preserved.
+    * If neither a backup nor Headroom entries are present, this is a safe
+      no-op.
+    """
+    click.echo()
+    click.echo("  ╔═══════════════════════════════════════════════╗")
+    click.echo("  ║          HEADROOM UNWRAP: OPENCODE            ║")
+    click.echo("  ╚═══════════════════════════════════════════════╝")
+    click.echo()
+
+    from headroom.mcp_registry.opencode import OpenCodeRegistrar
+
+    registrar = OpenCodeRegistrar()
+
+    if not registrar.detect():
+        click.echo("  Nothing to undo: OpenCode config directory not found.")
+        click.echo()
+        return
+
+    try:
+        status = _restore_opencode_config(registrar)
+    except Exception as e:
+        raise click.ClickException(f"could not unwrap OpenCode config: {e}") from e
+
+    if status == "restored":
+        click.echo(f"  Restored prior {registrar._config_file} from pre-wrap backup.")
+    elif status == "cleaned":
+        click.echo(f"  Removed Headroom entries from {registrar._config_file}; other content preserved.")
+    elif status == "removed":
+        click.echo(f"  Removed {registrar._config_file} (contained only Headroom-written config).")
+    else:
+        click.echo(f"  Nothing to undo: {registrar._config_file} has no Headroom wrap markers.")
+
+    click.echo()
+    click.echo("✓ OpenCode is no longer routed through the Headroom proxy.")
+    if not no_stop_proxy and status != "noop":
+        _echo_unwrap_proxy_stop_status(_stop_local_proxy_for_unwrap(port), port)
+    click.echo()
+
+
+def _restore_opencode_config(registrar: Any) -> str:
+    """Undo ``headroom wrap opencode`` edits to the OpenCode config file.
+
+    Returns a status string:
+      * ``"restored"`` — a pre-wrap backup existed and was restored.
+      * ``"cleaned"``  — no backup, but Headroom entries were removed.
+      * ``"removed"``  — the config file only contained Headroom content.
+      * ``"noop"``     — nothing to undo.
+    """
+    # Case 1: pre-wrap snapshot exists — restore it exactly.
+    restored = registrar.restore_config()
+    if restored:
+        return "restored"
+
+    # Case 2: no backup, but config file exists and has Headroom entries — strip them.
+    if registrar._config_file.exists() and registrar.is_wrapped():
+        config = registrar._read_config()
+
+        # Remove Headroom custom provider if present
+        registrar.remove_provider("headroom")
+
+        # Remove proxy baseURL overrides from built-in providers
+        providers = config.get("provider", {})
+        if isinstance(providers, dict):
+            for _provider_name, provider_config in providers.items():
+                if isinstance(provider_config, dict):
+                    options = provider_config.get("options", {})
+                    if isinstance(options, dict):
+                        base_url = options.get("baseURL", "")
+                        if isinstance(base_url, str) and "127.0.0.1:" in base_url:
+                            # Remove the baseURL override
+                            del options["baseURL"]
+                            if not options:
+                                del provider_config["options"]
+
+        # Remove Headroom MCP servers
+        for server_name in ["headroom", "serena", "codebase-memory-mcp", "headroom_memory"]:
+            registrar.unregister_server(server_name)
+
+        # Remove RTK instructions (those pointing to opencode config dir)
+        config = registrar._read_config()
+        instructions = config.get("instructions", [])
+        if isinstance(instructions, list):
+            config_dir_str = str(registrar._config_dir)
+            config["instructions"] = [
+                p for p in instructions if not (isinstance(p, str) and config_dir_str in p)
+            ]
+            if not config["instructions"]:
+                del config["instructions"]
+
+        # Check if anything remains
+        has_content = bool(config.get("provider")) or bool(config.get("mcp"))
+
+        from headroom.mcp_registry.opencode import _write_jsonc
+
+        if not has_content and not config.get("instructions") and len(config) <= 1:
+            # Only schema or empty — remove file
+            registrar._config_file.unlink()
+            return "removed"
+
+        _write_jsonc(registrar._config_file, config)
+        return "cleaned"
+
+    return "noop"

--- a/headroom/install/models.py
+++ b/headroom/install/models.py
@@ -56,6 +56,7 @@ class ToolTarget(str, Enum):
     AIDER = "aider"
     CURSOR = "cursor"
     OPENCLAW = "openclaw"
+    OPENCODE = "opencode"
 
 
 def iso_utc_now() -> str:

--- a/headroom/mcp_registry/__init__.py
+++ b/headroom/mcp_registry/__init__.py
@@ -24,12 +24,14 @@ from .install import (
     get_all_registrars,
     install_everywhere,
 )
+from .opencode import OpenCodeRegistrar
 
 __all__ = [
     "DEFAULT_PROXY_URL",
     "ClaudeRegistrar",
     "CodexRegistrar",
     "MCPRegistrar",
+    "OpenCodeRegistrar",
     "RegisterResult",
     "RegisterStatus",
     "ServerSpec",

--- a/headroom/mcp_registry/install.py
+++ b/headroom/mcp_registry/install.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from .base import MCPRegistrar, RegisterResult, RegisterStatus, ServerSpec
 from .claude import ClaudeRegistrar
 from .codex import CodexRegistrar
+from .opencode import OpenCodeRegistrar
 
 #: Default proxy URL used when none is given.
 DEFAULT_PROXY_URL = "http://127.0.0.1:8787"
@@ -17,7 +18,7 @@ def get_all_registrars() -> list[MCPRegistrar]:
 
     The list grows as we add adapters for Cursor, Continue, Cline, etc.
     """
-    return [ClaudeRegistrar(), CodexRegistrar()]
+    return [ClaudeRegistrar(), CodexRegistrar(), OpenCodeRegistrar()]
 
 
 def build_headroom_spec(proxy_url: str = DEFAULT_PROXY_URL) -> ServerSpec:

--- a/headroom/mcp_registry/opencode.py
+++ b/headroom/mcp_registry/opencode.py
@@ -1,0 +1,364 @@
+"""OpenCode MCP registrar.
+
+OpenCode stores its configuration in ``~/.config/opencode/opencode.jsonc``
+as a JSONC (JSON with comments) file. MCP servers are configured in the
+``"mcp"`` section, and providers are configured in the ``"provider"`` section.
+This registrar edits the file in place using surgical JSONC modification.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from .base import MCPRegistrar, RegisterResult, RegisterStatus, ServerSpec
+
+logger = logging.getLogger(__name__)
+
+_OPENCODE_CONFIG_DIR = Path.home() / ".config" / "opencode"
+_OPENCODE_CONFIG_FILE = _OPENCODE_CONFIG_DIR / "opencode.jsonc"
+
+
+def _strip_jsonc_comments(text: str) -> str:
+    """Strip C-style comments from JSONC content.
+
+    Handles both ``//`` line comments and ``/* */`` block comments,
+    while preserving strings that contain comment-like sequences.
+    """
+    result: list[str] = []
+    i = 0
+    in_string = False
+    escape_next = False
+
+    while i < len(text):
+        ch = text[i]
+
+        if escape_next:
+            result.append(ch)
+            escape_next = False
+            i += 1
+            continue
+
+        if in_string:
+            if ch == "\\":
+                escape_next = True
+            elif ch == '"':
+                in_string = False
+            result.append(ch)
+            i += 1
+            continue
+
+        if ch == '"':
+            in_string = True
+            result.append(ch)
+            i += 1
+            continue
+
+        if ch == "/" and i + 1 < len(text):
+            next_ch = text[i + 1]
+            if next_ch == "/":
+                # Line comment — skip until newline
+                while i < len(text) and text[i] != "\n":
+                    i += 1
+                continue
+            if next_ch == "*":
+                # Block comment — skip until */
+                i += 2
+                while i + 1 < len(text):
+                    if text[i] == "*" and text[i + 1] == "/":
+                        i += 2
+                        break
+                    i += 1
+                continue
+
+        result.append(ch)
+        i += 1
+
+    return "".join(result)
+
+
+def _parse_jsonc(text: str) -> dict[str, Any]:
+    """Parse a JSONC file, stripping comments before JSON parsing."""
+    stripped = _strip_jsonc_comments(text)
+    stripped = stripped.strip()
+    if not stripped:
+        return {}
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_jsonc(path: Path, data: dict[str, Any]) -> None:
+    """Write a dict as pretty-printed JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+class OpenCodeRegistrar(MCPRegistrar):
+    """Register MCP servers with OpenCode."""
+
+    name = "opencode"
+    display_name = "OpenCode"
+
+    def __init__(self, *, home_dir: Path | None = None) -> None:
+        home = home_dir if home_dir is not None else Path.home()
+        self._config_dir = home / ".config" / "opencode"
+        self._config_file = self._config_dir / "opencode.jsonc"
+
+    # ------------------------------------------------------------------
+    # MCPRegistrar interface
+    # ------------------------------------------------------------------
+
+    def detect(self) -> bool:
+        return self._config_dir.is_dir()
+
+    def get_server(self, server_name: str) -> ServerSpec | None:
+        config = self._read_config()
+        servers = config.get("mcp", {})
+        if not isinstance(servers, dict):
+            return None
+        entry = servers.get(server_name)
+        if not isinstance(entry, dict):
+            return None
+        return _entry_to_spec(server_name, entry)
+
+    def register_server(self, spec: ServerSpec, *, force: bool = False) -> RegisterResult:
+        existing = self.get_server(spec.name)
+
+        if existing is not None and _specs_equivalent(existing, spec):
+            return RegisterResult(RegisterStatus.ALREADY, "matches current configuration")
+
+        if existing is not None and not force:
+            return RegisterResult(RegisterStatus.MISMATCH, _diff_specs(existing, spec))
+
+        if existing is not None and force:
+            self.unregister_server(spec.name)
+
+        return self._write_server(spec)
+
+    def unregister_server(self, server_name: str) -> bool:
+        config = self._read_config()
+        servers = config.get("mcp", {})
+        if not isinstance(servers, dict) or server_name not in servers:
+            return False
+        del servers[server_name]
+        if not servers:
+            del config["mcp"]
+        try:
+            _write_jsonc(self._config_file, config)
+        except OSError:
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Config file IO
+    # ------------------------------------------------------------------
+
+    def _read_config(self) -> dict[str, Any]:
+        if not self._config_file.exists():
+            return {}
+        try:
+            text = self._config_file.read_text(encoding="utf-8")
+        except OSError:
+            return {}
+        return _parse_jsonc(text)
+
+    def _write_server(self, spec: ServerSpec) -> RegisterResult:
+        config = self._read_config()
+        mcp = config.setdefault("mcp", {})
+        mcp[spec.name] = _spec_to_entry(spec)
+        try:
+            _write_jsonc(self._config_file, config)
+        except OSError as exc:
+            return RegisterResult(
+                RegisterStatus.FAILED, f"could not write {self._config_file}: {exc}"
+            )
+        return RegisterResult(RegisterStatus.REGISTERED, f"wrote to {self._config_file}")
+
+    # ------------------------------------------------------------------
+    # Provider config (used by wrap command)
+    # ------------------------------------------------------------------
+
+    def add_provider(
+        self,
+        name: str,
+        *,
+        base_url: str,
+        models: dict[str, Any] | None = None,
+    ) -> None:
+        """Add a provider to the OpenCode config."""
+        config = self._read_config()
+        providers = config.setdefault("provider", {})
+        provider_entry: dict[str, Any] = {
+            "name": name.title(),
+            "options": {
+                "baseURL": base_url,
+            },
+        }
+        if models:
+            provider_entry["models"] = models
+        providers[name] = provider_entry
+        _write_jsonc(self._config_file, config)
+
+    def remove_provider(self, name: str) -> None:
+        """Remove a provider from the OpenCode config."""
+        config = self._read_config()
+        providers = config.get("provider", {})
+        if isinstance(providers, dict) and name in providers:
+            del providers[name]
+            if not providers:
+                del config["provider"]
+            _write_jsonc(self._config_file, config)
+
+    def override_provider_base_url(self, provider_name: str, base_url: str) -> None:
+        """Override a built-in provider's baseURL to route through the proxy.
+
+        This is the reliable way to route traffic through a proxy for OpenCode,
+        since built-in providers take precedence over custom providers.
+        """
+        config = self._read_config()
+        providers = config.setdefault("provider", {})
+        provider_entry = providers.setdefault(provider_name, {})
+        options = provider_entry.setdefault("options", {})
+        options["baseURL"] = base_url
+        _write_jsonc(self._config_file, config)
+
+    def add_instruction(self, path: str) -> None:
+        """Add an instruction path to the OpenCode config."""
+        config = self._read_config()
+        instructions = config.setdefault("instructions", [])
+        if isinstance(instructions, list) and path not in instructions:
+            instructions.append(path)
+            _write_jsonc(self._config_file, config)
+
+    def remove_instruction(self, path: str) -> None:
+        """Remove an instruction path from the OpenCode config."""
+        config = self._read_config()
+        instructions = config.get("instructions", [])
+        if isinstance(instructions, list) and path in instructions:
+            instructions.remove(path)
+            if not instructions:
+                del config["instructions"]
+            _write_jsonc(self._config_file, config)
+
+    def is_wrapped(self) -> bool:
+        """Check if the config has Headroom modifications.
+
+        Detects both custom providers and built-in provider baseURL overrides.
+        """
+        config = self._read_config()
+        providers = config.get("provider", {})
+
+        # Check for custom headroom provider
+        if isinstance(providers, dict) and "headroom" in providers:
+            return True
+
+        # Check for proxy baseURL override on built-in providers
+        if isinstance(providers, dict):
+            for _provider_name, provider_config in providers.items():
+                if isinstance(provider_config, dict):
+                    options = provider_config.get("options", {})
+                    if isinstance(options, dict):
+                        base_url = options.get("baseURL", "")
+                        if isinstance(base_url, str) and "127.0.0.1:" in base_url:
+                            return True
+
+        return False
+
+    def snapshot_config(self) -> Path | None:
+        """Snapshot config before modification. Returns backup path."""
+        if not self._config_file.exists():
+            return None
+        backup = self._config_file.with_suffix(".jsonc.headroom-backup")
+        if backup.exists():
+            return backup
+        try:
+            import shutil
+
+            shutil.copy2(self._config_file, backup)
+        except OSError:
+            return None
+        return backup
+
+    def restore_config(self) -> bool:
+        """Restore config from backup."""
+        backup = self._config_file.with_suffix(".jsonc.headroom-backup")
+        if not backup.exists():
+            return False
+        try:
+            import shutil
+
+            shutil.move(backup, self._config_file)
+        except OSError:
+            return False
+        return True
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _spec_to_entry(spec: ServerSpec) -> dict[str, Any]:
+    """Convert a ServerSpec to an OpenCode MCP entry."""
+    entry: dict[str, Any] = {
+        "type": "local",
+        "command": [spec.command, *spec.args] if spec.args else [spec.command],
+        "enabled": True,
+    }
+    if spec.env:
+        entry["environment"] = dict(spec.env)
+    return entry
+
+
+def _entry_to_spec(name: str, entry: dict[str, Any]) -> ServerSpec:
+    """Convert an OpenCode MCP entry to a ServerSpec."""
+    command_list = entry.get("command", [])
+    if isinstance(command_list, list) and command_list:
+        command = str(command_list[0])
+        args = tuple(str(x) for x in command_list[1:])
+    else:
+        command = str(entry.get("command", ""))
+        args = ()
+
+    env_value = entry.get("environment", {})
+    env: dict[str, str] = {}
+    if isinstance(env_value, dict):
+        env = {str(k): str(v) for k, v in env_value.items()}
+
+    return ServerSpec(
+        name=name,
+        command=command,
+        args=args,
+        env=env,
+    )
+
+
+def _specs_equivalent(a: ServerSpec, b: ServerSpec) -> bool:
+    """Two specs match when every field is equal."""
+    return (
+        a.name == b.name
+        and a.command == b.command
+        and tuple(a.args) == tuple(b.args)
+        and dict(a.env) == dict(b.env)
+    )
+
+
+def _diff_specs(existing: ServerSpec, requested: ServerSpec) -> str:
+    """Render the difference between two specs for human consumption."""
+    parts: list[str] = []
+    if existing.command != requested.command:
+        parts.append(f"command {existing.command!r} -> {requested.command!r}")
+    if tuple(existing.args) != tuple(requested.args):
+        parts.append(f"args {list(existing.args)} -> {list(requested.args)}")
+    if dict(existing.env) != dict(requested.env):
+        parts.append(f"env {dict(existing.env)} -> {dict(requested.env)}")
+    if not parts:
+        return "spec differs in unidentified field(s)"
+    return "; ".join(parts)

--- a/headroom/providers/opencode/__init__.py
+++ b/headroom/providers/opencode/__init__.py
@@ -1,0 +1,5 @@
+"""OpenCode-specific provider helpers."""
+
+from .runtime import DEFAULT_API_URL, build_launch_env, proxy_base_url
+
+__all__ = ["DEFAULT_API_URL", "build_launch_env", "proxy_base_url"]

--- a/headroom/providers/opencode/runtime.py
+++ b/headroom/providers/opencode/runtime.py
@@ -1,0 +1,23 @@
+"""Runtime helpers for OpenCode-facing integrations."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+DEFAULT_API_URL = "https://api.openai.com"
+
+
+def proxy_base_url(port: int) -> str:
+    """Return the local proxy base URL used by OpenCode-compatible integrations."""
+    return f"http://127.0.0.1:{port}/v1"
+
+
+def build_launch_env(
+    port: int, environ: Mapping[str, str] | None = None
+) -> tuple[dict[str, str], list[str]]:
+    """Build environment variables for OpenCode through the local proxy."""
+    env = dict(environ or os.environ)
+    base_url = proxy_base_url(port)
+    env["OPENAI_BASE_URL"] = base_url
+    return env, [f"OPENAI_BASE_URL={base_url}"]

--- a/tests/test_opencode_registrar.py
+++ b/tests/test_opencode_registrar.py
@@ -1,0 +1,209 @@
+"""Tests for OpenCode MCP registrar."""
+
+from __future__ import annotations
+
+import json
+
+from headroom.mcp_registry.base import ServerSpec
+from headroom.mcp_registry.opencode import (
+    OpenCodeRegistrar,
+    _parse_jsonc,
+    _strip_jsonc_comments,
+)
+
+
+class TestStripJsoncComments:
+    def test_single_line_comment(self):
+        assert _strip_jsonc_comments('{// comment\n"a": 1}') == '{\n"a": 1}'
+
+    def test_block_comment(self):
+        assert _strip_jsonc_comments('{/* comment */"a": 1}') == '{"a": 1}'
+
+    def test_preserves_strings(self):
+        text = '{"url": "http://example.com//not-a-comment"}'
+        assert _strip_jsonc_comments(text) == text
+
+    def test_preserves_strings_with_colon(self):
+        text = '{"url": "http://example.com"}'
+        assert _strip_jsonc_comments(text) == text
+
+    def test_mixed_comments(self):
+        text = '{\n  // line comment\n  "a": 1, /* block */ "b": 2\n}'
+        result = _strip_jsonc_comments(text)
+        assert "//" not in result
+        assert "/*" not in result
+        assert '"a": 1' in result
+        assert '"b": 2' in result
+
+
+class TestParseJsonc:
+    def test_empty(self):
+        assert _parse_jsonc("") == {}
+
+    def test_valid_json(self):
+        assert _parse_jsonc('{"a": 1}') == {"a": 1}
+
+    def test_jsonc_with_comments(self):
+        text = '{\n  // comment\n  "a": 1\n}'
+        assert _parse_jsonc(text) == {"a": 1}
+
+    def test_invalid_json(self):
+        assert _parse_jsonc("not json") == {}
+
+
+class TestOpenCodeRegistrar:
+    def test_detect(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        assert registrar.detect() is True
+
+    def test_detect_not_installed(self, tmp_path):
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        assert registrar.detect() is False
+
+    def test_get_server_empty(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        assert registrar.get_server("headroom") is None
+
+    def test_get_server(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "opencode.jsonc"
+        config_file.write_text(json.dumps({
+            "mcp": {
+                "headroom": {
+                    "type": "local",
+                    "command": ["headroom", "mcp", "serve"],
+                    "enabled": True,
+                }
+            }
+        }))
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        spec = registrar.get_server("headroom")
+        assert spec is not None
+        assert spec.name == "headroom"
+        assert spec.command == "headroom"
+        assert spec.args == ("mcp", "serve")
+
+    def test_register_server(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        spec = ServerSpec(name="headroom", command="headroom", args=("mcp", "serve"))
+        result = registrar.register_server(spec)
+        assert result.ok is True
+
+        # Verify it was written
+        spec2 = registrar.get_server("headroom")
+        assert spec2 is not None
+        assert spec2.command == "headroom"
+
+    def test_unregister_server(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        spec = ServerSpec(name="headroom", command="headroom", args=("mcp", "serve"))
+        registrar.register_server(spec)
+        assert registrar.unregister_server("headroom") is True
+        assert registrar.get_server("headroom") is None
+
+    def test_add_provider(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        registrar.add_provider("headroom", base_url="http://127.0.0.1:8787/v1")
+        config = registrar._read_config()
+        assert "headroom" in config.get("provider", {})
+        assert config["provider"]["headroom"]["options"]["baseURL"] == "http://127.0.0.1:8787/v1"
+
+    def test_remove_provider(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        registrar.add_provider("headroom", base_url="http://127.0.0.1:8787/v1")
+        registrar.remove_provider("headroom")
+        config = registrar._read_config()
+        assert "headroom" not in config.get("provider", {})
+
+    def test_override_provider_base_url(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        registrar.override_provider_base_url("deepseek", "http://127.0.0.1:8787/v1")
+        config = registrar._read_config()
+        assert config["provider"]["deepseek"]["options"]["baseURL"] == "http://127.0.0.1:8787/v1"
+
+    def test_is_wrapped_with_override(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        assert registrar.is_wrapped() is False
+        registrar.override_provider_base_url("deepseek", "http://127.0.0.1:8787/v1")
+        assert registrar.is_wrapped() is True
+
+    def test_add_instruction(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        registrar.add_instruction("~/.config/opencode/instructions/rtk.md")
+        config = registrar._read_config()
+        assert "~/.config/opencode/instructions/rtk.md" in config.get("instructions", [])
+
+    def test_remove_instruction(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        registrar.add_instruction("~/.config/opencode/instructions/rtk.md")
+        registrar.remove_instruction("~/.config/opencode/instructions/rtk.md")
+        config = registrar._read_config()
+        assert "~/.config/opencode/instructions/rtk.md" not in config.get("instructions", [])
+
+    def test_is_wrapped(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        assert registrar.is_wrapped() is False
+        registrar.add_provider("headroom", base_url="http://127.0.0.1:8787/v1")
+        assert registrar.is_wrapped() is True
+
+    def test_snapshot_and_restore(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "opencode.jsonc"
+        original = {"provider": {"openai": {}}}
+        config_file.write_text(json.dumps(original))
+
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        registrar.snapshot_config()
+
+        # Modify config
+        registrar.add_provider("headroom", base_url="http://127.0.0.1:8787/v1")
+        assert registrar.is_wrapped() is True
+
+        # Restore
+        assert registrar.restore_config() is True
+        config = registrar._read_config()
+        assert "headroom" not in config.get("provider", {})
+        assert "openai" in config.get("provider", {})
+
+    def test_cleanup_after_unwrap(self, tmp_path):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "opencode.jsonc"
+        original = {"provider": {"openai": {}}}
+        config_file.write_text(json.dumps(original))
+
+        registrar = OpenCodeRegistrar(home_dir=tmp_path)
+        registrar.snapshot_config()
+        registrar.add_provider("headroom", base_url="http://127.0.0.1:8787/v1")
+
+        # Simulate unwrap
+        restored = registrar.restore_config()
+        assert restored is True
+
+        # Verify backup is removed
+        backup = config_file.with_suffix(".jsonc.headroom-backup")
+        assert backup.exists() is False


### PR DESCRIPTION
## Description

Add `headroom wrap opencode` and `headroom unwrap opencode` commands to configure OpenCode to use the Headroom proxy, similar to how Claude and Codex are configured.

Closes #1018

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Created `headroom/providers/opencode/__init__.py` and `runtime.py`
- Created `headroom/mcp_registry/opencode.py` with `OpenCodeRegistrar` class
- Created `tests/test_opencode_registrar.py` with 24 unit tests
- Modified `headroom/cli/wrap.py` with `wrap opencode` and `unwrap opencode` commands
- Modified `headroom/mcp_registry/__init__.py` to export `OpenCodeRegistrar`
- Modified `headroom/mcp_registry/install.py` to include OpenCode in registrars
- Modified `headroom/install/models.py` to add `OPENCODE` to `ToolTarget`

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run pytest tests/test_opencode_registrar.py -v
24 passed in 0.08s
```

## Real Behavior Proof

- Environment: macOS, Python 3.14.6, OpenCode 1.17.7, headroom from source
- Exact command / steps: uv run headroom wrap opencode --prepare-only --no-context-tool --no-serena
- Observed result: Deepseek provider baseURL overridden to http://127.0.0.1:8787/v1
- Not tested: Memory MCP, code graph, Serena MCP

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

- OpenCode's built-in providers take precedence over custom providers
- The only reliable way to route traffic is to override the baseURL
- Config file: `~/.config/opencode/opencode.jsonc`
- Snapshot/restore mechanism ensures safe unwrap