### PR TITLE
Fix UnboundLocalError: bind ccr_workspace_key before CCR-inject block

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -1299,6 +1299,7 @@ class AnthropicHandlerMixin:
                         )
                 except Exception:  # advisory hint only — must never fail a request
                     pass
+            ccr_workspace_key = ccr_workspace_label = None
             if (
                 self.config.ccr_inject_tool or self.config.ccr_inject_system_instructions
             ) and not _bypass:


### PR DESCRIPTION
## Summary

`headroom proxy --no-ccr-inject-tool` (or any config where both `ccr_inject_tool` and `ccr_inject_system_instructions` are off) returns **HTTP 500 on every request**:

```
UnboundLocalError: cannot access local variable 'ccr_workspace_key' where it is not associated with a value
```

### Root cause
In `headroom/proxy/handlers/anthropic.py`, `ccr_workspace_key` / `ccr_workspace_label` are assigned **inside** the CCR-injection block (~L1360):
```python
if (self.config.ccr_inject_tool or self.config.ccr_inject_system_instructions) and not _bypass:
    ...
    ccr_workspace_key, ccr_workspace_label = self._resolve_ccr_workspace(request, body)
```
…but read **outside** it, in the proactive-expansion guard (~L1394, `ccr_proactive_expansion` is on by default):
```python
if (self.ccr_context_tracker and self.config.ccr_proactive_expansion and ccr_workspace_key):
```
When the injection block is skipped, the name is never bound → `UnboundLocalError` → 500. `--no-ccr-inject-tool` is suggested in `--help`, so it is a documented path users hit.

### Fix
Bind both names to `None` before the block so they are always defined (one line, no behavior change on the existing path).

## Description

One-line fix for the crash reported in #1145.

Closes #1145

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/handlers/anthropic.py`: initialize `ccr_workspace_key = ccr_workspace_label = None` immediately before the CCR-injection `if` block, so the later proactive-expansion guard never reads an unbound local.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
Repro (pre-fix) — headroom-ai 0.26.0, Docker python:3.12-slim, mock upstream on 127.0.0.1:9999:
  $ headroom proxy --port 8787 --no-ccr-inject-tool --anthropic-api-url http://127.0.0.1:9999
  $ curl -s -o /dev/null -w '%{http_code}\n' -X POST localhost:8787/v1/messages -d '{"model":"claude-3","messages":[{"role":"user","content":"hi"}]}'
  500
  # server log: UnboundLocalError: cannot access local variable 'ccr_workspace_key' ...
With this patch the variable is always bound, so the guard evaluates normally instead of raising.
```

## Real Behavior Proof

- Environment: headroom-ai 0.26.0, Docker `python:3.12-slim`, `pip install 'headroom-ai[proxy]'`, mock Anthropic upstream on 127.0.0.1:9999.
- Exact command / steps: `headroom proxy --port 8787 --no-ccr-inject-tool --anthropic-api-url http://127.0.0.1:9999`, then any `POST /v1/messages`.
- Observed result: pre-fix → HTTP 500 `UnboundLocalError: ccr_workspace_key` on every request (full write-up in #1145).
- Not tested: I did not run the repo CI (`pytest`/`ruff`/`mypy`) for this single-line, web-editor change.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes