### PR TITLE
feat(wrap): add a memory-pressure governor to gate agent launches

### DIFF
--- a/headroom/cli/mem_governor.py
+++ b/headroom/cli/mem_governor.py
@@ -1,0 +1,163 @@
+"""Memory-pressure governor for ``headroom wrap`` (root-cause OOM guard).
+
+Every wrapped agent (``headroom wrap claude``) crosses one ``wrap`` process
+before it spawns the heavy ``claude`` + MCP stack (e.g. serena + rust-analyzer,
+often several GB each). On a busy multi-agent box the *Nth* launch is what tips
+total RAM past the limit and triggers a **global** OOM — which the kernel can
+only resolve by killing some victim, in practice the desktop compositor,
+freezing the whole session.
+
+``wrap`` is the single choke point every agent passes through, so it is the
+natural place to throttle. Before launching the child, :func:`gate_launch`
+checks how much memory is actually available and, when the box is already low:
+
+* ``wait``   (default) — poll until memory recovers, then proceed; if it never
+  recovers within the budget, proceed anyway (fail-open) with a loud warning.
+* ``refuse`` — exit immediately with ``EX_TEMPFAIL`` (75) so a supervisor or
+  queue worker can retry later instead of OOMing the host.
+* ``off``    — disabled.
+
+Fail-open by construction: if available memory cannot be measured (e.g. a
+non-Linux host without ``psutil``) the gate never blocks a launch.
+
+Configuration (env):
+    HEADROOM_WRAP_MEM_POLICY        wait | refuse | off          (default: wait)
+    HEADROOM_WRAP_MEM_MIN_MB        floor of available MiB        (default: 2048)
+    HEADROOM_WRAP_MEM_WAIT_SECONDS  max wait in ``wait`` mode     (default: 120)
+    HEADROOM_WRAP_MEM_POLL_SECONDS  poll interval while waiting   (default: 3)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable, Mapping
+
+__all__ = ["gate_launch", "available_memory_mb", "EX_TEMPFAIL"]
+
+# sysexits.h: a temporary failure; signals "retry later" to a supervisor.
+EX_TEMPFAIL = 75
+
+_POLICY_ENV = "HEADROOM_WRAP_MEM_POLICY"
+_MIN_MB_ENV = "HEADROOM_WRAP_MEM_MIN_MB"
+_WAIT_ENV = "HEADROOM_WRAP_MEM_WAIT_SECONDS"
+_POLL_ENV = "HEADROOM_WRAP_MEM_POLL_SECONDS"
+
+_DEFAULT_MIN_MB = 2048
+_DEFAULT_WAIT_SECONDS = 120.0
+_DEFAULT_POLL_SECONDS = 3.0
+
+
+def available_memory_mb() -> int | None:
+    """Best-effort available system memory in MiB, or ``None`` if unknown.
+
+    Prefers Linux ``/proc/meminfo`` ``MemAvailable`` (the kernel's own estimate
+    of what can be allocated without swapping), falling back to ``psutil`` where
+    present. Returns ``None`` when neither is available so callers fail open.
+    """
+    try:
+        with open("/proc/meminfo", encoding="ascii") as fh:
+            for line in fh:
+                if line.startswith("MemAvailable:"):
+                    # Format: "MemAvailable:   12345678 kB"
+                    return int(line.split()[1]) // 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil  # type: ignore[import-untyped]  # optional dependency
+
+        return int(psutil.virtual_memory().available // (1024 * 1024))
+    except Exception:  # noqa: BLE001 -- any failure -> unmeasured -> fail open
+        return None
+
+
+def _env_int(env: Mapping[str, str], key: str, default: int) -> int:
+    raw = env.get(key)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        return default
+
+
+def _env_float(env: Mapping[str, str], key: str, default: float) -> float:
+    raw = env.get(key)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw.strip())
+    except ValueError:
+        return default
+
+
+def gate_launch(
+    echo: Callable[[str], None] | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    read_available_mb: Callable[[], int | None] = available_memory_mb,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> str:
+    """Throttle a wrapped-agent launch on system memory pressure.
+
+    Returns a short outcome tag for telemetry/tests: ``off``, ``unmeasured``,
+    ``ok`` (enough headroom up front), ``recovered`` (waited, memory freed), or
+    ``proceeded`` (waited out the budget and launched anyway, fail-open). In
+    ``refuse`` mode it raises ``SystemExit(EX_TEMPFAIL)`` instead of returning
+    when memory is below the floor.
+
+    All side effects (clock, sleep, memory read) are injectable so the wait loop
+    is deterministic under test.
+    """
+    env = os.environ if env is None else env
+    say = echo if echo is not None else (lambda _msg: None)
+
+    policy = (env.get(_POLICY_ENV) or "wait").strip().lower()
+    if policy == "off":
+        return "off"
+    if policy not in ("wait", "refuse"):
+        policy = "wait"
+
+    min_mb = _env_int(env, _MIN_MB_ENV, _DEFAULT_MIN_MB)
+    if min_mb <= 0:
+        return "off"
+
+    avail = read_available_mb()
+    if avail is None:
+        return "unmeasured"  # fail-open: cannot measure -> never block
+    if avail >= min_mb:
+        return "ok"
+
+    if policy == "refuse":
+        say(
+            f"  Memory governor: {avail} MiB available < {min_mb} MiB floor; "
+            f"refusing launch ({_POLICY_ENV}=refuse). Retry when memory frees."
+        )
+        raise SystemExit(EX_TEMPFAIL)
+
+    # policy == "wait": poll until memory recovers or the budget elapses.
+    wait_s = _env_float(env, _WAIT_ENV, _DEFAULT_WAIT_SECONDS)
+    poll_s = _env_float(env, _POLL_ENV, _DEFAULT_POLL_SECONDS)
+    if poll_s <= 0:
+        poll_s = _DEFAULT_POLL_SECONDS
+    say(
+        f"  Memory governor: {avail} MiB available < {min_mb} MiB floor; "
+        f"waiting up to {wait_s:.0f}s for memory to free "
+        f"(set {_POLICY_ENV}=off to disable)..."
+    )
+    deadline = monotonic() + wait_s
+    while monotonic() < deadline:
+        sleep(poll_s)
+        avail = read_available_mb()
+        if avail is None:
+            return "unmeasured"
+        if avail >= min_mb:
+            say(f"  Memory governor: {avail} MiB available; proceeding.")
+            return "recovered"
+    # Budget exhausted: proceed anyway (fail-open) but make the risk visible.
+    say(
+        f"  Memory governor: still low ({avail} MiB) after {wait_s:.0f}s; "
+        "proceeding anyway (fail-open). Consider fewer concurrent agents."
+    )
+    return "proceeded"

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from headroom._subprocess import run
+from headroom.cli.mem_governor import gate_launch
 
 # Fix Windows cp1252 encoding — box-drawing characters require UTF-8
 if sys.platform == "win32" and hasattr(sys.stdout, "buffer"):
@@ -3366,6 +3367,13 @@ def claude(
                 f"  {_ANTHROPIC_MODEL_ENV}={env[_ANTHROPIC_MODEL_ENV]} "
                 "(1M context window; issue #1158)"
             )
+
+        # Memory-pressure governor: wrap is the single choke point every agent
+        # crosses before spawning the heavy claude + MCP (serena/rust-analyzer)
+        # stack. When the box is already low on RAM, wait for it to recover (or
+        # refuse) so the Nth agent does not tip the host into a global OOM that
+        # kills the desktop. Fail-open when memory cannot be measured.
+        gate_launch(echo=click.echo)
 
         result = subprocess.run([claude_bin, *claude_args], env=env)
         raise SystemExit(result.returncode)

--- a/tests/test_wrap_mem_governor.py
+++ b/tests/test_wrap_mem_governor.py
@@ -1,0 +1,216 @@
+"""Tests for the ``headroom wrap`` memory-pressure governor.
+
+The wait loop's clock, sleep, and memory read are all injected so these tests
+are deterministic and run instantly (no real sleeping).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from headroom.cli.mem_governor import (
+    EX_TEMPFAIL,
+    available_memory_mb,
+    gate_launch,
+)
+
+
+class _FakeClock:
+    """Monotonic clock whose ``sleep`` advances the clock, so the wait loop
+    converges without wall-clock time."""
+
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def monotonic(self) -> float:
+        return self.t
+
+    def sleep(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def _reader(values: list[int | None]) -> Callable[[], int | None]:
+    """Return a read_available_mb that yields ``values`` in order, then repeats
+    the last value forever (mimics a sustained condition)."""
+    state = {"i": 0}
+
+    def read() -> int | None:
+        i = state["i"]
+        if i < len(values):
+            state["i"] = i + 1
+            return values[i]
+        return values[-1] if values else None
+
+    return read
+
+
+# --------------------------------------------------------------------------
+# Disabled / short-circuit paths
+# --------------------------------------------------------------------------
+
+
+def test_policy_off_short_circuits_without_reading() -> None:
+    reads = {"n": 0}
+
+    def read() -> int | None:
+        reads["n"] += 1
+        return 0
+
+    out = gate_launch(
+        env={"HEADROOM_WRAP_MEM_POLICY": "off"},
+        read_available_mb=read,
+    )
+    assert out == "off"
+    assert reads["n"] == 0  # never even measured
+
+
+def test_min_mb_zero_disables() -> None:
+    out = gate_launch(
+        env={"HEADROOM_WRAP_MEM_MIN_MB": "0"},
+        read_available_mb=lambda: 10,
+    )
+    assert out == "off"
+
+
+def test_unmeasured_fails_open() -> None:
+    out = gate_launch(env={}, read_available_mb=lambda: None)
+    assert out == "unmeasured"
+
+
+def test_enough_headroom_proceeds_immediately() -> None:
+    msgs: list[str] = []
+    out = gate_launch(
+        echo=msgs.append,
+        env={"HEADROOM_WRAP_MEM_MIN_MB": "2048"},
+        read_available_mb=lambda: 5000,
+    )
+    assert out == "ok"
+    assert msgs == []  # quiet on the happy path
+
+
+# --------------------------------------------------------------------------
+# refuse policy
+# --------------------------------------------------------------------------
+
+
+def test_refuse_below_floor_exits_tempfail() -> None:
+    msgs: list[str] = []
+    with pytest.raises(SystemExit) as exc:
+        gate_launch(
+            echo=msgs.append,
+            env={"HEADROOM_WRAP_MEM_POLICY": "refuse", "HEADROOM_WRAP_MEM_MIN_MB": "2048"},
+            read_available_mb=lambda: 500,
+        )
+    assert exc.value.code == EX_TEMPFAIL
+    assert any("refusing launch" in m for m in msgs)
+
+
+def test_refuse_with_headroom_proceeds() -> None:
+    out = gate_launch(
+        env={"HEADROOM_WRAP_MEM_POLICY": "refuse", "HEADROOM_WRAP_MEM_MIN_MB": "2048"},
+        read_available_mb=lambda: 4096,
+    )
+    assert out == "ok"
+
+
+# --------------------------------------------------------------------------
+# wait policy
+# --------------------------------------------------------------------------
+
+
+def test_wait_then_recovers() -> None:
+    clock = _FakeClock()
+    msgs: list[str] = []
+    # 1000 (< floor) up front -> wait; stays low one poll, then frees to 3000.
+    read = _reader([1000, 1000, 3000])
+    out = gate_launch(
+        echo=msgs.append,
+        env={
+            "HEADROOM_WRAP_MEM_MIN_MB": "2048",
+            "HEADROOM_WRAP_MEM_WAIT_SECONDS": "60",
+            "HEADROOM_WRAP_MEM_POLL_SECONDS": "3",
+        },
+        read_available_mb=read,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+    assert out == "recovered"
+    assert clock.t == pytest.approx(6.0)  # two polls of 3s
+    assert any("waiting up to" in m for m in msgs)
+    assert any("proceeding" in m for m in msgs)
+
+
+def test_wait_times_out_then_fails_open() -> None:
+    clock = _FakeClock()
+    msgs: list[str] = []
+    out = gate_launch(
+        echo=msgs.append,
+        env={
+            "HEADROOM_WRAP_MEM_MIN_MB": "2048",
+            "HEADROOM_WRAP_MEM_WAIT_SECONDS": "9",
+            "HEADROOM_WRAP_MEM_POLL_SECONDS": "3",
+        },
+        read_available_mb=_reader([1000]),  # never recovers
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+    assert out == "proceeded"
+    assert clock.t == pytest.approx(9.0)  # 3 polls then deadline
+    assert any("proceeding anyway (fail-open)" in m for m in msgs)
+
+
+def test_wait_aborts_if_memory_becomes_unmeasurable() -> None:
+    clock = _FakeClock()
+    out = gate_launch(
+        env={
+            "HEADROOM_WRAP_MEM_MIN_MB": "2048",
+            "HEADROOM_WRAP_MEM_WAIT_SECONDS": "60",
+            "HEADROOM_WRAP_MEM_POLL_SECONDS": "3",
+        },
+        read_available_mb=_reader([1000, None]),
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+    assert out == "unmeasured"
+
+
+def test_unknown_policy_defaults_to_wait() -> None:
+    clock = _FakeClock()
+    out = gate_launch(
+        env={
+            "HEADROOM_WRAP_MEM_POLICY": "bogus",
+            "HEADROOM_WRAP_MEM_MIN_MB": "2048",
+            "HEADROOM_WRAP_MEM_WAIT_SECONDS": "3",
+            "HEADROOM_WRAP_MEM_POLL_SECONDS": "3",
+        },
+        read_available_mb=_reader([1000]),
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+    assert out == "proceeded"  # treated as wait, timed out, fail-open
+
+
+def test_bad_env_values_fall_back_to_defaults() -> None:
+    # Non-numeric overrides must not crash; they fall back to defaults and the
+    # happy path (plenty of memory) still returns "ok".
+    out = gate_launch(
+        env={
+            "HEADROOM_WRAP_MEM_MIN_MB": "not-a-number",
+            "HEADROOM_WRAP_MEM_WAIT_SECONDS": "soon",
+        },
+        read_available_mb=lambda: 10_000,
+    )
+    assert out == "ok"
+
+
+# --------------------------------------------------------------------------
+# available_memory_mb integration
+# --------------------------------------------------------------------------
+
+
+def test_available_memory_mb_returns_sane_value() -> None:
+    val = available_memory_mb()
+    # None on a host with neither /proc/meminfo nor psutil; otherwise positive.
+    assert val is None or val > 0


### PR DESCRIPTION
## Problem

`headroom wrap` is the single point every wrapped agent crosses before it spawns
the heavy `claude` + MCP stack (e.g. serena + a language server, often several
GB each). On a busy multi-agent host the *Nth* launch is what tips total RAM
past the limit and triggers a **global** OOM — which the kernel can only resolve
by killing some victim (in practice the desktop compositor), freezing the whole
session.

## What this does

Gate the launch at that choke point. Before exec'ing the child, check available
memory (`/proc/meminfo` `MemAvailable`, `psutil` fallback) and, when it's below
a floor:

- **`wait`** (default) — poll until memory recovers, then proceed; if it never
  recovers within the budget, proceed anyway (fail-open) with a loud warning.
- **`refuse`** — exit `EX_TEMPFAIL` (75) so a supervisor / queue worker can retry
  later instead of OOMing the host.
- **`off`** — disabled.

Fail-open by construction: if available memory can't be measured (e.g. a
non-Linux host without `psutil`), the gate never blocks a launch.

## Config (env)

| var | default | meaning |
|---|---|---|
| `HEADROOM_WRAP_MEM_POLICY` | `wait` | `wait` \| `refuse` \| `off` |
| `HEADROOM_WRAP_MEM_MIN_MB` | `2048` | floor of available MiB |
| `HEADROOM_WRAP_MEM_WAIT_SECONDS` | `120` | max wait in `wait` mode |
| `HEADROOM_WRAP_MEM_POLL_SECONDS` | `3` | poll interval while waiting |

## Tests

`tests/test_wrap_mem_governor.py` — 12 tests covering off / enough-headroom /
unmeasurable / refuse / wait-then-recover / wait-timeout / mid-wait-unmeasurable
/ unknown-policy / bad-env. The clock, sleep, and memory read are all injected,
so the wait loop is deterministic and the suite runs instantly (no real
sleeping). `ruff` and `mypy` clean.

## Notes

Gates only the `claude` launch path (the heavy MCP/LSP multiplier); other wrap
targets are untouched. Defaults are conservative (2 GiB floor, wait-then-proceed)
so it never hard-fails a launch out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
