### PR TITLE
fix(scripts): rename .releaseetadata to .releasemetadata

### DIFF
--- a/scripts/tests/test_version_sync.py
+++ b/scripts/tests/test_version_sync.py
@@ -128,8 +128,8 @@ def test_version_sync_explicit_version(temp_project: dict[str, Path]) -> None:
     github_plugin = json.loads(temp_project["github_plugin"].read_text())
     assert github_plugin["version"] == "0.7.0"
 
-    # Verify .releaseetadata was created
-    release_metadata = root / ".releaseetadata"
+    # Verify .releasemetadata was created
+    release_metadata = root / ".releasemetadata"
     assert release_metadata.exists()
     metadata = json.loads(release_metadata.read_text())
     assert metadata["version"] == "0.7.0"
@@ -230,7 +230,7 @@ def test_bump_major(temp_project: dict[str, Path]) -> None:
 
 
 def test_release_metadata_written(temp_project: dict[str, Path]) -> None:
-    """Test .releaseetadata is written correctly."""
+    """Test .releasemetadata is written correctly."""
     root = temp_project["root"]
     script = Path(__file__).parent.parent / "version-sync.py"
 
@@ -242,7 +242,7 @@ def test_release_metadata_written(temp_project: dict[str, Path]) -> None:
 
     assert result.returncode == 0, f"Script failed: {result.stderr}"
 
-    release_metadata = root / ".releaseetadata"
+    release_metadata = root / ".releasemetadata"
     assert release_metadata.exists()
 
     metadata = json.loads(release_metadata.read_text())
@@ -288,4 +288,4 @@ def test_plugin_manifests_only_leaves_package_versions_unchanged(
         json.loads(temp_project["repo_github_marketplace"].read_text())["metadata"]["version"]
         == "0.8.0"
     )
-    assert not (root / ".releaseetadata").exists()
+    assert not (root / ".releasemetadata").exists()

--- a/scripts/version-sync.py
+++ b/scripts/version-sync.py
@@ -113,7 +113,7 @@ def update_pyproject_version(root: Path, version: str) -> None:
 
 
 def write_release_metadata(root: Path, version: str) -> None:
-    """Write .releaseetadata JSON file."""
+    """Write .releasemetadata JSON file."""
     metadata = {
         "version": version,
         "packages": {
@@ -123,7 +123,7 @@ def write_release_metadata(root: Path, version: str) -> None:
             "agent-hooks-plugin": version,
         },
     }
-    metadata_path = root / ".releaseetadata"
+    metadata_path = root / ".releasemetadata"
     with open(metadata_path, "w", encoding="utf-8") as f:
         json.dump(metadata, f, indent=2)
         f.write("\n")


### PR DESCRIPTION
## Description
  
  Fixes a typo in the release metadata filename written by `scripts/version-sync.py`.
  The file was being created as `.releaseetadata` (double `e`) instead of `.releasemetadata`.
  Any downstream tooling or developer looking for the artifact by its correct name would not find it.

  Closes #

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Performance improvement 
  - [ ] Code refactoring (no functional changes)

  ## Changes Made

  - `scripts/version-sync.py`: corrected the filename in `write_release_metadata()` — both the docstring and the `metadata_path` assignment.
  - `scripts/tests/test_version_sync.py`: updated 3 test assertions to reference `.releasemetadata`.

  ## Testing

  - [x] Unit tests pass (`pytest`)
  - [ ] Linting passes (`ruff check .`)
  - [ ] Type checking passes (`mypy headroom`)
  - [ ] New tests added for new functionality
  - [ ] Manual testing performed

  ### Test Output

  ```text   
  $ uv run python -m pytest scripts/tests/test_version_sync.py -q
  ============================= test session starts ==============================
  platform linux -- Python 3.14.0, pytest-9.1.1, pluggy-1.6.0
  rootdir: /home/sepurisaikrishna/Documents/calude-here/headroom
  configfile: pyproject.toml
  collected 6 items
  
  scripts/tests/test_version_sync.py ......                                [100%]

  =============================== warnings summary ===============================
  PytestConfigWarning: Unknown config option: asyncio_mode

  -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
  ========================= 6 passed, 1 warning in 1.00s =========================

  $ git diff --check origin/main..HEAD
  # no output; command exited 0
 ```

  ## Real Behavior Proof

  - Environment: Linux, Python 3.14.0, uv-managed .venv, branch based on current origin/main.
  - Exact command / steps: grep -r "releaseetadata" scripts/ before the fix returns hits; after the fix returns nothing. Confirmed .releasemetadata is written correctly by
  test_release_metadata_written.
  - Observed result: all 6 test_version_sync.py tests pass with the corrected filename.
  - Not tested: full repository pytest, ruff, and mypy — this is a one-line spelling fix with no logic changes.

  ## Review Readiness

  - [x] I have performed a self-review
  - [x] This PR is ready for human review
  
  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [ ] I have updated the CHANGELOG.md if applicable

  ## Screenshots (if applicable)   

  N/A.

  ## Additional Notes

  - The typo was consistent across implementation and tests, so all tests passed before this fix with the wrong name. The fix corrects both the code and the test expectations together.
  - No production behaviour changes the file is written but not yet consumed by any workflow step.

