### PR TITLE
fix(wrap): remove RTK instruction block from Codex AGENTS.md on unwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-
 ### Changed
 
 * **telemetry:** anonymous usage telemetry is now **opt-in** (off by default) instead of opt-out. Nothing is collected or sent unless you set `HEADROOM_TELEMETRY=on` or pass `--telemetry` to `headroom proxy` / `headroom install apply`. `is_telemetry_enabled()` is fail-closed — only explicit on-values (`on`/`true`/`1`/`yes`/`enable`/`enabled`) enable it; unset, empty, or unrecognized values stay disabled. The existing `--no-telemetry` flag and `HEADROOM_TELEMETRY=off` remain accepted for back-compat, and install manifests now write the `HEADROOM_TELEMETRY` value explicitly so generated deployments are unambiguous.
@@ -29,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* **wrap:** `headroom unwrap codex` now removes Headroom's RTK instruction block from the Codex global `AGENTS.md` (`$CODEX_HOME/AGENTS.md`). `wrap codex` injects that durable block but `unwrap` only restored `config.toml` and Serena MCP state, so it was left behind — a later plain `codex` launch kept following the instruction to prefix shell commands with `rtk`, failing with `rtk: command not found` when Headroom's managed binary was not on `PATH`. `unwrap codex` now calls `_remove_rtk_instructions(...)` on the Codex global AGENTS file, mirroring `unwrap copilot`, and preserves any user-authored content in that file ([#1421](https://github.com/headroomlabs-ai/headroom/issues/1421)).
 * **transforms/content_router:** stop replacing `role="tool"` output with a lossy-unrecoverable summary on the live compression path (refs [#1307](https://github.com/chopratejas/headroom/issues/1307)). `ContentRouter.apply()` routed OpenAI-style `role="tool"` string messages — `Bash`/`grep`/`ls`/`cat` output — through the ML/word-drop summarizers; when the result carried no CCR retrieve marker (CCR off, ratio >= 0.8, or the size-gate fallback) the original was unrecoverable and the agent acted on a fabricated summary. Tool-role string content is now kept verbatim unless the compressed form is CCR-recoverable. Assistant/user text is unaffected, and structurally-lossless passes (SmartCrusher/Log/Search) still apply. The Anthropic `tool_result` block path is tracked separately.
 * **rtk:** stop `rtk` hook registration from spuriously timing out during `headroom wrap`. Output is captured to a temp file instead of pipes, and `stdin` is closed, so a background process forked by `rtk init` can no longer hold the pipe open and block `subprocess.run` past its 10s timeout after the hooks were already registered.
 * **ccr:** stop re-compressing `headroom_retrieve` output, which created an infinite retrieval loop, and stop emitting retrieval markers when the `headroom_retrieve` tool is not injected, which silently dropped data ([#1077](https://github.com/chopratejas/headroom/issues/1077), [#1006](https://github.com/chopratejas/headroom/issues/1006)).

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -5483,6 +5483,14 @@ def unwrap_codex(port: int, no_stop_proxy: bool) -> None:
         elif serena_status == "failed":
             click.echo("  Serena MCP server matched Headroom ledger but could not be removed.")
 
+    # wrap_codex injects the RTK instruction block into the Codex global
+    # AGENTS.md ($CODEX_HOME/AGENTS.md). That block is durable and lives outside
+    # config.toml, so the restore above never touches it — strip it here so a
+    # later plain `codex` launch does not keep prefixing shell commands with rtk
+    # (mirrors unwrap_copilot).
+    if _remove_rtk_instructions(_codex_home_dir() / "AGENTS.md"):
+        click.echo("  Removed Headroom rtk instructions from Codex.")
+
     if status in {"restored", "cleaned", "removed"}:
         # Hand the threads back to the native-provider menu so the full history
         # stays visible once Codex no longer routes through Headroom. Best-effort.

--- a/tests/test_cli/test_wrap_codex.py
+++ b/tests/test_cli/test_wrap_codex.py
@@ -1348,6 +1348,53 @@ def test_unwrap_codex_preserves_unrelated_sections(
     assert restored == original
 
 
+def test_unwrap_codex_removes_rtk_block_from_global_agents_md(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`wrap codex` writes the RTK block to $CODEX_HOME/AGENTS.md; `unwrap` must remove it.
+
+    Regression for the durable RTK instructions surviving unwrap, which left a
+    plain `codex` launch still prefixing shell commands with `rtk`.
+    """
+    _set_test_home(monkeypatch, tmp_path)
+    agents_md = tmp_path / ".codex" / "AGENTS.md"
+
+    fake_rtk = tmp_path / "rtk"
+    fake_rtk.write_text("#!/bin/sh\n")
+    with patch("headroom.cli.wrap._ensure_rtk_binary", return_value=fake_rtk):
+        wrap_result = runner.invoke(main, ["wrap", "codex", "--prepare-only", "--port", "8787"])
+    assert wrap_result.exit_code == 0, wrap_result.output
+    assert agents_md.exists()
+    assert wrap_mod._RTK_MARKER in agents_md.read_text()
+
+    unwrap_result = runner.invoke(main, ["unwrap", "codex"])
+    assert unwrap_result.exit_code == 0, unwrap_result.output
+    assert "Removed Headroom rtk instructions from Codex." in unwrap_result.output
+    # The block must be gone — either the file is cleaned or removed entirely
+    # (it held only the Headroom block).
+    assert not agents_md.exists() or wrap_mod._RTK_MARKER not in agents_md.read_text()
+
+
+def test_unwrap_codex_preserves_user_agents_md_content(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """unwrap strips only the marker-fenced RTK block, keeping the user's own AGENTS.md."""
+    _set_test_home(monkeypatch, tmp_path)
+    agents_md = tmp_path / ".codex" / "AGENTS.md"
+    agents_md.parent.mkdir(parents=True)
+    agents_md.write_text("# My Codex instructions\n\nDo the thing.\n")
+    wrap_mod._inject_rtk_instructions(agents_md)
+    assert wrap_mod._RTK_MARKER in agents_md.read_text()
+
+    result = runner.invoke(main, ["unwrap", "codex"])
+    assert result.exit_code == 0, result.output
+
+    remaining = agents_md.read_text()
+    assert wrap_mod._RTK_MARKER not in remaining
+    assert "My Codex instructions" in remaining
+    assert "Do the thing." in remaining
+
+
 # ---------------------------------------------------------------------------
 # Per-project savings: env_http_headers in the injected provider block
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`headroom wrap codex` injects Headroom's RTK instruction block into the Codex **global** `AGENTS.md` (`$CODEX_HOME/AGENTS.md`, default `~/.codex/AGENTS.md`). `headroom unwrap codex` restored `config.toml` and removed Headroom's Serena MCP entry, but it never removed that AGENTS.md block.

Result: after unwrapping, a plain `codex` launch still inherits the instruction to prefix shell commands with `rtk`. If Headroom's managed RTK binary isn't on `PATH`, commands fail (e.g. `rtk: command not found` / `The term 'rtk' is not recognized...`).

`unwrap_codex()` now strips the marker-fenced RTK block from the Codex global AGENTS file via the existing `_remove_rtk_instructions(...)` helper — mirroring what `unwrap copilot` already does.

Closes #1421

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cli/wrap.py`: `unwrap_codex()` now calls `_remove_rtk_instructions(_codex_home_dir() / "AGENTS.md")` after the existing config/Serena cleanup and echoes a confirmation, matching `unwrap_copilot`.
- The existing helper already preserves surrounding content (strips only the `<!-- headroom:rtk-instructions -->` … `<!-- /headroom:rtk-instructions -->` fence) and removes the file only when it held nothing else.
- Tests: two regression tests in `tests/test_cli/test_wrap_codex.py` — an end-to-end `wrap codex --prepare-only` → `unwrap codex` (asserts the marker is written then gone), and one asserting user-authored AGENTS.md content survives unwrap.
- `CHANGELOG.md`: added a Fixed entry.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`) — not run locally (mypy not in the `[dev]` extra here)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run ruff check headroom/cli/wrap.py tests/test_cli/test_wrap_codex.py
All checks passed!

$ uv run pytest tests/test_cli/test_wrap_codex.py -q
======================== 68 passed in 5.34s ========================
```

The two new tests genuinely guard the fix — with the new `_remove_rtk_instructions(...)` call temporarily removed, both fail:

```text
FAILED ...::test_unwrap_codex_removes_rtk_block_from_global_agents_md
FAILED ...::test_unwrap_codex_preserves_user_agents_md_content
2 failed
```

## Real Behavior Proof

- Environment: macOS (arm64), Python 3.13, `uv run headroom ...`, throwaway `HOME` with `CODEX_HOME=~/.codex` and a fake `rtk` on `PATH` so wrap performs its normal RTK setup.
- Exact command / steps: `headroom wrap codex --prepare-only --port 8787` → inspect `$CODEX_HOME/AGENTS.md` → `headroom unwrap codex --no-stop-proxy` → re-inspect.
- Observed result: wrap writes the marker block (marker count 2); after unwrap the file is removed entirely and the marker is gone (full output below).
- Not tested: the original report is Windows/PowerShell; verified on macOS. The code path is OS-agnostic (`_codex_home_dir()` + marker-fenced text removal); the Windows behavior in the issue is the same missing call this PR adds.

```text
$ headroom wrap codex --prepare-only --port 8787
  Setting up rtk for Codex...
  rtk instructions injected into <tmp>/.codex/AGENTS.md
# AGENTS.md marker count: 2  -> MARKER PRESENT

$ headroom unwrap codex --no-stop-proxy
  HEADROOM UNWRAP: CODEX
  Removed <tmp>/.codex/config.toml (contained only Headroom-written config).
  Removed Headroom rtk instructions from Codex.
  Codex is no longer routed through the Headroom proxy.
# AGENTS.md after unwrap: file removed entirely -> MARKER GONE
```

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

- Placement: the removal runs after the config restore and Serena cleanup, unconditionally — the AGENTS.md block is durable and independent of `config.toml`, so it should be cleaned even when the config restore is a no-op. It is a safe no-op when no block is present.
- `mypy headroom` not run locally (not part of the `[dev]` extra in this environment); `ruff check` and the full `test_wrap_codex.py` suite are green.
