### PR TITLE
feat(router): per-content-type bias multipliers for kompress (domain routing)

### DIFF
--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -1678,6 +1678,16 @@ class ContentRouterConfig:
     search_group_by_file: bool = False
 
 
+# Domain routing values derived from kompress-v4 evaluation with 20 samples
+# per content type and a >=95% must-keep survival threshold. Values below 1.0
+# make Kompress more aggressive; unlisted domains retain the caller's bias.
+_DOMAIN_BIAS_MULTIPLIERS: dict[ContentType, float] = {
+    ContentType.BUILD_OUTPUT: 0.50,
+    ContentType.SOURCE_CODE: 0.50,
+    ContentType.SEARCH_RESULTS: 0.70,
+}
+
+
 class ContentRouter(Transform):
     """Intelligent router that selects optimal compression strategy.
 
@@ -2204,6 +2214,11 @@ class ContentRouter(Transform):
                         else "content_detection"
                     ),
                 )
+
+            # Preserve explicit force-Kompress behavior: domain routing only
+            # applies when normal content detection selected the strategy.
+            if not force_kompress:
+                bias *= _DOMAIN_BIAS_MULTIPLIERS.get(detection.content_type, 1.0)
 
             if strategy == CompressionStrategy.MIXED:
                 result = self._compress_mixed(content, context, question, bias=bias)

--- a/tests/test_transforms_content_router.py
+++ b/tests/test_transforms_content_router.py
@@ -388,6 +388,72 @@ def test_normal_compress_path_still_uses_content_detection(
     assert calls["detect"] > 0
 
 
+@pytest.mark.parametrize(
+    ("content_type", "multiplier"),
+    [
+        (ContentType.BUILD_OUTPUT, 0.50),
+        (ContentType.SOURCE_CODE, 0.50),
+        (ContentType.SEARCH_RESULTS, 0.70),
+        (ContentType.PLAIN_TEXT, 1.00),
+    ],
+)
+def test_domain_routing_scales_detected_content_bias(
+    monkeypatch: pytest.MonkeyPatch,
+    content_type: ContentType,
+    multiplier: float,
+) -> None:
+    router = ContentRouter()
+    observed: dict[str, float] = {}
+
+    monkeypatch.setattr(content_router_module, "is_mixed_content", lambda _content: False)
+    monkeypatch.setattr(
+        content_router_module,
+        "_detect_content",
+        lambda _content: DetectionResult(content_type, 1.0, {}),
+    )
+    monkeypatch.setattr(
+        router,
+        "_determine_strategy",
+        lambda _content, **_kwargs: CompressionStrategy.KOMPRESS,
+    )
+
+    def _capture_pure(*args, **kwargs) -> RouterCompressionResult:
+        observed["bias"] = kwargs["bias"]
+        return RouterCompressionResult(
+            compressed="compressed",
+            original="payload",
+            strategy_used=CompressionStrategy.KOMPRESS,
+        )
+
+    monkeypatch.setattr(router, "_compress_pure", _capture_pure)
+
+    router.compress("payload", bias=1.6)
+
+    assert observed["bias"] == pytest.approx(1.6 * multiplier)
+
+
+def test_domain_routing_does_not_change_forced_kompress_bias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = ContentRouter()
+    router._runtime_force_kompress = True
+    observed: dict[str, float] = {}
+
+    def _capture_pure(*args, **kwargs) -> RouterCompressionResult:
+        observed["bias"] = kwargs["bias"]
+        return RouterCompressionResult(
+            compressed="compressed",
+            original="payload",
+            strategy_used=CompressionStrategy.KOMPRESS,
+        )
+
+    monkeypatch.setattr(router, "_compress_pure", _capture_pure)
+
+    router.compress("payload", bias=1.6)
+
+    assert observed["bias"] == pytest.approx(1.6)
+
+
 def test_force_kompress_apply_uses_lightweight_detection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Description

Adds data-backed per-content-type bias multipliers to the kompress compression path. Different content types tolerate different compression aggressiveness while maintaining must-keep token survival (≥95% threshold).

Derived from `eval_domain_routing.py` on kompress-v4 with 20 samples per domain.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Performance improvement

## Changes Made

- `headroom/transforms/content_router.py` — `_DOMAIN_BIAS_MULTIPLIERS` dict at module level, applied before `_compress_pure`/`_compress_mixed` when content detection ran

## Testing

- [x] Unit tests pass
- [x] Linting passes

### Test Output

```
BUILD_OUTPUT  bias=0.50  ratio=2.15x  mk=96.8%   (error/build traces)
SOURCE_CODE   bias=0.50  ratio=1.99x  mk=96.8%   (file reads)
SEARCH_RESULTS bias=0.70 ratio=1.45x  mk=98.9%   (search output)
PLAIN_TEXT    bias=1.00  unchanged
JSON_ARRAY    SmartCrusher path, not affected
```

## Real Behavior Proof

- Environment: macOS 15.5, Python 3.12, kompress-v4, headroom 0.28.0
- Exact command / steps: `python3 ultrawhale/scripts/eval_domain_routing.py --model PeetPedro/kompress-v4 --samples 20`
- Observed result: error traces 2.15x compression at 96.8% must-keep survival; import OK after change
- Not tested: live proxy session end-to-end

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review