### PR TITLE
Make all standard optional dependencies install by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,13 @@ dependencies = [
     "opentelemetry-api>=1.24.0",  # Safe no-op OTEL API for instrumentation
     "ast-grep-cli>=0.30.0",       # AST-aware code slicing (CodeCompressor); binary wheel
     "tomli>=2.0.0; python_version < '3.11'",  # tomllib backport for helper scripts
+    # Batteries-included: pull in every standard optional feature by default so a
+    # plain `pip install headroom-ai` ships the proxy, ML/Kompress, code, memory,
+    # relevance, image, reports, otel, evals, voice, html, benchmark, mcp and
+    # spreadsheet extras. Self-references the [all] aggregate (same pattern already
+    # used by [all]/[proxy-prod]/[voice-train]); platform-specific extras
+    # (pytorch-mps, proxy-prod/gunicorn, memory-stack) stay opt-in as before.
+    "headroom-ai[all]",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What

Adds a single self-referential `headroom-ai[all]` entry to the core `[project.dependencies]` in `pyproject.toml`, so a plain `pip install headroom-ai` (or `npm`-style discovery → `uvx`/`pipx`) ships every **standard** feature out of the box.

## Why

New users install `headroom-ai`, run `headroom proxy`, and hit:

```
Error: Proxy dependencies not installed. Run: pip install headroom-ai[proxy]
```

The CLI's headline commands (`proxy`, `learn`, code/memory features) all live behind optional extras, so the default install can't run them. This makes the documented quickstart fail until users discover and append the right extra.

## How

```toml
dependencies = [
    ...
    "headroom-ai[all]",   # batteries-included default
]
```

- Reuses the **same intra-package self-reference pattern** the project already relies on for the `all`, `proxy-prod`, and `voice-train` extras — nothing new for the build backend (maturin) to support.
- `[all]` already curates the cross-platform-safe set (proxy, code, ml, memory, relevance, image, reports, otel, evals, voice, html, benchmark, mcp, spreadsheet).
- Platform-specific extras that `[all]` **intentionally omits** stay opt-in: `pytorch-mps` (macOS-only), `proxy-prod`/`gunicorn` (Unix-only), `memory-stack` (Qdrant/Neo4j). So Windows, CI, and Python 3.14 installs are unaffected.

## Trade-off (please weigh)

This is deliberately the **batteries-included** direction: the default install gets heavier (pulls `torch`, `transformers`, etc. via `[ml]`/`[voice]`). That is the explicit goal of this PR — make the documented commands work with zero extra steps. If you'd prefer to keep the lean core, a lighter alternative would be to default only to `[proxy]` (what the quickstart actually needs) and/or emit a clearer "run `pip install headroom-ai[all]`" hint on missing extras. Happy to repoint this PR at either approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)