### PR TITLE
fix(installers): verify SHA-256 digests for rtk, lean-ctx, cbm release binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (LLMs, loggers, attribution parsers) a machine-readable provenance
   boundary and preventing misattribution in multi-agent threads.
 
+### Security
+
+* **installers:** pin and verify SHA-256 digests for the `rtk`, `lean-ctx`, and `codebase-memory-mcp` release binaries before extraction. These installers fetch prebuilt binaries that `headroom wrap` then *executes* (`rtk` is auto-downloaded as part of normal operation), but previously did so without any integrity check — a tampered or substituted release artifact would have been run silently. Each installer now verifies downloaded bytes against a pinned digest map (`RTK_ASSET_DIGESTS` / `LEAN_CTX_ASSET_DIGESTS` / `CBM_ASSET_DIGESTS`) and aborts on mismatch. Overridden versions / cross-target downloads have no pinned digest and are refused unless the operator opts out with `HEADROOM_RTK_ALLOW_UNVERIFIED` / `HEADROOM_LEAN_CTX_ALLOW_UNVERIFIED` / `HEADROOM_CBM_ALLOW_UNVERIFIED`. Extends the digest-pinning pattern introduced for the tokensave installer to the remaining release-binary installers ([#1407](https://github.com/headroomlabs-ai/headroom/issues/1407)).
+
 ### Changed
 
 * **telemetry:** anonymous usage telemetry is now **opt-in** (off by default) instead of opt-out. Nothing is collected or sent unless you set `HEADROOM_TELEMETRY=on` or pass `--telemetry` to `headroom proxy` / `headroom install apply`. `is_telemetry_enabled()` is fail-closed — only explicit on-values (`on`/`true`/`1`/`yes`/`enable`/`enabled`) enable it; unset, empty, or unrecognized values stay disabled. The existing `--no-telemetry` flag and `HEADROOM_TELEMETRY=off` remain accepted for back-compat, and install manifests now write the `HEADROOM_TELEMETRY` value explicitly so generated deployments are unambiguous.

--- a/headroom/graph/installer.py
+++ b/headroom/graph/installer.py
@@ -1,9 +1,21 @@
-"""Download and install codebase-memory-mcp binary from GitHub releases."""
+"""Download and install codebase-memory-mcp binary from GitHub releases.
+
+Supply-chain integrity:
+    Headroom downloads and then executes this binary, so every pinned
+    release asset is verified against a SHA-256 digest in
+    ``CBM_ASSET_DIGESTS`` below before the archive is unpacked. A mismatch
+    aborts the install rather than running a tampered or substituted
+    artifact. When the version is overridden there is no pinned digest, so
+    the download is refused unless the operator opts out via
+    ``HEADROOM_CBM_ALLOW_UNVERIFIED=1``.
+"""
 
 from __future__ import annotations
 
+import hashlib
 import io
 import logging
+import os
 import platform
 import shutil
 import stat
@@ -19,6 +31,56 @@ CBM_BIN_DIR = Path.home() / ".local" / "bin"
 CBM_BIN_NAME = "codebase-memory-mcp"
 
 GITHUB_RELEASE_URL = f"https://github.com/{CBM_REPO}/releases/download"
+
+#: SHA-256 of each pinned release asset (``CBM_VERSION``), keyed by asset
+#: filename. The binary is downloaded and executed, so its bytes are verified
+#: against this map before extraction. Regenerate when bumping CBM_VERSION:
+#:   gh api repos/DeusData/codebase-memory-mcp/releases/tags/$CBM_VERSION \
+#:     --jq '.assets[]|"\(.name) \(.digest)"'
+CBM_ASSET_DIGESTS: dict[str, str] = {
+    "codebase-memory-mcp-darwin-arm64.tar.gz": (
+        "fbd047509852021b5446a11141bcb0a3d1dcaebf6e5112460960f29f052c1c58"
+    ),
+    "codebase-memory-mcp-darwin-amd64.tar.gz": (
+        "fb62da3016ea12b948351208759b5c083fb1446cf6e78d6db8b7cd28fe86fd54"
+    ),
+    "codebase-memory-mcp-linux-arm64.tar.gz": (
+        "d2f842d1365da5c35d9c5796f57a821c9745267350994346735e1e6e04d46091"
+    ),
+    "codebase-memory-mcp-linux-amd64.tar.gz": (
+        "dbd3b92ea870ef240b63059f26bda15015f76ef9978931bebc3a0f9d09470973"
+    ),
+}
+
+
+def _verify_asset_digest(filename: str, data: bytes, expected: str | None) -> None:
+    """Verify downloaded bytes against the pinned SHA-256 digest.
+
+    ``expected`` is the pinned digest for this asset, or ``None`` when no
+    digest is pinned (an overridden version). An unpinned asset is refused
+    unless ``HEADROOM_CBM_ALLOW_UNVERIFIED`` is set, so unverified code is
+    never executed by default. Raises ``RuntimeError`` on a digest mismatch
+    or an unpinned-without-opt-out.
+    """
+    if expected is None:
+        if os.environ.get("HEADROOM_CBM_ALLOW_UNVERIFIED"):
+            logger.warning(
+                "codebase-memory-mcp asset %s has no pinned digest; installing unverified "
+                "(HEADROOM_CBM_ALLOW_UNVERIFIED is set)",
+                filename,
+            )
+            return
+        raise RuntimeError(
+            f"no pinned SHA-256 digest for codebase-memory-mcp asset {filename!r}; refusing to "
+            "install unverified. Set HEADROOM_CBM_ALLOW_UNVERIFIED=1 to override."
+        )
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != expected:
+        raise RuntimeError(
+            f"codebase-memory-mcp asset {filename!r} failed integrity check: "
+            f"expected sha256 {expected}, got {actual}"
+        )
+    logger.debug("Verified codebase-memory-mcp asset %s (sha256 %s)", filename, actual)
 
 
 def _detect_platform() -> str:
@@ -53,12 +115,23 @@ def get_cbm_path() -> Path | None:
     return None
 
 
+def _normalize_version(version: str) -> str:
+    """Canonicalize a release version to the ``v``-prefixed tag form.
+
+    The pinned digest map is keyed to ``CBM_VERSION`` (``vX.Y.Z``). Comparing
+    canonical forms stops a bare ``X.Y.Z`` for the current release from being
+    treated as a version override and routed through the unverified path.
+    """
+    version = version.strip()
+    return version if version.startswith("v") else f"v{version}"
+
+
 def download_cbm(version: str | None = None) -> Path:
     """Download codebase-memory-mcp binary from GitHub releases.
 
     Returns path to installed binary.
     """
-    version = version or CBM_VERSION
+    version = _normalize_version(version or CBM_VERSION)
     plat = _detect_platform()
     filename = f"codebase-memory-mcp-{plat}.tar.gz"
     url = f"{GITHUB_RELEASE_URL}/{version}/{filename}"
@@ -76,6 +149,10 @@ def download_cbm(version: str | None = None) -> Path:
             data = response.read()
     except Exception as e:
         raise RuntimeError(f"Failed to download codebase-memory-mcp from {url}: {e}") from e
+
+    # Verify integrity before unpacking — this binary is later executed.
+    expected = CBM_ASSET_DIGESTS.get(filename) if version == CBM_VERSION else None
+    _verify_asset_digest(filename, data, expected)
 
     # Extract binary from tar.gz
     try:

--- a/headroom/lean_ctx/installer.py
+++ b/headroom/lean_ctx/installer.py
@@ -1,7 +1,19 @@
-"""Download and install lean-ctx binary from GitHub releases."""
+"""Download and install lean-ctx binary from GitHub releases.
+
+Supply-chain integrity:
+    Headroom downloads and then executes this binary, so every pinned
+    release asset is verified against a SHA-256 digest in
+    ``LEAN_CTX_ASSET_DIGESTS`` below before the archive is unpacked. A
+    mismatch aborts the install rather than running a tampered or
+    substituted artifact. When the version is overridden or a cross-target
+    asset is requested (``HEADROOM_LEAN_CTX_TARGET`` / ``LEAN_CTX_TARGET``)
+    there is no pinned digest, so the download is refused unless the
+    operator opts out via ``HEADROOM_LEAN_CTX_ALLOW_UNVERIFIED=1``.
+"""
 
 from __future__ import annotations
 
+import hashlib
 import io
 import logging
 import os
@@ -20,6 +32,65 @@ from . import LEAN_CTX_BIN_DIR, LEAN_CTX_VERSION
 logger = logging.getLogger(__name__)
 
 GITHUB_RELEASE_URL = "https://github.com/yvgude/lean-ctx/releases/download"
+
+#: SHA-256 of each pinned release asset (``LEAN_CTX_VERSION``), keyed by asset
+#: filename. The binary is downloaded and executed, so its bytes are verified
+#: against this map before extraction. Regenerate when bumping LEAN_CTX_VERSION:
+#:   gh api repos/yvgude/lean-ctx/releases/tags/$LEAN_CTX_VERSION \
+#:     --jq '.assets[]|"\(.name) \(.digest)"'
+LEAN_CTX_ASSET_DIGESTS: dict[str, str] = {
+    "lean-ctx-aarch64-apple-darwin.tar.gz": (
+        "c4db95966f80ab47aadfca296d0f95937085cf601833f0288eeec8b9f02872cd"
+    ),
+    "lean-ctx-x86_64-apple-darwin.tar.gz": (
+        "9d55d9ed24d3b3726c16eea3cc16255538f286a880531b7fa90e7fb00361e2e2"
+    ),
+    "lean-ctx-aarch64-unknown-linux-gnu.tar.gz": (
+        "72435a42bb33afc3d3cd5a62426955c6488192826a3a84d57e26f587740534d9"
+    ),
+    "lean-ctx-aarch64-unknown-linux-musl.tar.gz": (
+        "be68c45ebb19e30ae6fc4713ec56f148ef2dfa08669b2db4abe57706e625c0e8"
+    ),
+    "lean-ctx-x86_64-unknown-linux-gnu.tar.gz": (
+        "ec405e643a4c4cb3e7fdd2818801f11a6d0209cbcfe0ce085df1d62335a5053b"
+    ),
+    "lean-ctx-x86_64-unknown-linux-musl.tar.gz": (
+        "d2cb70294044a04edc32b7bb9ba2e81f826c042db4840226058d2bd4941e0034"
+    ),
+    "lean-ctx-x86_64-pc-windows-msvc.zip": (
+        "57ff7ff936228828ffc94e0803e1727c5ad03d92791283614406b7e4f66706b0"
+    ),
+}
+
+
+def _verify_asset_digest(filename: str, data: bytes, expected: str | None) -> None:
+    """Verify downloaded bytes against the pinned SHA-256 digest.
+
+    ``expected`` is the pinned digest for this asset, or ``None`` when no
+    digest is pinned (an overridden version or cross-target download). An
+    unpinned asset is refused unless ``HEADROOM_LEAN_CTX_ALLOW_UNVERIFIED``
+    is set, so unverified code is never executed by default. Raises
+    ``RuntimeError`` on a digest mismatch or an unpinned-without-opt-out.
+    """
+    if expected is None:
+        if os.environ.get("HEADROOM_LEAN_CTX_ALLOW_UNVERIFIED"):
+            logger.warning(
+                "lean-ctx asset %s has no pinned digest; installing unverified "
+                "(HEADROOM_LEAN_CTX_ALLOW_UNVERIFIED is set)",
+                filename,
+            )
+            return
+        raise RuntimeError(
+            f"no pinned SHA-256 digest for lean-ctx asset {filename!r}; refusing to install "
+            "unverified. Set HEADROOM_LEAN_CTX_ALLOW_UNVERIFIED=1 to override."
+        )
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != expected:
+        raise RuntimeError(
+            f"lean-ctx asset {filename!r} failed integrity check: "
+            f"expected sha256 {expected}, got {actual}"
+        )
+    logger.debug("Verified lean-ctx asset %s (sha256 %s)", filename, actual)
 
 
 def _detect_runtime_target_triple() -> str:
@@ -87,9 +158,21 @@ def _get_download_url(version: str) -> tuple[str, str]:
     return url, ext
 
 
+def _normalize_version(version: str) -> str:
+    """Canonicalize a release version to the ``v``-prefixed tag form.
+
+    The pinned digest map is keyed to ``LEAN_CTX_VERSION`` (``vX.Y.Z``).
+    Comparing canonical forms stops a bare ``X.Y.Z`` for the current release
+    from being treated as a version override and routed through the unverified
+    path.
+    """
+    version = version.strip()
+    return version if version.startswith("v") else f"v{version}"
+
+
 def download_lean_ctx(version: str | None = None) -> Path:
     """Download lean-ctx binary from GitHub releases."""
-    version = version or LEAN_CTX_VERSION
+    version = _normalize_version(version or LEAN_CTX_VERSION)
     target = _get_target_triple()
     url, ext = _get_download_url(version)
     target_path = LEAN_CTX_BIN_DIR / _binary_name_for_target(target)
@@ -113,6 +196,11 @@ def download_lean_ctx(version: str | None = None) -> Path:
             raise
     except Exception as e:
         raise RuntimeError(f"Failed to download lean-ctx from {url}: {e}") from e
+
+    # Verify integrity before unpacking — this binary is later executed.
+    filename = f"lean-ctx-{target}.{ext}"
+    expected = LEAN_CTX_ASSET_DIGESTS.get(filename) if version == LEAN_CTX_VERSION else None
+    _verify_asset_digest(filename, data, expected)
 
     try:
         if ext == "tar.gz":

--- a/headroom/rtk/installer.py
+++ b/headroom/rtk/installer.py
@@ -1,7 +1,19 @@
-"""Download and install rtk binary from GitHub releases."""
+"""Download and install rtk binary from GitHub releases.
+
+Supply-chain integrity:
+    ``headroom wrap`` auto-downloads and then *executes* this binary, so
+    every pinned release asset is verified against a SHA-256 digest in
+    ``RTK_ASSET_DIGESTS`` below before the archive is unpacked. A mismatch
+    aborts the install rather than running a tampered or substituted
+    artifact. When the version is overridden (``download_rtk(version=...)``)
+    or a cross-target asset is requested (``HEADROOM_RTK_TARGET``) there is
+    no pinned digest, so the download is refused unless the operator opts
+    out via ``HEADROOM_RTK_ALLOW_UNVERIFIED=1``.
+"""
 
 from __future__ import annotations
 
+import hashlib
 import io
 import logging
 import os
@@ -21,6 +33,58 @@ from . import RTK_BIN_DIR, RTK_BIN_PATH, RTK_VERSION
 logger = logging.getLogger(__name__)
 
 GITHUB_RELEASE_URL = "https://github.com/rtk-ai/rtk/releases/download"
+
+#: SHA-256 of each pinned release asset (``RTK_VERSION``), keyed by asset
+#: filename. The binary is downloaded and executed, so its bytes are verified
+#: against this map before extraction. Regenerate when bumping RTK_VERSION:
+#:   gh api repos/rtk-ai/rtk/releases/tags/$RTK_VERSION --jq '.assets[]|"\(.name) \(.digest)"'
+RTK_ASSET_DIGESTS: dict[str, str] = {
+    "rtk-aarch64-apple-darwin.tar.gz": (
+        "f223ca074a0215af002679bc1d34ca92b93e25b3e8ae16aace6e84c06e586802"
+    ),
+    "rtk-x86_64-apple-darwin.tar.gz": (
+        "84121316867613e61925c209607f033b2113bb0ce312c267a79d3e3e8f221e49"
+    ),
+    "rtk-aarch64-unknown-linux-gnu.tar.gz": (
+        "cc2b91c064eb670c097c184913c8fbcb1a943d53d7fe505375e96ba0c5b6459f"
+    ),
+    "rtk-x86_64-unknown-linux-musl.tar.gz": (
+        "34975116da11e09e502501daf758143e0b22ed3a42a10eb67fb693a6270d9e36"
+    ),
+    "rtk-x86_64-pc-windows-msvc.zip": (
+        "f0ec18963581657173bd6a51f5ba012b093823f844db749fec218581af30a568"
+    ),
+}
+
+
+def _verify_asset_digest(filename: str, data: bytes, expected: str | None) -> None:
+    """Verify downloaded bytes against the pinned SHA-256 digest.
+
+    ``expected`` is the pinned digest for this asset, or ``None`` when no
+    digest is pinned (an overridden version or cross-target download). An
+    unpinned asset is refused unless ``HEADROOM_RTK_ALLOW_UNVERIFIED`` is
+    set, so unverified code is never executed by default. Raises
+    ``RuntimeError`` on a digest mismatch or an unpinned-without-opt-out.
+    """
+    if expected is None:
+        if os.environ.get("HEADROOM_RTK_ALLOW_UNVERIFIED"):
+            logger.warning(
+                "rtk asset %s has no pinned digest; installing unverified "
+                "(HEADROOM_RTK_ALLOW_UNVERIFIED is set)",
+                filename,
+            )
+            return
+        raise RuntimeError(
+            f"no pinned SHA-256 digest for rtk asset {filename!r}; refusing to install "
+            "unverified. Set HEADROOM_RTK_ALLOW_UNVERIFIED=1 to override."
+        )
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != expected:
+        raise RuntimeError(
+            f"rtk asset {filename!r} failed integrity check: "
+            f"expected sha256 {expected}, got {actual}"
+        )
+    logger.debug("Verified rtk asset %s (sha256 %s)", filename, actual)
 
 
 def _detect_runtime_target_triple() -> str:
@@ -72,6 +136,19 @@ def _get_download_url(version: str) -> tuple[str, str]:
     return url, ext
 
 
+def _normalize_version(version: str) -> str:
+    """Canonicalize a release version to the ``v``-prefixed tag form.
+
+    The pinned digest map is keyed to ``RTK_VERSION`` (``vX.Y.Z``). Without
+    this, a bare ``X.Y.Z`` for the current release would not equal
+    ``RTK_VERSION``, get treated as a version override, and route the pinned
+    release through the unverified path — letting an operator bypass the digest
+    map by accident. Comparing canonical forms closes that gap.
+    """
+    version = version.strip()
+    return version if version.startswith("v") else f"v{version}"
+
+
 def download_rtk(version: str | None = None) -> Path:
     """Download rtk binary from GitHub releases.
 
@@ -84,7 +161,7 @@ def download_rtk(version: str | None = None) -> Path:
     Raises:
         RuntimeError: If download or extraction fails.
     """
-    version = version or RTK_VERSION
+    version = _normalize_version(version or RTK_VERSION)
     target = _get_target_triple()
     url, ext = _get_download_url(version)
     target_path = RTK_BIN_DIR / _binary_name_for_target(target)
@@ -110,6 +187,11 @@ def download_rtk(version: str | None = None) -> Path:
             raise
     except Exception as e:
         raise RuntimeError(f"Failed to download rtk from {url}: {e}") from e
+
+    # Verify integrity before unpacking — this binary is later executed.
+    filename = f"rtk-{target}.{ext}"
+    expected = RTK_ASSET_DIGESTS.get(filename) if version == RTK_VERSION else None
+    _verify_asset_digest(filename, data, expected)
 
     # Extract binary
     try:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -78,6 +78,9 @@ def test_get_cbm_path_prefers_path_then_install_dir(monkeypatch, tmp_path: Path)
 def test_download_cbm_success_and_verification_paths(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(installer, "CBM_BIN_DIR", tmp_path)
     monkeypatch.setattr(installer, "_detect_platform", lambda: "linux-amd64")
+    # version override (v1.2.3) has no pinned digest; opt out of verification so
+    # this test exercises the extraction/exec paths rather than digest checking.
+    monkeypatch.setenv("HEADROOM_CBM_ALLOW_UNVERIFIED", "1")
     monkeypatch.setattr(
         installer, "urlopen", lambda url, timeout=60: FakeResponse(_build_archive())
     )
@@ -111,10 +114,14 @@ def test_download_cbm_invalid_url_download_failure_and_extract_errors(
 ) -> None:
     monkeypatch.setattr(installer, "CBM_BIN_DIR", tmp_path)
     monkeypatch.setattr(installer, "_detect_platform", lambda: "linux-amd64")
+    # The extract-error cases below feed bytes that cannot match the pinned
+    # digest; use a non-pinned version + opt-out so the failure surfaces at
+    # extraction rather than at the integrity check.
+    monkeypatch.setenv("HEADROOM_CBM_ALLOW_UNVERIFIED", "1")
 
     monkeypatch.setattr(installer, "GITHUB_RELEASE_URL", "ftp://example.test/releases")
     with pytest.raises(RuntimeError, match="Invalid URL"):
-        installer.download_cbm()
+        installer.download_cbm(version="v1.2.3")
 
     monkeypatch.setattr(installer, "GITHUB_RELEASE_URL", "https://example.test/releases")
     monkeypatch.setattr(
@@ -123,7 +130,7 @@ def test_download_cbm_invalid_url_download_failure_and_extract_errors(
         lambda url, timeout=60: (_ for _ in ()).throw(OSError("network down")),
     )
     with pytest.raises(RuntimeError, match="Failed to download codebase-memory-mcp"):
-        installer.download_cbm()
+        installer.download_cbm(version="v1.2.3")
 
     monkeypatch.setattr(
         installer,
@@ -131,11 +138,11 @@ def test_download_cbm_invalid_url_download_failure_and_extract_errors(
         lambda url, timeout=60: FakeResponse(_build_archive("some/other-binary")),
     )
     with pytest.raises(RuntimeError, match="binary not found in archive"):
-        installer.download_cbm()
+        installer.download_cbm(version="v1.2.3")
 
     monkeypatch.setattr(installer, "urlopen", lambda url, timeout=60: FakeResponse(b"not a tar"))
     with pytest.raises(RuntimeError, match="Failed to extract archive"):
-        installer.download_cbm()
+        installer.download_cbm(version="v1.2.3")
 
 
 def test_ensure_cbm_uses_existing_or_returns_none_on_failure(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_installer_digest_verification.py
+++ b/tests/test_installer_digest_verification.py
@@ -1,0 +1,158 @@
+"""Supply-chain integrity tests for release-binary installers.
+
+``rtk``, ``lean-ctx`` and ``codebase-memory-mcp`` are downloaded and then
+executed by ``headroom wrap``. These tests assert that every installer
+verifies the downloaded bytes against a pinned SHA-256 digest before
+unpacking, and fails closed (refuses to install) on a mismatch or an
+unpinned asset unless the operator explicitly opts out.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import tarfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from headroom.graph import installer as cbm_installer
+from headroom.lean_ctx import installer as lean_installer
+from headroom.rtk import installer as rtk_installer
+
+# (module, allow-unverified env var, pinned-asset filename, error-label)
+INSTALLERS = [
+    pytest.param(
+        rtk_installer,
+        "HEADROOM_RTK_ALLOW_UNVERIFIED",
+        "rtk-x86_64-unknown-linux-musl.tar.gz",
+        "rtk",
+        id="rtk",
+    ),
+    pytest.param(
+        lean_installer,
+        "HEADROOM_LEAN_CTX_ALLOW_UNVERIFIED",
+        "lean-ctx-x86_64-unknown-linux-gnu.tar.gz",
+        "lean-ctx",
+        id="lean-ctx",
+    ),
+    pytest.param(
+        cbm_installer,
+        "HEADROOM_CBM_ALLOW_UNVERIFIED",
+        "codebase-memory-mcp-linux-amd64.tar.gz",
+        "codebase-memory-mcp",
+        id="cbm",
+    ),
+]
+
+
+@pytest.mark.parametrize(("mod", "allow_env", "filename", "label"), INSTALLERS)
+def test_matching_digest_passes(mod, allow_env, filename, label) -> None:
+    data = b"trusted release bytes"
+    digest = hashlib.sha256(data).hexdigest()
+    # Returns None (no raise) when the bytes match the pinned digest.
+    assert mod._verify_asset_digest(filename, data, digest) is None
+
+
+@pytest.mark.parametrize(("mod", "allow_env", "filename", "label"), INSTALLERS)
+def test_tampered_bytes_are_rejected(mod, allow_env, filename, label) -> None:
+    pinned = hashlib.sha256(b"trusted release bytes").hexdigest()
+    tampered = b"malicious substituted artifact"
+    with pytest.raises(RuntimeError, match="failed integrity check"):
+        mod._verify_asset_digest(filename, tampered, pinned)
+
+
+@pytest.mark.parametrize(("mod", "allow_env", "filename", "label"), INSTALLERS)
+def test_unpinned_asset_refused_by_default(mod, allow_env, filename, label, monkeypatch) -> None:
+    monkeypatch.delenv(allow_env, raising=False)
+    with pytest.raises(RuntimeError, match="no pinned SHA-256 digest"):
+        mod._verify_asset_digest(filename, b"some bytes", None)
+
+
+@pytest.mark.parametrize(("mod", "allow_env", "filename", "label"), INSTALLERS)
+def test_unpinned_asset_allowed_with_optout(mod, allow_env, filename, label, monkeypatch) -> None:
+    monkeypatch.setenv(allow_env, "1")
+    # Opt-out lets an unpinned (e.g. version-overridden) asset through.
+    assert mod._verify_asset_digest(filename, b"some bytes", None) is None
+
+
+@pytest.mark.parametrize(("mod", "allow_env", "filename", "label"), INSTALLERS)
+def test_every_pinned_digest_is_a_sha256_hex(mod, allow_env, filename, label) -> None:
+    digests = {
+        rtk_installer: rtk_installer.RTK_ASSET_DIGESTS,
+        lean_installer: lean_installer.LEAN_CTX_ASSET_DIGESTS,
+        cbm_installer: cbm_installer.CBM_ASSET_DIGESTS,
+    }[mod]
+    assert digests, "expected at least one pinned asset digest"
+    for name, digest in digests.items():
+        assert len(digest) == 64, f"{name}: not a sha256 hex digest"
+        assert all(c in "0123456789abcdef" for c in digest), f"{name}: non-hex digest"
+
+
+def _tar_gz_with(member: str, payload: bytes) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name=member)
+        info.size = len(payload)
+        tf.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+class _Response:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self) -> bytes:
+        return self._data
+
+
+def test_download_rtk_rejects_tampered_pinned_asset(monkeypatch, tmp_path: Path) -> None:
+    """End-to-end: a tampered archive for a pinned target aborts the install."""
+    monkeypatch.delenv("HEADROOM_RTK_TARGET", raising=False)
+    monkeypatch.delenv("HEADROOM_RTK_ALLOW_UNVERIFIED", raising=False)
+    tampered = _tar_gz_with("rtk", b"not the real rtk binary")
+
+    with patch.object(rtk_installer, "RTK_BIN_DIR", tmp_path):
+        with patch.object(
+            rtk_installer, "_get_target_triple", return_value="x86_64-unknown-linux-musl"
+        ):
+            with patch.object(rtk_installer, "urlopen", return_value=_Response(tampered)):
+                with pytest.raises(RuntimeError, match="failed integrity check"):
+                    # Pin to the current release so this exercises the verified
+                    # path (not the unpinned-override branch) regardless of the
+                    # value of RTK_VERSION.
+                    rtk_installer.download_rtk(rtk_installer.RTK_VERSION)
+
+    # Nothing was unpacked.
+    assert not (tmp_path / "rtk").exists()
+
+
+def test_download_rtk_bare_version_still_hits_pinned_path(monkeypatch, tmp_path: Path) -> None:
+    """A bare ``X.Y.Z`` for the current release normalizes to the pinned path.
+
+    Without version normalization, ``download_rtk("0.42.4")`` would not equal
+    ``RTK_VERSION`` (``v0.42.4``), be treated as an override, and skip the digest
+    map — an accidental bypass. The tampered bytes must therefore fail the
+    integrity check, not the "no pinned digest" override branch.
+    """
+    monkeypatch.delenv("HEADROOM_RTK_TARGET", raising=False)
+    monkeypatch.delenv("HEADROOM_RTK_ALLOW_UNVERIFIED", raising=False)
+    bare_version = rtk_installer.RTK_VERSION.lstrip("v")
+    tampered = _tar_gz_with("rtk", b"not the real rtk binary")
+
+    with patch.object(rtk_installer, "RTK_BIN_DIR", tmp_path):
+        with patch.object(
+            rtk_installer, "_get_target_triple", return_value="x86_64-unknown-linux-musl"
+        ):
+            with patch.object(rtk_installer, "urlopen", return_value=_Response(tampered)):
+                with pytest.raises(RuntimeError, match="failed integrity check"):
+                    rtk_installer.download_rtk(bare_version)
+
+    assert not (tmp_path / "rtk").exists()

--- a/tests/test_lean_ctx_installer.py
+++ b/tests/test_lean_ctx_installer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
 import tarfile
 import zipfile
@@ -76,6 +77,11 @@ def test_download_lean_ctx_skips_verify_for_non_native_target(monkeypatch, tmp_p
             return archive_bytes
 
     monkeypatch.setenv("HEADROOM_LEAN_CTX_TARGET", "x86_64-apple-darwin")
+    monkeypatch.setitem(
+        installer.LEAN_CTX_ASSET_DIGESTS,
+        "lean-ctx-x86_64-apple-darwin.tar.gz",
+        hashlib.sha256(archive_bytes).hexdigest(),
+    )
 
     with patch.object(installer, "LEAN_CTX_BIN_DIR", tmp_path):
         with patch.object(installer, "urlopen", return_value=_Response()):
@@ -103,6 +109,11 @@ def test_download_lean_ctx_extracts_zip_binary(monkeypatch, tmp_path: Path) -> N
             return archive.getvalue()
 
     monkeypatch.setenv("HEADROOM_LEAN_CTX_TARGET", "x86_64-pc-windows-msvc")
+    monkeypatch.setitem(
+        installer.LEAN_CTX_ASSET_DIGESTS,
+        "lean-ctx-x86_64-pc-windows-msvc.zip",
+        hashlib.sha256(archive.getvalue()).hexdigest(),
+    )
 
     with patch.object(installer, "LEAN_CTX_BIN_DIR", tmp_path):
         with patch.object(installer, "urlopen", return_value=_Response()):
@@ -134,6 +145,12 @@ def test_download_lean_ctx_verifies_native_target(monkeypatch, tmp_path: Path) -
             return archive.getvalue()
 
     run_result = SimpleNamespace(returncode=0, stdout="lean-ctx 3.4.7", stderr="")
+
+    monkeypatch.setitem(
+        installer.LEAN_CTX_ASSET_DIGESTS,
+        "lean-ctx-x86_64-unknown-linux-gnu.tar.gz",
+        hashlib.sha256(archive.getvalue()).hexdigest(),
+    )
 
     with patch.object(installer, "LEAN_CTX_BIN_DIR", tmp_path):
         with patch.object(

--- a/tests/test_rtk_installer.py
+++ b/tests/test_rtk_installer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
 import stat
 import tarfile
@@ -48,6 +49,11 @@ def test_download_rtk_skips_verify_for_non_native_target(monkeypatch, tmp_path: 
             return archive_bytes
 
     monkeypatch.setenv("HEADROOM_RTK_TARGET", "x86_64-apple-darwin")
+    monkeypatch.setitem(
+        installer.RTK_ASSET_DIGESTS,
+        "rtk-x86_64-apple-darwin.tar.gz",
+        hashlib.sha256(archive_bytes).hexdigest(),
+    )
 
     with patch.object(installer, "RTK_BIN_DIR", tmp_path):
         with patch.object(installer, "urlopen", return_value=_Response()):


### PR DESCRIPTION
## Description

The `rtk`, `lean-ctx`, and `codebase-memory-mcp` installers fetch prebuilt release binaries and then **execute** them — `rtk` in particular is auto-downloaded and run as part of a normal `headroom wrap`. Until now they did this with **no integrity check**: their `_should_verify_target` is only a runtime `--version` probe, so a tampered or substituted release artifact would be run silently.

This pins a SHA-256 digest for every release asset and verifies the downloaded bytes **before extraction**, mirroring the pattern already shipped for the tokensave installer in #1230.

Closes #1407

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/rtk/installer.py`, `headroom/lean_ctx/installer.py`, `headroom/graph/installer.py`: added a pinned `*_ASSET_DIGESTS` map and a `_verify_asset_digest()` helper, invoked between download and extraction.
- A digest mismatch raises `RuntimeError` and aborts the install (binary is never unpacked or executed).
- Overridden versions / cross-target downloads have no pinned digest and are **refused by default**, with an explicit per-tool opt-out: `HEADROOM_RTK_ALLOW_UNVERIFIED`, `HEADROOM_LEAN_CTX_ALLOW_UNVERIFIED`, `HEADROOM_CBM_ALLOW_UNVERIFIED`.
- Digests were taken from each upstream release's published asset digests for the currently pinned versions (rtk `v0.28.2`, lean-ctx `v3.4.7`, codebase-memory-mcp `v0.8.1`).
- Tests: new `tests/test_installer_digest_verification.py`; updated the existing fake-byte download tests to exercise the new verification path.
- `CHANGELOG.md`: added a Security entry.

### Note on the Windows codebase-memory-mcp asset

`graph/installer.py` builds `codebase-memory-mcp-windows-amd64.tar.gz`, but the upstream release only publishes a `.zip` for Windows — so that download already 404s today, independent of this change. No Windows digest is pinned; the path now fails closed at verification rather than at the (already failing) download. Happy to file/fix the `.tar.gz`/`.zip` mismatch as a separate issue to keep this PR scoped to integrity verification.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`) — not run locally (see Additional Notes)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run ruff check headroom/rtk/installer.py headroom/lean_ctx/installer.py headroom/graph/installer.py tests/test_installer_digest_verification.py tests/test_rtk_installer.py tests/test_lean_ctx_installer.py tests/test_graph.py
All checks passed!

$ uv run pytest tests/test_installer_digest_verification.py tests/test_rtk_installer.py tests/test_lean_ctx_installer.py tests/test_graph.py -q
======================== 45 passed, 6 warnings in 0.16s ========================
```

(The 6 warnings are the pre-existing Python 3.14 `tarfile.extract` filter deprecation in the installers — untouched by this PR.)

## Real Behavior Proof

- Environment: macOS (arm64), Python 3.13, `uv run`, headroom @ this branch. Verified end-to-end against the real published rtk release.
- Exact command / steps: download the real `rtk-x86_64-unknown-linux-musl.tar.gz` for `v0.28.2`, compare its SHA-256 to the pinned value, then drive `download_rtk()` with (a) the real bytes and (b) the same bytes with one flipped byte.
- Observed result: pinned digest matches the real artifact; real bytes install; tampered bytes are rejected with nothing written (full output below).
- Not tested: live download of lean-ctx / codebase-memory-mcp assets through `headroom wrap` on each OS (rtk exercises the shared code path end-to-end; the other two are structurally identical and covered by unit tests). Windows codebase-memory-mcp path not exercised (pre-existing asset-name mismatch, noted above).

```text
1) Downloading REAL published asset:
   https://github.com/rtk-ai/rtk/releases/download/v0.28.2/rtk-x86_64-unknown-linux-musl.tar.gz
   real   sha256 = c7b61e87b8430e42b04ab84fbe1b3b41b563454b0181247fd04844b8e9194371
   pinned sha256 = c7b61e87b8430e42b04ab84fbe1b3b41b563454b0181247fd04844b8e9194371
   MATCH

2) Install with REAL bytes (pinned target+version) -> should SUCCEED
   installed at: /tmp/.../rtk | exists: True

3) Install with TAMPERED bytes -> should ABORT, nothing written
   REJECTED: rtk asset 'rtk-x86_64-unknown-linux-musl.tar.gz' failed integrity check:
     expected sha256 c7b61e87...4371, got 64e2ab60...7764
   binary written?: False
```

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

- `mypy headroom` was not run locally (mypy isn't part of the `[dev]` extra in this environment); `ruff check` and the full touched-test suite are green. Happy to address any type findings CI surfaces.
- Verification is intentionally fail-closed for unpinned assets, with a documented per-tool opt-out env var so version overrides remain possible.
