### PR TITLE
fix(code): slice tree-sitter byte offsets by byte, not str index

### DIFF
--- a/headroom/transforms/code_compressor.py
+++ b/headroom/transforms/code_compressor.py
@@ -851,7 +851,7 @@ class CodeAwareCompressor(Transform):
         body_line_counts: dict[str, int] = {}
         for qname, node in definitions.items():
             collect_calls_in_function(node, qname)
-            node_text = code[node.start_byte : node.end_byte]
+            node_text = _get_node_text(node, code)
             body_line_counts[qname] = max(1, len(node_text.split("\n")) - 2)
 
         # Reference counts: subtract definition occurrences
@@ -1257,8 +1257,8 @@ class CodeAwareCompressor(Transform):
                             child, code, language, lang_config, body_limits, analysis
                         )
                         # Reconstruct export with compressed inner definition
-                        export_prefix = code[node.start_byte : child.start_byte]
-                        export_suffix = code[child.end_byte : node.end_byte]
+                        export_prefix = _slice_code_bytes(code, node.start_byte, child.start_byte)
+                        export_suffix = _slice_code_bytes(code, child.end_byte, node.end_byte)
                         structure.function_signatures.append(
                             export_prefix + compressed + export_suffix
                         )
@@ -1568,7 +1568,7 @@ class CodeAwareCompressor(Transform):
         if signature_lines:
             result_parts.extend(signature_lines)
         else:
-            sig_text = code[node.start_byte : body_node.start_byte].rstrip()
+            sig_text = _slice_code_bytes(code, node.start_byte, body_node.start_byte).rstrip()
             result_parts.append(sig_text)
 
         if opening_brace_line is not None:
@@ -1977,9 +1977,20 @@ class CodeAwareCompressor(Transform):
 # =========================================================================
 
 
+def _slice_code_bytes(code: str, start_byte: int, end_byte: int) -> str:
+    """Slice source by tree-sitter UTF-8 *byte* offsets.
+
+    tree-sitter reports node positions as UTF-8 byte offsets, but a Python
+    ``str`` is indexed by code point, so ``code[start_byte:end_byte]`` cuts
+    non-ASCII (CJK/emoji) source mid-token once a multi-byte character appears
+    earlier in the file. Index the encoded bytes instead.
+    """
+    return code.encode("utf-8")[start_byte:end_byte].decode("utf-8")
+
+
 def _get_node_text(node: Any, code: str) -> str:
-    """Extract text from AST node."""
-    return code[node.start_byte : node.end_byte]
+    """Extract text from an AST node, honoring UTF-8 byte offsets."""
+    return _slice_code_bytes(code, node.start_byte, node.end_byte)
 
 
 def _get_definition_name(node: Any) -> str | None:

--- a/tests/test_transforms/test_code_compressor.py
+++ b/tests/test_transforms/test_code_compressor.py
@@ -19,6 +19,9 @@ from headroom.transforms.code_compressor import (
     CodeCompressorConfig,
     CodeLanguage,
     DocstringMode,
+    _get_node_text,
+    _get_parser,
+    _slice_code_bytes,
     detect_language,
     is_tree_sitter_available,
     is_tree_sitter_loaded,
@@ -1396,3 +1399,33 @@ class TestRealASTRuns:
         assert result.syntax_valid is True
         # Signature is preserved verbatim.
         assert "pub fn add(a: i64, b: i64) -> i64" in result.compressed
+
+
+@pytest.mark.skipif(not TREE_SITTER_INSTALLED, reason="tree-sitter-languages not installed")
+class TestNonAsciiByteOffsets:
+    """Regression for #1319: tree-sitter reports UTF-8 *byte* offsets, but the
+    compressor indexed them into the code-point-indexed ``str``, so any non-ASCII
+    (CJK/emoji) character earlier in the file shifted every later slice and cut
+    nodes mid-token (e.g. ``import os`` -> ``port os`` / dropped)."""
+
+    def test_slice_code_bytes_uses_byte_offsets(self):
+        code = "中文xy"  # 中, 文 are 3 bytes each in UTF-8
+        # bytes 6..8 are "xy"; code-point slice [6:8] would be out of range / wrong
+        assert _slice_code_bytes(code, 6, 8) == "xy"
+
+    def test_get_node_text_for_node_after_non_ascii(self):
+        code = 'def first():\n    """中文占位"""\n    return 1\n\ndef second():\n    return 2\n'
+        root = _get_parser("python").parse(bytes(code, "utf-8")).root_node
+        funcs = [n for n in root.children if n.type == "function_definition"]
+        # The second function follows a multi-byte docstring; its slice must not
+        # be shifted by the byte/char drift.
+        assert _get_node_text(funcs[1], code) == "def second():\n    return 2"
+
+    def test_imports_after_cjk_module_docstring_not_corrupted(self):
+        code = '"""模块中文中文中文 占位."""\nimport os\nimport sys\n'
+        root = _get_parser("python").parse(bytes(code, "utf-8")).root_node
+        imports = [
+            n for n in root.children if n.type in ("import_statement", "import_from_statement")
+        ]
+        assert _get_node_text(imports[0], code) == "import os"
+        assert _get_node_text(imports[1], code) == "import sys"


### PR DESCRIPTION
## Description

Fixes #1319. tree-sitter reports node positions as **UTF-8 byte offsets**
(`node.start_byte` / `node.end_byte`), but several sites in
`code_compressor.py` index those directly into the Python `str` `code`, which
is indexed by **code point**. For ASCII the two coincide; as soon as a
multi-byte character (CJK comment/docstring, emoji) appears earlier in the
file, every later slice shifts left by `(bytes - chars)` and cuts nodes
mid-token — `import os` → `port os`, signatures truncated, definitions dropped.
The fail-safe `_verify_syntax` then discards the broken result and returns the
original, so **non-ASCII source silently compresses 0%** with no error.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- `headroom/transforms/code_compressor.py`: add `_slice_code_bytes(code,
  start_byte, end_byte)` (indexes the encoded UTF-8 bytes) and route the five
  offending sites through it — `_get_node_text` plus the four direct
  `code[start_byte:end_byte]` slices (~lines 854, 1260, 1261, 1571). The
  reconstruction path (`_assemble_compressed`) already stitches pre-extracted
  strings, so fixing the slice sites fixes the whole flow.
- `tests/test_transforms/test_code_compressor.py`: `TestNonAsciiByteOffsets`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/test_transforms/test_code_compressor.py::TestNonAsciiByteOffsets -q
3 passed

$ ruff check headroom/transforms/code_compressor.py tests/test_transforms/test_code_compressor.py
All checks passed!
```

## Real Behavior Proof

- Environment: Windows, Python 3.10, `tree-sitter==0.25.x` +
  `tree-sitter-language-pack==0.x` (the `[code]` extra), against the real
  `code_compressor` (no proxy / LLM).
- Exact command / steps: parse `'"""模块中文中文中文 占位."""\nimport os\nimport sys\n'`
  and call `_get_node_text(import_node, code)`; also the issue's two-function
  repro with a CJK docstring in the first function.
- Observed result: **before** the fix → the import nodes return `'\n'` and `''`
  (sliced into garbage by the docstring's byte drift) and the second function
  returns `'nd():\n    return 2\n'`; **after** → `'import os'` / `'import sys'`
  and `'def second():\n    return 2'`. A CJK file now compresses with valid
  syntax instead of a 0% no-op.
- Not tested: a full `headroom optimize` end-to-end run; verified at the
  compressor/AST level, which is where the byte-offset slicing lives.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review