### PR TITLE
fix(proxy): keep excluded tool outputs protected

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -645,11 +645,10 @@ class HeadroomProxy(
         # ContentRouter, so merge rather than assign.
         if config.exclude_tools:
             router_config.exclude_tools = set(DEFAULT_EXCLUDE_TOOLS) | config.exclude_tools
-        # Token mode: allow compression of older excluded-tool results,
-        # and emit search results grouped by file (path once per file
-        # instead of repeated on every match line).
+        # Token mode: emit search results grouped by file (path once per file
+        # instead of repeated on every match line). Keep excluded-tool outputs
+        # protected for the full conversation; these are exact reference data.
         if is_token_mode(config.mode):
-            router_config.protect_recent_reads_fraction = 0.3
             router_config.search_group_by_file = True
         # `--compress-user-messages` flips the router's default skip rule.
         # Off by default for prefix-cache safety; enabled for workloads where

--- a/tests/test_proxy_per_provider_kompress.py
+++ b/tests/test_proxy_per_provider_kompress.py
@@ -50,6 +50,59 @@ def test_default_enables_kompress_and_shares_one_router() -> None:
     assert anthropic is openai
 
 
+def test_token_mode_keeps_excluded_tool_outputs_protected(monkeypatch) -> None:
+    anthropic, openai = _routers(_build(mode="token"))
+    assert anthropic is openai
+    assert anthropic.config.search_group_by_file is True
+    assert anthropic.config.protect_recent_reads_fraction == 0.0
+
+    def fail_if_compressed(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("excluded tool output reached compression")
+
+    monkeypatch.setattr(anthropic, "compress", fail_if_compressed)
+
+    from headroom.providers import OpenAIProvider
+    from headroom.tokenizer import Tokenizer
+
+    provider = OpenAIProvider()
+    tokenizer = Tokenizer(provider.get_token_counter("gpt-4o"), "gpt-4o")
+    old_tool_content = "\n".join(
+        f"src/module_{i}.py:{i}: important exact grep match" for i in range(120)
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_grep_old",
+                    "name": "Grep",
+                    "input": {"pattern": "important"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_grep_old",
+                    "content": old_tool_content,
+                }
+            ],
+        },
+        *(
+            {"role": "assistant" if i % 2 else "user", "content": f"filler turn {i}"}
+            for i in range(30)
+        ),
+    ]
+
+    result = anthropic.apply(messages, tokenizer)
+
+    assert result.messages[1]["content"][0]["content"] == old_tool_content
+    assert "router:excluded:tool" in result.transforms_applied
+
+
 def test_global_disable_respected_by_both() -> None:
     anthropic, openai = _routers(_build(disable_kompress=True))
     assert anthropic.config.enable_kompress is False


### PR DESCRIPTION
## Description

Keeps excluded tool outputs protected for the full conversation in token mode.

Previously, proxy token mode overrode `ContentRouterConfig.protect_recent_reads_fraction`
to `0.3`, which meant excluded tools such as `Read`, `Glob`, `Grep`, `Write`, `Edit`,
or tools explicitly listed with `--exclude-tools` / `HEADROOM_EXCLUDE_TOOLS`, could age
out of the protected window and fall through to lossy compression. That contradicts the
meaning of excluded tools and can corrupt exact reference data that agents rely on.

Closes #1307

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Removed the token-mode override that shortened excluded-tool protection to 30% of the conversation.
- Kept token-mode search-result grouping behavior unchanged.
- Added a regression test proving an old excluded `Grep` tool result stays byte-for-byte unchanged and never reaches compression.

## Testing

- [ ] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ rtk env PYTHONPATH=/tmp/headroom-core-stub:/Users/vinaygupta/Desktop/git/headroom-fix-tool-result-exclusion-window pytest tests/test_proxy_per_provider_kompress.py
============================= test session starts ==============================
platform darwin -- Python 3.13.5, pytest-9.0.1, pluggy-1.6.0 -- /Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13
collected 10 items

tests/test_proxy_per_provider_kompress.py::test_default_enables_kompress_and_shares_one_router PASSED [ 10%]
tests/test_proxy_per_provider_kompress.py::test_token_mode_keeps_excluded_tool_outputs_protected PASSED [ 20%]
tests/test_proxy_per_provider_kompress.py::test_global_disable_respected_by_both PASSED [ 30%]
tests/test_proxy_per_provider_kompress.py::test_disable_for_anthropic_only PASSED [ 40%]
tests/test_proxy_per_provider_kompress.py::test_disable_for_openai_only PASSED [ 50%]
tests/test_proxy_per_provider_kompress.py::test_per_provider_override_beats_global PASSED [ 60%]
tests/test_proxy_per_provider_kompress.py::test_get_env_optional_bool_tristate PASSED [ 70%]
tests/test_proxy_per_provider_kompress.py::test_proxy_config_from_env_reads_per_provider_kompress PASSED [ 80%]
tests/test_proxy_per_provider_kompress.py::test_cli_disable_kompress_anthropic_only PASSED [ 90%]
tests/test_proxy_per_provider_kompress.py::test_cli_enable_kompress_openai_from_env PASSED [100%]

======================== 10 passed, 1 warning in 0.76s =========================

$ rtk uv run --with ruff --no-project ruff check headroom/proxy/server.py tests/test_proxy_per_provider_kompress.py
All checks passed!

$ rtk uv run --with ruff --no-project ruff format --check headroom/proxy/server.py tests/test_proxy_per_provider_kompress.py
2 files already formatted
```

## Real Behavior Proof

- Environment:
  - macOS arm64
  - Python 3.13.5 for pytest
  - Branch: `fix-tool-result-exclusion-window`
- Exact command / steps:
  - Built a token-mode `HeadroomProxy`.
  - Pulled the shared `ContentRouter` from the Anthropic/OpenAI pipelines.
  - Patched `router.compress` to raise if an excluded tool result reaches compression.
  - Sent an old Anthropic-format `Grep` `tool_result` followed by 30 filler turns.
- Observed result:
  - `router.config.protect_recent_reads_fraction == 0.0`
  - `router.config.search_group_by_file is True`
  - The old `Grep` output remains byte-for-byte unchanged.
  - The test records `router:excluded:tool`.
- Not tested:
  - Full `pytest`: local native extension build was blocked by the machine C++ toolchain missing standard-library headers (`iostream` / `cstdint`) while building `headroom._core`.
  - `mypy headroom`: not run locally.

## Review Readiness

- [x] I have performed a self-review
- [ ] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

- Documentation: N/A, this preserves the existing documented meaning of excluded tools.
- CHANGELOG: N/A for this small bug fix unless maintainers prefer an entry.
- The local pytest command used a temporary `/tmp/headroom-core-stub` import shim only because the native Rust extension could not be built on this machine; CI should exercise the real `headroom._core`.
