### PR TITLE
chore: bump RTK from v0.28.2 to v0.42.4

### DIFF
--- a/headroom/rtk/__init__.py
+++ b/headroom/rtk/__init__.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from headroom import paths as _paths
 
-RTK_VERSION = "v0.28.2"
+RTK_VERSION = "v0.42.4"
 RTK_BIN_DIR = _paths.bin_dir()
 _RTK_NAME = "rtk.exe" if platform.system() == "Windows" else "rtk"
 RTK_BIN_PATH = RTK_BIN_DIR / _RTK_NAME

--- a/headroom/rtk/installer.py
+++ b/headroom/rtk/installer.py
@@ -73,7 +73,7 @@ def download_rtk(version: str | None = None) -> Path:
     """Download rtk binary from GitHub releases.
 
     Args:
-        version: Version to download (e.g., "v0.28.2"). Defaults to pinned version.
+        version: Version to download (e.g., "v0.42.4"). Defaults to pinned version.
 
     Returns:
         Path to the installed binary.

--- a/tests/test_rtk_installer.py
+++ b/tests/test_rtk_installer.py
@@ -51,7 +51,7 @@ def test_download_rtk_skips_verify_for_non_native_target(monkeypatch, tmp_path: 
     with patch.object(installer, "RTK_BIN_DIR", tmp_path):
         with patch.object(installer, "urlopen", return_value=_Response()):
             with patch.object(installer.subprocess, "run") as subprocess_run:
-                installed_path = installer.download_rtk("v0.28.2")
+                installed_path = installer.download_rtk("v0.42.4")
 
     assert installed_path == tmp_path / "rtk"
     assert installed_path.exists()


### PR DESCRIPTION
## Description

Bumps the pinned RTK binary version from v0.28.2 to v0.42.4. This brings native Windows hook support — RTK can now auto-rewrite Bash commands via Claude's PreToolUse hook instead of relying on CLAUDE.md injection (which only instructs rather than intercepts).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Dependency update
- [ ] Code refactoring (no functional changes)

## Changes Made

- **`headroom/rtk/__init__.py`**: `RTK_VERSION` constant changed from `v0.28.2` to `v0.42.4`
- **`headroom/rtk/installer.py`**: Updated docstring example version to match
- **`tests/test_rtk_installer.py`**: Updated test version string for `test_download_rtk_skips_verify_for_non_native_target`

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ pytest tests/test_rtk_installer.py -v
============================= test session starts =============================
platform win32 -- Python 3.13.11
tests/test_rtk_installer.py::test_get_rtk_path_finds_windows_managed_binary PASSED
tests/test_rtk_installer.py::test_get_target_triple_uses_override PASSED
tests/test_rtk_installer.py::test_download_rtk_skips_verify_for_non_native_target PASSED
============================== 3 passed in 0.12s ==============================

$ ruff check .
All checks passed!

$ ruff format --check .
835 files already formatted
```

## Real Behavior Proof

- Environment: Windows 11 (native, not WSL), Python 3.13.11, RTK upgrade from v0.28.2 to v0.42.4
- Exact command / steps: (1) Download rtk-x86_64-pc-windows-msvc.zip from v0.42.4 release, (2) Replace ~/.headroom/bin/rtk.exe, (3) Run `rtk init -g --auto-patch` to register hook, (4) Run `rtk gain` to verify
- Observed result: `rtk --version` shows "rtk 0.42.4". `rtk init -g --auto-patch` registers hook in settings.json with "RTK hook registered (global)" and creates RTK.md. `rtk gain` shows "No tracking data yet" (expected before sessions run through Claude)
- Not tested: Linux/macOS environments, other AI agent integrations (Cursor, Codex, etc.), long-running Claude Code sessions with real traffic

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

This is a dependency version bump only — no logic changes. The test version string was updated to match for consistency.
