### PR TITLE
fix(providers): update DeepSeek V3 context limit from 128K to 1M (#1038)

### DIFF
--- a/headroom/providers/openai_compatible.py
+++ b/headroom/providers/openai_compatible.py
@@ -84,10 +84,11 @@ _DEFAULT_CONTEXT_LIMITS: dict[str, int] = {
     "qwen2-72b": 32768,
     "qwen2.5": 131072,
     # DeepSeek
-    "deepseek": 32768,
-    "deepseek-coder": 16384,
+    "deepseek": 1048576,
+    "deepseek-coder": 128000,
     "deepseek-v2": 128000,
-    "deepseek-v3": 128000,
+    "deepseek-v3": 1048576,
+    "deepseek-v4": 1048576,
     # Yi
     "yi": 32768,
     "yi-34b": 32768,

--- a/tests/test_providers/test_universal.py
+++ b/tests/test_providers/test_universal.py
@@ -81,6 +81,14 @@ class TestOpenAICompatibleProvider:
         limit = provider.get_context_limit("llama-3.1-8b")
         assert limit == 128000
 
+    def test_get_context_limit_deepseek_v3_is_1m(self):
+        """DeepSeek V3/V4 support 1M context, not 128K (#1038)."""
+        provider = OpenAICompatibleProvider()
+        assert provider.get_context_limit("deepseek-v3") == 1048576
+        assert provider.get_context_limit("deepseek-v4") == 1048576
+        assert provider.get_context_limit("deepseek") == 1048576
+        assert provider.get_context_limit("deepseek-v2") == 128000
+
     def test_get_context_limit_unknown_model(self):
         """Test context limit for unknown models (defaults to 128K)."""
         provider = OpenAICompatibleProvider()


### PR DESCRIPTION
## Description

Update `_DEFAULT_CONTEXT_LIMITS` so DeepSeek V3/V4 use their actual 1M (1,048,576) context window instead of the outdated 128K. The hardcoded 128K causes Headroom to trigger compression far too early, defeating the purpose of using a long-context model.

Closes #1038

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Update `deepseek` default from 32,768 to 1,048,576 (V3/V4 family default)
- Update `deepseek-v3` from 128,000 to 1,048,576
- Update `deepseek-coder` from 16,384 to 128,000 (Coder V2+)
- Add `deepseek-v4` entry at 1,048,576
- `deepseek-v2` stays at 128,000 (unchanged)

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_providers/test_universal.py -v -x
37 passed, 3 skipped in 38.08s
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.11, headroom main (6904d47)
- Exact command / steps: python -m pytest tests/test_providers/test_universal.py::TestOpenAICompatibleProvider::test_get_context_limit_deepseek_v3_is_1m -v
- Observed result: PASSED - deepseek-v3 returns 1048576, deepseek-v4 returns 1048576, deepseek returns 1048576, deepseek-v2 returns 128000
- Not tested: no manual proxy testing with a live DeepSeek endpoint

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

The context limit values are based on the DeepSeek V3 technical report and API documentation, which specify a 1M-token context window. DeepSeek Coder V2+ also supports 128K, up from the original Coder's 16K.