### PR TITLE
fix: suppress '[transformers] PyTorch was not found' startup warning

### DIFF
--- a/headroom/memory/adapters/embedders.py
+++ b/headroom/memory/adapters/embedders.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 # We operate in an authenticated-optional mode; warnings are not actionable.
 os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
 os.environ.setdefault("HF_HUB_DISABLE_IMPLICIT_TOKEN", "1")
+os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
 warnings.filterwarnings("ignore", category=UserWarning, module="huggingface_hub")
 # Also silence the huggingface_hub logger which emits rate-limit advisory messages.
 logging.getLogger("huggingface_hub").setLevel(logging.ERROR)

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -425,6 +425,11 @@ def _build_agent_usage_summary(
     }
 
 
+# Suppress "[transformers] PyTorch was not found" warning emitted when
+# transformers is imported for availability checks (e.g. kompress ONNX probe).
+# PyTorch is optional in headroom; the warning is not actionable for operators.
+os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
+
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )


### PR DESCRIPTION
## Description

`transformers` is imported for lightweight availability checks (e.g. the kompress ONNX probe in `_is_onnx_available`) and at memory-embedder import. When PyTorch is not installed, `transformers` emits a non-actionable `[transformers] PyTorch was not found. Models won't be available...` warning on proxy startup. PyTorch is optional in headroom, so the warning is noise. This silences it by setting `TRANSFORMERS_VERBOSITY=error`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/server.py`: `os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")` at module import, before logging is configured.
- `headroom/memory/adapters/embedders.py`: same `setdefault`, alongside the existing HF Hub warning suppressions.
- `setdefault` preserves any operator-provided `TRANSFORMERS_VERBOSITY` override.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ .venv/Scripts/python.exe -m ruff check headroom/proxy/server.py headroom/memory/adapters/embedders.py
All checks passed!
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.11, transformers 5.12.1, PyTorch not installed.
- Exact command / steps: `python -c "import io, logging; from headroom.proxy.server import ProxyConfig; buf=io.StringIO(); logging.getLogger('transformers').addHandler(logging.StreamHandler(buf)); import transformers, os; print(os.environ.get('TRANSFORMERS_VERBOSITY')); print(repr(buf.getvalue()))"`
- Observed result: prints `error` then `''` — importing the proxy server sets the env var, and the subsequent `transformers` import emits no captured warning. Without the fix the same steps print the `[transformers] PyTorch was not found...` line.
- Not tested: `mypy` not run; behavior with an explicit operator override (preserved by `setdefault`) not exercised.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

Two-line, presentation-only change (suppresses a noisy startup log). No new test added — the behavior is a third-party library log-verbosity setting; manual proof above. `mypy` not run; CHANGELOG not updated.
