### PR TITLE
docs: clarify Cursor setup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Headroom compresses everything your AI agent reads — tool outputs, logs, RAG c
 
 - **Library** — `compress(messages)` in Python or TypeScript, inline in any app
 - **Proxy** — `headroom proxy --port 8787`, zero code changes, any language
-- **Agent wrap** — `headroom wrap claude|codex|cursor|aider|copilot|opencode` in one command
+- **Agent wrap** — `headroom wrap claude|codex|aider|copilot|opencode` in one command; Cursor prints manual proxy settings to paste into the app
 - **MCP server** — `headroom_compress`, `headroom_retrieve`, `headroom_stats` for any MCP client
 - **Cross-agent memory** — shared store across Claude, Codex, Gemini, auto-dedup
 - **`headroom learn`** — mines failed sessions, writes corrections to `CLAUDE.md` / `AGENTS.md`
@@ -194,7 +194,7 @@ shows an **Output Tokens Saved** card next to input compression, labelled
 |--------------|:---------------:|----------------------------------|
 | Claude Code  | ✅              | `--memory` · `--code-graph` · `--1m` |
 | Codex        | ✅              | shares memory with Claude        |
-| Cursor       | ✅              | prints config — paste once       |
+| Cursor       | Manual setup    | starts proxy and prints base URLs for Cursor settings |
 | Aider        | ✅              | starts proxy + launches          |
 | Copilot CLI  | ✅              | starts proxy + launches          |
 | OpenClaw     | ✅              | installs as ContextEngine plugin |

--- a/docs/content/docs/proxy.mdx
+++ b/docs/content/docs/proxy.mdx
@@ -203,7 +203,7 @@ Set `x-headroom-bypass: true` to skip compression.
 
 ## Agent wrapping
 
-Use `headroom wrap` to transparently proxy any CLI tool:
+Use `headroom wrap` to launch supported CLI agents through the local proxy:
 
 ```bash
 # Claude Code
@@ -215,18 +215,22 @@ headroom wrap codex
 # Aider
 headroom wrap aider
 
-# Cursor
+# Cursor (starts the proxy and prints settings to paste into Cursor)
 headroom wrap cursor
 ```
 
-Or set the base URL manually:
+Cursor reads model endpoints from its settings UI, so `headroom wrap cursor`
+does not rewrite Cursor configuration or launch the app. After it starts the
+proxy, copy the printed base URL into Cursor's model settings.
+
+For environment-driven clients, you can also set the base URL manually:
 
 ```bash
 # Claude Code
 ANTHROPIC_BASE_URL=http://localhost:8787 claude
 
-# Cursor / any OpenAI-compatible client
-OPENAI_BASE_URL=http://localhost:8787/v1 cursor
+# Any OpenAI-compatible CLI client that reads OPENAI_BASE_URL
+OPENAI_BASE_URL=http://localhost:8787/v1 your-client
 ```
 
 ## Cloud providers


### PR DESCRIPTION
## Description

Clarifies Cursor support so the docs no longer imply Cursor is fully auto-configured or launched like CLI agents. `headroom wrap cursor` starts the local proxy and prints base URLs for Cursor settings; Cursor still requires manual settings changes in the app.

Closes #1436

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Updated the README feature list so Cursor is not grouped with one-command launch/configure agents.
- Changed the README compatibility matrix to mark Cursor as manual setup and explain what `headroom wrap cursor` actually does.
- Updated proxy docs to say Cursor reads endpoints from its settings UI and to remove the misleading `OPENAI_BASE_URL=... cursor` example.

## Testing

- [x] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
uv run --with pytest --with pytest-asyncio python -m pytest tests/test_provider_cursor.py tests/test_cli/test_wrap_bridge.py::test_wrap_cursor_prepare_only_injects_cursorrules tests/test_cli/test_wrap_bridge.py::test_wrap_cursor_prepare_only_uses_lean_ctx_when_configured -q
7 passed in 0.65s

cd docs && npm run types:check
fumadocs-mdx && next typegen && tsc --noEmit
Types generated successfully

cd docs && npm run build
next build
Compiled successfully; generated static pages successfully.
Note: existing Recharts width/height warnings were emitted during static generation.

uv run --with mkdocs-material mkdocs build
Documentation built in 1.52 seconds.
Note: existing mkdocs nav/link warnings were emitted.

git diff --check
(no output)
```

## Real Behavior Proof

- Environment: Windows PowerShell, Python 3.13.3, Node/npm from local environment, isolated worktree `C:\git\headroom\.worktrees\issue-1368-install-prereqs`.
- Exact command / steps: inspected `headroom.providers.cursor.runtime.render_setup_lines`, Cursor provider tests, and `headroom wrap cursor --prepare-only` coverage; ran the commands listed above.
- Observed result: Cursor runtime only renders manual setup instructions and project-attributed base URLs; docs now match that behavior. Local Cursor-focused tests and docs builds passed.
- Not tested: launching the Cursor desktop app or manually configuring Cursor settings, because this PR changes documentation only.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A - documentation wording only.

## Additional Notes

Tests were not added because the implementation behavior was already covered; this PR aligns the public docs with the existing Cursor runtime behavior. Ruff and mypy were not run because no Python code changed. CHANGELOG is not updated for this docs-only clarification.
