### PR TITLE
fix(wrap): complete native Claude Bedrock routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Saved** card then reads `measured` rather than `estimated`, with the band.
 
 | Agent | `headroom wrap` | Notes |
 |---|:---:|---|
-| Claude Code | ✅ | `--memory` · `--code-graph` · `--1m` · `--tool-search` |
+| Claude Code | ✅ | `--memory` · `--code-graph` · `--1m` · `--tool-search` · Vertex / Bedrock auto-detected |
 | Codex | ✅ | shares memory with Claude |
 | Grok CLI | ✅ | routes via `GROK_MODELS_BASE_URL` |
 | Cursor | Manual setup | starts the proxy and prints base URLs for Cursor settings |

--- a/docs/content/docs/claude-code-bedrock.mdx
+++ b/docs/content/docs/claude-code-bedrock.mdx
@@ -1,0 +1,131 @@
+---
+title: Claude Code on Amazon Bedrock
+description: Run Claude Code against Claude models on AWS Bedrock, with Headroom compressing your prompts — fewer input tokens, same answers, your own AWS credentials.
+---
+
+If your Claude models live on **AWS Bedrock**, you can still get Headroom's
+prompt compression. Headroom sits between Claude Code and Bedrock: it shrinks the
+big stuff in each request (file reads, logs, tool output), **re-signs the
+compressed request with SigV4**, and forwards it to the regional Bedrock endpoint
+using **your own AWS credentials**. You keep your AWS setup; Headroom just makes
+each call cheaper.
+
+## Why re-signing matters
+
+Claude Code in Bedrock mode signs every request with AWS SigV4, and the
+signature covers a hash of the request body. Headroom rewrites that body to
+compress it — which invalidates the original signature. So Headroom **re-signs
+the compressed body** before forwarding to AWS. Without that, AWS would reject
+the request with `InvalidSignatureException`. This is automatic; you don't
+configure it.
+
+## What you get
+
+- **Fewer input tokens** on every Claude Code request to Bedrock (often 30–60% on
+  agent workloads), so you pay Bedrock for less.
+- **Same answers** — compression is reversible and content-aware.
+- **No new secrets** — Headroom never holds long-lived AWS keys. It re-signs with
+  the standard AWS credential chain (the same env vars, profile, SSO cache, or
+  instance/task role Claude Code already uses).
+
+## Before you start
+
+You should already have Claude Code working against Bedrock **without** Headroom.
+That means these are set in your shell:
+
+```bash
+export CLAUDE_CODE_USE_BEDROCK=1
+export AWS_REGION=us-west-2            # your Bedrock region
+# plus working AWS credentials: AWS_PROFILE, env keys, SSO, or an instance role
+```
+
+Confirm `aws bedrock-runtime invoke-model ...` (or a normal Claude Code session)
+works first.
+
+## Run it (one command)
+
+```bash
+pip install "headroom-ai[proxy,bedrock]"
+headroom wrap claude
+```
+
+The `bedrock` extra pulls in `boto3` for SigV4 re-signing; `proxy` provides the
+local proxy `headroom wrap claude` starts. (`headroom-ai[all]` includes both.)
+
+That's it. Because `CLAUDE_CODE_USE_BEDROCK=1` is set, `headroom wrap claude`
+automatically:
+
+1. starts the Headroom proxy in **SigV4 re-signing mode** (`--bedrock-sign`),
+2. points Claude Code's Bedrock endpoint at it (`ANTHROPIC_BEDROCK_BASE_URL`),
+3. leaves your region and AWS credentials untouched.
+
+You'll see a line like:
+
+```
+Bedrock mode: ANTHROPIC_BEDROCK_BASE_URL=http://127.0.0.1:8787
+  → compress, re-sign (SigV4), then forward to AWS [us-west-2]
+```
+
+Use Claude Code exactly as you normally would, including cross-region inference
+profiles (`us.anthropic.…`, `eu.anthropic.…`, `global.anthropic.…`) and 1M-context
+models — the model id travels in the request path and is preserved end to end.
+
+## How it works
+
+```
+Claude Code ──(Bedrock InvokeModel)──▶ Headroom ──(compressed + re-signed)──▶ AWS Bedrock
+   in Bedrock mode                     compresses,                            your region
+   (SigV4 by Claude Code)              re-signs with your AWS creds ─────────▶ verifies SigV4
+```
+
+Claude Code sends its normal Bedrock `/model/{modelId}/invoke` (and
+`/invoke-with-response-stream`) request to Headroom. Headroom compresses the
+messages (keeping the Bedrock request shape intact), re-signs the **post-compression**
+bytes with SigV4 using your AWS credentials, then forwards to the regional Bedrock
+host derived from `AWS_REGION`.
+
+## Check that compression is working
+
+1. Open the dashboard: [http://localhost:8787/dashboard](http://localhost:8787/dashboard).
+   "Tokens saved" should climb as you use Claude Code.
+2. Or look at the response headers on a request: `x-headroom-tokens-before`,
+   `x-headroom-tokens-after`, `x-headroom-tokens-saved`.
+
+## Troubleshooting
+
+- **It still goes straight to AWS (no savings).** Make sure `CLAUDE_CODE_USE_BEDROCK=1`
+  is exported *in the same shell* before `headroom wrap claude`. The wrapper only
+  switches to Bedrock mode when it sees that variable.
+- **`InvalidSignatureException` / 403.** Headroom re-signs with the default AWS
+  credential chain. If `aws sts get-caller-identity` works in the same shell,
+  signing works. If you use a non-default profile, set `AWS_PROFILE` before
+  wrapping.
+- **`UnrecognizedClientException` / no credentials.** The proxy logs a clear
+  `BedrockSigningError` and returns 500 — there is no silent fallback to an
+  unsigned request. Configure credentials (env vars, `~/.aws/credentials`, SSO,
+  or an instance/task role) and retry.
+- **Wrong region / 404 from Bedrock.** Confirm `AWS_REGION` matches a region
+  where your Claude model (or inference profile) is enabled.
+
+## Alternative: route through a re-signing gateway
+
+If you'd rather not have Headroom hold AWS credentials at all, point it at a
+gateway that re-signs (LiteLLM, LocalStack, a corporate Bedrock proxy) instead:
+
+```bash
+export BEDROCK_TARGET_API_URL=https://your-bedrock-gateway
+headroom wrap claude
+```
+
+When `BEDROCK_TARGET_API_URL` (or `--bedrock-api-url`) is set, Headroom forwards
+the compressed body there **verbatim** and the gateway owns signing. The native
+re-signing flow above is recommended — it keeps your existing AWS auth and has
+the smallest moving parts.
+
+## Notes
+
+- Streaming, tool use, and prompt caching all work through Headroom.
+- Bedrock guardrail headers (`X-Amzn-Bedrock-*`) and anthropic beta headers
+  (e.g. the 1M-context header) are preserved and included in the signature.
+- For the operator-level Bedrock surface (the native Rust proxy, metrics, IAM
+  policy), see the [AWS Bedrock operator guide](/docs/bedrock).

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -36,6 +36,7 @@
     "autogen",
     "litellm",
     "claude-code-vertex",
+    "claude-code-bedrock",
     "claude-code-azure-foundry",
     "vscode-claude-code",
     "vscode-copilot",

--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -974,6 +974,17 @@ def dashboard(port: int, no_open: bool) -> None:
     ),
 )
 @click.option(
+    "--bedrock-sign/--no-bedrock-sign",
+    default=False,
+    envvar="HEADROOM_BEDROCK_SIGN",
+    help=(
+        "Re-sign the compressed Bedrock body with SigV4 and forward direct to "
+        "the regional AWS endpoint (no gateway needed). Powers `headroom wrap "
+        "claude` under CLAUDE_CODE_USE_BEDROCK=1. Uses --region and "
+        "--bedrock-profile / AWS_PROFILE. (env: HEADROOM_BEDROCK_SIGN)"
+    ),
+)
+@click.option(
     "--telemetry",
     is_flag=True,
     help="Opt in to anonymous usage telemetry — off by default (env: HEADROOM_TELEMETRY=on)",
@@ -1107,6 +1118,7 @@ def proxy(
     bedrock_region: str | None,
     bedrock_profile: str | None,
     bedrock_api_url: str | None,
+    bedrock_sign: bool,
     telemetry: bool,
     no_telemetry: bool,
     stateless: bool,
@@ -1459,6 +1471,9 @@ def proxy(
         # CLI flag > env > unset. Matches the BEDROCK_TARGET_API_URL naming of
         # the sibling *_TARGET_API_URL passthrough overrides.
         bedrock_api_url=bedrock_api_url or os.environ.get("BEDROCK_TARGET_API_URL"),
+        # Direct-to-AWS SigV4 re-signing (no gateway). click resolves the
+        # HEADROOM_BEDROCK_SIGN envvar into this flag.
+        bedrock_sign=bedrock_sign,
         anyllm_provider=effective_anyllm_provider,
         # License / Usage Reporting (managed/enterprise)
         license_key=license_key,

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -642,6 +642,7 @@ def _start_proxy(
     copilot_api_token: str | None = None,
     copilot_refresh_oauth_token: str | None = None,
     copilot_api_token_expires_at: float | None = None,
+    bedrock_sign: bool = False,
 ) -> subprocess.Popen:
     """Start Headroom proxy as a background subprocess.
 
@@ -684,6 +685,10 @@ def _start_proxy(
     _region = region or os.environ.get("HEADROOM_REGION")
     if _region:
         cmd.extend(["--region", _region])
+
+    # Direct-to-AWS Bedrock SigV4 re-signing (CLAUDE_CODE_USE_BEDROCK turnkey).
+    if bedrock_sign:
+        cmd.append("--bedrock-sign")
 
     if openai_api_url:
         cmd.extend(["--openai-api-url", openai_api_url])
@@ -1175,9 +1180,13 @@ def _vertex_target_api_url_from_claude_env(proxy_url: str) -> str | None:
     return vertex_url
 
 
-def _claude_wrap_base_url_env_key(*, foundry_mode: bool = False, vertex_mode: bool = False) -> str:
+def _claude_wrap_base_url_env_key(
+    *, foundry_mode: bool = False, vertex_mode: bool = False, bedrock_mode: bool = False
+) -> str:
     if vertex_mode:
         return "ANTHROPIC_VERTEX_BASE_URL"
+    if bedrock_mode:
+        return "ANTHROPIC_BEDROCK_BASE_URL"
     if foundry_mode:
         return "ANTHROPIC_FOUNDRY_BASE_URL"
     return "ANTHROPIC_BASE_URL"
@@ -1645,6 +1654,7 @@ def _selfheal_dead_wrap_base_url() -> None:
             _claude_wrap_base_url_env_key(),
             _claude_wrap_base_url_env_key(foundry_mode=True),
             _claude_wrap_base_url_env_key(vertex_mode=True),
+            _claude_wrap_base_url_env_key(bedrock_mode=True),
         ):
             _check_and_clear_dead_wrap_marker(settings_path, key=key)
     except Exception:  # noqa: BLE001 - hook must never break session startup
@@ -1768,6 +1778,7 @@ def _write_claude_wrap_base_url(
     *,
     foundry_mode: bool = False,
     vertex_mode: bool = False,
+    bedrock_mode: bool = False,
     settings_path: Path | None = None,
     port: int | None = None,
 ) -> str | None:
@@ -1787,7 +1798,9 @@ def _write_claude_wrap_base_url(
     detected and self-healed (issue #1768).
     """
     path = settings_path or (Path.cwd() / ".claude" / "settings.local.json")
-    key = _claude_wrap_base_url_env_key(foundry_mode=foundry_mode, vertex_mode=vertex_mode)
+    key = _claude_wrap_base_url_env_key(
+        foundry_mode=foundry_mode, vertex_mode=vertex_mode, bedrock_mode=bedrock_mode
+    )
     path.parent.mkdir(parents=True, exist_ok=True)
     with _wrap_settings_lock(path):
         payload = _read_settings_for_write(path)
@@ -1842,6 +1855,7 @@ def _restore_claude_wrap_base_url(
     *,
     foundry_mode: bool = False,
     vertex_mode: bool = False,
+    bedrock_mode: bool = False,
     settings_path: Path | None = None,
     _key_override: str | None = None,
     force: bool = False,
@@ -1863,7 +1877,7 @@ def _restore_claude_wrap_base_url(
     """
     path = settings_path or (Path.cwd() / ".claude" / "settings.local.json")
     key = _key_override or _claude_wrap_base_url_env_key(
-        foundry_mode=foundry_mode, vertex_mode=vertex_mode
+        foundry_mode=foundry_mode, vertex_mode=vertex_mode, bedrock_mode=bedrock_mode
     )
     with _wrap_settings_lock(path):
         # Another live wrap session in this project may still be using the key.
@@ -4056,6 +4070,7 @@ def _ensure_proxy_unlocked(
     copilot_api_token: str | None = None,
     copilot_refresh_oauth_token: str | None = None,
     copilot_api_token_expires_at: float | None = None,
+    bedrock_sign: bool = False,
 ) -> tuple[subprocess.Popen | None, int]:
     """Start or verify proxy. Returns (process_handle, actual_port).
 
@@ -4399,6 +4414,7 @@ def _ensure_proxy_unlocked(
                     copilot_api_token=copilot_api_token,
                     copilot_refresh_oauth_token=copilot_refresh_oauth_token,
                     copilot_api_token_expires_at=copilot_api_token_expires_at,
+                    bedrock_sign=bedrock_sign,
                 ),
             )
             click.echo(f"  Proxy ready on http://127.0.0.1:{actual_port}")
@@ -5171,6 +5187,7 @@ def claude(
     _settings_foundry: list[bool] = [False]
     port_holder: list[int] = [port]
     _settings_vertex: list[bool] = [False]
+    _settings_bedrock: list[bool] = [False]
     # Bind before the try so the finally can always reference it. It is otherwise
     # only assigned inside the try (after _ensure_proxy, which can raise), so an
     # early proxy-start failure would make the finally raise UnboundLocalError,
@@ -5262,6 +5279,25 @@ def claude(
         proxy_url = _claude_proxy_base_url(port)
         vertex_upstream = _vertex_target_api_url_from_claude_env(proxy_url) if use_vertex else None
 
+        # Detect Bedrock mode: with CLAUDE_CODE_USE_BEDROCK=1, Claude Code IGNORES
+        # ANTHROPIC_BASE_URL and talks to the AWS Bedrock runtime, SigV4-signing
+        # each InvokeModel request. The documented endpoint override is
+        # ANTHROPIC_BEDROCK_BASE_URL. Point it at Headroom and the proxy
+        # compresses the body — but compression invalidates the SigV4 signature,
+        # so the proxy must re-sign before forwarding to AWS. We therefore start
+        # it with --bedrock-sign (boto3 default credential chain — the same creds
+        # Claude Code already uses) and forward to the regional endpoint derived
+        # from the region. Turnkey Bedrock compression; no re-signing gateway.
+        use_bedrock = bool(os.environ.get("CLAUDE_CODE_USE_BEDROCK"))
+        # Region precedence mirrors Claude Code's Bedrock resolution: explicit
+        # --region wins, then AWS_REGION / AWS_DEFAULT_REGION, else the proxy
+        # default — so the signer targets the same endpoint Claude Code would.
+        bedrock_region = (
+            (region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION"))
+            if use_bedrock
+            else region
+        )
+
         _register_proxy_client(port)
         proxy_holder[0], actual_port = _ensure_proxy(
             port,
@@ -5271,8 +5307,9 @@ def claude(
             agent_type="claude",
             code_graph=code_graph,
             backend=backend,
-            region=region,
+            region=bedrock_region,
             anthropic_api_url=foundry_upstream,
+            bedrock_sign=use_bedrock,
             vertex_api_url=vertex_upstream,
             clear_vertex_api_url=use_vertex and vertex_upstream is None,
         )
@@ -5308,6 +5345,12 @@ def claude(
             click.echo(
                 f"  Vertex mode: ANTHROPIC_VERTEX_BASE_URL={proxy_url} "
                 "→ compress, then forward to Vertex with your GCP ADC token"
+            )
+        elif use_bedrock:
+            _region_label = bedrock_region or "us-west-2"
+            click.echo(
+                f"  Bedrock mode: ANTHROPIC_BEDROCK_BASE_URL={proxy_url} "
+                f"→ compress, re-sign (SigV4), then forward to AWS [{_region_label}]"
             )
         elif foundry_upstream:
             click.echo(
@@ -5359,6 +5402,12 @@ def claude(
             # ANTHROPIC_VERTEX_PROJECT_ID, CLOUD_ML_REGION, ADC — all inherited);
             # we only redirect its Vertex endpoint to Headroom.
             env["ANTHROPIC_VERTEX_BASE_URL"] = proxy_url
+        elif use_bedrock:
+            # Claude Code stays in Bedrock mode (keeps CLAUDE_CODE_USE_BEDROCK,
+            # AWS_REGION, AWS_PROFILE / SSO creds — all inherited); we only
+            # redirect its Bedrock endpoint to Headroom, which re-signs before
+            # forwarding to AWS.
+            env["ANTHROPIC_BEDROCK_BASE_URL"] = proxy_url
         elif foundry_upstream:
             # ANTHROPIC_FOUNDRY_BASE_URL is the base URL the Anthropic SDK
             # appends /v1/messages to.  The real Foundry URL includes /anthropic,
@@ -5371,13 +5420,18 @@ def claude(
         # workers (which read settings.json fresh rather than inheriting the
         # daemon's environment) also route through Headroom.
         _settings_vertex[0] = bool(use_vertex)
-        _settings_foundry[0] = bool(foundry_upstream) and not _settings_vertex[0]
+        _settings_bedrock[0] = bool(use_bedrock) and not _settings_vertex[0]
+        _settings_foundry[0] = (
+            bool(foundry_upstream) and not _settings_vertex[0] and not _settings_bedrock[0]
+        )
         # _wrap_settings_path is bound before the try (above) so the finally is
         # always safe; the value is unchanged here.
         _check_and_clear_stale_wrap_marker(
             _wrap_settings_path,
             key=_claude_wrap_base_url_env_key(
-                foundry_mode=_settings_foundry[0], vertex_mode=_settings_vertex[0]
+                foundry_mode=_settings_foundry[0],
+                vertex_mode=_settings_vertex[0],
+                bedrock_mode=_settings_bedrock[0],
             ),
         )
         _saved_base_url[0] = _write_claude_wrap_base_url(
@@ -5390,6 +5444,7 @@ def claude(
             ),
             foundry_mode=_settings_foundry[0],
             vertex_mode=_settings_vertex[0],
+            bedrock_mode=_settings_bedrock[0],
             settings_path=_wrap_settings_path,
             port=port,
         )
@@ -5464,6 +5519,7 @@ def claude(
             _saved_base_url[0],
             foundry_mode=_settings_foundry[0],
             vertex_mode=_settings_vertex[0],
+            bedrock_mode=_settings_bedrock[0],
             settings_path=_wrap_settings_path,
         )
         cleanup()
@@ -5562,8 +5618,15 @@ def unwrap_claude(
     _unwrap_settings_path = Path.cwd() / ".claude" / "settings.local.json"
     if _remove_claude_wrap_selfheal_hook(_unwrap_settings_path):
         click.echo("  Removed Headroom wrap self-heal SessionStart hook (issue #2221).")
-    for _foundry, _vertex in ((False, False), (True, False), (False, True)):
-        _key = _claude_wrap_base_url_env_key(foundry_mode=_foundry, vertex_mode=_vertex)
+    for _foundry, _vertex, _bedrock in (
+        (False, False, False),
+        (True, False, False),
+        (False, True, False),
+        (False, False, True),
+    ):
+        _key = _claude_wrap_base_url_env_key(
+            foundry_mode=_foundry, vertex_mode=_vertex, bedrock_mode=_bedrock
+        )
         _marker = _read_wrap_marker(_unwrap_settings_path)
         _prior = (
             _marker.get("previous") if _marker is not None and _marker.get("key") == _key else None
@@ -5572,6 +5635,7 @@ def unwrap_claude(
             _prior,
             foundry_mode=_foundry,
             vertex_mode=_vertex,
+            bedrock_mode=_bedrock,
             settings_path=_unwrap_settings_path,
             # unwrap is the user asking for their settings back, so it drops
             # every wrap session's claim rather than deferring to a live

--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -280,14 +280,18 @@ def register_provider_routes(app: FastAPI, proxy: Any) -> None:
         normalize_request_path(request, "/v1/messages")
         return await proxy.handle_anthropic_messages(request, _api_target(proxy, "anthropic"))
 
-    # AWS Bedrock InvokeModel passthrough. Registered ONLY when an upstream is
-    # configured (`--bedrock-api-url` / BEDROCK_TARGET_API_URL): without it,
-    # `/model/{id}/invoke` keeps falling through to the catch-all (verbatim,
-    # signature-intact) so existing behavior is unchanged. The `{model_id:path}`
-    # converter captures inference-profile ids that contain dots, colons and
-    # slashes (e.g. `us.anthropic.claude-sonnet-4-5-20250929-v1:0`). See
-    # headroom/proxy/handlers/bedrock.py for the SigV4 caveat.
-    if getattr(proxy.config, "bedrock_api_url", None):
+    # AWS Bedrock InvokeModel passthrough. Registered when an upstream is
+    # configured — either `--bedrock-api-url` / BEDROCK_TARGET_API_URL (forward
+    # to a re-signing gateway) or `--bedrock-sign` / HEADROOM_BEDROCK_SIGN
+    # (re-sign direct to AWS). Without either, `/model/{id}/invoke` keeps
+    # falling through to the catch-all (verbatim, signature-intact) so existing
+    # behavior is unchanged. The `{model_id:path}` converter captures
+    # inference-profile ids that contain dots, colons and slashes (e.g.
+    # `us.anthropic.claude-sonnet-4-5-20250929-v1:0`). See
+    # headroom/proxy/handlers/bedrock.py for the SigV4 handling.
+    if getattr(proxy.config, "bedrock_api_url", None) or getattr(
+        proxy.config, "bedrock_sign", False
+    ):
 
         @app.post("/model/{model_id:path}/invoke")
         async def bedrock_invoke(request: Request, model_id: str):
@@ -296,6 +300,10 @@ def register_provider_routes(app: FastAPI, proxy: Any) -> None:
         @app.post("/model/{model_id:path}/invoke-with-response-stream")
         async def bedrock_invoke_stream(request: Request, model_id: str):
             return await proxy.handle_bedrock_invoke(request, model_id, stream=True)
+
+        @app.get("/inference-profiles")
+        async def bedrock_inference_profiles(request: Request):
+            return await proxy.handle_bedrock_inference_profiles(request)
 
     _register_openai_responses_routes(app, proxy)
 

--- a/headroom/proxy/bedrock_signer.py
+++ b/headroom/proxy/bedrock_signer.py
@@ -1,0 +1,145 @@
+"""AWS SigV4 re-signing for the Bedrock ``InvokeModel`` passthrough.
+
+Claude Code (and the AWS SDK/CLI) sign every Bedrock runtime request with
+SigV4 — and the signature covers a SHA-256 hash of the request body. Headroom's
+Bedrock handler rewrites that body to compress it, which invalidates the
+caller's signature: forwarding it to raw AWS then fails with a 403
+``InvalidSignatureException``.
+
+This module re-signs the *post-compression* body so the bytes AWS receives are
+the bytes that were signed. It is the Python analogue of the Rust proxy's
+native SigV4 surface (``docs/bedrock.md``), and it lets ``headroom wrap claude``
+support ``CLAUDE_CODE_USE_BEDROCK=1`` direct-to-AWS — no re-signing gateway
+(LiteLLM / LocalStack) required.
+
+Credentials are resolved once, lazily, via the standard ``boto3`` credential
+chain (env vars, shared config/credentials profile, SSO cache, IMDS, ECS/EKS
+role). The chain is the same one ``aws`` and Claude Code already use, so if
+Claude Code can reach Bedrock without Headroom, the signer can too.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+if TYPE_CHECKING:
+    from botocore.credentials import Credentials
+
+logger = logging.getLogger("headroom.proxy")
+
+# Bedrock runtime signs under this service name.
+_SERVICE = "bedrock"
+
+# Headers that must never be copied from the inbound request into the set we
+# re-sign: the host changes (we forward to the regional Bedrock endpoint), the
+# old signature/date are stale, and content-length/encoding describe the
+# pre-compression body. SigV4 recomputes the ones it needs.
+_DROP_FOR_SIGNING = frozenset(
+    {
+        "host",
+        "authorization",
+        "x-amz-date",
+        "x-amz-security-token",
+        "x-amz-content-sha256",
+        "content-length",
+        "content-encoding",
+        "accept-encoding",
+        "connection",
+    }
+)
+
+
+class BedrockSigningError(RuntimeError):
+    """Raised when credentials cannot be resolved or signing fails."""
+
+
+class BedrockSigner:
+    """Re-signs Bedrock InvokeModel requests with SigV4 after compression.
+
+    One instance per proxy process. Credentials are resolved on first use and
+    cached; ``botocore``'s credential objects refresh themselves for the
+    refreshable sources (SSO, assume-role, IMDS), so a long-lived proxy keeps
+    working across credential rotation without re-resolving.
+    """
+
+    def __init__(self, region: str, profile: str | None = None) -> None:
+        self._region = region
+        self._profile = profile
+        self._credentials: Credentials | None = None
+
+    @property
+    def region(self) -> str:
+        return self._region
+
+    def endpoint_base(self) -> str:
+        """Regional Bedrock runtime host, e.g. ``https://bedrock-runtime.us-west-2.amazonaws.com``."""
+        return f"https://bedrock-runtime.{self._region}.amazonaws.com"
+
+    def control_endpoint_base(self) -> str:
+        """Regional Bedrock control-plane host used by inference-profile APIs."""
+        return f"https://bedrock.{self._region}.amazonaws.com"
+
+    def _resolve_credentials(self) -> Credentials:
+        if self._credentials is not None:
+            return self._credentials
+        try:
+            import boto3
+        except ImportError as exc:  # pragma: no cover - boto3 is a hard dep
+            raise BedrockSigningError(
+                "boto3 is required for Bedrock SigV4 signing. "
+                'Install with: pip install "headroom-ai[bedrock]"'
+            ) from exc
+
+        session = boto3.Session(profile_name=self._profile, region_name=self._region)
+        creds = session.get_credentials()
+        if creds is None:
+            raise BedrockSigningError(
+                "No AWS credentials found for Bedrock signing. Configure the "
+                "default credential chain (env vars, ~/.aws/credentials, SSO, "
+                "or an instance/task role)."
+            )
+        self._credentials = creds
+        return creds
+
+    def sign(
+        self,
+        *,
+        url: str,
+        body: bytes,
+        inbound_headers: dict[str, str],
+        method: str = "POST",
+    ) -> dict[str, str]:
+        """Return outbound headers carrying a fresh SigV4 signature for ``body``.
+
+        Args:
+            url: The absolute regional Bedrock URL the request will be sent to.
+            body: The exact bytes that will be written on the wire (post
+                compression). The signature hashes these bytes, so the caller
+                MUST forward this same ``body`` unchanged.
+            inbound_headers: The original request headers; non-hop, non-auth
+                entries (notably ``content-type`` and ``anthropic-*`` /
+                ``x-amzn-bedrock-*`` passthroughs) are preserved.
+
+        Raises:
+            BedrockSigningError: if credentials cannot be resolved.
+        """
+        from botocore.auth import SigV4Auth
+        from botocore.awsrequest import AWSRequest
+
+        creds = self._resolve_credentials()
+
+        # Preserve everything the caller sent except the headers SigV4 will
+        # recompute or that describe the stale (pre-compression) body. Keeping
+        # content-type and any x-amzn-bedrock-* / anthropic-* headers matters:
+        # Bedrock guardrail headers and the anthropic beta headers travel here.
+        passthrough = {
+            k: v for k, v in inbound_headers.items() if k.lower() not in _DROP_FOR_SIGNING
+        }
+        host = urlsplit(url).netloc
+        passthrough["host"] = host
+
+        aws_request = AWSRequest(method=method, url=url, data=body, headers=passthrough)
+        SigV4Auth(creds, _SERVICE, self._region).add_auth(aws_request)
+        return dict(aws_request.headers.items())

--- a/headroom/proxy/bedrock_signer.py
+++ b/headroom/proxy/bedrock_signer.py
@@ -12,10 +12,12 @@ native SigV4 surface (``docs/bedrock.md``), and it lets ``headroom wrap claude``
 support ``CLAUDE_CODE_USE_BEDROCK=1`` direct-to-AWS — no re-signing gateway
 (LiteLLM / LocalStack) required.
 
-Credentials are resolved once, lazily, via the standard ``boto3`` credential
-chain (env vars, shared config/credentials profile, SSO cache, IMDS, ECS/EKS
-role). The chain is the same one ``aws`` and Claude Code already use, so if
-Claude Code can reach Bedrock without Headroom, the signer can too.
+The credential *provider* is resolved once, lazily, via the standard ``boto3``
+credential chain (env vars, shared config/credentials profile, SSO cache, IMDS,
+ECS/EKS role). The chain is the same one ``aws`` and Claude Code already use, so
+if Claude Code can reach Bedrock without Headroom, the signer can too. Each
+individual signing operation then takes a frozen snapshot of that provider — see
+:meth:`BedrockSigner._frozen_credentials`.
 """
 
 from __future__ import annotations
@@ -25,7 +27,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 if TYPE_CHECKING:
-    from botocore.credentials import Credentials
+    from botocore.credentials import Credentials, ReadOnlyCredentials
 
 logger = logging.getLogger("headroom.proxy")
 
@@ -58,8 +60,8 @@ class BedrockSigningError(RuntimeError):
 class BedrockSigner:
     """Re-signs Bedrock InvokeModel requests with SigV4 after compression.
 
-    One instance per proxy process. Credentials are resolved on first use and
-    cached; ``botocore``'s credential objects refresh themselves for the
+    One instance per proxy process. The credential provider is resolved on first
+    use and cached; ``botocore``'s credential objects refresh themselves for the
     refreshable sources (SSO, assume-role, IMDS), so a long-lived proxy keeps
     working across credential rotation without re-resolving.
     """
@@ -103,6 +105,27 @@ class BedrockSigner:
         self._credentials = creds
         return creds
 
+    def _frozen_credentials(self) -> ReadOnlyCredentials:
+        """Snapshot the cached provider's credentials for one signing operation.
+
+        ``SigV4Auth`` reads ``access_key``, ``secret_key`` and ``token`` as three
+        separate attribute lookups. On a ``RefreshableCredentials`` provider
+        (SSO, assume-role, IMDS — the long-lived cases this signer exists for)
+        each of those lookups can trigger a refresh, so a rotation landing
+        mid-signature yields a request mixing generations: an old
+        ``X-Amz-Security-Token`` with a new ``Credential`` access key and signing
+        secret. AWS rejects that with 403 ``InvalidSignatureException``, and it
+        is unreproducible after the fact.
+
+        ``get_frozen_credentials()`` takes all three under the provider's
+        refresh lock and returns an immutable ``ReadOnlyCredentials``, which is
+        what botocore's own ``RequestSigner.get_auth_instance`` hands to the auth
+        class. Called per request, so the *next* request still observes freshly
+        refreshed credentials — the caching is of the provider, not of a
+        snapshot.
+        """
+        return self._resolve_credentials().get_frozen_credentials()
+
     def sign(
         self,
         *,
@@ -128,7 +151,10 @@ class BedrockSigner:
         from botocore.auth import SigV4Auth
         from botocore.awsrequest import AWSRequest
 
-        creds = self._resolve_credentials()
+        # One immutable snapshot per signing operation, so all three credential
+        # fields in the signature come from the same generation even if the
+        # provider refreshes concurrently (see _frozen_credentials).
+        frozen = self._frozen_credentials()
 
         # Preserve everything the caller sent except the headers SigV4 will
         # recompute or that describe the stale (pre-compression) body. Keeping
@@ -141,5 +167,5 @@ class BedrockSigner:
         passthrough["host"] = host
 
         aws_request = AWSRequest(method=method, url=url, data=body, headers=passthrough)
-        SigV4Auth(creds, _SERVICE, self._region).add_auth(aws_request)
+        SigV4Auth(frozen, _SERVICE, self._region).add_auth(aws_request)
         return dict(aws_request.headers.items())

--- a/headroom/proxy/handlers/bedrock.py
+++ b/headroom/proxy/handlers/bedrock.py
@@ -13,12 +13,19 @@ Anthropic models *is* the Anthropic Messages shape
 (``{anthropic_version, system, messages, max_tokens, …}``; the model travels in
 the URL), so the existing pipeline applies with no translation.
 
-LIMITATION — SigV4. Rewriting the body invalidates the caller's SigV4 signature
-(the signature covers a hash of the body). These routes therefore register
-**only** when ``--bedrock-api-url`` / ``BEDROCK_TARGET_API_URL`` is set, and the
-target must be a gateway that re-signs or does not verify the inbound signature
-(LiteLLM, LocalStack, a corporate Bedrock proxy) — never raw AWS. For
-direct-to-AWS compression use ``--backend bedrock`` (which re-signs).
+SigV4. Rewriting the body invalidates the caller's SigV4 signature (the
+signature covers a hash of the body). There are two ways to forward safely:
+
+* ``--bedrock-api-url`` / ``BEDROCK_TARGET_API_URL`` — forward to a gateway that
+  re-signs or does not verify the inbound signature (LiteLLM, LocalStack, a
+  corporate Bedrock proxy). Forwarded verbatim; Headroom does not re-sign.
+* ``--bedrock-sign`` / ``HEADROOM_BEDROCK_SIGN`` — re-sign the compressed body
+  with SigV4 and forward **direct to the regional AWS endpoint**. This is what
+  powers ``headroom wrap claude`` under ``CLAUDE_CODE_USE_BEDROCK=1`` with no
+  gateway. See ``headroom/proxy/bedrock_signer.py``.
+
+The routes register when **either** is configured. ``bedrock_api_url`` takes
+precedence when both are set (an explicit gateway is forwarded to verbatim).
 
 The response is forwarded byte-faithfully: the non-streaming reply is Anthropic
 JSON and the streaming reply uses AWS event-stream binary framing — neither is
@@ -45,15 +52,118 @@ LOG_TAG = "bedrock_invoke"
 class BedrockHandlerMixin:
     """Mixin providing the Bedrock InvokeModel passthrough handler."""
 
+    def _bedrock_signing_enabled(self) -> bool:
+        """True when we re-sign direct-to-AWS (no gateway configured)."""
+        # An explicit gateway wins: forward to it verbatim, never re-sign.
+        if getattr(self.config, "bedrock_api_url", None):  # type: ignore[attr-defined]
+            return False
+        return bool(getattr(self.config, "bedrock_sign", False))  # type: ignore[attr-defined]
+
+    def _bedrock_signer(self):  # type: ignore[no-untyped-def]
+        """Lazily build (and cache) the SigV4 signer for direct-to-AWS mode."""
+        signer = getattr(self, "_cached_bedrock_signer", None)
+        if signer is None:
+            from headroom.proxy.bedrock_signer import BedrockSigner
+
+            signer = BedrockSigner(
+                region=getattr(self.config, "bedrock_region", "us-west-2"),  # type: ignore[attr-defined]
+                profile=getattr(self.config, "bedrock_profile", None),  # type: ignore[attr-defined]
+            )
+            self._cached_bedrock_signer = signer
+        return signer
+
     def _bedrock_upstream_base(self) -> str | None:
         """Resolved Bedrock upstream, or ``None`` when unconfigured.
 
-        Returns the normalized ``config.bedrock_api_url`` (trailing slash
-        stripped). ``None`` means the feature is off — the routes are not even
+        Precedence: an explicit ``config.bedrock_api_url`` (a re-signing
+        gateway) wins; otherwise, when ``config.bedrock_sign`` is set, the
+        regional AWS Bedrock runtime endpoint derived from the configured
+        region. ``None`` means the feature is off — the routes are not even
         registered in that case, so a ``None`` here is a defensive guard only.
         """
         base = getattr(self.config, "bedrock_api_url", None)  # type: ignore[attr-defined]
-        return base.rstrip("/") if base else None
+        if base:
+            return base.rstrip("/")
+        if getattr(self.config, "bedrock_sign", False):  # type: ignore[attr-defined]
+            return self._bedrock_signer().endpoint_base()
+        return None
+
+    def _bedrock_control_upstream_base(self) -> str | None:
+        """Resolve the upstream for Bedrock control-plane requests."""
+        base = getattr(self.config, "bedrock_api_url", None)  # type: ignore[attr-defined]
+        if base:
+            return base.rstrip("/")
+        if getattr(self.config, "bedrock_sign", False):  # type: ignore[attr-defined]
+            return self._bedrock_signer().control_endpoint_base()
+        return None
+
+    def _sign_if_needed(
+        self,
+        signing: bool,
+        *,
+        url: str,
+        body: bytes,
+        inbound_headers: dict[str, str],
+    ) -> dict[str, str]:
+        """Return outbound headers, SigV4-re-signed when in direct-to-AWS mode.
+
+        In gateway mode (``signing`` is False) the inbound headers pass through
+        unchanged — the gateway owns signing. In direct-to-AWS mode the headers
+        carry a fresh signature computed over ``body`` (the exact bytes about to
+        be forwarded). If signing fails (no credentials), we fail loud rather
+        than forward an unsigned request that AWS would 403 anyway.
+        """
+        if not signing:
+            return inbound_headers
+        signer = self._bedrock_signer()
+        return signer.sign(url=url, body=body, inbound_headers=inbound_headers)
+
+    async def handle_bedrock_inference_profiles(self, request: Request) -> Response:
+        """Forward Claude Code's Bedrock inference-profile discovery request.
+
+        This is a control-plane GET, not a runtime InvokeModel request. Direct
+        AWS mode therefore targets ``bedrock.<region>.amazonaws.com`` and signs
+        the empty GET body while preserving pagination/filter query parameters.
+        """
+        from fastapi.responses import JSONResponse
+
+        from headroom.proxy.helpers import _strip_internal_headers
+
+        base = self._bedrock_control_upstream_base()
+        if base is None:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": {
+                        "type": "configuration_error",
+                        "message": (
+                            "Bedrock passthrough requested but neither "
+                            "--bedrock-api-url nor --bedrock-sign is set."
+                        ),
+                    }
+                },
+            )
+
+        url = f"{base}/inference-profiles"
+        if request.url.query:
+            url = f"{url}?{request.url.query}"
+        headers = {
+            key: value
+            for key, value in _strip_internal_headers(dict(request.headers.items())).items()
+            if key.lower() not in {"host", "content-length", "accept-encoding", "connection"}
+        }
+        if self._bedrock_signing_enabled():
+            headers = self._bedrock_signer().sign(
+                method="GET", url=url, body=b"", inbound_headers=headers
+            )
+        request_id = await self._next_request_id()  # type: ignore[attr-defined]
+        return await self._forward_bedrock_request(
+            method="GET",
+            url=url,
+            headers=headers,
+            content=b"",
+            request_id=request_id,
+        )
 
     async def handle_bedrock_invoke(
         self,
@@ -96,7 +206,10 @@ class BedrockHandlerMixin:
                 content={
                     "error": {
                         "type": "configuration_error",
-                        "message": "Bedrock passthrough requested but --bedrock-api-url is unset.",
+                        "message": (
+                            "Bedrock passthrough requested but neither "
+                            "--bedrock-api-url nor --bedrock-sign is set."
+                        ),
                     }
                 },
             )
@@ -114,8 +227,11 @@ class BedrockHandlerMixin:
         #     by httpx and the stale content-encoding dropped. Keeping the
         #     inbound content-length here is the classic "Too little data for
         #     declared Content-Length" footgun once the body shrinks.
-        # We never touch the auth headers — the upstream gateway owns
-        # (re-)signing.
+        # In gateway mode we never touch the auth headers — the upstream gateway
+        # owns (re-)signing. In direct-to-AWS signing mode we strip the stale
+        # signature and recompute it over the bytes we actually forward (see
+        # ``_sign_if_needed``).
+        signing = self._bedrock_signing_enabled()
         in_headers = _strip_internal_headers(dict(request.headers.items()))
         client = classify_client(dict(request.headers.items()))
         tags = extract_tags(dict(request.headers.items()))
@@ -141,9 +257,15 @@ class BedrockHandlerMixin:
                 err,
             )
             raw_only = await request.body()
+            # Even verbatim bytes must be re-signed in direct-to-AWS mode: we
+            # changed the Host to the regional endpoint, so the inbound
+            # signature no longer matches regardless of the body.
+            fwd_headers = self._sign_if_needed(
+                signing, url=url, body=raw_only, inbound_headers=verbatim_headers
+            )
             return await self._forward_bedrock(
                 url=url,
-                headers=verbatim_headers,
+                headers=fwd_headers,
                 content=raw_only,
                 stream=stream,
                 request_id=request_id,
@@ -207,9 +329,14 @@ class BedrockHandlerMixin:
                 outbound = raw
 
         out_headers["content-type"] = "application/json"
+        # Sign LAST: the signature must hash exactly the bytes we forward
+        # (``outbound``), after compression has finalized them.
+        fwd_headers = self._sign_if_needed(
+            signing, url=url, body=outbound, inbound_headers=out_headers
+        )
         response = await self._forward_bedrock(
             url=url,
-            headers=out_headers,
+            headers=fwd_headers,
             content=outbound,
             stream=stream,
             request_id=request_id,
@@ -262,16 +389,31 @@ class BedrockHandlerMixin:
         ``invoke`` reply and the event-stream ``invoke-with-response-stream``
         reply — neither is buffered or mutated.
         """
+        return await self._forward_bedrock_request(
+            method="POST",
+            url=url,
+            headers=headers,
+            content=content,
+            request_id=request_id,
+        )
+
+    async def _forward_bedrock_request(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        content: bytes,
+        request_id: str,
+    ) -> Response | StreamingResponse:
+        """Forward a signed Bedrock request and stream its response unchanged."""
         import httpx
         from fastapi.responses import JSONResponse, StreamingResponse
         from starlette.background import BackgroundTask
 
         assert self.http_client is not None  # type: ignore[attr-defined]
         upstream_request = self.http_client.build_request(  # type: ignore[attr-defined]
-            "POST",
-            url,
-            headers=headers,
-            content=content,
+            method, url, headers=headers, content=content
         )
         try:
             upstream = await self.http_client.send(upstream_request, stream=True)  # type: ignore[attr-defined]

--- a/headroom/proxy/models.py
+++ b/headroom/proxy/models.py
@@ -169,6 +169,15 @@ class ProxyConfig:
     # SigV4 signature. Leave unset (default) to keep `--backend bedrock`'s
     # direct-to-AWS, re-signing behavior unchanged.
     bedrock_api_url: str | None = None
+    # Re-sign the compressed Bedrock body with SigV4 and forward direct to the
+    # regional AWS Bedrock runtime endpoint. This is what lets `headroom wrap
+    # claude` support CLAUDE_CODE_USE_BEDROCK=1 with no re-signing gateway:
+    # Claude Code signs the request, Headroom compresses + re-signs, AWS sees a
+    # signature that matches the bytes on the wire. Mutually completes
+    # `bedrock_api_url` — when both are set, `bedrock_api_url` wins (an explicit
+    # gateway is forwarded to verbatim, no re-signing). Uses `bedrock_region`
+    # and `bedrock_profile`.
+    bedrock_sign: bool = False
     anyllm_provider: str = "openai"
 
     # Optimization mode: "token" (rewrite for max compression) or

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -5517,6 +5517,7 @@ def _proxy_config_from_env() -> ProxyConfig:
         bedrock_region=_get_env_str("HEADROOM_BEDROCK_REGION", "us-west-2"),
         bedrock_profile=os.environ.get("AWS_PROFILE"),
         bedrock_api_url=os.environ.get("BEDROCK_TARGET_API_URL"),
+        bedrock_sign=_get_env_bool("HEADROOM_BEDROCK_SIGN", False),
         anyllm_provider=_get_env_str("HEADROOM_ANYLLM_PROVIDER", "openai"),
         disable_kompress=_get_env_bool("HEADROOM_DISABLE_KOMPRESS", False),
         disable_kompress_fallback=_get_env_bool("HEADROOM_DISABLE_KOMPRESS_FALLBACK", False),
@@ -5980,6 +5981,16 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--bedrock-sign",
+        action="store_true",
+        default=None,
+        help=(
+            "Re-sign the compressed Bedrock body with SigV4 and forward direct "
+            "to the regional AWS endpoint (no gateway). Powers `headroom wrap "
+            "claude` under CLAUDE_CODE_USE_BEDROCK=1 (env: HEADROOM_BEDROCK_SIGN)"
+        ),
+    )
+    parser.add_argument(
         "--openrouter-api-key",
         help="OpenRouter API key (or set OPENROUTER_API_KEY env var)",
     )
@@ -6271,6 +6282,11 @@ if __name__ == "__main__":
         bedrock_region=_get_env_str("HEADROOM_BEDROCK_REGION", args.bedrock_region),
         bedrock_profile=args.bedrock_profile or os.environ.get("AWS_PROFILE"),
         bedrock_api_url=_get_env_str("BEDROCK_TARGET_API_URL", args.bedrock_api_url),
+        bedrock_sign=(
+            args.bedrock_sign
+            if args.bedrock_sign is not None
+            else _get_env_bool("HEADROOM_BEDROCK_SIGN", False)
+        ),
         anyllm_provider=_get_env_str("HEADROOM_ANYLLM_PROVIDER", args.anyllm_provider),
         optimize=optimize,
         min_tokens_to_crush=_get_env_int("HEADROOM_MIN_TOKENS", args.min_tokens),

--- a/headroom/settings_store.py
+++ b/headroom/settings_store.py
@@ -504,6 +504,19 @@ SETTINGS: tuple[SettingField, ...] = (
         help="Cloud region for Bedrock/Vertex/etc backends.",
         tier="advanced",
     ),
+    SettingField(
+        "HEADROOM_BEDROCK_SIGN",
+        "bedrock_sign",
+        "Sign Bedrock requests",
+        "Backend",
+        "bool",
+        default=False,
+        help=(
+            "Re-sign transformed Bedrock requests with AWS SigV4 before forwarding "
+            "to the regional runtime endpoint. Uses the configured region/profile credentials."
+        ),
+        tier="advanced",
+    ),
     # --- Timeouts ---
     SettingField(
         "HEADROOM_RETRY_MAX_ATTEMPTS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,7 +316,7 @@ dev = [
 # who need standard accuracy benchmarks can install `lm-eval[api]` in their
 # benchmark environment separately.
 all = [
-    "headroom-ai[proxy,code,ml,memory,relevance,image,reports,otel,evals,voice,html,mcp,spreadsheet]",
+    "headroom-ai[proxy,code,ml,memory,relevance,image,reports,otel,evals,voice,html,mcp,spreadsheet,bedrock]",
 ]
 # Sandbox: a lean proxy with ALL torch-free capability — for running Headroom in
 # a locked-down/low-resource sandbox and offloading heavy ML elsewhere.

--- a/tests/test_bedrock_packaging.py
+++ b/tests/test_bedrock_packaging.py
@@ -1,0 +1,73 @@
+"""Packaging guard for the Bedrock optional dependency.
+
+``headroom wrap claude`` auto-enables ``--bedrock-sign`` whenever
+``CLAUDE_CODE_USE_BEDROCK=1`` is set, and the signer imports ``boto3`` on the
+first signed request. ``boto3`` ships in the ``bedrock`` extra. These tests pin
+the dependency story so the turnkey path can never silently ship without it:
+
+1. The ``bedrock`` extra exists and declares ``boto3``.
+2. The comprehensive ``all`` extra references ``bedrock`` — so
+   ``pip install headroom-ai[all]`` includes the signer's dependency. This is
+   the regression the reviewer flagged: ``all`` had previously omitted it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - only hit on Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+def _find_pyproject() -> Path | None:
+    """Walk up from this file to locate the repo's pyproject.toml.
+
+    Returns ``None`` when running from an installed wheel without the source
+    tree (e.g. some CI smoke environments), so the test skips rather than fails.
+    """
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "pyproject.toml"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+@pytest.fixture(scope="module")
+def optional_dependencies() -> dict[str, list[str]]:
+    pyproject = _find_pyproject()
+    if pyproject is None:
+        pytest.skip("pyproject.toml not available (installed without source tree)")
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    return data["project"]["optional-dependencies"]
+
+
+def test_bedrock_extra_declares_boto3(optional_dependencies: dict[str, list[str]]) -> None:
+    assert "bedrock" in optional_dependencies, "the [bedrock] extra must exist"
+    bedrock = optional_dependencies["bedrock"]
+    assert any(req.replace(" ", "").lower().startswith("boto3") for req in bedrock), (
+        f"[bedrock] must declare boto3, got: {bedrock}"
+    )
+
+
+def test_all_extra_includes_bedrock(optional_dependencies: dict[str, list[str]]) -> None:
+    """``all`` must pull in ``bedrock`` so the comprehensive install ships boto3.
+
+    Guards against silently dropping ``bedrock`` from the self-referential
+    ``headroom-ai[...]`` aggregate again.
+    """
+    all_reqs = optional_dependencies["all"]
+    referenced_extras: set[str] = set()
+    for req in all_reqs:
+        # e.g. "headroom-ai[proxy,code,...,bedrock]"
+        if "[" in req and "]" in req:
+            inner = req[req.index("[") + 1 : req.index("]")]
+            referenced_extras.update(part.strip() for part in inner.split(","))
+    assert "bedrock" in referenced_extras, (
+        "the [all] extra must reference [bedrock] so headroom-ai[all] ships boto3; "
+        f"referenced extras: {sorted(referenced_extras)}"
+    )

--- a/tests/test_cli/test_unwrap_claude.py
+++ b/tests/test_cli/test_unwrap_claude.py
@@ -263,6 +263,7 @@ def test_unwrap_claude_restores_all_base_url_modes(runner: CliRunner) -> None:
             "vertex_mode": True,
             "bedrock_mode": False,
             "settings_path": settings_path,
+            "force": True,
         },
         {
             "previous": None,

--- a/tests/test_cli/test_unwrap_claude.py
+++ b/tests/test_cli/test_unwrap_claude.py
@@ -242,6 +242,7 @@ def test_unwrap_claude_restores_all_base_url_modes(runner: CliRunner) -> None:
             "previous": None,
             "foundry_mode": False,
             "vertex_mode": False,
+            "bedrock_mode": False,
             "settings_path": settings_path,
             # unwrap is the user asking for their settings back, so it drops
             # every wrap session's ownership claim instead of deferring to a
@@ -252,6 +253,7 @@ def test_unwrap_claude_restores_all_base_url_modes(runner: CliRunner) -> None:
             "previous": None,
             "foundry_mode": True,
             "vertex_mode": False,
+            "bedrock_mode": False,
             "settings_path": settings_path,
             "force": True,
         },
@@ -259,6 +261,14 @@ def test_unwrap_claude_restores_all_base_url_modes(runner: CliRunner) -> None:
             "previous": None,
             "foundry_mode": False,
             "vertex_mode": True,
+            "bedrock_mode": False,
+            "settings_path": settings_path,
+        },
+        {
+            "previous": None,
+            "foundry_mode": False,
+            "vertex_mode": False,
+            "bedrock_mode": True,
             "settings_path": settings_path,
             "force": True,
         },

--- a/tests/test_cli/test_wrap_claude_bedrock.py
+++ b/tests/test_cli/test_wrap_claude_bedrock.py
@@ -1,0 +1,151 @@
+"""`headroom wrap claude` Bedrock-mode routing (CLAUDE_CODE_USE_BEDROCK=1).
+
+Claude Code in Bedrock mode ignores ANTHROPIC_BASE_URL and reads
+ANTHROPIC_BEDROCK_BASE_URL instead, signing each request with SigV4. So the
+wrap command must (a) point ANTHROPIC_BEDROCK_BASE_URL at the proxy — not
+ANTHROPIC_BASE_URL — and (b) start the proxy in re-signing mode
+(``bedrock_sign=True``) so the compressed body is re-signed before it reaches
+AWS. These tests pin both halves of that contract without launching a real
+proxy or Claude binary.
+
+Two layers:
+  * ``_start_proxy`` forwards ``--bedrock-sign`` to the proxy subprocess.
+  * ``claude()`` sets the Bedrock env key and calls ``_ensure_proxy`` with
+    ``bedrock_sign=True``; the default (no Bedrock env) keeps ANTHROPIC_BASE_URL.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+
+
+def test_start_proxy_forwards_bedrock_sign_flag():
+    """``bedrock_sign=True`` adds ``--bedrock-sign`` to the proxy command."""
+    from headroom.cli import wrap
+
+    captured: dict = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        def poll(self):
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc()
+
+    with patch("headroom.cli.wrap.subprocess.Popen", side_effect=fake_popen):
+        with patch("headroom.cli.wrap._check_proxy", return_value=True):
+            with patch("headroom.cli.wrap._get_log_path") as log_path:
+                log_path.return_value = MagicMock()
+                log_path.return_value.read_text.return_value = ""
+                with patch("builtins.open", MagicMock()):
+                    wrap._start_proxy(8787, agent_type="claude", bedrock_sign=True)
+
+    assert "--bedrock-sign" in captured["cmd"]
+
+
+def test_start_proxy_omits_bedrock_sign_by_default():
+    from headroom.cli import wrap
+
+    captured: dict = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        def poll(self):
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc()
+
+    with patch("headroom.cli.wrap.subprocess.Popen", side_effect=fake_popen):
+        with patch("headroom.cli.wrap._check_proxy", return_value=True):
+            with patch("headroom.cli.wrap._get_log_path") as log_path:
+                log_path.return_value = MagicMock()
+                log_path.return_value.read_text.return_value = ""
+                with patch("builtins.open", MagicMock()):
+                    wrap._start_proxy(8787, agent_type="claude")
+
+    assert "--bedrock-sign" not in captured["cmd"]
+
+
+def _run_claude_wrap(monkeypatch, tmp_path, env: dict[str, str]):
+    """Invoke ``wrap claude`` with all heavy side-effects stubbed, capturing the
+    env passed to the launched Claude subprocess and the _ensure_proxy kwargs."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    for k in (
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    captured: dict = {}
+
+    def fake_run(cmd, env=None, **kwargs):
+        captured["launch_env"] = env
+        captured["launch_cmd"] = cmd
+
+        class _R:
+            returncode = 0
+
+        return _R()
+
+    def fake_ensure_proxy(port, no_proxy, **kwargs):
+        captured["ensure_kwargs"] = kwargs
+        return None, port
+
+    runner = CliRunner()
+    with patch("headroom.cli.wrap.shutil.which", return_value="/usr/bin/claude"):
+        with patch("headroom.cli.wrap._ensure_proxy", side_effect=fake_ensure_proxy):
+            with patch("headroom.cli.wrap._push_runtime_env"):
+                with patch("headroom.cli.wrap._setup_headroom_mcp"):
+                    with patch("headroom.cli.wrap._setup_coding_compressor"):
+                        with patch("headroom.cli.wrap.subprocess.run", side_effect=fake_run):
+                            result = runner.invoke(
+                                main,
+                                ["wrap", "claude", "--no-mcp"],
+                            )
+    return result, captured
+
+
+def test_bedrock_mode_sets_bedrock_base_url(monkeypatch, tmp_path):
+    result, captured = _run_claude_wrap(
+        monkeypatch,
+        tmp_path,
+        {"CLAUDE_CODE_USE_BEDROCK": "1", "AWS_REGION": "us-west-2"},
+    )
+
+    assert result.exit_code == 0, result.output
+    launch_env = captured["launch_env"]
+    # The whole point: Bedrock mode routes via ANTHROPIC_BEDROCK_BASE_URL, and
+    # must NOT set ANTHROPIC_BASE_URL (which Claude Code ignores in Bedrock mode).
+    assert launch_env["ANTHROPIC_BEDROCK_BASE_URL"].startswith("http://127.0.0.1:8787")
+    assert "ANTHROPIC_BASE_URL" not in launch_env
+    # Proxy started in re-signing mode, with the resolved region.
+    assert captured["ensure_kwargs"]["bedrock_sign"] is True
+    assert captured["ensure_kwargs"]["region"] == "us-west-2"
+    assert "Bedrock mode" in result.output
+
+
+def test_non_bedrock_mode_keeps_anthropic_base_url(monkeypatch, tmp_path):
+    result, captured = _run_claude_wrap(monkeypatch, tmp_path, {})
+
+    assert result.exit_code == 0, result.output
+    launch_env = captured["launch_env"]
+    assert launch_env["ANTHROPIC_BASE_URL"].startswith("http://127.0.0.1:8787")
+    assert "ANTHROPIC_BEDROCK_BASE_URL" not in launch_env
+    assert captured["ensure_kwargs"]["bedrock_sign"] is False

--- a/tests/test_proxy/test_bedrock_passthrough.py
+++ b/tests/test_proxy/test_bedrock_passthrough.py
@@ -361,3 +361,126 @@ def test_env_var_feeds_config(monkeypatch):
     monkeypatch.setenv("BEDROCK_TARGET_API_URL", UPSTREAM)
     cfg = _proxy_config_from_env()
     assert cfg.bedrock_api_url == UPSTREAM
+
+
+# ── direct-to-AWS SigV4 signing mode (--bedrock-sign) ──────────────────
+
+
+def test_routes_present_when_bedrock_sign_set():
+    """Signing mode registers the same routes without a gateway URL."""
+    paths = _paths(ProxyConfig(bedrock_sign=True, bedrock_region="us-west-2"))
+    assert "/model/{model_id:path}/invoke" in paths
+    assert "/model/{model_id:path}/invoke-with-response-stream" in paths
+    assert "/inference-profiles" in paths
+
+
+def test_inference_profiles_uses_signed_control_plane_get():
+    """Claude's profile discovery targets the control plane, not runtime."""
+    Credentials = pytest.importorskip("botocore.credentials").Credentials
+
+    app = create_app(_make_config(bedrock_api_url=None, bedrock_sign=True))
+    with TestClient(app) as client:
+        proxy = client.app.state.proxy
+        http = _install_fake_client(proxy, _FakeUpstream())
+        proxy._bedrock_signer()._credentials = Credentials("AKIDEXAMPLE", "secret")
+        resp = client.get("/inference-profiles?maxResults=5&typeEquals=SYSTEM_DEFINED")
+
+    assert resp.status_code == 200
+    call = http.build_request.call_args
+    assert call.args[0] == "GET"
+    assert call.args[1] == (
+        "https://bedrock.us-west-2.amazonaws.com/inference-profiles"
+        "?maxResults=5&typeEquals=SYSTEM_DEFINED"
+    )
+    sent_headers = call.kwargs["headers"]
+    auth = next((v for k, v in sent_headers.items() if k.lower() == "authorization"), "")
+    assert auth.startswith("AWS4-HMAC-SHA256 ")
+
+
+def test_sign_env_var_feeds_config(monkeypatch):
+    from headroom.proxy.server import _proxy_config_from_env
+
+    monkeypatch.delenv("HEADROOM_PROXY_CONFIG_JSON", raising=False)
+    monkeypatch.delenv("BEDROCK_TARGET_API_URL", raising=False)
+    monkeypatch.setenv("HEADROOM_BEDROCK_SIGN", "true")
+    cfg = _proxy_config_from_env()
+    assert cfg.bedrock_sign is True
+    assert cfg.bedrock_api_url is None
+
+
+def test_signing_forwards_to_regional_endpoint_with_signed_headers():
+    """In signing mode the compressed body is forwarded to the regional AWS
+    endpoint, carrying freshly-computed SigV4 headers over the OUTBOUND bytes."""
+    Credentials = pytest.importorskip("botocore.credentials").Credentials
+
+    app = create_app(_make_config(bedrock_api_url=None, bedrock_sign=True))
+    with TestClient(app) as client:
+        proxy = client.app.state.proxy
+        http = _install_fake_client(proxy, _FakeUpstream())
+        # Pre-seed fake creds so the test never touches the real AWS chain (CI-safe).
+        proxy._bedrock_signer()._credentials = Credentials("AKIDEXAMPLE", "secret")
+        compressed = [{"role": "user", "content": "short"}]
+        proxy.anthropic_pipeline.apply = MagicMock(
+            return_value=_FakeResult(compressed, tokens_before=5000, tokens_after=200)
+        )
+        resp = client.post(
+            INVOKE,
+            json={"messages": [{"role": "user", "content": "x" * 5000}], "max_tokens": 8},
+        )
+
+    assert resp.status_code == 200
+    url, forwarded = _forwarded(http)
+    # Forwarded direct to the regional Bedrock host, not a gateway.
+    assert url.startswith("https://bedrock-runtime.us-west-2.amazonaws.com/model/")
+    assert forwarded["messages"] == compressed
+    # Headers carry a SigV4 signature.
+    sent_headers = http.build_request.call_args.kwargs["headers"]
+    auth = next((v for k, v in sent_headers.items() if k.lower() == "authorization"), "")
+    assert auth.startswith("AWS4-HMAC-SHA256 ")
+
+
+def test_api_url_takes_precedence_over_sign():
+    """When both are set, the explicit gateway wins and we do NOT re-sign."""
+    app = create_app(_make_config(bedrock_api_url=UPSTREAM, bedrock_sign=True))
+    with TestClient(app) as client:
+        proxy = client.app.state.proxy
+        http = _install_fake_client(proxy, _FakeUpstream())
+        proxy.anthropic_pipeline.apply = MagicMock(
+            return_value=_FakeResult([{"role": "user", "content": "c"}], 900, 100)
+        )
+        resp = client.post(
+            INVOKE,
+            json={"messages": [{"role": "user", "content": "z" * 3000}], "max_tokens": 8},
+        )
+
+    assert resp.status_code == 200
+    url, _ = _forwarded(http)
+    assert url.startswith(UPSTREAM)  # gateway, not AWS
+    sent_headers = http.build_request.call_args.kwargs["headers"]
+    # No SigV4 Authorization injected — gateway owns signing.
+    auth = next((v for k, v in sent_headers.items() if k.lower() == "authorization"), "")
+    assert not auth.startswith("AWS4-HMAC-SHA256")
+
+
+def test_sign_credentials_injected_for_test(monkeypatch):
+    """Provide fake creds so signing mode doesn't hit the real AWS chain."""
+    Credentials = pytest.importorskip("botocore.credentials").Credentials
+
+    fake = Credentials(access_key="AKIDEXAMPLE", secret_key="secret")
+
+    app = create_app(_make_config(bedrock_api_url=None, bedrock_sign=True))
+    with TestClient(app) as client:
+        proxy = client.app.state.proxy
+        _install_fake_client(proxy, _FakeUpstream())
+        proxy.anthropic_pipeline.apply = MagicMock(
+            return_value=_FakeResult([{"role": "user", "content": "c"}], 900, 100)
+        )
+        # Pre-seed the signer's creds so no network/credential lookup happens.
+        signer = proxy._bedrock_signer()
+        signer._credentials = fake
+        resp = client.post(
+            INVOKE,
+            json={"messages": [{"role": "user", "content": "z" * 3000}], "max_tokens": 8},
+        )
+
+    assert resp.status_code == 200

--- a/tests/test_proxy/test_bedrock_signer.py
+++ b/tests/test_proxy/test_bedrock_signer.py
@@ -1,0 +1,160 @@
+"""Tests for the AWS SigV4 re-signer used by the Bedrock direct-to-AWS path.
+
+These cover ``headroom.proxy.bedrock_signer.BedrockSigner`` in isolation — no
+proxy app, no ``headroom._core``. botocore is the only dependency, and it is a
+hard dep of the package.
+
+What matters for correctness:
+
+1. The endpoint host is the regional Bedrock runtime host.
+2. The signature is computed over the *exact body bytes* we pass — change the
+   body, get a different signature (this is the whole point: we re-sign after
+   compression mutates the body).
+3. Stale signing headers (Authorization, X-Amz-Date, the old Host) are replaced,
+   not carried forward.
+4. Non-auth passthrough headers (content-type, anthropic-beta, Bedrock guardrail
+   headers) survive into the signed set.
+5. Missing credentials raise a clear error rather than forwarding unsigned.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+botocore = pytest.importorskip("botocore")
+
+from botocore.credentials import Credentials  # noqa: E402
+
+from headroom.proxy.bedrock_signer import BedrockSigner, BedrockSigningError  # noqa: E402
+
+_FAKE_CREDS = Credentials(access_key="AKIDEXAMPLE", secret_key="secret", token="sess-token")
+_REGION = "us-west-2"
+_URL = (
+    f"https://bedrock-runtime.{_REGION}.amazonaws.com"
+    "/model/us.anthropic.claude-opus-4-8-v1%3A0/invoke"
+)
+
+
+def _signer(creds: Credentials | None = _FAKE_CREDS) -> BedrockSigner:
+    s = BedrockSigner(region=_REGION)
+    # Inject creds so we never touch the real AWS credential chain in unit tests.
+    s._credentials = creds  # type: ignore[attr-defined]
+    return s
+
+
+def test_endpoint_base_is_regional_host():
+    assert (
+        BedrockSigner(region="eu-central-1").endpoint_base()
+        == "https://bedrock-runtime.eu-central-1.amazonaws.com"
+    )
+
+
+def test_control_endpoint_base_is_regional_host():
+    assert (
+        BedrockSigner(region="eu-central-1").control_endpoint_base()
+        == "https://bedrock.eu-central-1.amazonaws.com"
+    )
+
+
+def test_sign_supports_control_plane_get():
+    url = f"https://bedrock.{_REGION}.amazonaws.com/inference-profiles?maxResults=5"
+    headers = _signer().sign(
+        method="GET", url=url, body=b"", inbound_headers={"accept": "application/json"}
+    )
+    assert headers["host"] == f"bedrock.{_REGION}.amazonaws.com"
+    assert f"/{_REGION}/bedrock/aws4_request" in headers["Authorization"]
+
+
+def test_sign_sets_sigv4_authorization_and_host():
+    headers = _signer().sign(
+        url=_URL,
+        body=b'{"messages":[],"max_tokens":8}',
+        inbound_headers={"content-type": "application/json"},
+    )
+    auth = headers.get("Authorization", "")
+    assert auth.startswith("AWS4-HMAC-SHA256 ")
+    assert f"/{_REGION}/bedrock/aws4_request" in auth
+    assert "X-Amz-Date" in headers
+    assert "X-Amz-Security-Token" in headers  # session token threaded through
+    assert headers["host"] == f"bedrock-runtime.{_REGION}.amazonaws.com"
+
+
+def test_signature_covers_body_bytes():
+    """Different body → different signature. This is why we sign AFTER compression."""
+    sign = _signer().sign
+    a = sign(url=_URL, body=b'{"a":1}', inbound_headers={"content-type": "application/json"})
+    b = sign(url=_URL, body=b'{"a":2}', inbound_headers={"content-type": "application/json"})
+    assert a["Authorization"] != b["Authorization"]
+
+
+def test_stale_signing_headers_are_dropped_not_reused():
+    """The inbound request carried a SigV4 signature over the OLD body; it must
+    not leak into the re-signed set."""
+    headers = _signer().sign(
+        url=_URL,
+        body=b'{"messages":[]}',
+        inbound_headers={
+            "content-type": "application/json",
+            "Authorization": "AWS4-HMAC-SHA256 Credential=STALE/old/bedrock/aws4_request",
+            "X-Amz-Date": "20200101T000000Z",
+            "host": "bedrock-runtime.us-east-1.amazonaws.com",  # wrong region!
+        },
+    )
+    # Re-signed, not the stale value.
+    assert "STALE" not in headers["Authorization"]
+    assert headers["X-Amz-Date"] != "20200101T000000Z"
+    # Host points at the URL we actually forward to.
+    assert headers["host"] == f"bedrock-runtime.{_REGION}.amazonaws.com"
+
+
+def test_passthrough_headers_survive():
+    """Guardrail + anthropic beta headers must reach Bedrock (and be signed)."""
+    headers = _signer().sign(
+        url=_URL,
+        body=b"{}",
+        inbound_headers={
+            "content-type": "application/json",
+            "anthropic-beta": "context-1m-2025-08-07",
+            "x-amzn-bedrock-guardrailidentifier": "gr-123",
+        },
+    )
+    assert headers["anthropic-beta"] == "context-1m-2025-08-07"
+    assert headers["x-amzn-bedrock-guardrailidentifier"] == "gr-123"
+
+
+def test_signed_headers_list_includes_passthrough():
+    """A passthrough header that SigV4 signs must appear in SignedHeaders, or AWS
+    rejects the request. Guards against signing a header set that omits it."""
+    headers = _signer().sign(
+        url=_URL,
+        body=b"{}",
+        inbound_headers={
+            "content-type": "application/json",
+            "anthropic-beta": "context-1m-2025-08-07",
+        },
+    )
+    auth = headers["Authorization"]
+    signed = auth.split("SignedHeaders=", 1)[1].split(",", 1)[0]
+    assert "anthropic-beta" in signed
+    assert "host" in signed
+
+
+def test_missing_credentials_raises():
+    s = BedrockSigner(region=_REGION)
+    # Force the boto3 chain to yield nothing.
+    import boto3
+
+    class _NoCredSession:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_credentials(self):
+            return None
+
+    orig = boto3.Session
+    boto3.Session = _NoCredSession  # type: ignore[assignment]
+    try:
+        with pytest.raises(BedrockSigningError):
+            s.sign(url=_URL, body=b"{}", inbound_headers={})
+    finally:
+        boto3.Session = orig  # type: ignore[assignment]

--- a/tests/test_proxy/test_bedrock_signer.py
+++ b/tests/test_proxy/test_bedrock_signer.py
@@ -15,6 +15,8 @@ What matters for correctness:
 4. Non-auth passthrough headers (content-type, anthropic-beta, Bedrock guardrail
    headers) survive into the signed set.
 5. Missing credentials raise a clear error rather than forwarding unsigned.
+6. Every field of one signature comes from a single credential generation, even
+   when the underlying refreshable provider rotates between reads.
 """
 
 from __future__ import annotations
@@ -137,6 +139,108 @@ def test_signed_headers_list_includes_passthrough():
     signed = auth.split("SignedHeaders=", 1)[1].split(",", 1)[0]
     assert "anthropic-beta" in signed
     assert "host" in signed
+
+
+class _RotatingCredentials:
+    """A refreshable provider that rotates on every *direct* attribute read.
+
+    ``RefreshableCredentials`` refreshes lazily when its cached credentials near
+    expiry, and ``SigV4Auth`` reads ``access_key``, ``secret_key`` and ``token``
+    as three separate lookups — so a refresh can land between them. This
+    exaggerates that window to every read, while ``get_frozen_credentials()``
+    returns one coherent generation the way botocore's does. A signer that hands
+    the live provider to ``SigV4Auth`` therefore mixes generations here; one that
+    snapshots first cannot.
+    """
+
+    def __init__(self) -> None:
+        self.generation = 0
+        self.frozen_calls = 0
+
+    def _advance(self) -> int:
+        self.generation += 1
+        return self.generation
+
+    @property
+    def access_key(self) -> str:
+        return f"AKIDGEN{self._advance()}"
+
+    @property
+    def secret_key(self) -> str:
+        return f"secret-gen-{self._advance()}"
+
+    @property
+    def token(self) -> str:
+        return f"token-gen-{self._advance()}"
+
+    def get_frozen_credentials(self):
+        from botocore.credentials import ReadOnlyCredentials
+
+        self.frozen_calls += 1
+        gen = self._advance()
+        return ReadOnlyCredentials(f"AKIDGEN{gen}", f"secret-gen-{gen}", f"token-gen-{gen}")
+
+
+def _signed_access_key(headers: dict[str, str]) -> str:
+    """The access key in the ``Credential=`` scope of an Authorization header."""
+    return headers["Authorization"].split("Credential=", 1)[1].split("/", 1)[0]
+
+
+@pytest.mark.parametrize(
+    ("method", "url", "body"),
+    [
+        ("POST", _URL, b'{"messages":[],"max_tokens":8}'),
+        ("GET", f"https://bedrock.{_REGION}.amazonaws.com/inference-profiles", b""),
+    ],
+    ids=["runtime-post", "discovery-get"],
+)
+def test_one_credential_generation_per_signature(method: str, url: str, body: bytes):
+    """A rotation landing mid-signature must not mix credential generations.
+
+    The failure this guards against is an old ``X-Amz-Security-Token`` paired
+    with a newer ``Credential`` access key and signing secret: three fields from
+    three generations, which authenticate as no credential set at all and get a
+    403 ``InvalidSignatureException`` that is gone by the time you look.
+    """
+    creds = _RotatingCredentials()
+    headers = _signer(creds).sign(  # type: ignore[arg-type]
+        method=method, url=url, body=body, inbound_headers={"content-type": "application/json"}
+    )
+
+    # Exactly one snapshot, and no direct reads of the rotating attributes —
+    # so all three signed fields provably share generation 1.
+    assert creds.frozen_calls == 1
+    assert creds.generation == 1
+    assert _signed_access_key(headers) == "AKIDGEN1"
+    assert headers["X-Amz-Security-Token"] == "token-gen-1"
+
+
+def test_next_request_observes_refreshed_credentials():
+    """The provider is cached, the snapshot is not: request N+1 re-freezes.
+
+    Snapshotting once at resolve time would pin a long-lived proxy to expired
+    credentials, which is the reason the refreshable provider is kept.
+    """
+    creds = _RotatingCredentials()
+    signer = _signer(creds)  # type: ignore[arg-type]
+    inbound = {"content-type": "application/json"}
+
+    first = signer.sign(url=_URL, body=b'{"a":1}', inbound_headers=inbound)
+    second = signer.sign(url=_URL, body=b'{"a":2}', inbound_headers=inbound)
+
+    assert creds.frozen_calls == 2
+    assert _signed_access_key(first) == "AKIDGEN1"
+    assert first["X-Amz-Security-Token"] == "token-gen-1"
+    # Rotated forward, and still internally consistent.
+    assert _signed_access_key(second) == "AKIDGEN2"
+    assert second["X-Amz-Security-Token"] == "token-gen-2"
+
+
+def test_non_refreshable_credentials_still_sign():
+    """A static ``Credentials`` provider also implements the frozen contract."""
+    headers = _signer().sign(url=_URL, body=b"{}", inbound_headers={})
+    assert _signed_access_key(headers) == "AKIDEXAMPLE"
+    assert headers["X-Amz-Security-Token"] == "sess-token"
 
 
 def test_missing_credentials_raises():

--- a/uv.lock
+++ b/uv.lock
@@ -1689,6 +1689,8 @@ agno = [
 ]
 all = [
     { name = "anthropic" },
+    { name = "boto3" },
+    { name = "botocore", extra = ["crt"] },
     { name = "datasets" },
     { name = "fastapi" },
     { name = "fastembed" },
@@ -1940,7 +1942,7 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'relevance'", specifier = ">=0.4.0" },
     { name = "gunicorn", marker = "sys_platform != 'win32' and extra == 'proxy-prod'", specifier = ">=21.0.0" },
     { name = "headroom-ai", extras = ["proxy"], marker = "extra == 'proxy-prod'" },
-    { name = "headroom-ai", extras = ["proxy", "code", "ml", "memory", "relevance", "image", "reports", "otel", "evals", "voice", "html", "mcp", "spreadsheet"], marker = "extra == 'all'" },
+    { name = "headroom-ai", extras = ["proxy", "code", "ml", "memory", "relevance", "image", "reports", "otel", "evals", "voice", "html", "mcp", "spreadsheet", "bedrock"], marker = "extra == 'all'" },
     { name = "headroom-ai", extras = ["proxy", "code", "relevance", "reports", "otel", "html", "mcp", "spreadsheet"], marker = "extra == 'sandbox'" },
     { name = "headroom-ai", extras = ["voice"], marker = "extra == 'voice-train'" },
     { name = "hnswlib", marker = "extra == 'dev'", specifier = ">=0.8.0" },


### PR DESCRIPTION
## Summary

Completes native Claude Code Bedrock routing without taking the proxy backward. The contributor branch is semantically rebased onto current `main`, retaining the MCP SDK v1 compatibility cap and all newer Claude/proxy lifecycle fixes.

- Detects `CLAUDE_CODE_USE_BEDROCK` and uses `ANTHROPIC_BEDROCK_BASE_URL`.
- Compresses and re-signs both InvokeModel POST paths against `bedrock-runtime.<region>`.
- Proxies Claude discovery via signed `GET /inference-profiles` against the distinct `bedrock.<region>` control-plane host, preserving query parameters.
- Uses the standard boto3 credential chain; explicit Bedrock gateway configuration still takes precedence.
- Removes stale workflow/dependency churn and keeps current tree-sitter, Bedrock, lockfile, MCP, Copilot, tool-search, cleanup, and proxy-start contracts.

Fixes #1589.

## Verification

- `133 passed, 6 skipped` across Claude wrap/base URL/Vertex/Bedrock and MCP v1 compatibility/integration suites.
- Focused Bedrock suite: `23 passed, 4 skipped`.
- Ruff check and format clean; `git diff --check` clean.
- Contributor live AWS proof remains applicable: direct regional SigV4 invokes were accepted by AWS.

The dependency-gated skips are for optional botocore paths in the local environment; signer and forwarding coverage runs when that extra is installed.