### PR TITLE
feat(config): add 'none' tool profile to skip compression entirely (#1307)

### DIFF
--- a/headroom/config.py
+++ b/headroom/config.py
@@ -435,7 +435,10 @@ class CompressionProfile:
 
 
 # Named presets for convenience
+# "none" uses bias=inf as a sentinel: ContentRouter detects isinf(bias) and
+# skips compression entirely, returning the tool output verbatim.
 PROFILE_PRESETS: dict[str, CompressionProfile] = {
+    "none": CompressionProfile(bias=float("inf"), min_k=0),
     "conservative": CompressionProfile(bias=1.5, min_k=5),
     "moderate": CompressionProfile(bias=1.0, min_k=3),
     "aggressive": CompressionProfile(bias=0.7, min_k=3),

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -5271,7 +5271,7 @@ def _parse_tool_profiles(cli_profiles: list[str]) -> dict[str, Any]:
             profiles[tool_name] = PROFILE_PRESETS[level]
         else:
             logger.warning(
-                "Unknown profile level '%s' for tool '%s'. Use: conservative, moderate, aggressive",
+                "Unknown profile level '%s' for tool '%s'. Use: none, conservative, moderate, aggressive",
                 level,
                 tool_name,
             )

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -5034,6 +5034,13 @@ class ContentRouter(Transform):
                 # Look up tool-specific compression bias for OpenAI tool messages
                 tool_name = tool_name_map.get(tool_call_id, "")
                 bias = self._get_tool_bias(tool_name) if tool_name else 1.0
+                # "none" profile: bias=inf sentinel → skip compression for this tool
+                if math.isinf(bias):
+                    result_slots[i] = message
+                    transforms_applied.append("router:protected:tool_profile_none")
+                    route_counts.setdefault("tool_profile_none", 0)
+                    route_counts["tool_profile_none"] += 1
+                    continue
 
                 # Bash-search lossless pre-empt: a read-only search (grep/rg/git
                 # grep) run via a shell tool yields byte-losslessly foldable
@@ -5971,6 +5978,14 @@ class ContentRouter(Transform):
                 # Look up tool-specific compression bias
                 tool_name = (tool_name_map or {}).get(tool_use_id, "")
                 bias = self._get_tool_bias(tool_name) if tool_name else 1.0
+                # "none" profile: bias=inf sentinel → skip compression for this tool
+                if math.isinf(bias):
+                    new_blocks.append(block)
+                    transforms_applied.append("router:protected:tool_profile_none")
+                    if route_counts is not None:
+                        route_counts.setdefault("tool_profile_none", 0)
+                        route_counts["tool_profile_none"] += 1
+                    continue
 
                 # Enrich the relevance query with the triggering tool call's
                 # args (grep pattern, read path, …) — the sharpest, per-output

--- a/tests/test_cli_proxy_env.py
+++ b/tests/test_cli_proxy_env.py
@@ -1284,7 +1284,6 @@ class TestCLIProxyExcludeToolsEnvVar:
         assert result.exit_code == 0, result.output
         assert captured_config["config"].tool_profiles is None
 
-
 class TestCLIProxyRpmTpm:
     """--rpm/--tpm flags and HEADROOM_RPM/HEADROOM_TPM env vars must reach ProxyConfig."""
 
@@ -1431,3 +1430,27 @@ class TestSettingsFileToEnv:
 
         assert result.exit_code == 0, result.output
         assert captured_config["config"].port == 7777
+
+
+def test_tool_profiles_none_level_accepted(runner):
+    """HEADROOM_TOOL_PROFILES=Bash:none is accepted and yields an inf bias."""
+    import math
+
+    captured_config = {}
+
+    def mock_run_server(config, **kwargs):
+        captured_config["config"] = config
+
+    with patch("headroom.proxy.server.run_server", mock_run_server):
+        result = runner.invoke(
+            main,
+            ["proxy"],
+            env={"HEADROOM_TOOL_PROFILES": "Bash:none"},
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    cfg = captured_config["config"]
+    assert cfg.tool_profiles is not None
+    assert "Bash" in cfg.tool_profiles
+    assert math.isinf(cfg.tool_profiles["Bash"].bias)

--- a/tests/test_cli_proxy_env.py
+++ b/tests/test_cli_proxy_env.py
@@ -1284,6 +1284,7 @@ class TestCLIProxyExcludeToolsEnvVar:
         assert result.exit_code == 0, result.output
         assert captured_config["config"].tool_profiles is None
 
+
 class TestCLIProxyRpmTpm:
     """--rpm/--tpm flags and HEADROOM_RPM/HEADROOM_TPM env vars must reach ProxyConfig."""
 

--- a/tests/test_transforms_content_router.py
+++ b/tests/test_transforms_content_router.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 import headroom.transforms.content_router as content_router_module
+from headroom.config import CompressionProfile
 from headroom.transforms.content_detector import ContentType, DetectionResult
 from headroom.transforms.content_router import (
     CompressionCache,
@@ -35,6 +36,14 @@ def _reset_detect_module_state(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(content_router_module, "_detect_native_unhealthy", False)
     monkeypatch.setattr(content_router_module, "_detect_backend_warned", False)
     monkeypatch.setattr(content_router_module, "_detect_panic_warned", False)
+
+
+class _TinyTokenizer:
+    def count_text(self, text: str) -> int:
+        return max(1, len(text) // 4)
+
+    def count_messages(self, messages: list[dict]) -> int:
+        return sum(self.count_text(str(message.get("content", ""))) for message in messages)
 
 
 def test_compression_cache_handles_hits_skips_evictions_and_clear(
@@ -228,6 +237,67 @@ def test_short_instruction_with_embedded_json_compresses_without_kompress() -> N
     assert any(
         decision.strategy is CompressionStrategy.SMART_CRUSHER for decision in result.routing_log
     )
+
+
+def test_tool_profile_none_skips_openai_tool_message() -> None:
+    tool_output = "important exact output\n" * 200
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "Bash", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": tool_output},
+    ]
+    router = ContentRouter(
+        ContentRouterConfig(tool_profiles={"Bash": CompressionProfile(bias=float("inf"), min_k=0)})
+    )
+
+    result = router.apply(messages, _TinyTokenizer(), read_protection_window=0)
+
+    assert result.messages == messages
+    assert "router:protected:tool_profile_none" in result.transforms_applied
+
+
+def test_tool_profile_none_skips_anthropic_tool_result_block() -> None:
+    tool_output = "important exact output\n" * 200
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "Bash",
+                    "input": {},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": tool_output,
+                }
+            ],
+        },
+    ]
+    router = ContentRouter(
+        ContentRouterConfig(tool_profiles={"Bash": CompressionProfile(bias=float("inf"), min_k=0)})
+    )
+
+    result = router.apply(messages, _TinyTokenizer(), read_protection_window=0)
+
+    assert result.messages == messages
+    assert "router:protected:tool_profile_none" in result.transforms_applied
 
 
 def test_extract_json_block_ignores_brackets_inside_strings() -> None:


### PR DESCRIPTION
## Description

Adds a `none` compression level to `--tool-profile` / `HEADROOM_TOOL_PROFILES`, letting users opt specific tool outputs out of all lossy compression. Fixes #1307 (the CLI workaround half).

`none` is added to `PROFILE_PRESETS` with `bias=float("inf")` as a sentinel. At both ContentRouter bias-lookup sites, an `isinf(bias)` check short-circuits before any compression pipeline runs, returning the original message/block verbatim. Backward-compatible: no existing profiles affected.

Fixes #1307

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `headroom/config.py` — `PROFILE_PRESETS["none"]` with `bias=inf, min_k=0`
- `headroom/transforms/content_router.py` — `isinf` gate at both tool-bias usage sites; annotates `router:protected:tool_profile_none` in transforms log
- `headroom/proxy/server.py` — `_parse_tool_profiles` warning updated to include `none` as a valid level
- `tests/test_cli_proxy_env.py` — regression test: `Bash:none` → parsed profile has `isinf(bias)`

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
pytest tests/test_cli_proxy_env.py -k tool_profile
3 passed in 0.21s

pytest tests/test_transforms/
377 passed (1 pre-existing unrelated failure in test_tree_sitter_thread_safety)
```

## Real Behavior Proof

- Environment: macOS 14, Python 3.12, headroom-ai 0.27.0-dev, Claude Code 2.x
- Exact command / steps: `headroom proxy --tool-profile Bash:none --mode token` then observe proxy logs via `/stats`
- Observed result: Proxy logs show `router:protected:tool_profile_none` for Bash tool outputs; outputs arrive verbatim with no compression artifacts
- Not tested: live Codex/Copilot sessions (unit-tested only), streaming path, Windows

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review