### PR TITLE
fix(install): write deployment manifest atomically and tolerate corrupt manifests

### DIFF
--- a/headroom/install/state.py
+++ b/headroom/install/state.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
+import tempfile
 from dataclasses import asdict
+from pathlib import Path
 
 from .models import ArtifactRecord, DeploymentManifest, ManagedMutation, iso_utc_now
 from .paths import deploy_root, manifest_path, profile_root
@@ -17,18 +20,42 @@ class ManifestError(Exception):
     """A deployment manifest exists on disk but could not be parsed."""
 
 
+def _atomic_write_text(path: Path, data: str) -> None:
+    """Write ``data`` to ``path`` atomically.
+
+    The payload is written to a temporary file in the same directory, flushed and
+    fsynced, then moved into place with :func:`os.replace` (an atomic rename on
+    both POSIX and Windows). A crash between truncate and full write therefore
+    leaves either the previous file or the complete new one on disk, never a
+    truncated manifest.
+    """
+    directory = path.parent
+    fd, tmp_name = tempfile.mkstemp(dir=directory, prefix=f".{path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
 def save_manifest(manifest: DeploymentManifest) -> None:
     """Persist a deployment manifest to disk.
 
-    Gracefully handles read-only filesystems by logging a warning
-    instead of crashing.
+    The write is atomic so an interrupted save (SIGKILL, system restart, OOM)
+    cannot leave a truncated ``manifest.json`` behind. Gracefully handles
+    read-only filesystems by logging a warning instead of crashing.
     """
     try:
         root = profile_root(manifest.profile)
         root.mkdir(parents=True, exist_ok=True)
         manifest.updated_at = iso_utc_now()
         path = manifest_path(manifest.profile)
-        path.write_text(json.dumps(asdict(manifest), indent=2) + "\n", encoding="utf-8")
+        _atomic_write_text(path, json.dumps(asdict(manifest), indent=2) + "\n")
     except OSError as e:
         logger.warning("Cannot save deployment manifest: %s — continuing without persistence", e)
 

--- a/tests/test_install/test_state.py
+++ b/tests/test_install/test_state.py
@@ -2,8 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from headroom.install.models import ArtifactRecord, DeploymentManifest, ManagedMutation
-from headroom.install.state import delete_manifest, list_manifests, load_manifest, save_manifest
+from headroom.install.state import (
+    ManifestError,
+    delete_manifest,
+    list_manifests,
+    load_manifest,
+    save_manifest,
+)
 
 
 def _manifest() -> DeploymentManifest:
@@ -34,6 +42,33 @@ def test_save_and_load_manifest_round_trip(monkeypatch, tmp_path: Path) -> None:
     assert loaded.profile == "default"
     assert loaded.mutations[0].kind == "shell-block"
     assert loaded.artifacts[0].kind == "script"
+
+
+def test_load_manifest_raises_manifest_error_on_corrupt_payload(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Simulate a crash mid-write: a truncated/garbage manifest left on disk.
+    profile_dir = tmp_path / ".headroom" / "deploy" / "default"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "manifest.json").write_text("{not json", encoding="utf-8")
+
+    # A present-but-corrupt manifest surfaces a typed ManifestError so callers can
+    # report cleanly or degrade, rather than a raw JSONDecodeError traceback.
+    with pytest.raises(ManifestError):
+        load_manifest("default")
+
+
+def test_save_manifest_writes_atomically(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    save_manifest(_manifest())
+
+    # No leftover temp file from the atomic write; only the manifest itself.
+    profile_dir = tmp_path / ".headroom" / "deploy" / "default"
+    assert sorted(p.name for p in profile_dir.iterdir()) == ["manifest.json"]
+    # And the persisted manifest still round-trips.
+    assert load_manifest("default") is not None
 
 
 def test_list_manifests_ignores_invalid_payloads(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

Make deployment-manifest persistence in `headroom/install/state.py` crash-safe by writing the manifest **atomically**. `save_manifest` used a plain `path.write_text(...)` (truncate-then-write), so an interrupted save (Ctrl-C, system restart, container OOM/SIGKILL) could leave a truncated `manifest.json` on disk.

> **Note (rebased onto current `main`):** since this PR was opened, #1491 hardened `load_manifest` to raise a typed `ManifestError` on a corrupt manifest. I've rebased and **dropped my original `load_manifest → return None` change in favour of that deliberate typed-error design**, so this PR now scopes down to the still-missing piece: the **atomic write** (upstream `save_manifest` is still a plain `write_text`), plus a regression test for the `ManifestError` path that `main` added without test coverage.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add `_atomic_write_text(path, data)`: write to a same-directory temp file → `flush()` + `os.fsync()` → `os.replace()` (atomic rename on POSIX and Windows); the temp file is cleaned up if anything fails.
- `save_manifest` now persists via `_atomic_write_text` instead of `path.write_text(...)`, so a crash between truncate and full write leaves either the previous file or the complete new one — never a truncated manifest.
- `load_manifest` is left exactly as `main` has it (raises `ManifestError` on a corrupt payload) — no behavioural change from me there.
- Tests: add `test_save_manifest_writes_atomically` (no leftover temp file; manifest round-trips) and `test_load_manifest_raises_manifest_error_on_corrupt_payload` (covers the `ManifestError` path #1491 introduced but did not test).

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/test_install/test_state.py -q
.....                                                                    [100%]
5 passed in 0.11s

$ ruff check headroom/install/state.py tests/test_install/test_state.py
All checks passed!

$ ruff format --check headroom/install/state.py tests/test_install/test_state.py
2 files already formatted

$ mypy headroom/install/state.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- **Environment:** macOS (Darwin), Python 3.13, rebased onto current `main`.
- **Exact command / steps:** `save_manifest(manifest)` then inspect the profile dir and reload.
- **Observed result:** after a save the profile directory contains only `manifest.json` (no leftover `.manifest.json.*.tmp`), and `load_manifest("default")` round-trips the persisted manifest. A deliberately-corrupt `manifest.json` (`"{not json"`) makes `load_manifest` raise `ManifestError` (typed), not a raw `JSONDecodeError`.
- **Not tested:** the physical-crash-mid-write window is reasoned about via `os.replace()` atomicity, not fault-injected.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

Documentation / CHANGELOG boxes are unchecked as N/A — this is an internal persistence-hardening fix with no user-facing surface. The diff is now small (atomic write + two tests); the corrupt-manifest handling itself lives in `main` via #1491.
