### PR TITLE
fix(tokenizers): treat literal special-token strings as plain text

### DIFF
--- a/headroom/providers/openai.py
+++ b/headroom/providers/openai.py
@@ -298,7 +298,14 @@ class OpenAITokenCounter:
         """Count tokens in text."""
         if not text:
             return 0
-        return len(self._encoding.encode(text))
+        try:
+            return len(self._encoding.encode(text))
+        except ValueError:
+            # Passthrough content can legitimately contain strings that look
+            # like tiktoken special tokens (e.g. "<|endoftext|>"). Treat them
+            # as ordinary text instead of raising. Matches
+            # AnthropicTokenCounter.count_text.
+            return len(self._encoding.encode(text, disallowed_special=()))
 
     def count_message(self, message: dict[str, Any]) -> int:
         """

--- a/headroom/tokenizers/tiktoken_counter.py
+++ b/headroom/tokenizers/tiktoken_counter.py
@@ -234,7 +234,15 @@ class TiktokenCounter(BaseTokenizer):
         """
         if not text:
             return 0
-        return len(self.encoding.encode(text))
+        try:
+            return len(self.encoding.encode(text))
+        except ValueError:
+            # Passthrough content can legitimately contain strings that look
+            # like tiktoken special tokens (e.g. "<|endoftext|>" or FIM markers
+            # in code/tool output). Treat them as ordinary text instead of
+            # raising, which would otherwise abort token counting for the whole
+            # request. Matches AnthropicTokenCounter.count_text.
+            return len(self.encoding.encode(text, disallowed_special=()))
 
     def count_messages(self, messages: list[dict[str, Any]]) -> int:
         """Count tokens in messages using OpenAI's exact formula.
@@ -311,7 +319,13 @@ class TiktokenCounter(BaseTokenizer):
         Returns:
             List of token IDs.
         """
-        return self.encoding.encode(text)
+        try:
+            return self.encoding.encode(text)
+        except ValueError:
+            # See count_text: literal special-token strings in passthrough
+            # content must be encoded as ordinary text, not rejected. The
+            # round-trip through decode() is unaffected.
+            return self.encoding.encode(text, disallowed_special=())
 
     def decode(self, tokens: list[int]) -> str:
         """Decode token IDs to text.

--- a/tests/test_providers/test_openai.py
+++ b/tests/test_providers/test_openai.py
@@ -21,6 +21,18 @@ class TestOpenAITokenCounting:
         count = openai_tokenizer.count_text(text)
         assert count > 0
 
+    def test_count_text_allows_literal_special_tokens(self, openai_tokenizer):
+        """count_text must not raise on literal tiktoken special-token strings.
+
+        Regression: a /v1/responses request whose context contained the literal
+        "<|endoftext|>" made tiktoken raise ValueError (default
+        disallowed_special="all"), which the proxy turned into an HTTP 413
+        compression_refused. Markers must be counted as ordinary text instead.
+        """
+        text = "before <|endoftext|> after"
+        count = openai_tokenizer.count_text(text)
+        assert count > openai_tokenizer.count_text("before  after")
+
     def test_count_messages_single(self, openai_tokenizer):
         messages = [{"role": "user", "content": "Hello"}]
         count = openai_tokenizer.count_messages(messages)

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -111,6 +111,29 @@ class TestTiktokenCounter:
         decoded = counter.decode(tokens)
         assert decoded == text
 
+    def test_count_text_allows_literal_special_tokens(self):
+        """count_text must not raise on literal tiktoken special-token strings.
+
+        Regression: passthrough/tool content containing "<|endoftext|>" (or FIM
+        markers) made tiktoken raise ValueError under its default
+        disallowed_special="all", aborting token counting for the whole request.
+        Through the proxy this surfaced as an HTTP 413 compression_refused.
+        """
+        counter = TiktokenCounter("gpt-4o")
+        text = "before <|endoftext|> after <|fim_prefix|> end"
+        # Must not raise; markers are counted as ordinary text.
+        count = counter.count_text(text)
+        assert count > counter.count_text("before  after  end")
+
+    def test_encode_allows_literal_special_tokens(self):
+        """encode must treat literal special-token strings as ordinary text."""
+        counter = TiktokenCounter("gpt-4o")
+        text = "x <|endoftext|> y"
+        tokens = counter.encode(text)
+        assert isinstance(tokens, list) and len(tokens) > 0
+        # Encoding as ordinary text round-trips back to the original literal.
+        assert counter.decode(tokens) == text
+
     def test_repr(self):
         """Test string representation."""
         counter = TiktokenCounter("gpt-4o")


### PR DESCRIPTION
## Description

`tiktoken`'s `Encoding.encode()` defaults to `disallowed_special="all"`, which **raises `ValueError`** when the input text contains a literal special-token string such as `<|endoftext|>` or an FIM marker. Three tokenizer call sites still call `encode()` without guarding against this, so any passthrough/tool content containing those literals crashes token counting.

In the proxy this aborts compression of `/v1/responses` requests. For request bodies above the 256 KiB fail-closed threshold (`WS_COMPRESSION_OVERSIZE_BYTES_DEFAULT`), the compression failure is then converted to an **HTTP 413 `compression_refused`**, which stalls Codex in a retry loop (the offending string stays in context every turn, so every retry fails identically).

Observed in production with the token-mode proxy in front of Codex:

```text
WARNING /v1/responses compression failed (bytes=588269):
  ValueError: Encountered text corresponding to disallowed special token '<|endoftext|>'.
ERROR   /v1/responses REFUSING to forward request after compression failure
  (reason=oversize:bytes=588269>threshold=262144, bytes=588269); returning HTTP 413
```

`AnthropicTokenCounter.count_text` already handles this exact case (try/except → `disallowed_special=()`); this PR propagates the same fix to the remaining OpenAI/tiktoken counters.

Closes # <!-- no issue filed; happy to open one if preferred -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/providers/openai.py` — `OpenAITokenCounter.count_text`: fall back to `disallowed_special=()` on `ValueError`.
- `headroom/tokenizers/tiktoken_counter.py` — same fallback in `TiktokenCounter.count_text` **and** `TiktokenCounter.encode` (the latter is used by the compression path, which must round-trip such content rather than reject it).
- Each fallback mirrors the existing `AnthropicTokenCounter.count_text` idiom and comments.
- Added regression tests for both counters (provider + tokenizer) that fail without the fix.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest -q tests/test_tokenizers.py tests/test_tokenizer.py \
            tests/test_providers/test_openai.py tests/test_providers/test_anthropic.py
75 passed, 14 skipped, 2 warnings in 2.22s

$ pytest -q tests/test_proxy_count_tokens_integration.py \
            tests/test_openai_responses_context_compaction.py \
            tests/test_openai_codex_routing.py
23 passed, 20 skipped, 1 warning in 4.33s

$ ruff check <changed files>         # All checks passed!
$ ruff format --check <changed files> # 4 files already formatted
$ mypy headroom/tokenizers/tiktoken_counter.py headroom/providers/openai.py
Success: no issues found in 2 source files
```

## Real Behavior Proof

- Environment: clean clone at `v0.26.0-41-g7c26a54d`, editable install (`pip install -e ".[dev,proxy]"`), Python 3.14.
- Exact command / steps: negative control — stash only the source fix (keep the new tests), run the three new regression tests, then restore the fix and re-run:

```text
$ git stash push headroom/tokenizers/tiktoken_counter.py headroom/providers/openai.py
$ pytest -q <the 3 new tests>
E   ValueError: Encountered text corresponding to disallowed special token '<|endoftext|>'.
3 failed in 0.21s
$ git stash pop      # restore fix
$ pytest -q <the 3 new tests>
3 passed
```

- Observed result: without the fix the new tests reproduce the exact production `ValueError`; with the fix, `count_text`/`encode` treat the markers as ordinary text (e.g. `"x <|endoftext|> y"` → 16 tokens, `decode(encode(text)) == text`).
- Not tested: the full live proxy → HTTP 413 `compression_refused` → Codex retry-loop path was not reproduced end-to-end against a running proxy. Reproduction is at the tokenizer/counter unit level plus the existing proxy/compaction integration tests; no live Codex session was run against a patched proxy.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
