### PR TITLE
docs(ci): add CI/CD flow diagrams

### DIFF
--- a/docs/content/docs/ci-cd-flows.mdx
+++ b/docs/content/docs/ci-cd-flows.mdx
@@ -1,0 +1,242 @@
+---
+title: CI/CD Flow Diagrams
+description: Visual decision trees for pull requests, release publishing, Docker images, docs deploys, and manual validation.
+---
+
+## Purpose
+
+This page is the quick visual map for Headroom automation. Use it when opening a PR, reviewing a PR, cutting a release, or deciding which workflow owns a failure.
+
+The short version:
+
+- Pull requests are gated by PR governance, path-filtered CI, targeted e2e workflows, and human review.
+- Release publishing is not triggered by every merge to `main`. `release-please` maintains a release PR; merging that release PR creates the tag and GitHub Release that trigger publishing.
+- Docker images are built as multi-architecture digests first, then merged into tagged manifests.
+- Docs deploy only after docs changes land on `main`.
+
+## PR Flow
+
+```mermaid
+flowchart TD
+    A[Open, edit, synchronize, or mark PR ready] --> B[PR Governance]
+    B --> B1{Template complete and ready?}
+    B1 -- no --> B2[Add needs author action label and governance comment]
+    B1 -- yes --> B3[Add ready for review label when no blocking status exists]
+
+    A --> C[Path filters decide workflow surface]
+    C --> D{Code paths changed?}
+    D -- yes --> E[CI changes job]
+    E --> F[lint: ruff, format, mypy]
+    E --> G[build-wheel: Rust extension wheel]
+    E --> H[prefetch-model: Hugging Face cache]
+    G --> I[test shards 1 to 4]
+    H --> I
+    G --> J[test-extras, test-agno, dashboard UI]
+    E --> K[build: release-profile wheel and sdist smoke]
+
+    C --> L{E2E paths changed?}
+    L -- yes --> M[Docker native e2e and platform wrapper checks]
+    C --> N{Init or wrap paths changed?}
+    N -- yes --> O[Init E2E, Wrap E2E, native init or wrap smoke tests]
+    C --> P{Rust paths changed?}
+    P -- yes --> Q[Rust fmt, clippy, tests, wheel build, audit]
+    C --> R{Devcontainer paths changed?}
+    R -- yes --> S[Devcontainer validation and linked worktree smoke]
+    C --> T{Release-critical paths changed?}
+    T -- yes --> U[Release dry-run: wheel matrix and smoke-import gates]
+    C --> V{Workflow files changed?}
+    V -- yes --> W[Workflow validation with actionlint and act dry-run]
+
+    F --> X{All required checks green?}
+    I --> X
+    J --> X
+    K --> X
+    M --> X
+    O --> X
+    Q --> X
+    S --> X
+    U --> X
+    W --> X
+    B3 --> X
+    X -- no --> Y[Fix, rebase, or request changes]
+    X -- yes --> Z[Human review and merge when approved]
+```
+
+## PR Decision Tree
+
+```mermaid
+flowchart TD
+    A[Review an open PR] --> B{Draft?}
+    B -- yes --> C[Do not approve. Comment with remaining readiness steps.]
+    B -- no --> D{Governance label says needs author action?}
+    D -- yes --> E[Fix or ask author to complete template and real behavior proof]
+    D -- no --> F{Merge state dirty or behind?}
+    F -- dirty --> G[Resolve conflicts before reviewing final code]
+    F -- behind --> H[Rebase or update branch, then rerun checks]
+    F -- clean or unknown --> I{Any failing check?}
+    I -- yes --> J[Read failing logs, classify as stale-main, infra, or code bug]
+    J --> K{Can maintainer safely fix without changing author intent?}
+    K -- yes --> L[Patch, test locally, push with lease]
+    K -- no --> M[Request changes with exact file and line references]
+    I -- no --> N{Code review complete?}
+    N -- no --> O[Review diff, tests, docs, and behavior proof]
+    N -- yes --> P[Approve]
+```
+
+## Fork Workflow Approval
+
+GitHub may leave product workflows in `action_required` for first-time or fork contributors. Approve only after the diff is safe enough to execute in CI.
+
+```mermaid
+flowchart TD
+    A[Fork PR has action_required workflows] --> B{Diff is understandable and not suspicious?}
+    B -- no --> C[Do not approve. Ask for changes or close if unsafe.]
+    B -- yes --> D{Workflow runs use pull_request with read-scoped token?}
+    D -- no --> E[Inspect workflow permissions before approving]
+    D -- yes --> F[Approve queued CI runs]
+    F --> G[Wait for fresh check results on latest head SHA]
+```
+
+## Release Flow
+
+```mermaid
+flowchart TD
+    A[Merge ordinary PR to main] --> B[Release Please on push to main]
+    B --> C{Commit is releasable?}
+    C -- docs, ci, chore only --> D[No release PR change]
+    C -- fix, feat, breaking change --> E[Create or update Release PR]
+    E --> F[Release PR contains version bump and changelog]
+    F --> G{Ready to ship?}
+    G -- no --> H[Keep merging regular PRs; bot updates Release PR]
+    G -- yes --> I[Merge Release PR]
+    I --> J[release-please tags vX.Y.Z and publishes GitHub Release]
+    J --> K[release.yml starts on release: published]
+    K --> L[detect-version]
+    L --> M[build: sync versions, verify versions, changelog, npm packs]
+    M --> N[build-wheels matrix]
+    N --> O[collect-dist]
+    O --> P[smoke-import wheels]
+    P --> Q{Smoke import green?}
+    Q -- no --> R[Stop before publishing broken wheels]
+    Q -- yes --> S[publish PyPI]
+    Q -- yes --> T[publish npm packages]
+    Q -- yes --> U[publish GitHub Package Registry packages]
+    Q -- yes --> V[publish Docker images through docker.yml]
+    S --> W{PyPI published or PYPI_SKIP=true?}
+    W -- no --> X[Do not update release assets]
+    W -- yes --> Y[Create or update GitHub Release assets and notes]
+    T --> Y
+    U --> Y
+    V --> Y
+```
+
+## Release Decision Tree
+
+```mermaid
+flowchart TD
+    A[Need a release?] --> B{Release PR exists?}
+    B -- no --> C[Merge at least one releasable conventional commit to main]
+    B -- yes --> D{Release PR checks green and changelog correct?}
+    D -- no --> E[Fix source PRs or release config, then let release-please update]
+    D -- yes --> F{Registry skip variables needed?}
+    F -- yes --> G[Set PYPI_SKIP, NPM_SKIP, or GH_PACKAGES_SKIP deliberately]
+    F -- no --> H[Merge Release PR]
+    G --> H
+    H --> I[Watch release.yml]
+    I --> J{Failure before publish?}
+    J -- yes --> K[Fix and rerun before any package is public]
+    J -- no --> L{Failure after partial publish?}
+    L -- yes --> M[Use rerun or skip variables to reach consistent GitHub Release state]
+    L -- no --> N[Release complete]
+```
+
+## Docker Publish Flow
+
+`docker.yml` can run directly on `push`, `workflow_dispatch`, or `release: published`, and it is also called by `release.yml`.
+
+```mermaid
+flowchart TD
+    A[Docker workflow starts] --> B[Matrix: variant x architecture]
+    B --> C[Build each platform image by digest only]
+    C --> D[Smoke-test image imports pydantic_core and headroom._core]
+    D --> E{Smoke test green?}
+    E -- no --> F[Stop before tag manifest]
+    E -- yes --> G[Upload digest marker]
+    G --> H[Per-variant manifest merge]
+    H --> I[Apply tags to multi-arch manifest]
+    I --> J{Release event?}
+    J -- yes --> K[Version tags and latest retag rules]
+    J -- no --> L[Branch, PR, dev, or manual tags as configured]
+```
+
+## Docs Deploy Flow
+
+```mermaid
+flowchart TD
+    A[Docs change in PR] --> B[PR review and normal checks]
+    B --> C[Merge to main]
+    C --> D{docs/**, mkdocs.yml, or docs workflow changed?}
+    D -- no --> E[No docs deploy]
+    D -- yes --> F[Deploy Documentation workflow]
+    F --> G[Build docs site]
+    G --> H[Deploy generated site]
+```
+
+## Manual Validation Flow
+
+Use this when editing workflows or release automation.
+
+```mermaid
+flowchart TD
+    A[Edit workflow or release scripts] --> B[Run local workflow validation]
+    B --> C[actionlint]
+    B --> D[act dry-run fixtures]
+    C --> E{Local validation green?}
+    D --> E
+    E -- no --> F[Fix before opening or updating PR]
+    E -- yes --> G[Push PR]
+    G --> H[workflow-validation job reruns same validation in CI]
+```
+
+Recommended local command:
+
+```bash
+bash scripts/validate-workflows.sh
+```
+
+For release dry-runs:
+
+```bash
+act workflow_dispatch -W .github/workflows/release.yml -e .github/act/dry-run.json
+```
+
+## Gate Summary
+
+| Flow | Trigger | Main gates | Success condition |
+|------|---------|------------|-------------------|
+| PR governance | `pull_request_target`, schedule, manual | Template, readiness labels, merge state, check labels | PR has no governance blockers |
+| CI | PR, push to `main`, manual | Path filter, lint, mypy, wheel build, model prefetch, test shards, package smoke | Required jobs green or path-skipped |
+| Rust | Rust paths, schedule | fmt, clippy, cargo test, wheel build, audit | Rust checks green; nightly parity is allowed to fail in Phase 0 |
+| E2E | CLI, install, wrap, Docker, package paths | Docker init/wrap, native init/wrap/install, platform smoke | Relevant lifecycle checks green |
+| Release dry-run | PRs touching release-critical paths | Version detection, wheel matrix, smoke imports | Publish path can build before merge |
+| Release publish | GitHub Release published by release-please | Version sync, changelog, wheels, smoke import, PyPI gate, npm, GPR, Docker | Public packages and GitHub Release assets are consistent |
+| Docs deploy | Push to `main` with docs paths | Docs build | Site deploy completes |
+
+## Workflow Ownership
+
+| Workflow | Owns |
+|----------|------|
+| `.github/workflows/pr-health.yml` | PR body governance, readiness labels, rebase/conflict/failing-check labels |
+| `.github/workflows/ci.yml` | Python lint, type checks, wheel build, test shards, package smoke, workflow validation |
+| `.github/workflows/rust.yml` | Rust workspace quality gates and native wheel smoke artifacts |
+| `.github/workflows/init-e2e.yml` | Dockerized `headroom init` behavior |
+| `.github/workflows/wrap-e2e.yml` | Dockerized `headroom wrap` behavior |
+| `.github/workflows/init-native-e2e.yml` | Host-specific `headroom init -g` smoke tests |
+| `.github/workflows/install-native-e2e.yml` | Host-specific install CLI smoke tests |
+| `.github/workflows/wrap-native-e2e.yml` | Host-specific wrap prepare-only smoke tests |
+| `.github/workflows/devcontainers.yml` | Devcontainer startup and linked worktree compatibility |
+| `.github/workflows/release-please.yml` | Release PR aggregation from conventional commits |
+| `.github/workflows/release.yml` | Release build, wheel smoke-import gates, registry publishing, GitHub Release assets |
+| `.github/workflows/docker.yml` | GHCR multi-architecture image builds and manifests |
+| `.github/workflows/docs.yml` | Documentation deploy after docs changes merge |
+

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -43,6 +43,8 @@
     "api-reference",
     "---Architecture---",
     "architecture",
+    "ci-cd-flows",
+    "releases",
     "benchmarks",
     "limitations",
     "---Help---",

--- a/docs/content/docs/releases.mdx
+++ b/docs/content/docs/releases.mdx
@@ -1,13 +1,15 @@
 ---
 title: Releases & CI/CD
-description: Automated release pipeline with semantic versioning, multi-package publishing, and changelog generation.
+description: Automated release pipeline with release-please, semantic versioning, multi-package publishing, and changelog generation.
 ---
 
 ## Overview
 
-Headroom uses a unified GitHub Actions workflow (`.github/workflows/release.yml`) that automatically publishes all three packages, builds version-matched Docker images, generates changelogs from conventional commits, and creates GitHub Releases with package assets attached.
+Headroom uses `release-please` to maintain a release PR from conventional commits on `main`. Merging that release PR creates the release tag and GitHub Release, which triggers `.github/workflows/release.yml` to publish all packages, build version-matched Docker images, and attach release assets.
 
 The release workflow also calls `.github/workflows/docker.yml` as a reusable workflow so GHCR images are published in the same release run with the exact same synced version as PyPI, npm, and GitHub release assets.
+
+For the end-to-end visual flow, see [CI/CD Flow Diagrams](/docs/ci-cd-flows).
 
 ## Packages & Registries
 
@@ -24,69 +26,73 @@ The release workflow also calls `.github/workflows/docker.yml` as a reusable wor
 
 ## Version Strategy
 
-The workflow uses a **canonical + commit-height** algorithm that eliminates infinite loops:
+Release Please calculates the release version from conventional commits and the release manifest. The release workflow still computes and verifies the version it is about to publish:
 
-1. `pyproject.toml` holds the **canonical version** (e.g., `0.5.25`). This is the single source of truth — set manually before merging.
-2. On every push to `main`, the workflow counts commits since the last tagged release at the same canonical level.
-3. The **git tag** uses `v{canonical}.{height}` format (e.g., `v0.5.25.3` = 3 commits since canonical `0.5.25`).
-4. The **npm version** uses 3-part semver — bumped from canonical based on commit type (e.g., `feat:` + canonical `0.5.25` → `0.6.0`).
+1. `.release-please-config.json` defines release-please behavior.
+2. `.release-please-manifest.json` tracks current package versions.
+3. The release PR updates versions and changelog content.
+4. Merging the release PR publishes a GitHub Release tagged `vX.Y.Z`.
+5. `release.yml` uses that tag as the manual version for the publish run.
 
 ### Version Files
 
-- `pyproject.toml` — `[project].version` — **canonical** (set manually before merge)
-- `headroom/_version.py` — `__version__` — synced at build time
-- `plugins/openclaw/package.json` — `version` — synced at build time
-- `sdk/typescript/package.json` — `version` — synced at build time
+- `.release-please-config.json` - release-please package configuration
+- `.release-please-manifest.json` - release-please version manifest
+- `pyproject.toml` - `[project].version`
+- `headroom/_version.py` - `__version__`, synced at build time
+- `plugins/openclaw/package.json` - `version`, synced at build time
+- `sdk/typescript/package.json` - `version`, synced at build time
 
-**The workflow NEVER commits back to the repo** — this breaks the infinite loop.
+`release.yml` does not commit back to the repo. Version synchronization happens inside the release build workspace.
 
 ## Conventional Commits & Semantic Bumping
 
-The workflow analyzes the **unreleased commits since the previous release tag** and applies the highest required bump level:
+Release Please analyzes unreleased conventional commits and applies the highest required bump level:
 
-| Commit | Bump | Git Tag Example | npm Version |
-|--------|------|-----------------|-------------|
-| `fix:`, `ci:`, `chore:`, `perf:`, `refactor:` | patch | `v0.5.25.3` | `0.5.26` |
-| `feat:` | minor | `v0.6.0.0` | `0.6.0` |
-| Any conventional commit with `!` or any commit with `BREAKING CHANGE` in the body | major | `v1.0.0.0` | `1.0.0` |
+| Commit | Bump |
+|--------|------|
+| `fix:` | patch |
+| `feat:` | minor |
+| Any conventional commit with `!` or any commit with `BREAKING CHANGE` in the body | major |
+| `docs:`, `ci:`, `chore:`, `refactor:` | no release note by default unless configured |
 
 Commits are linted in CI via `commitlint` using `@commitlint/config-conventional`.
 
-### How the Canonical + Height Algorithm Works
-
-```
-Canonical in pyproject.toml: 0.5.25
-Last tag at this canonical:  v0.5.25.2 (2 commits ago)
-
-HEAD commit: fix: resolve bug
-  → bump = patch
-  → height = 3 (2 prior + 1 new)
-  → git tag: v0.5.25.3
-  → npm version: 0.5.26 (canonical 0.5.25 + 1 patch bump)
-```
-
-After npm publishes `0.5.26`, update `pyproject.toml` to `0.5.26` (manually, before next release).
+The release PR is the place where version and changelog changes are reviewed before publishing.
 
 ## Release Workflow
 
-The `release.yml` workflow runs on every push to `main` and consists of five jobs:
+The `release.yml` workflow runs when a GitHub Release is published, which normally happens when the release-please PR is merged. It also supports manual `workflow_dispatch` and PR dry-runs for release-critical workflow/package changes.
 
 ```
-detect-version → build → publish-pypi
-                        → publish-npm
-                        → publish-github-packages → create-release
+detect-version → build → build-wheels → collect-dist → smoke-import-wheels
+                                      ↘ publish-pypi
+                                      ↘ publish-npm
+                                      ↘ publish-github-packages
+                                      ↘ publish-docker
+                                        → create-release
 ```
 
-**Note:** The workflow never commits back to the repo. `pyproject.toml` is updated manually before merging.
+The workflow never commits back to the repo.
 
 ### detect-version
-Reads canonical version from `pyproject.toml`, counts commits since the previous release tag, chooses the highest bump level across that unreleased commit range, and computes both the git tag version (`v{canonical}.{height}`) and npm version (3-part semver).
+Resolves the release version from the trigger. On `release: published`, it uses the published tag (`vX.Y.Z`) as the manual version for the run. On `workflow_dispatch`, it uses the optional `version` input when provided. PR dry-runs compute a version without publishing.
 
 ### build
-1. Syncs version across TypeScript package files via `scripts/version-sync.py --version {npm_version}`
-2. Generates changelog via `scripts/changelog-gen.py`
-3. Builds the Python package (`python -m build`)
-4. Uploads artifacts (dist + changelog)
+1. Syncs version across package files via `scripts/version-sync.py --version {npm_version}`
+2. Verifies package versions with `scripts/verify-versions.py`
+3. Generates the changelog artifact
+4. Builds npm release packages for the TypeScript SDK and OpenClaw plugin
+5. Uploads release asset artifacts for downstream publish jobs
+
+### build-wheels
+Builds the Python wheel matrix for Linux x86_64, Linux arm64, and Apple Silicon macOS, plus one source distribution. Linux wheels are audited for glibc symbol compatibility.
+
+### collect-dist
+Collects the wheel matrix, source distribution, and npm tarballs into the canonical artifacts used by publishing and GitHub Release asset upload.
+
+### smoke-import-wheels
+Installs the built wheels into representative customer environments and imports `headroom._core`. This blocks publishing if a wheel builds successfully but cannot import on its promised platform floor.
 
 ### publish-pypi
 Downloads the Python dist artifact and publishes to PyPI via `pypa/gh-action-pypi-publish@release/v1` (trusted publisher).
@@ -108,7 +114,7 @@ Uploads the built Python distributions and both npm tarballs to the GitHub Relea
 Calls the reusable Docker workflow to publish GHCR images with the same semantic version and synced package metadata as the rest of the release.
 
 ### create-release
-Creates or updates the GitHub Release in the current repo, uploads the built Python distributions and npm tarballs as release assets, and publishes the generated changelog as release notes. The job still runs after the build succeeds even if one of the external registry publishes fails, so GitHub-hosted artifacts remain available on `main`.
+Creates or updates the GitHub Release in the current repo and uploads the built Python distributions and npm tarballs as release assets. PyPI publish is a hard gate unless `PYPI_SKIP=true`, so release notes and assets do not advertise a version that failed to publish to PyPI.
 
 ## Configuration
 
@@ -160,37 +166,43 @@ for a top-level `LICENSE` file before any publish job can consume it.
 
 ## Workflow Triggers
 
-The workflow runs on push to `main`, but ignores pushes that only touch docs, CI config, or scripts:
+Release Please runs on pushes to `main` and maintains the release PR:
 
 ```yaml
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/publish.yml"
-      - "scripts/**"
-      - ...
 ```
 
-For manual control, use `workflow_dispatch`:
+The publish workflow runs when a GitHub Release is published, on PR dry-runs for release-critical paths, and by manual dispatch:
 
 ```yaml
 on:
+  release:
+    types: [published]
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - ".github/workflows/docker.yml"
+      - "crates/headroom-py/**"
+      - "pyproject.toml"
+      - "scripts/verify-versions.py"
+      - "scripts/version-sync.py"
+      - "Cargo.toml"
+      - "Cargo.lock"
   workflow_dispatch:
     inputs:
       version:
-        description: "Manual version override (e.g. 0.6.0)"
+        description: "Manual version override"
         required: false
       dry_run:
         description: "Skip publish"
         type: boolean
         default: false
 ```
-
-- **No version input:** auto-detected from commits (normal flow)
-- **`dry_run: true`:** runs all jobs except publish steps — useful for testing
+- **Normal release:** merge the release-please PR; the bot publishes a GitHub Release, which triggers `release.yml`.
+- **PR dry-run:** release-critical PRs build and smoke-import wheels before merge, but do not publish.
+- **Manual dispatch:** use `version` to override the release version and `dry_run: true` to skip publish steps.
 
 ## Local Testing with `act`
 
@@ -212,13 +224,21 @@ act workflow_dispatch -W .github/workflows/release.yml -e .github/act/dry-run.js
 
 This runs the full workflow end-to-end with `dry_run=true`, skipping all publish steps.
 
-### Test a Specific Commit Type
+### Simulate Release Please
 
 ```bash
-act push -W .github/workflows/release.yml -e .github/act/push-feat.json
+act push -W .github/workflows/release-please.yml -e .github/act/push-feat.json
 ```
 
-The `push-feat.json` event file simulates a `feat:` commit on `main`.
+The `push-feat.json` event file simulates a `feat:` commit on `main` so the release-please workflow can be validated locally.
+
+### Simulate a Published Release
+
+```bash
+act release -W .github/workflows/release.yml -e .github/act/release-published.json -n
+```
+
+The `release-published.json` event file simulates the event emitted when the release-please PR is merged.
 
 ### Validate the Release and Docker Workflows
 
@@ -242,6 +262,7 @@ cp .env.act.example .env.act
 | File | Purpose |
 |------|---------|
 | `.github/workflows/release.yml` | Main release pipeline |
+| `.github/workflows/release-please.yml` | Release PR aggregation from conventional commits |
 | `.github/workflows/ci.yml` | CI — lint, test, commitlint |
 | `.github/workflows/publish.yml` | Manual-only PyPI fallback (superseded by `release.yml`) |
 | `.commitlintrc.json` | Conventional commit rules |
@@ -250,6 +271,7 @@ cp .env.act.example .env.act
 | `scripts/verify-versions.py` | Pre-release version alignment check |
 | `.github/act/dry-run.json` | `act` event file for dry-run testing |
 | `.github/act/push-feat.json` | `act` event file for feat commit testing |
+| `.github/act/release-published.json` | `act` event file for release publish simulation |
 | `.github/act/docker-version.json` | `act` event file for Docker workflow validation |
 | `scripts/validate-workflows.sh` | Shared `actionlint` + `act -n` workflow validation script |
 | `.actrc` | Default `act` flags (Ubuntu runner, reuse, quiet) |
@@ -264,14 +286,12 @@ cp .env.act.example .env.act
 
 The PyPI publish uses trusted publisher OIDC — no secret required, only the `pypi` GitHub Environment must be configured with your PyPI project.
 
-## First Release Note
+## Release Cadence
 
-TypeScript packages (`headroom-ai` SDK and `headroom-openclaw`) start at version `0.1.0`, while Python `headroom-ai` is at `0.5.25`. Before the first automated release:
+Day to day:
 
-1. Update `pyproject.toml` to set the desired canonical version (e.g., `0.6.0`)
-2. Use `workflow_dispatch` with a manual `version` input to set the target version explicitly
-3. The workflow will align all three packages to the same version on first release
-
-### Release Cadence with Canonical + Height
-
-After each release, update `pyproject.toml` to match the published version before merging the next feature branch. This keeps the canonical current and ensures each release gets a unique git tag.
+1. Merge regular PRs to `main`.
+2. Release Please updates the open release PR when releasable conventional commits land.
+3. Review the release PR changelog and version bump.
+4. Merge the release PR when ready to ship.
+5. Watch `release.yml` publish PyPI, npm, GitHub Packages, Docker, and GitHub Release assets.

--- a/docs/lib/cn.ts
+++ b/docs/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/docs/lib/layout.shared.ts
+++ b/docs/lib/layout.shared.ts
@@ -1,0 +1,10 @@
+import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
+
+export function baseOptions(): BaseLayoutProps {
+  return {
+    nav: {
+      title: 'Headroom',
+    },
+    githubUrl: 'https://github.com/chopratejas/headroom',
+  };
+}

--- a/docs/lib/shared.ts
+++ b/docs/lib/shared.ts
@@ -1,0 +1,8 @@
+export const docsRoute = '/docs';
+export const docsContentRoute = '/llms.mdx/docs';
+
+export const gitConfig = {
+  user: 'chopratejas',
+  repo: 'headroom',
+  branch: 'main',
+};

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -1,0 +1,35 @@
+import { loader } from 'fumadocs-core/source';
+import { docs } from '../.source/server';
+
+export const source = loader({
+  baseUrl: '/docs',
+  source: docs.toFumadocsSource(),
+});
+
+type Page = ReturnType<typeof source.getPages>[number];
+
+export function getPageMarkdownUrl(page: Page) {
+  const segments = page.slugs.length > 0 ? [...page.slugs, 'content.md'] : ['index', 'content.md'];
+
+  return {
+    segments,
+    url: `/llms.mdx/docs/${segments.join('/')}`,
+  };
+}
+
+export function getPageImage(page: Page) {
+  const segments = page.slugs.length > 0 ? [...page.slugs, 'image.png'] : ['index', 'image.png'];
+
+  return {
+    segments,
+    url: `/og/docs/${segments.join('/')}`,
+  };
+}
+
+export async function getLLMText(page: Page) {
+  try {
+    return await page.data.getText('processed');
+  } catch {
+    return `# ${page.data.title}\n\n${page.data.description ?? ''}`;
+  }
+}

--- a/docs/lib/telemetry.ts
+++ b/docs/lib/telemetry.ts
@@ -1,0 +1,46 @@
+export interface CommunityStats {
+  total_tokens_saved: number;
+  total_cost_saved: number;
+  total_requests: number;
+  unique_instances: number;
+}
+
+const fallbackStats: CommunityStats = {
+  total_tokens_saved: 0,
+  total_cost_saved: 0,
+  total_requests: 0,
+  unique_instances: 0,
+};
+
+export function fmtNum(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    notation: value >= 10000 ? 'compact' : 'standard',
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+export function fmtUsd(value: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    notation: value >= 10000 ? 'compact' : 'standard',
+    maximumFractionDigits: value >= 1000 ? 1 : 2,
+  }).format(value);
+}
+
+export async function fetchCommunityStats(): Promise<CommunityStats> {
+  const endpoint = process.env.NEXT_PUBLIC_COMMUNITY_STATS_URL;
+  if (!endpoint) return fallbackStats;
+
+  try {
+    const response = await fetch(endpoint, { next: { revalidate: 300 } });
+    if (!response.ok) return fallbackStats;
+
+    return {
+      ...fallbackStats,
+      ...(await response.json()),
+    };
+  } catch {
+    return fallbackStats;
+  }
+}

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,12 +9,15 @@
 			"version": "0.0.0",
 			"hasInstallScript": true,
 			"dependencies": {
+				"@radix-ui/react-slot": "1.3.0",
+				"class-variance-authority": "0.7.1",
+				"clsx": "2.1.1",
 				"dotted-map": "^3.1.0",
-				"fumadocs-core": "16.7.10",
-				"fumadocs-mdx": "14.3.2",
+				"fumadocs-core": "16.10.3",
+				"fumadocs-mdx": "15.0.12",
 				"fumadocs-twoslash": "^3.1.3",
 				"fumadocs-typescript": "^4.0.3",
-				"fumadocs-ui": "16.7.10",
+				"fumadocs-ui": "16.10.3",
 				"headroom-ai": "file:../sdk/typescript",
 				"lucide-react": "^1.7.0",
 				"next": "16.2.6",
@@ -46,7 +49,7 @@
 				"@ai-sdk/anthropic": "^3.0.64",
 				"@ai-sdk/openai": "^3.0.48",
 				"@ai-sdk/provider": "^1.0.0",
-				"@anthropic-ai/sdk": "^0.39.0",
+				"@anthropic-ai/sdk": "^0.104.1",
 				"ai": "^6.0.0",
 				"dotenv": "^17.3.1",
 				"openai": "^4.80.0",
@@ -602,6 +605,8 @@
 		},
 		"node_modules/@floating-ui/core": {
 			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/utils": "^0.2.11"
@@ -609,6 +614,8 @@
 		},
 		"node_modules/@floating-ui/dom": {
 			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/core": "^1.7.5",
@@ -617,6 +624,8 @@
 		},
 		"node_modules/@floating-ui/react-dom": {
 			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+			"integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/dom": "^1.7.6"
@@ -628,29 +637,39 @@
 		},
 		"node_modules/@floating-ui/utils": {
 			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
 			"license": "MIT"
 		},
-		"node_modules/@formatjs/fast-memoize": {
-			"version": "3.1.1",
-			"license": "MIT"
-		},
-		"node_modules/@formatjs/intl-localematcher": {
-			"version": "0.8.2",
+		"node_modules/@fuma-translate/react": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@fuma-translate/react/-/react-1.0.2.tgz",
+			"integrity": "sha512-uOiOtBx3nRXR8Nu1GzBf1tApgF1FErDBTHxRIAQeyQdyOoZbrNRN6H4kDCWObY4qyGeGbHydG0DHzgeUgFDMIw==",
 			"license": "MIT",
-			"dependencies": {
-				"@formatjs/fast-memoize": "3.1.1"
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^19.2.0",
+				"react-dom": "^19.2.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@fumadocs/tailwind": {
-			"version": "0.0.3",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@fumadocs/tailwind/-/tailwind-0.0.5.tgz",
+			"integrity": "sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ==",
 			"license": "MIT",
-			"dependencies": {
-				"postcss-selector-parser": "^7.1.1"
-			},
 			"peerDependencies": {
+				"@tailwindcss/oxide": "^4.0.0",
 				"tailwindcss": "^4.0.0"
 			},
 			"peerDependenciesMeta": {
+				"@tailwindcss/oxide": {
+					"optional": true
+				},
 				"tailwindcss": {
 					"optional": true
 				}
@@ -1337,26 +1356,32 @@
 			}
 		},
 		"node_modules/@radix-ui/number": {
-			"version": "1.1.1",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz",
+			"integrity": "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==",
 			"license": "MIT"
 		},
 		"node_modules/@radix-ui/primitive": {
-			"version": "1.1.3",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+			"integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
 			"license": "MIT"
 		},
 		"node_modules/@radix-ui/react-accordion": {
-			"version": "1.2.12",
+			"version": "1.2.14",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.14.tgz",
+			"integrity": "sha512-iE8YB9nmTBH8zd73ofBISZ8JCzgMoMkATJr7qDwa6u5F1+7mTM81V6fa71jgZ65rpjVpecDf1vSnwIFP9Ly1zw==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-collapsible": "1.1.12",
-				"@radix-ui/react-collection": "1.1.7",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-id": "1.1.1",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-controllable-state": "1.2.2"
+				"@radix-ui/primitive": "1.1.4",
+				"@radix-ui/react-collapsible": "1.1.14",
+				"@radix-ui/react-collection": "1.1.10",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.1.4",
+				"@radix-ui/react-direction": "1.1.2",
+				"@radix-ui/react-id": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-controllable-state": "1.2.3"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1374,10 +1399,12 @@
 			}
 		},
 		"node_modules/@radix-ui/react-arrow": {
-			"version": "1.1.7",
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz",
+			"integrity": "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-primitive": "2.1.3"
+				"@radix-ui/react-primitive": "2.1.6"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1395,17 +1422,19 @@
 			}
 		},
 		"node_modules/@radix-ui/react-collapsible": {
-			"version": "1.1.12",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.14.tgz",
+			"integrity": "sha512-9bT+FvifX1FK2Mj6UEsTdyu0cN3JaA3KdfhaBao+ONrYFy/pyOy3TU1TNw7iOk1o+0hOEq67RojlUUmoFGwxyA==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-id": "1.1.1",
-				"@radix-ui/react-presence": "1.1.5",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-controllable-state": "1.2.2",
-				"@radix-ui/react-use-layout-effect": "1.1.1"
+				"@radix-ui/primitive": "1.1.4",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.1.4",
+				"@radix-ui/react-id": "1.1.2",
+				"@radix-ui/react-presence": "1.1.6",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-controllable-state": "1.2.3",
+				"@radix-ui/react-use-layout-effect": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1423,13 +1452,15 @@
 			}
 		},
 		"node_modules/@radix-ui/react-collection": {
-			"version": "1.1.7",
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.10.tgz",
+			"integrity": "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-slot": "1.2.3"
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.1.4",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-slot": "1.3.0"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1446,24 +1477,10 @@
 				}
 			}
 		},
-		"node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
-			"version": "1.2.3",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-compose-refs": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@radix-ui/react-compose-refs": {
-			"version": "1.1.2",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+			"integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1476,7 +1493,9 @@
 			}
 		},
 		"node_modules/@radix-ui/react-context": {
-			"version": "1.1.2",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+			"integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1489,23 +1508,25 @@
 			}
 		},
 		"node_modules/@radix-ui/react-dialog": {
-			"version": "1.1.15",
+			"version": "1.1.17",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.17.tgz",
+			"integrity": "sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-dismissable-layer": "1.1.11",
-				"@radix-ui/react-focus-guards": "1.1.3",
-				"@radix-ui/react-focus-scope": "1.1.7",
-				"@radix-ui/react-id": "1.1.1",
-				"@radix-ui/react-portal": "1.1.9",
-				"@radix-ui/react-presence": "1.1.5",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-slot": "1.2.3",
-				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"@radix-ui/primitive": "1.1.4",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.1.4",
+				"@radix-ui/react-dismissable-layer": "1.1.13",
+				"@radix-ui/react-focus-guards": "1.1.4",
+				"@radix-ui/react-focus-scope": "1.1.10",
+				"@radix-ui/react-id": "1.1.2",
+				"@radix-ui/react-portal": "1.1.12",
+				"@radix-ui/react-presence": "1.1.6",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-slot": "1.3.0",
+				"@radix-ui/react-use-controllable-state": "1.2.3",
 				"aria-hidden": "^1.2.4",
-				"react-remove-scroll": "^2.6.3"
+				"react-remove-scroll": "^2.7.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1522,24 +1543,10 @@
 				}
 			}
 		},
-		"node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
-			"version": "1.2.3",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-compose-refs": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@radix-ui/react-direction": {
-			"version": "1.1.1",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+			"integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1552,14 +1559,16 @@
 			}
 		},
 		"node_modules/@radix-ui/react-dismissable-layer": {
-			"version": "1.1.11",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
+			"integrity": "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-callback-ref": "1.1.1",
-				"@radix-ui/react-use-escape-keydown": "1.1.1"
+				"@radix-ui/primitive": "1.1.4",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-callback-ref": "1.1.2",
+				"@radix-ui/react-use-escape-keydown": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1577,7 +1586,9 @@
 			}
 		},
 		"node_modules/@radix-ui/react-focus-guards": {
-			"version": "1.1.3",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+			"integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1590,12 +1601,14 @@
 			}
 		},
 		"node_modules/@radix-ui/react-focus-scope": {
-			"version": "1.1.7",
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.10.tgz",
+			"integrity": "sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-callback-ref": "1.1.1"
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-callback-ref": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1613,10 +1626,12 @@
 			}
 		},
 		"node_modules/@radix-ui/react-id": {
-			"version": "1.1.1",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+			"integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-use-layout-effect": "1.1.1"
+				"@radix-ui/react-use-layout-effect": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1629,23 +1644,25 @@
 			}
 		},
 		"node_modules/@radix-ui/react-navigation-menu": {
-			"version": "1.2.14",
+			"version": "1.2.16",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.16.tgz",
+			"integrity": "sha512-nJ0SkrSQgudyYhMiYeHA1ayLVuduEJCFLan1RZZN7c9kqzzCFLaU9kuy81uNtqzweM9YaQPgWzxi9MwQ9jZ04g==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-collection": "1.1.7",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-dismissable-layer": "1.1.11",
-				"@radix-ui/react-id": "1.1.1",
-				"@radix-ui/react-presence": "1.1.5",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-callback-ref": "1.1.1",
-				"@radix-ui/react-use-controllable-state": "1.2.2",
-				"@radix-ui/react-use-layout-effect": "1.1.1",
-				"@radix-ui/react-use-previous": "1.1.1",
-				"@radix-ui/react-visually-hidden": "1.2.3"
+				"@radix-ui/primitive": "1.1.4",
+				"@radix-ui/react-collection": "1.1.10",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.1.4",
+				"@radix-ui/react-direction": "1.1.2",
+				"@radix-ui/react-dismissable-layer": "1.1.13",
+				"@radix-ui/react-id": "1.1.2",
+				"@radix-ui/react-presence": "1.1.6",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-callback-ref": "1.1.2",
+				"@radix-ui/react-use-controllable-state": "1.2.3",
+				"@radix-ui/react-use-layout-effect": "1.1.2",
+				"@radix-ui/react-use-previous": "1.1.2",
+				"@radix-ui/react-visually-hidden": "1.2.6"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1663,24 +1680,26 @@
 			}
 		},
 		"node_modules/@radix-ui/react-popover": {
-			"version": "1.1.15",
+			"version": "1.1.17",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.17.tgz",
+			"integrity": "sha512-/YSAOdJ7YJvdn7bn5sdSx2egW+SKY+u7O5RyAVs94Ymrg2fg5QTSFPMRkzvhGyFuE4/qsmPBdrwYoZMZh/4f+g==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-dismissable-layer": "1.1.11",
-				"@radix-ui/react-focus-guards": "1.1.3",
-				"@radix-ui/react-focus-scope": "1.1.7",
-				"@radix-ui/react-id": "1.1.1",
-				"@radix-ui/react-popper": "1.2.8",
-				"@radix-ui/react-portal": "1.1.9",
-				"@radix-ui/react-presence": "1.1.5",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-slot": "1.2.3",
-				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"@radix-ui/primitive": "1.1.4",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.1.4",
+				"@radix-ui/react-dismissable-layer": "1.1.13",
+				"@radix-ui/react-focus-guards": "1.1.4",
+				"@radix-ui/react-focus-scope": "1.1.10",
+				"@radix-ui/react-id": "1.1.2",
+				"@radix-ui/react-popper": "1.3.1",
+				"@radix-ui/react-portal": "1.1.12",
+				"@radix-ui/react-presence": "1.1.6",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-slot": "1.3.0",
+				"@radix-ui/react-use-controllable-state": "1.2.3",
 				"aria-hidden": "^1.2.4",
-				"react-remove-scroll": "^2.6.3"
+				"react-remove-scroll": "^2.7.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1697,36 +1716,22 @@
 				}
 			}
 		},
-		"node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
-			"version": "1.2.3",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-compose-refs": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@radix-ui/react-popper": {
-			"version": "1.2.8",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.1.tgz",
+			"integrity": "sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==",
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/react-dom": "^2.0.0",
-				"@radix-ui/react-arrow": "1.1.7",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-callback-ref": "1.1.1",
-				"@radix-ui/react-use-layout-effect": "1.1.1",
-				"@radix-ui/react-use-rect": "1.1.1",
-				"@radix-ui/react-use-size": "1.1.1",
-				"@radix-ui/rect": "1.1.1"
+				"@radix-ui/react-arrow": "1.1.10",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.1.4",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-callback-ref": "1.1.2",
+				"@radix-ui/react-use-layout-effect": "1.1.2",
+				"@radix-ui/react-use-rect": "1.1.2",
+				"@radix-ui/react-use-size": "1.1.2",
+				"@radix-ui/rect": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1744,11 +1749,13 @@
 			}
 		},
 		"node_modules/@radix-ui/react-portal": {
-			"version": "1.1.9",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
+			"integrity": "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-layout-effect": "1.1.1"
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-layout-effect": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1766,11 +1773,12 @@
 			}
 		},
 		"node_modules/@radix-ui/react-presence": {
-			"version": "1.1.5",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+			"integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-use-layout-effect": "1.1.1"
+				"@radix-ui/react-use-layout-effect": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1788,10 +1796,12 @@
 			}
 		},
 		"node_modules/@radix-ui/react-primitive": {
-			"version": "2.1.3",
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+			"integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-slot": "1.2.3"
+				"@radix-ui/react-slot": "1.3.0"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1808,35 +1818,21 @@
 				}
 			}
 		},
-		"node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
-			"version": "1.2.3",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-compose-refs": "1.1.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@radix-ui/react-roving-focus": {
-			"version": "1.1.11",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.13.tgz",
+			"integrity": "sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-collection": "1.1.7",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-id": "1.1.1",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-callback-ref": "1.1.1",
-				"@radix-ui/react-use-controllable-state": "1.2.2"
+				"@radix-ui/primitive": "1.1.4",
+				"@radix-ui/react-collection": "1.1.10",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.1.4",
+				"@radix-ui/react-direction": "1.1.2",
+				"@radix-ui/react-id": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-callback-ref": "1.1.2",
+				"@radix-ui/react-use-controllable-state": "1.2.3"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1854,18 +1850,20 @@
 			}
 		},
 		"node_modules/@radix-ui/react-scroll-area": {
-			"version": "1.2.10",
+			"version": "1.2.12",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.12.tgz",
+			"integrity": "sha512-xuafVzQiTCLsyEjakowTdG3OgTXsmO7IdCiO77otIa+z44xoLNs9Do5eg7POFumIOCjtG6djfm6RKUKpUa/csA==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/number": "1.1.1",
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-presence": "1.1.5",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-callback-ref": "1.1.1",
-				"@radix-ui/react-use-layout-effect": "1.1.1"
+				"@radix-ui/number": "1.1.2",
+				"@radix-ui/primitive": "1.1.4",
+				"@radix-ui/react-compose-refs": "1.1.3",
+				"@radix-ui/react-context": "1.1.4",
+				"@radix-ui/react-direction": "1.1.2",
+				"@radix-ui/react-presence": "1.1.6",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-use-callback-ref": "1.1.2",
+				"@radix-ui/react-use-layout-effect": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1883,10 +1881,12 @@
 			}
 		},
 		"node_modules/@radix-ui/react-slot": {
-			"version": "1.2.4",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+			"integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-compose-refs": "1.1.2"
+				"@radix-ui/react-compose-refs": "1.1.3"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1899,17 +1899,19 @@
 			}
 		},
 		"node_modules/@radix-ui/react-tabs": {
-			"version": "1.1.13",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.15.tgz",
+			"integrity": "sha512-kxc9gI6/HfcU4nfMMVS3AmQK414kbU1IE6UCJmMmxjhO3cRPXOyYnmvyKD+ODt7q56nRq9l7Wovi6uaGwKgMlg==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-id": "1.1.1",
-				"@radix-ui/react-presence": "1.1.5",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-roving-focus": "1.1.11",
-				"@radix-ui/react-use-controllable-state": "1.2.2"
+				"@radix-ui/primitive": "1.1.4",
+				"@radix-ui/react-context": "1.1.4",
+				"@radix-ui/react-direction": "1.1.2",
+				"@radix-ui/react-id": "1.1.2",
+				"@radix-ui/react-presence": "1.1.6",
+				"@radix-ui/react-primitive": "2.1.6",
+				"@radix-ui/react-roving-focus": "1.1.13",
+				"@radix-ui/react-use-controllable-state": "1.2.3"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1927,7 +1929,9 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-callback-ref": {
-			"version": "1.1.1",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+			"integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1940,11 +1944,13 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-controllable-state": {
-			"version": "1.2.2",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+			"integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-use-effect-event": "0.0.2",
-				"@radix-ui/react-use-layout-effect": "1.1.1"
+				"@radix-ui/react-use-effect-event": "0.0.3",
+				"@radix-ui/react-use-layout-effect": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1957,10 +1963,12 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-effect-event": {
-			"version": "0.0.2",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+			"integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-use-layout-effect": "1.1.1"
+				"@radix-ui/react-use-layout-effect": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1973,10 +1981,12 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-escape-keydown": {
-			"version": "1.1.1",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+			"integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-use-callback-ref": "1.1.1"
+				"@radix-ui/react-use-callback-ref": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1989,7 +1999,9 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-layout-effect": {
-			"version": "1.1.1",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+			"integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "*",
@@ -2002,7 +2014,9 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-previous": {
-			"version": "1.1.1",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
+			"integrity": "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "*",
@@ -2015,10 +2029,12 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-rect": {
-			"version": "1.1.1",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+			"integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/rect": "1.1.1"
+				"@radix-ui/rect": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -2031,10 +2047,12 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-size": {
-			"version": "1.1.1",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+			"integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-use-layout-effect": "1.1.1"
+				"@radix-ui/react-use-layout-effect": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -2047,10 +2065,12 @@
 			}
 		},
 		"node_modules/@radix-ui/react-visually-hidden": {
-			"version": "1.2.3",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.6.tgz",
+			"integrity": "sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@radix-ui/react-primitive": "2.1.3"
+				"@radix-ui/react-primitive": "2.1.6"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -2068,7 +2088,9 @@
 			}
 		},
 		"node_modules/@radix-ui/rect": {
-			"version": "1.1.1",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+			"integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
 			"license": "MIT"
 		},
 		"node_modules/@reduxjs/toolkit": {
@@ -2118,33 +2140,78 @@
 			}
 		},
 		"node_modules/@shikijs/engine-javascript": {
-			"version": "4.0.2",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
+			"integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.0.2",
+				"@shikijs/types": "4.2.0",
 				"@shikijs/vscode-textmate": "^10.0.2",
-				"oniguruma-to-es": "^4.3.4"
+				"oniguruma-to-es": "^4.3.6"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/engine-javascript/node_modules/@shikijs/types": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
 			},
 			"engines": {
 				"node": ">=20"
 			}
 		},
 		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "4.0.2",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
+			"integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.0.2",
+				"@shikijs/types": "4.2.0",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			},
 			"engines": {
 				"node": ">=20"
 			}
 		},
-		"node_modules/@shikijs/langs": {
-			"version": "4.0.2",
+		"node_modules/@shikijs/engine-oniguruma/node_modules/@shikijs/types": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.0.2"
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
+			"integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "4.2.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/langs/node_modules/@shikijs/types": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
 			},
 			"engines": {
 				"node": ">=20"
@@ -2162,37 +2229,26 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/@shikijs/rehype": {
-			"version": "4.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "4.0.2",
-				"@types/hast": "^3.0.4",
-				"hast-util-to-string": "^3.0.1",
-				"shiki": "4.0.2",
-				"unified": "^11.0.5",
-				"unist-util-visit": "^5.1.0"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
 		"node_modules/@shikijs/themes": {
-			"version": "4.0.2",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
+			"integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.0.2"
+				"@shikijs/types": "4.2.0"
 			},
 			"engines": {
 				"node": ">=20"
 			}
 		},
-		"node_modules/@shikijs/transformers": {
-			"version": "4.0.2",
+		"node_modules/@shikijs/themes/node_modules/@shikijs/types": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/core": "4.0.2",
-				"@shikijs/types": "4.0.2"
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
 			},
 			"engines": {
 				"node": ">=20"
@@ -2270,7 +2326,7 @@
 		},
 		"node_modules/@tailwindcss/oxide": {
 			"version": "4.2.2",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 20"
@@ -2933,6 +2989,8 @@
 		},
 		"node_modules/class-variance-authority": {
 			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+			"integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"clsx": "^2.1.1"
@@ -2947,6 +3005,8 @@
 		},
 		"node_modules/clsx": {
 			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -2975,16 +3035,6 @@
 		"node_modules/compute-scroll-into-view": {
 			"version": "3.1.1",
 			"license": "MIT"
-		},
-		"node_modules/cssesc": {
-			"version": "3.0.0",
-			"license": "MIT",
-			"bin": {
-				"cssesc": "bin/cssesc"
-			},
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/csstype": {
 			"version": "3.2.3",
@@ -3389,11 +3439,13 @@
 			}
 		},
 		"node_modules/framer-motion": {
-			"version": "12.38.0",
+			"version": "12.40.0",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+			"integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
 			"license": "MIT",
 			"dependencies": {
-				"motion-dom": "^12.38.0",
-				"motion-utils": "^12.36.0",
+				"motion-dom": "^12.40.0",
+				"motion-utils": "^12.39.0",
 				"tslib": "^2.4.0"
 			},
 			"peerDependencies": {
@@ -3414,36 +3466,32 @@
 			}
 		},
 		"node_modules/fumadocs-core": {
-			"version": "16.7.10",
+			"version": "16.10.3",
+			"resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-16.10.3.tgz",
+			"integrity": "sha512-xXhqz/fqbN7pLlshJb/B5L+vzMJOmWxoPj7+KMRTa/4A669hKeeCBPpRAiooMqjblWqIRSxLiO02/ds8ltvUPQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@formatjs/intl-localematcher": "^0.8.2",
 				"@orama/orama": "^3.1.18",
-				"@shikijs/rehype": "^4.0.2",
-				"@shikijs/transformers": "^4.0.2",
 				"estree-util-value-to-estree": "^3.5.0",
 				"github-slugger": "^2.0.0",
 				"hast-util-to-estree": "^3.1.3",
 				"hast-util-to-jsx-runtime": "^2.3.6",
-				"image-size": "^2.0.2",
+				"js-yaml": "^4.2.0",
 				"mdast-util-mdx": "^3.0.0",
 				"mdast-util-to-markdown": "^2.1.2",
-				"negotiator": "^1.0.0",
-				"npm-to-yarn": "^3.0.1",
-				"path-to-regexp": "^8.4.0",
 				"remark": "^15.0.1",
 				"remark-gfm": "^4.0.1",
 				"remark-rehype": "^11.1.2",
 				"scroll-into-view-if-needed": "^3.1.0",
-				"shiki": "^4.0.2",
-				"tinyglobby": "^0.2.15",
+				"shiki": "^4.2.0",
+				"tinyglobby": "^0.2.17",
 				"unified": "^11.0.5",
 				"unist-util-visit": "^5.1.0",
 				"vfile": "^6.0.3"
 			},
 			"peerDependencies": {
 				"@mdx-js/mdx": "*",
-				"@mixedbread/sdk": "^0.46.0",
+				"@mixedbread/sdk": "0.x.x",
 				"@orama/core": "1.x.x",
 				"@oramacloud/client": "2.x.x",
 				"@tanstack/react-router": "1.x.x",
@@ -3458,7 +3506,7 @@
 				"react": "^19.2.0",
 				"react-dom": "^19.2.0",
 				"react-router": "7.x.x",
-				"waku": "^0.26.0 || ^0.27.0 || ^1.0.0",
+				"waku": "*",
 				"zod": "4.x.x"
 			},
 			"peerDependenciesMeta": {
@@ -3519,9 +3567,9 @@
 			}
 		},
 		"node_modules/fumadocs-mdx": {
-			"version": "14.3.2",
-			"resolved": "https://registry.npmjs.org/fumadocs-mdx/-/fumadocs-mdx-14.3.2.tgz",
-			"integrity": "sha512-73SoZkbUuqnD91G/0zBcaQdM1TMnYw5JJzKgkGvQTiZbtLQFuWTt8/uRqnzFMuNIUu/WY9Lo9d1iZ8G+jOVieA==",
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/fumadocs-mdx/-/fumadocs-mdx-15.0.12.tgz",
+			"integrity": "sha512-R4WenrNQxSKi+QU46Q1cscVWi+S90dj3As4jdN+vgChO2o0TVOj+FFIe3onWM7mglhPj53NxZp/upP+t/ryekQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@mdx-js/mdx": "^3.1.1",
@@ -3529,31 +3577,31 @@
 				"chokidar": "^5.0.0",
 				"esbuild": "^0.28.0",
 				"estree-util-value-to-estree": "^3.5.0",
-				"js-yaml": "^4.1.1",
+				"js-yaml": "^4.2.0",
 				"mdast-util-mdx": "^3.0.0",
-				"mdast-util-to-markdown": "^2.1.2",
 				"picocolors": "^1.1.1",
 				"picomatch": "^4.0.4",
-				"tinyexec": "^1.1.1",
-				"tinyglobby": "^0.2.16",
+				"tinyexec": "^1.2.4",
+				"tinyglobby": "^0.2.17",
 				"unified": "^11.0.5",
 				"unist-util-remove-position": "^5.0.0",
 				"unist-util-visit": "^5.1.0",
 				"vfile": "^6.0.3",
-				"zod": "^4.3.6"
+				"zod": "^4.4.3"
 			},
 			"bin": {
-				"fumadocs-mdx": "dist/bin.js"
+				"fumadocs-mdx": "bin.js"
 			},
 			"peerDependencies": {
 				"@types/mdast": "*",
 				"@types/mdx": "*",
 				"@types/react": "*",
-				"fumadocs-core": "^15.0.0 || ^16.0.0",
+				"fumadocs-core": "^16.7.0",
 				"mdast-util-directive": "*",
 				"next": "^15.3.0 || ^16.0.0",
 				"react": "^19.2.0",
-				"vite": "6.x.x || 7.x.x || 8.x.x"
+				"rolldown": "*",
+				"vite": "7.x.x || 8.x.x"
 			},
 			"peerDependenciesMeta": {
 				"@types/mdast": {
@@ -3572,6 +3620,9 @@
 					"optional": true
 				},
 				"react": {
+					"optional": true
+				},
+				"rolldown": {
 					"optional": true
 				},
 				"vite": {
@@ -3643,40 +3694,42 @@
 			}
 		},
 		"node_modules/fumadocs-ui": {
-			"version": "16.7.10",
+			"version": "16.10.3",
+			"resolved": "https://registry.npmjs.org/fumadocs-ui/-/fumadocs-ui-16.10.3.tgz",
+			"integrity": "sha512-0aSLdQ73EWoCmYcQYr2uNHlSB/s2fD+NMugtdZF3vC4lqs0MfyOtwnZPyYAskUnXNs6HECly/Hu6oY5JqmlkHg==",
 			"license": "MIT",
 			"dependencies": {
-				"@fumadocs/tailwind": "0.0.3",
-				"@radix-ui/react-accordion": "^1.2.12",
-				"@radix-ui/react-collapsible": "^1.1.12",
-				"@radix-ui/react-dialog": "^1.1.15",
-				"@radix-ui/react-direction": "^1.1.1",
-				"@radix-ui/react-navigation-menu": "^1.2.14",
-				"@radix-ui/react-popover": "^1.1.15",
-				"@radix-ui/react-presence": "^1.1.5",
-				"@radix-ui/react-scroll-area": "^1.2.10",
-				"@radix-ui/react-slot": "^1.2.4",
-				"@radix-ui/react-tabs": "^1.1.13",
+				"@fuma-translate/react": "^1.0.2",
+				"@fumadocs/tailwind": "0.0.5",
+				"@radix-ui/react-accordion": "^1.2.13",
+				"@radix-ui/react-collapsible": "^1.1.13",
+				"@radix-ui/react-dialog": "^1.1.16",
+				"@radix-ui/react-direction": "^1.1.2",
+				"@radix-ui/react-navigation-menu": "^1.2.15",
+				"@radix-ui/react-popover": "^1.1.16",
+				"@radix-ui/react-presence": "^1.1.6",
+				"@radix-ui/react-scroll-area": "^1.2.11",
+				"@radix-ui/react-slot": "^1.2.5",
+				"@radix-ui/react-tabs": "^1.1.14",
 				"class-variance-authority": "^0.7.1",
-				"lucide-react": "^1.7.0",
-				"motion": "^12.38.0",
+				"lucide-react": "^1.17.0",
+				"motion": "^12.40.0",
 				"next-themes": "^0.4.6",
-				"react-medium-image-zoom": "^5.4.1",
 				"react-remove-scroll": "^2.7.2",
 				"rehype-raw": "^7.0.0",
 				"scroll-into-view-if-needed": "^3.1.0",
-				"tailwind-merge": "^3.5.0",
+				"shiki": "^4.2.0",
+				"tailwind-merge": "^3.6.0",
 				"unist-util-visit": "^5.1.0"
 			},
 			"peerDependencies": {
 				"@takumi-rs/image-response": "*",
 				"@types/mdx": "*",
 				"@types/react": "*",
-				"fumadocs-core": "16.7.10",
+				"fumadocs-core": "16.10.3",
 				"next": "16.x.x",
 				"react": "^19.2.0",
-				"react-dom": "^19.2.0",
-				"shiki": "*"
+				"react-dom": "^19.2.0"
 			},
 			"peerDependenciesMeta": {
 				"@takumi-rs/image-response": {
@@ -3689,9 +3742,6 @@
 					"optional": true
 				},
 				"next": {
-					"optional": true
-				},
-				"shiki": {
 					"optional": true
 				}
 			}
@@ -3853,17 +3903,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/hast-util-to-string": {
-			"version": "3.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/hast-util-whitespace": {
 			"version": "3.0.0",
 			"license": "MIT",
@@ -3900,16 +3939,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/image-size": {
-			"version": "2.0.2",
-			"license": "MIT",
-			"bin": {
-				"image-size": "bin/image-size.js"
-			},
-			"engines": {
-				"node": ">=16.x"
 			}
 		},
 		"node_modules/immer": {
@@ -3986,7 +4015,19 @@
 			}
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -4276,7 +4317,9 @@
 			}
 		},
 		"node_modules/lucide-react": {
-			"version": "1.7.0",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.20.0.tgz",
+			"integrity": "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==",
 			"license": "ISC",
 			"peerDependencies": {
 				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -5228,10 +5271,12 @@
 			}
 		},
 		"node_modules/motion": {
-			"version": "12.38.0",
+			"version": "12.40.0",
+			"resolved": "https://registry.npmjs.org/motion/-/motion-12.40.0.tgz",
+			"integrity": "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==",
 			"license": "MIT",
 			"dependencies": {
-				"framer-motion": "^12.38.0",
+				"framer-motion": "^12.40.0",
 				"tslib": "^2.4.0"
 			},
 			"peerDependencies": {
@@ -5252,14 +5297,18 @@
 			}
 		},
 		"node_modules/motion-dom": {
-			"version": "12.38.0",
+			"version": "12.40.0",
+			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+			"integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
 			"license": "MIT",
 			"dependencies": {
-				"motion-utils": "^12.36.0"
+				"motion-utils": "^12.39.0"
 			}
 		},
 		"node_modules/motion-utils": {
-			"version": "12.36.0",
+			"version": "12.39.0",
+			"resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+			"integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
 			"license": "MIT"
 		},
 		"node_modules/ms": {
@@ -5280,13 +5329,6 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
-		},
-		"node_modules/negotiator": {
-			"version": "1.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/next": {
@@ -5376,25 +5418,19 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
-		"node_modules/npm-to-yarn": {
-			"version": "3.0.1",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/nebrelbug/npm-to-yarn?sponsor=1"
-			}
-		},
 		"node_modules/oniguruma-parser": {
-			"version": "0.12.1",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+			"integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
 			"license": "MIT"
 		},
 		"node_modules/oniguruma-to-es": {
-			"version": "4.3.5",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+			"integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
 			"license": "MIT",
 			"dependencies": {
-				"oniguruma-parser": "^0.12.1",
+				"oniguruma-parser": "^0.12.2",
 				"regex": "^6.1.0",
 				"regex-recursion": "^6.0.2"
 			}
@@ -5454,14 +5490,6 @@
 			"version": "1.0.1",
 			"license": "MIT"
 		},
-		"node_modules/path-to-regexp": {
-			"version": "8.4.2",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"license": "ISC"
@@ -5512,17 +5540,6 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
-		"node_modules/postcss-selector-parser": {
-			"version": "7.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/proj4": {
 			"version": "2.20.8",
 			"license": "MIT",
@@ -5563,20 +5580,6 @@
 			"version": "19.2.5",
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/react-medium-image-zoom": {
-			"version": "5.4.3",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/rpearce"
-				}
-			],
-			"license": "BSD-3-Clause",
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
 		},
 		"node_modules/react-redux": {
 			"version": "9.2.0",
@@ -5773,6 +5776,8 @@
 		},
 		"node_modules/regex": {
 			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+			"integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
 			"license": "MIT",
 			"dependencies": {
 				"regex-utilities": "^2.3.0"
@@ -5780,6 +5785,8 @@
 		},
 		"node_modules/regex-recursion": {
 			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+			"integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
 			"license": "MIT",
 			"dependencies": {
 				"regex-utilities": "^2.3.0"
@@ -5787,6 +5794,8 @@
 		},
 		"node_modules/regex-utilities": {
 			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
 			"license": "MIT"
 		},
 		"node_modules/rehype-raw": {
@@ -5973,15 +5982,60 @@
 			}
 		},
 		"node_modules/shiki": {
-			"version": "4.0.2",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
+			"integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/core": "4.0.2",
-				"@shikijs/engine-javascript": "4.0.2",
-				"@shikijs/engine-oniguruma": "4.0.2",
-				"@shikijs/langs": "4.0.2",
-				"@shikijs/themes": "4.0.2",
-				"@shikijs/types": "4.0.2",
+				"@shikijs/core": "4.2.0",
+				"@shikijs/engine-javascript": "4.2.0",
+				"@shikijs/engine-oniguruma": "4.2.0",
+				"@shikijs/langs": "4.2.0",
+				"@shikijs/themes": "4.2.0",
+				"@shikijs/types": "4.2.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/shiki/node_modules/@shikijs/core": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
+			"integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/primitive": "4.2.0",
+				"@shikijs/types": "4.2.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4",
+				"hast-util-to-html": "^9.0.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/shiki/node_modules/@shikijs/primitive": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
+			"integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "4.2.0",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/shiki/node_modules/@shikijs/types": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
+			"license": "MIT",
+			"dependencies": {
 				"@shikijs/vscode-textmate": "^10.0.2",
 				"@types/hast": "^3.0.4"
 			},
@@ -6059,7 +6113,9 @@
 			}
 		},
 		"node_modules/tailwind-merge": {
-			"version": "3.5.0",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+			"integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -6309,10 +6365,6 @@
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"license": "MIT"
-		},
 		"node_modules/vfile": {
 			"version": "6.0.3",
 			"license": "MIT",
@@ -6385,7 +6437,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "4.3.6",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,12 +10,15 @@
 		"postinstall": "fumadocs-mdx"
 	},
 	"dependencies": {
+		"@radix-ui/react-slot": "1.3.0",
+		"class-variance-authority": "0.7.1",
+		"clsx": "2.1.1",
 		"dotted-map": "^3.1.0",
-		"fumadocs-core": "16.7.10",
-		"fumadocs-mdx": "14.3.2",
+		"fumadocs-core": "16.10.3",
+		"fumadocs-mdx": "15.0.12",
 		"fumadocs-twoslash": "^3.1.3",
 		"fumadocs-typescript": "^4.0.3",
-		"fumadocs-ui": "16.7.10",
+		"fumadocs-ui": "16.10.3",
 		"headroom-ai": "file:../sdk/typescript",
 		"lucide-react": "^1.7.0",
 		"next": "16.2.6",

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
           },
         }),
       ],
-      langs: ['js', 'jsx', 'ts', 'tsx', 'python', 'bash', 'json', 'yaml', 'toml', 'css'],
+      langs: ['js', 'jsx', 'ts', 'tsx', 'python', 'bash', 'json', 'yaml', 'toml', 'css', 'mermaid'],
     },
   },
 });


### PR DESCRIPTION
## Description

Adds a visual CI/CD flow reference for Headroom so contributors can quickly understand the gated PR, release, Docker, docs deploy, fork approval, and manual validation paths. Also updates the release documentation to match the current release-please release flow instead of the stale push-to-main release model.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Added `docs/content/docs/ci-cd-flows.mdx` with Mermaid diagrams and decision trees for PR review, release publishing, Docker publishing, docs deploys, fork workflow approval, and manual validation.
- Updated `docs/content/docs/releases.mdx` to describe the current `release-please` -> GitHub Release -> `release.yml` publishing path.
- Added the CI/CD flow page and existing release page to docs navigation.
- Added Mermaid to the docs code highlighter language list.
- Restored missing docs helper modules and aligned Fumadocs dependencies so the docs app can install, generate sources, type-check, and build.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ npm ci
> headroom-docs@0.0.0 postinstall
> fumadocs-mdx
[MDX] generated files
added 365 packages, and audited 367 packages

$ npm run types:check
> fumadocs-mdx && next typegen && tsc --noEmit
[MDX] generated files
Generating route types...
✓ Types generated successfully

$ npm run build
> next build
✓ Compiled successfully
Running TypeScript ...
Generating static pages ...
✓ Generating static pages (122/122)

Note: next build completed successfully and emitted two existing Recharts container-size warnings during static generation.

$ git diff --check
# no output

$ act workflow_dispatch -W .github/workflows/docs.yml -n
*DRYRUN* [Deploy Documentation/deploy] 🏁  Job succeeded
```

## Real Behavior Proof

- Environment: Windows local checkout, branch `docs-ci-flow`, Node.js v22.22.0, `act` 0.2.87.
- Exact command / steps: Ran `npm ci`, `npm run types:check`, and `npm run build` from `docs/`; ran `git diff --check` and `act workflow_dispatch -W .github/workflows/docs.yml -n` from the repository root.
- Observed result: Docs dependencies install, Fumadocs source generation includes `ci-cd-flows.mdx`, TypeScript passes, Next production build completes, whitespace check passes, and the docs workflow dry-run succeeds under `act`.
- Not tested: Full live GitHub Pages deploy and registry/release publishing, because this PR only changes docs and docs build wiring.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A. This is documentation and build wiring; the diagrams are Mermaid source blocks in the docs page.

## Additional Notes

- No issue is linked because this PR was not opened for a specific tracked issue.
- `npm run build` still reports two pre-existing Recharts container-size warnings while completing successfully.
- Python unit/lint/type checks and changelog updates are not applicable to this docs-only change.