### PR TITLE
fix(proxy): tolerate incomplete chunked passthrough bodies

### DIFF
--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -6150,12 +6150,65 @@ class OpenAIHandlerMixin:
         if _prefers_http1_passthrough(base_url):
             passthrough_client = self.http_client_h1 or self.http_client
         try:
-            response = await passthrough_client.request(  # type: ignore[union-attr]
-                method=request.method,
-                url=url,
-                headers=headers,
-                content=body,
-            )
+            if hasattr(passthrough_client, "build_request") and hasattr(passthrough_client, "send"):
+                upstream_request = passthrough_client.build_request(  # type: ignore[union-attr]
+                    request.method,
+                    url,
+                    headers=headers,
+                    content=body,
+                )
+                response = await passthrough_client.send(  # type: ignore[union-attr]
+                    upstream_request,
+                    stream=True,
+                )
+                response_chunks: list[bytes] = []
+                try:
+                    async for chunk in response.aiter_bytes():
+                        response_chunks.append(chunk)
+                except httpx.RemoteProtocolError as e:
+                    if not response_chunks:
+                        logger.warning(
+                            "Passthrough upstream protocol error with no response body: "
+                            "%s %s -> %s: %s",
+                            request.method,
+                            path,
+                            url,
+                            e,
+                        )
+                        return Response(
+                            content=json.dumps(
+                                {
+                                    "error": {
+                                        "type": "upstream_protocol_error",
+                                        "message": (
+                                            f"Upstream API response ended unexpectedly: {e}"
+                                        ),
+                                    }
+                                }
+                            ),
+                            status_code=502,
+                            media_type="application/json",
+                        )
+                    logger.warning(
+                        "Passthrough upstream response ended with an incomplete chunked read "
+                        "after %d bytes; forwarding received body: %s %s -> %s: %s",
+                        sum(len(chunk) for chunk in response_chunks),
+                        request.method,
+                        path,
+                        url,
+                        e,
+                    )
+                finally:
+                    await response.aclose()
+                response_content = b"".join(response_chunks)
+            else:
+                response = await passthrough_client.request(  # type: ignore[union-attr]
+                    method=request.method,
+                    url=url,
+                    headers=headers,
+                    content=body,
+                )
+                response_content = response.content
         except (httpx.ConnectError, httpx.TimeoutException) as e:
             logger.warning(
                 "Passthrough request failed before upstream response: %s %s -> %s: %s",
@@ -6176,18 +6229,38 @@ class OpenAIHandlerMixin:
                 status_code=502,
                 media_type="application/json",
             )
+        except httpx.RemoteProtocolError as e:
+            logger.warning(
+                "Passthrough upstream protocol error before response body: %s %s -> %s: %s",
+                request.method,
+                path,
+                url,
+                e,
+            )
+            return Response(
+                content=json.dumps(
+                    {
+                        "error": {
+                            "type": "upstream_protocol_error",
+                            "message": f"Upstream API response ended unexpectedly: {e}",
+                        }
+                    }
+                ),
+                status_code=502,
+                media_type="application/json",
+            )
 
         # Remove compression headers since httpx already decompressed the response
         response_headers = dict(response.headers)
         response_headers.pop("content-encoding", None)
         response_headers.pop("content-length", None)  # Length changed after decompression
-        response_content = response.content
+        response_headers.pop("transfer-encoding", None)
 
         if provider == "anthropic" and endpoint_name == "models":
             from headroom.providers.anthropic import sanitize_anthropic_model_metadata
 
             try:
-                payload = response.json()
+                payload = json.loads(response_content)
                 sanitized_payload = sanitize_anthropic_model_metadata(payload)
             except (TypeError, ValueError):
                 sanitized_payload = None
@@ -6210,7 +6283,7 @@ class OpenAIHandlerMixin:
             usage: dict[str, int] = {}
             if response.headers.get("content-type", "").lower().startswith("application/json"):
                 try:
-                    usage = _passthrough_usage_from_json(response.json())
+                    usage = _passthrough_usage_from_json(json.loads(response_content))
                 except (json.JSONDecodeError, ValueError, TypeError):
                     usage = {}
             input_tokens = usage.get("input_tokens", 0)

--- a/tests/test_proxy_handler_helpers.py
+++ b/tests/test_proxy_handler_helpers.py
@@ -166,6 +166,39 @@ class _AsyncChunks(httpx.AsyncByteStream):
             yield chunk
 
 
+class _IncompleteChunkStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self):  # noqa: ANN204
+        for chunk in self._chunks:
+            yield chunk
+        raise httpx.RemoteProtocolError(
+            "peer closed connection without sending complete message body "
+            "(incomplete chunked read)"
+        )
+
+
+class _IncompleteChunkClient:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    def build_request(self, method, url, headers, content):  # noqa: ANN001, ANN201
+        return httpx.Request(method, url, headers=headers, content=content)
+
+    async def send(self, request, stream=False):  # noqa: ANN001, ANN201
+        assert stream is True
+        return httpx.Response(
+            200,
+            request=request,
+            headers={
+                "content-type": "application/json",
+                "transfer-encoding": "chunked",
+            },
+            stream=_IncompleteChunkStream(self._chunks),
+        )
+
+
 class _VertexStreamClient:
     def __init__(self) -> None:
         self.sent_url = ""
@@ -274,6 +307,36 @@ def test_openai_passthrough_connect_timeout_returns_502() -> None:
     payload = json.loads(response.body)
     assert payload["error"]["type"] == "connection_error"
     assert "Failed to connect to upstream API" in payload["error"]["message"]
+
+
+def test_openai_passthrough_tolerates_incomplete_chunked_read_after_body() -> None:
+    handler = object.__new__(OpenAIHandlerMixin)
+    handler.http_client = _IncompleteChunkClient([b'{"data":[', b'{"id":"gpt-test"}]}'])
+    handler.http_client_h1 = None
+
+    response = asyncio.run(
+        handler.handle_passthrough(_PassthroughRequest(), "http://127.0.0.1:8317/v1")
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {"data": [{"id": "gpt-test"}]}
+    assert "transfer-encoding" not in response.headers
+    assert "content-length" not in response.headers
+
+
+def test_openai_passthrough_protocol_error_without_body_returns_502() -> None:
+    handler = object.__new__(OpenAIHandlerMixin)
+    handler.http_client = _IncompleteChunkClient([])
+    handler.http_client_h1 = None
+
+    response = asyncio.run(
+        handler.handle_passthrough(_PassthroughRequest(), "http://127.0.0.1:8317/v1")
+    )
+
+    assert response.status_code == 502
+    payload = json.loads(response.body)
+    assert payload["error"]["type"] == "upstream_protocol_error"
+    assert "ended unexpectedly" in payload["error"]["message"]
 
 
 def test_prefers_http1_passthrough_matches_chatgpt_hosts_only() -> None:


### PR DESCRIPTION
## Description

Tolerate OpenAI-compatible passthrough responses that deliver a complete body but close the chunked transfer without the final terminator. Some local OpenAI-compatible upstreams produce a valid JSON body and then trigger `httpx.RemoteProtocolError: incomplete chunked read`; Headroom previously surfaced that as a 502 before it could forward the body.

Closes #1112

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Read OpenAI passthrough upstream responses through `httpx` streaming internals so Headroom can retain bytes received before a late `RemoteProtocolError`.
- Forward the received body/status when an incomplete chunked read happens after response bytes arrive.
- Return a diagnostic `502 upstream_protocol_error` when the upstream closes before any body bytes are available.
- Added focused regression tests for both the partial-body and no-body protocol-error paths.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
rtk python3 -m py_compile headroom/proxy/handlers/openai.py tests/test_proxy_handler_helpers.py
# passed

rtk uv run --no-project --with ruff ruff check headroom/proxy/handlers/openai.py tests/test_proxy_handler_helpers.py
All checks passed!

Focused isolated behavior script with stubbed headroom._core and httpx/fastapi dependencies:
focused passthrough protocol-error behavior passed
```

Full focused pytest was attempted but is blocked in this local environment:

```text
rtk pytest tests/test_proxy_handler_helpers.py
ModuleNotFoundError: No module named 'headroom._core'

rtk uv run pytest tests/test_proxy_handler_helpers.py
Failed to build headroom-ai editable package.
esaxx-rs build failed: fatal error: 'cstdint' file not found
```

## Real Behavior Proof

- Environment: macOS, local checkout, Python 3.14 uv build environment for the attempted editable install.
- Exact command / steps: Ran a focused isolated script that imports the OpenAI handler with a stubbed `headroom._core`, uses an `httpx.AsyncByteStream` that yields a complete JSON body and then raises `httpx.RemoteProtocolError("incomplete chunked read")`, then repeats with no yielded body bytes.
- Observed result: The body-after-error case returns HTTP 200 with the upstream JSON body and strips transfer/content length headers; the no-body case returns HTTP 502 with `error.type == "upstream_protocol_error"`.
- Not tested: Full pytest suite and real upstream integration, because the local native extension build fails before tests can run.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

This intentionally keeps the behavior narrow: only a protocol error after already-received body bytes is tolerated. If no body bytes were received, Headroom still returns a 502 rather than fabricating a successful upstream response.
