### PR TITLE
feat(wrap): add HEADROOM_NO_SERENA env var for persistent Serena opt-out

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -1104,6 +1104,22 @@ def _prepare_wrap_rtk(verbose: bool = False, *, label: str | None = None) -> Pat
 # case-insensitively by headroom.proxy.project_context.PROJECT_HEADER).
 _PROJECT_HEADER_NAME = "X-Headroom-Project"
 
+# Persistent Serena opt-out: set HEADROOM_NO_SERENA=1 (or "true"/"yes") in
+# your shell profile to skip Serena MCP registration on every wrap without
+# passing --no-serena each time.  Closes #568 / #716.
+_SERENA_DISABLED_ENV = "HEADROOM_NO_SERENA"
+
+
+def _serena_disabled(no_serena_flag: bool) -> bool:
+    """Return True if Serena MCP should be skipped for this wrap session.
+
+    Checks the --no-serena CLI flag first, then the HEADROOM_NO_SERENA env
+    var so users can persist the preference in their shell profile or .env.
+    """
+    if no_serena_flag:
+        return True
+    return os.environ.get(_SERENA_DISABLED_ENV, "").strip().lower() in {"1", "true", "yes"}
+
 
 def _project_name_from_cwd() -> str | None:
     """Project label for X-Headroom-Project: basename of the launch directory.
@@ -2790,7 +2806,11 @@ def unwrap() -> None:
     is_flag=True,
     help="Skip headroom MCP server registration (compression markers will be unactionable)",
 )
-@click.option("--no-serena", is_flag=True, help="Skip Serena MCP server registration")
+@click.option(
+    "--no-serena",
+    is_flag=True,
+    help="Skip Serena MCP server registration (persistent: set HEADROOM_NO_SERENA=1)",
+)
 @click.option(
     "--code-graph",
     is_flag=True,
@@ -2955,7 +2975,7 @@ def claude(
         elif verbose:
             click.echo("  Skipping MCP retrieve tool (--no-mcp)")
 
-        if not no_serena:
+        if not _serena_disabled(no_serena):
             from headroom.mcp_registry import ClaudeRegistrar
 
             _setup_serena_mcp(ClaudeRegistrar(), context="claude-code", verbose=verbose)
@@ -3384,7 +3404,11 @@ def copilot(
     is_flag=True,
     help="Skip headroom MCP server registration (compression markers will be unactionable)",
 )
-@click.option("--no-serena", is_flag=True, help="Skip Serena MCP server registration")
+@click.option(
+    "--no-serena",
+    is_flag=True,
+    help="Skip Serena MCP server registration (persistent: set HEADROOM_NO_SERENA=1)",
+)
 @click.option(
     "--code-graph",
     is_flag=True,
@@ -3484,7 +3508,7 @@ def codex(
     elif verbose:
         click.echo("  Skipping MCP retrieve tool (--no-mcp)")
 
-    if not no_serena:
+    if not _serena_disabled(no_serena):
         from headroom.mcp_registry import CodexRegistrar
 
         _setup_serena_mcp(CodexRegistrar(), context="codex", verbose=verbose, force=True)

--- a/tests/test_cli/test_wrap_helpers.py
+++ b/tests/test_cli/test_wrap_helpers.py
@@ -707,3 +707,39 @@ class TestProxyClientRefCounting:
 
         # Second unregister is a no-op, not an error.
         wrap_mod._unregister_proxy_client(self.PORT)
+
+
+# ---------------------------------------------------------------------------
+# _serena_disabled — persistent HEADROOM_NO_SERENA opt-out (issues #568/#716)
+# ---------------------------------------------------------------------------
+
+
+class TestSerenaDisabled:
+    """_serena_disabled() honours --no-serena flag and HEADROOM_NO_SERENA env var."""
+
+    def test_flag_true_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("HEADROOM_NO_SERENA", raising=False)
+        assert wrap_mod._serena_disabled(True) is True
+
+    def test_flag_false_env_unset_enables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("HEADROOM_NO_SERENA", raising=False)
+        assert wrap_mod._serena_disabled(False) is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "True", "TRUE", "yes", "YES", "Yes"])
+    def test_env_truthy_disables(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("HEADROOM_NO_SERENA", value)
+        assert wrap_mod._serena_disabled(False) is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "  "])
+    def test_env_falsy_enables(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("HEADROOM_NO_SERENA", value)
+        assert wrap_mod._serena_disabled(False) is False
+
+    def test_flag_wins_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--no-serena flag disables even when env var is not set."""
+        monkeypatch.delenv("HEADROOM_NO_SERENA", raising=False)
+        assert wrap_mod._serena_disabled(True) is True
+
+    def test_env_with_whitespace_is_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HEADROOM_NO_SERENA", "  1  ")
+        assert wrap_mod._serena_disabled(False) is True


### PR DESCRIPTION
## Description

Users who never want Serena MCP registered had no persistent opt-out — they had to pass `--no-serena` on every single `headroom wrap` invocation. This PR adds `HEADROOM_NO_SERENA` env var so the preference can be set once in a shell profile or `.env` file.

Closes #568
Closes #716

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `headroom/cli/wrap.py` — added `_SERENA_DISABLED_ENV = "HEADROOM_NO_SERENA"` constant and `_serena_disabled(flag)` helper that checks the `--no-serena` flag first, then the env var (truthy values: `"1"`, `"true"`, `"yes"`, case-insensitive)
- Replaced both `if not no_serena:` blocks in `wrap claude` and `wrap codex` with `if not _serena_disabled(no_serena):`
- Updated `--no-serena` help text on both commands to mention the env var

Only `wrap claude` and `wrap codex` install Serena — no other subcommands needed changes.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] New tests added for new functionality

### Test Output

```text
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_flag_true_disables PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_flag_false_env_unset_enables PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_truthy_disables[1] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_truthy_disables[true] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_truthy_disables[True] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_truthy_disables[TRUE] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_truthy_disables[yes] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_truthy_disables[YES] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_truthy_disables[Yes] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_falsy_enables[0] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_falsy_enables[false] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_falsy_enables[no] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_falsy_enables[off] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_falsy_enables[] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_falsy_enables[  ] PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_flag_wins_over_env PASSED
tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled::test_env_with_whitespace_is_stripped PASSED
======================== 17 passed in 0.34s ================================
```

## Real Behavior Proof

- Environment: macOS 15, Python 3.11.9, headroom dev install from source
- Exact command / steps: `export HEADROOM_NO_SERENA=1` then `.venv/bin/pytest tests/test_cli/test_wrap_helpers.py::TestSerenaDisabled -v` — all 17 pass; `_serena_disabled(False)` returns `True` when env var is set
- Observed result: `_serena_disabled(False)` returns `True` for truthy env values (`1`/`true`/`yes`), `False` for falsy or unset; `--no-serena` flag still works as before
- Not tested: live end-to-end wrap session (no Claude API key in CI)

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes