### PR TITLE
ci: add Windows wheel build job (win_amd64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ name: CI
 #
 # Notes: CPU-only torch everywhere (no CUDA stack); test shards run HF_HUB_OFFLINE.
 # Multi-version (3.10/3.11/3.13) coverage on main is a planned follow-up.
+# Windows wheel (win_amd64) built separately — builds the Rust ext just like the
+# Linux wheel, then uploads as a separate artifact for downstream consumption.
 
 on:
   push:
@@ -111,6 +113,31 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: headroom-wheel
+          path: dist/*.whl
+          retention-days: 1
+
+  build-wheel-windows:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PY_VERSION }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - name: Build wheel (fast CI cargo profile)
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip maturin
+          maturin build --profile ci --out dist --interpreter "python${{ env.PY_VERSION }}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: headroom-wheel-windows
           path: dist/*.whl
           retention-days: 1
 


### PR DESCRIPTION
### Summary

Adds `build-wheel-windows` job to the CI pipeline that compiles the Rust extension on `windows-latest` and uploads the resulting `.whl` as a separate artifact (`headroom-wheel-windows`).

This addresses the long-standing missing Windows wheel.

### Changes

- New job `build-wheel-windows`: mirrors the existing `build-wheel` (Linux) job
- Uses `dtolnay/rust-toolchain@stable` for Rust setup on Windows
- Uses `Swatinem/rust-cache` for dependency caching
- Builds with CI cargo profile for speed
- 45-minute timeout (Windows Rust builds are slower)
- Uploads wheel as `headroom-wheel-windows` artifact

### Testing

✅ **Local compilation verified**: built v0.26.0 from source on Windows 10 (Python 3.12.10, Rust 1.96.0, MSVC Build Tools 2022). The wheel installed and ran successfully.

### Notes

Only the CI-profile build is added here. The release-wheel publish (`release.yml`) can be updated in a follow-up PR once this basic Windows build is proven in CI.