### PR TITLE
fix: tolerate legacy bytes in learn pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* **learn:** tolerate stray legacy bytes in agent transcripts, prior marker blocks, and CLI backend pipes so Windows locale codecs do not abort `headroom learn` ([#1202](https://github.com/chopratejas/headroom/issues/1202)).
 * **proxy:** enable SSO credential resolution in the native Bedrock route via the `aws-config` `sso` feature flag, making the credential chain match what `docs/bedrock.md` already documented ([#999](https://github.com/chopratejas/headroom/pull/999)).
 * **proxy:** route native Bedrock `/model/{id}/converse` requests to the upstream Converse endpoint instead of the hard-coded `/invoke` action — the non-streaming handler now resolves the action from the inbound path, matching the streaming handler ([#999](https://github.com/chopratejas/headroom/pull/999)).
 * **ccr:** make retrieval store TTL configurable with `HEADROOM_CCR_TTL_SECONDS`, expose the effective TTL in `/v1/retrieve/stats`, and distinguish expired retrievals from missing hashes.

--- a/headroom/cli/learn.py
+++ b/headroom/cli/learn.py
@@ -236,9 +236,15 @@ def learn(
             click.echo(f"Path: {proj.project_path}")
             click.echo(f"{'=' * 60}")
 
-            sessions = plugin.scan_project(
-                proj, max_workers=max_workers, include_subagents=not main_only
-            )
+            try:
+                sessions = plugin.scan_project(
+                    proj, max_workers=max_workers, include_subagents=not main_only
+                )
+            except (OSError, UnicodeError) as e:
+                click.echo(
+                    f"  Warning: failed to scan conversation data for {proj.project_path}: {e}"
+                )
+                continue
             if not sessions:
                 click.echo("  No conversation data found.")
                 continue

--- a/headroom/learn/analyzer.py
+++ b/headroom/learn/analyzer.py
@@ -198,7 +198,7 @@ def _build_prior_patterns_section(project: ProjectInfo) -> str:
     for label, path in candidates:
         if path is None or not path.exists():
             continue
-        block = extract_marker_block(path.read_text())
+        block = extract_marker_block(path.read_text(encoding="utf-8", errors="replace"))
         if block:
             parts.append((label, block))
 
@@ -486,6 +486,8 @@ def _call_cli_llm(digest: str, model: str) -> dict:
             input=prompt,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=hard_cap,
         )
     except FileNotFoundError:
@@ -541,6 +543,8 @@ def _call_claude_cli_streaming(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,  # line-buffered
         )
     except FileNotFoundError:

--- a/headroom/learn/plugins/claude.py
+++ b/headroom/learn/plugins/claude.py
@@ -167,7 +167,7 @@ class ClaudeCodePlugin(LearnPlugin, ConversationScanner):
         msg_index = 0
 
         try:
-            with open(jsonl_path) as f:
+            with open(jsonl_path, encoding="utf-8", errors="replace") as f:
                 for line in f:
                     try:
                         d = json.loads(line)

--- a/headroom/learn/plugins/codex.py
+++ b/headroom/learn/plugins/codex.py
@@ -126,7 +126,7 @@ class CodexPlugin(LearnPlugin, ConversationScanner):
     def _scan_json_session(self, json_path: Path) -> SessionData | None:
         """Parse a single Codex session file."""
         try:
-            with open(json_path) as f:
+            with open(json_path, encoding="utf-8", errors="replace") as f:
                 data = json.load(f)
         except (OSError, json.JSONDecodeError) as e:
             logger.debug("Failed to read Codex session %s: %s", json_path, e)
@@ -209,7 +209,7 @@ class CodexPlugin(LearnPlugin, ConversationScanner):
         msg_index = 0
 
         try:
-            with open(jsonl_path) as f:
+            with open(jsonl_path, encoding="utf-8", errors="replace") as f:
                 for line in f:
                     try:
                         entry = json.loads(line)

--- a/headroom/learn/plugins/gemini.py
+++ b/headroom/learn/plugins/gemini.py
@@ -143,7 +143,7 @@ class GeminiPlugin(LearnPlugin, ConversationScanner):
     def _scan_json_session(self, json_path: Path) -> SessionData | None:
         """Parse a Gemini JSON session file."""
         try:
-            with open(json_path) as f:
+            with open(json_path, encoding="utf-8", errors="replace") as f:
                 data = json.load(f)
         except (OSError, json.JSONDecodeError) as e:
             logger.debug("Failed to read Gemini session %s: %s", json_path, e)
@@ -167,7 +167,7 @@ class GeminiPlugin(LearnPlugin, ConversationScanner):
         messages: list[dict] = []
 
         try:
-            with open(jsonl_path) as f:
+            with open(jsonl_path, encoding="utf-8", errors="replace") as f:
                 for line in f:
                     try:
                         entry = json.loads(line)
@@ -314,7 +314,7 @@ class GeminiPlugin(LearnPlugin, ConversationScanner):
     def _detect_project_path(self, session_path: Path) -> Path | None:
         """Try to detect the project path from a session file."""
         try:
-            with open(session_path) as f:
+            with open(session_path, encoding="utf-8", errors="replace") as f:
                 data = json.load(f)
         except (OSError, json.JSONDecodeError):
             return None

--- a/headroom/learn/writer.py
+++ b/headroom/learn/writer.py
@@ -139,6 +139,11 @@ def _parse_prior_recommendations(existing: str) -> list[Recommendation]:
     return recs
 
 
+def _read_text_tolerant(file_path: Path) -> str:
+    """Read UTF-8 text while tolerating stray legacy bytes in user files."""
+    return file_path.read_text(encoding="utf-8", errors="replace")
+
+
 def _merge_recommendations(
     file_path: Path,
     new_recommendations: list[Recommendation],
@@ -153,7 +158,7 @@ def _merge_recommendations(
     """
     if not file_path.exists():
         return new_recommendations
-    prior = _parse_prior_recommendations(file_path.read_text(encoding="utf-8"))
+    prior = _parse_prior_recommendations(_read_text_tolerant(file_path))
     if not prior:
         return new_recommendations
     new_sections = {r.section for r in new_recommendations}
@@ -166,7 +171,7 @@ def _merge_into_file(file_path: Path, new_recommendations: list[Recommendation])
     merged = _merge_recommendations(file_path, new_recommendations)
     section = _build_section(merged)
     if file_path.exists():
-        existing = file_path.read_text(encoding="utf-8")
+        existing = _read_text_tolerant(file_path)
         if _MARKER_START in existing:
             return _MARKER_PATTERN.sub(lambda _match: section, existing)
         return existing.rstrip() + "\n\n" + section + "\n"

--- a/tests/test_cli_learn.py
+++ b/tests/test_cli_learn.py
@@ -43,6 +43,7 @@ class FakePlugin:
         self.writer = FakeWriter()
         self.scan_calls: list[tuple[object, int]] = []
         self.last_include_subagents: bool | None = None
+        self.fail_scan_for: object | None = None
 
     def detect(self) -> bool:
         return True
@@ -56,6 +57,8 @@ class FakePlugin:
     def scan_project(self, project, max_workers: int = 1, include_subagents: bool = True):  # noqa: ANN001, ANN201
         self.scan_calls.append((project, max_workers))
         self.last_include_subagents = include_subagents
+        if project is self.fail_scan_for:
+            raise UnicodeDecodeError("utf-8", b"\x9d", 0, 1, "invalid start byte")
         return [SimpleNamespace(events=["event"], tool_calls=[], failure_count=0)]
 
 
@@ -251,6 +254,27 @@ def test_learn_analyze_all_continues_when_one_project_write_fails(
     assert str(ok.project_path / "AGENTS.md") in result.output
     expected_workers = min(os.cpu_count() or 4, 8)
     assert plugin.scan_calls == [(blocked, expected_workers), (ok, expected_workers)]
+
+
+def test_learn_analyze_all_continues_when_one_project_scan_fails(
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
+) -> None:
+    unreadable = SimpleNamespace(name="unreadable", project_path=tmp_path / "unreadable")
+    ok = SimpleNamespace(name="ok", project_path=tmp_path / "ok")
+    plugin = FakePlugin("codex", "Codex", [unreadable, ok])
+    plugin.fail_scan_for = unreadable
+    analyzer = FakeAnalyzer()
+
+    monkeypatch.setattr("headroom.learn.analyzer._detect_default_model", lambda: "gpt-4o")
+    monkeypatch.setattr("headroom.learn.registry.get_plugin", lambda name: plugin)
+    monkeypatch.setattr("headroom.learn.analyzer.SessionAnalyzer", lambda model=None: analyzer)
+
+    result = runner.invoke(main, ["learn", "--agent", "codex", "--all"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert "Warning: failed to scan conversation data" in result.output
+    assert "[codex] ok" in result.output
+    assert "Recommendations: 1" in result.output
 
 
 def test_learn_handles_empty_sessions_and_no_pattern_outputs(

--- a/tests/test_learn/test_analyzer.py
+++ b/tests/test_learn/test_analyzer.py
@@ -241,6 +241,33 @@ class TestPriorPatternsInjection:
         digest = _build_digest(project, [])
         assert "Prior Learned Patterns" not in digest
 
+    def test_digest_tolerates_stray_legacy_bytes_in_prior_file(self, tmp_path):
+        proj_dir = tmp_path / "proj"
+        proj_dir.mkdir()
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        context_file = proj_dir / "CLAUDE.md"
+        context_file.write_bytes(
+            b"# Project\n\n"
+            b"<!-- headroom:learn:start -->\n"
+            b"## Headroom Learned Patterns\n"
+            b"### Windows Paths\n"
+            b"- Path contains one stray byte: \x9d\n"
+            b"<!-- headroom:learn:end -->\n"
+        )
+        project = ProjectInfo(
+            name="proj",
+            project_path=proj_dir,
+            data_path=data_dir,
+            context_file=context_file,
+            memory_file=None,
+        )
+
+        digest = _build_digest(project, [])
+
+        assert "Prior Learned Patterns" in digest
+        assert "stray byte: \ufffd" in digest
+
     def test_digest_surfaces_both_files_when_both_present(self, tmp_path):
         project = _project_with_files(
             tmp_path,
@@ -658,6 +685,8 @@ class TestCallCliLlm:
         assert result == {"context_file_rules": [], "memory_file_rules": []}
         cmd = popen.call_args[0][0]
         assert cmd == ["claude", "-p", "--output-format", "stream-json", "--verbose"]
+        assert popen.call_args.kwargs["encoding"] == "utf-8"
+        assert popen.call_args.kwargs["errors"] == "replace"
 
     def test_claude_cli_parses_fenced_result(self):
         stdout = [
@@ -756,6 +785,8 @@ class TestCallCliLlm:
         assert result == {"context_file_rules": [], "memory_file_rules": []}
         cmd = mock_run.call_args[0][0]
         assert cmd == ["codex", "exec"]
+        assert mock_run.call_args.kwargs["encoding"] == "utf-8"
+        assert mock_run.call_args.kwargs["errors"] == "replace"
 
     @patch("headroom.learn.analyzer.subprocess.run")
     def test_gemini_cli_uses_p_flag(self, mock_run: MagicMock):

--- a/tests/test_learn/test_encoding_tolerance.py
+++ b/tests/test_learn/test_encoding_tolerance.py
@@ -1,0 +1,80 @@
+"""Encoding tolerance tests for headroom learn transcript inputs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from headroom.learn.plugins.claude import ClaudeCodePlugin
+from headroom.learn.plugins.codex import CodexPlugin
+from headroom.learn.plugins.gemini import GeminiPlugin
+
+
+def test_codex_jsonl_scanner_tolerates_invalid_transcript_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "session.jsonl"
+    function_call = {
+        "type": "response_item",
+        "payload": {
+            "type": "function_call",
+            "call_id": "call-1",
+            "name": "exec_command",
+            "arguments": json.dumps({"cmd": "pytest"}),
+        },
+    }
+    output_line = (
+        b'{"type":"response_item","payload":{"type":"function_call_output",'
+        b'"call_id":"call-1","output":"Error before invalid byte: \x9d"}}'
+    )
+    path.write_bytes(json.dumps(function_call).encode("utf-8") + b"\n" + output_line + b"\n")
+
+    session = CodexPlugin(codex_dir=tmp_path)._scan_jsonl_session(path)
+
+    assert session is not None
+    assert len(session.tool_calls) == 1
+    assert "invalid byte: \ufffd" in session.tool_calls[0].output
+
+
+def test_claude_jsonl_scanner_tolerates_invalid_transcript_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "session.jsonl"
+    assistant = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "Bash",
+                    "input": {"command": "pytest"},
+                }
+            ]
+        },
+    }
+    user_result = (
+        b'{"type":"user","message":{"content":[{"type":"tool_result",'
+        b'"tool_use_id":"toolu_1","content":"Output with invalid byte: \x9d"}]}}'
+    )
+    path.write_bytes(json.dumps(assistant).encode("utf-8") + b"\n" + user_result + b"\n")
+
+    session = ClaudeCodePlugin(claude_dir=tmp_path)._scan_session(path)
+
+    assert session is not None
+    assert len(session.tool_calls) == 1
+    assert "invalid byte: \ufffd" in session.tool_calls[0].output
+
+
+def test_gemini_json_scanner_tolerates_invalid_transcript_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "session-test.json"
+    path.write_bytes(
+        b'{"id":"session-test","messages":['
+        b'{"role":"model","parts":[{"functionCall":{"name":"read_file",'
+        b'"args":{"path":"README.md"}}}]},'
+        b'{"role":"user","parts":[{"functionResponse":{"name":"read_file",'
+        b'"response":{"output":"Output with invalid byte: \x9d"}}}]}'
+        b"]}"
+    )
+
+    session = GeminiPlugin(gemini_dir=tmp_path)._scan_json_session(path)
+
+    assert session is not None
+    assert len(session.tool_calls) == 1
+    assert "invalid byte: \ufffd" in session.tool_calls[0].output

--- a/tests/test_learn/test_writer.py
+++ b/tests/test_learn/test_writer.py
@@ -174,6 +174,28 @@ class TestClaudeCodeWriter:
         assert r"C:\Users\john.doe\repo" in full_content
         assert "stale" not in full_content
 
+    def test_merge_tolerates_stray_legacy_bytes_in_existing_context(self, tmp_path):
+        proj = _project(tmp_path)
+        claude_md = proj.project_path / "CLAUDE.md"
+        claude_md.write_bytes(
+            b"# Existing\n\n"
+            b"Some legacy byte: \x9d\n\n"
+            b"<!-- headroom:learn:start -->\n"
+            b"## Headroom Learned Patterns\n"
+            b"### Existing Section\n"
+            b"- keep this\n"
+            b"<!-- headroom:learn:end -->\n"
+        )
+
+        full_content = _merge_into_file(
+            claude_md,
+            [_rec(RecommendationTarget.CONTEXT_FILE, "Windows Paths", "- Use UTF-8")],
+        )
+
+        assert "Some legacy byte: \ufffd" in full_content
+        assert "Existing Section" in full_content
+        assert "Windows Paths" in full_content
+
     def test_memory_md_carry_forward(self, tmp_path):
         """Carry-forward also works for MEMORY.md."""
         proj = _project(tmp_path)


### PR DESCRIPTION
## Description

Fixes `headroom learn` crashes caused by legacy or otherwise undecodable bytes in agent transcript/context files on Windows and other mixed-encoding environments.

Closes #1202

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Read Claude, Codex, and Gemini `headroom learn` transcript files with explicit UTF-8 replacement instead of the platform locale default.
- Tolerate stray legacy bytes when reading prior Headroom marker blocks and existing context files before merge.
- Pass prompts/results through UTF-8 text pipes for CLI LLM backends.
- Skip a single unreadable project with a warning instead of aborting the whole run.
- Add focused regressions for invalid transcript bytes, prior-marker reads, writer merges, CLI pipe encoding, and scan-level recovery.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
python -m pytest tests/test_learn/test_encoding_tolerance.py tests/test_learn/test_analyzer.py::TestPriorPatternsInjection::test_digest_tolerates_stray_legacy_bytes_in_prior_file tests/test_learn/test_analyzer.py::TestCallCliLlm::test_claude_cli_streams_and_parses_result_event tests/test_learn/test_analyzer.py::TestCallCliLlm::test_codex_cli_uses_exec tests/test_learn/test_writer.py::TestClaudeCodeWriter::test_merge_tolerates_stray_legacy_bytes_in_existing_context tests/test_cli_learn.py::test_learn_analyze_all_continues_when_one_project_scan_fails -q --basetemp .pytest-tmp
8 passed

python -m py_compile headroom/learn/plugins/claude.py headroom/learn/plugins/codex.py headroom/learn/plugins/gemini.py headroom/learn/analyzer.py headroom/learn/writer.py headroom/cli/learn.py tests/test_learn/test_encoding_tolerance.py tests/test_learn/test_analyzer.py tests/test_learn/test_writer.py tests/test_cli_learn.py
passed

python -m ruff check headroom/learn/plugins/claude.py headroom/learn/plugins/codex.py headroom/learn/plugins/gemini.py headroom/learn/analyzer.py headroom/learn/writer.py headroom/cli/learn.py tests/test_learn/test_encoding_tolerance.py tests/test_learn/test_analyzer.py tests/test_learn/test_writer.py tests/test_cli_learn.py
All checks passed!

python -m ruff format --check headroom/learn/plugins/claude.py headroom/learn/plugins/codex.py headroom/learn/plugins/gemini.py headroom/learn/analyzer.py headroom/learn/writer.py headroom/cli/learn.py tests/test_learn/test_encoding_tolerance.py tests/test_learn/test_analyzer.py tests/test_learn/test_writer.py tests/test_cli_learn.py
10 files already formatted

git diff --check
exited 0; Git printed an existing Windows CRLF warning for CHANGELOG.md
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.10, local checkout of `chopratejas/headroom`.
- Exact command / steps: ran the focused pytest, py_compile, Ruff check, Ruff format check, and `git diff --check` commands listed above.
- Observed result: focused regression set passed (`8 passed`), py_compile passed, Ruff passed, and whitespace diff check exited 0.
- Not tested: full `uv run pytest`; a broader learn-focused suite reached `190 passed, 1 skipped, 3 failed`, where the three failures were existing Windows/local-data assumptions outside this patch. Live Claude/Gemini/Codex CLI calls were not run; the changed subprocess options are covered by existing CLI backend mocks.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Documentation and changelog updates are not included because this is a narrow bug fix for existing `headroom learn` behavior.