### PR TITLE
fix(release): remove headroom package dependency from release_version.py

### DIFF
--- a/headroom/release_version.py
+++ b/headroom/release_version.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-from headroom._subprocess import run
 
 SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?$")
@@ -221,7 +221,7 @@ def get_canonical_version(root: Path) -> str:
 def list_release_tags(root: Path) -> list[str]:
     """List release tags from the local Git checkout."""
 
-    result = run(
+    result = subprocess.run(
         ["git", "tag", "-l", "v*"],
         cwd=root,
         check=True,
@@ -240,7 +240,7 @@ def list_release_commits(root: Path, previous_tag: str) -> list[CommitInfo]:
     else:
         cmd.append("HEAD")
 
-    result = run(
+    result = subprocess.run(
         cmd,
         cwd=root,
         check=True,
@@ -263,7 +263,7 @@ def commit_height_since(root: Path, previous_tag: str) -> str:
     if not previous_tag:
         return "0"
 
-    result = run(
+    result = subprocess.run(
         ["git", "rev-list", f"{previous_tag}..HEAD", "--count"],
         cwd=root,
         check=True,

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -146,7 +146,7 @@ def test_list_release_commits_parses_empty_body_entries(
     run.return_value = Mock(
         stdout="feat: add capability\x1f\x1efix: patch bug\x1fbody text\x1e",
     )
-    monkeypatch.setattr("headroom.release_version.run", run)
+    monkeypatch.setattr("headroom.release_version.subprocess.run", run)
 
     commits = list_release_commits(ROOT, "")
 


### PR DESCRIPTION
## Description

`release_version.py` was changed in PR #1311 to import `from headroom._subprocess import run` instead of using stdlib `import subprocess`. This breaks the `detect-version` CI job which runs `python headroom/release_version.py` without the `headroom` package installed.

On GitHub Actions (Ubuntu 24.04, Python 3.12 with safe-path mode), the working directory is not in `sys.path`, so `headroom` cannot be found as a package. Even if the path were fixed, `import headroom` triggers `__init__.py` which imports optional dependencies (opentelemetry) not available in CI.

**Fix:** Revert to `import subprocess` / `subprocess.run(...)`. `release_version.py` is a CI tool script and should not depend on the project's runtime package.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/release_version.py`: Remove `from headroom._subprocess import run`, restore `import subprocess`, change 3 `run(...)` calls back to `subprocess.run(...)`
- `tests/test_release_version.py`: Update monkeypatch target from `headroom.release_version.run` to `headroom.release_version.subprocess.run`

## Testing

- [x] Unit tests pass (`pytest`): `python -m pytest tests/test_release_version.py -v` — 15 passed
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
> python -m pytest tests/test_release_version.py -v
============================= 15 passed in 0.27s ==============================

> # CI simulation (no headroom package in sys.path)
> python3 -c "
import sys
sys.path = [p for p in sys.path if 'site-packages' not in p]
sys.path.insert(0, 'headroom')
sys.path = [p for p in sys.path if p != '']
exec(open('headroom/release_version.py').read())
"
version=0.28.0
npm_version=0.28.0
canonical=0.27.0
height=51
bump=minor
previous_tag=v0.27.0
```

## Real Behavior Proof

- **Environment:** Ubuntu 24.04 x86_64, Python 3.12.3, headroom repo cloned at `v0.27.0` tag
- **Exact commands / steps (3-part proof):**
  1. Run existing tests to confirm no regression: `python -m pytest tests/test_release_version.py -v` → 15 passed (same as on main)
  2. Simulate the CI `detect-version` job by stripping `site-packages` from `sys.path` and running the script standalone: `python3 -c "import sys; sys.path = [p for p in sys.path if 'site-packages' not in p]; sys.path.insert(0, 'headroom'); sys.path = [p for p in sys.path if p != '']; exec(open('headroom/release_version.py').read())"` → version info printed successfully
  3. Before the fix, step 2 would fail with `ModuleNotFoundError: No module named 'headroom'` — confirmed by reverting the change locally
- **Observed result:** After fix, the script runs correctly in a CI-like environment with zero package dependencies. The `detect-version` CI job will no longer crash on `import headroom`.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

This regression was introduced by PR #1311 (`d633e817`). The `release_version.py` script ran successfully in CI for years using stdlib `subprocess` — it does not need access to the `headroom` package internals. This fix restores that independence while preserving the same functional behavior.