### PR TITLE
fix(e2e): align Codex wrap e2e with global-only RTK guidance (#1240)

### DIFF
--- a/e2e/wrap/run.py
+++ b/e2e/wrap/run.py
@@ -548,11 +548,12 @@ def verify_codex_wrap(
         cwd=project_dir,
         timeout=120,
     )
-    project_agents = project_dir / "AGENTS.md"
+    # RTK guidance for Codex is global-only (#1240): it is injected into
+    # ~/.codex/AGENTS.md, never a project-level AGENTS.md. A project AGENTS.md is
+    # written only when `wrap codex --memory` is used (for memory guidance), which
+    # this scenario does not exercise.
     global_agents = Path(base_env["HOME"]) / ".codex" / "AGENTS.md"
-    assert_true(project_agents.exists(), "Codex wrap should create project AGENTS.md")
     assert_true(global_agents.exists(), "Codex wrap should create ~/.codex/AGENTS.md")
-    assert_true(RTK_MARKER in project_agents.read_text(encoding="utf-8"), "Missing RTK marker")
     assert_true(
         RTK_MARKER in global_agents.read_text(encoding="utf-8"), "Missing global RTK marker"
     )


### PR DESCRIPTION
## Description

`main` is red on the **Wrap E2E** workflow and on CI's **`docker-native-e2e`** job. Both run `e2e/wrap/run.py` and fail on the same assertion:

```
e2e/wrap/run.py:553  assert_true(project_agents.exists(), "Codex wrap should create project AGENTS.md")
AssertionError: Codex wrap should create project AGENTS.md
```

PR #1240 (`fix(wrap): keep Codex RTK guidance global`) intentionally moved Codex RTK guidance to the global `~/.codex/AGENTS.md` and stopped writing a project-level `AGENTS.md` (a project `AGENTS.md` is now created only when `wrap codex --memory` is used, for memory guidance). #1240 updated its unit test (`tests/test_cli/test_wrap_codex.py`) but not the wrap **e2e** harness, so `verify_codex_wrap` still asserted the old project-level behavior. This corrects the e2e harness to match the shipped behavior — it is a stale-test fix, not a behavior change.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `e2e/wrap/run.py` `verify_codex_wrap`: removed the two now-false project-level assertions (`project_agents.exists()` and the project RTK-marker check) and the unused `project_agents` variable.
- Kept the global assertions (`~/.codex/AGENTS.md` exists + contains the RTK marker) — these already match the shipped behavior.
- Added a comment documenting that Codex RTK guidance is global-only (#1240) and a project `AGENTS.md` appears only with `--memory`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ ruff check e2e/wrap/run.py
All checks passed!

$ python -m pytest tests/test_cli/test_wrap_codex.py -q
============================== 57 passed in 6.13s ==============================
# includes test_wrap_codex_injects_rtk_globally_without_changing_project_agents,
# which asserts the RTK marker lands in ~/.codex/AGENTS.md and the project
# AGENTS.md is left byte-for-byte unchanged — the contract this e2e now matches.
```

## Real Behavior Proof

- Environment: macOS (darwin 25.4.0), Python 3.12 venv; root-caused from the failing CI logs and verified the behavior contract via the unit suite (the Docker wrap-e2e itself runs in CI)
- Exact command / steps: read the failing step logs for CI run `27912260743` and Wrap E2E run `27912260746` (both fail at `e2e/wrap/run.py:553`); confirmed via `headroom/cli/wrap.py:3679` that RTK injects only into `~/.codex/AGENTS.md`; ran `pytest tests/test_cli/test_wrap_codex.py` and `ruff check e2e/wrap/run.py`
- Observed result: 57/57 codex-wrap unit tests pass; `test_wrap_codex_injects_rtk_globally_without_changing_project_agents` confirms the RTK marker is written to `~/.codex/AGENTS.md` while the project `AGENTS.md` is left unchanged — exactly what the corrected e2e asserts. ruff clean.
- Not tested: the full Docker `Wrap E2E` / `docker-native-e2e` jobs locally (require Docker + a wheel build); they run on this PR's CI to confirm the fix turns both jobs green.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A — e2e harness fix; evidence is under "Real Behavior Proof".

## Additional Notes

- `mypy` / "new tests added" are unchecked: this is a test-only correction to an existing e2e assertion, no production code or new test surface.
- Root-cause detail: a project-level `AGENTS.md` is created by `wrap codex` only inside the `if memory:` branch (`headroom/cli/wrap.py:3704`/`3715`); the e2e runs `wrap codex -- --help` without `--memory`, so no project file is created — the assertion could never pass after #1240.
- `ruff check .` scoped to the changed file here (the dashboard HTML template trips ruff's `invalid-syntax`, a known repo false-positive).
