### PR TITLE
feat(bedrock): support inference-profile ARNs and forward anthropic-beta (1M context)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,17 @@
 # Copy this file to .env and fill in real values before running in production.
 # IMPORTANT: Change NEO4J_AUTH before deploying — default credentials are insecure.
 NEO4J_AUTH=neo4j/CHANGEME
+
+# --- docker-compose.provider.yml (GLM / DeepSeek / any Anthropic-compatible) ---
+# Upstream endpoint Headroom forwards to. Examples:
+#   GLM (z.ai):  https://api.z.ai/api/anthropic
+#   DeepSeek:    https://api.deepseek.com/anthropic
+# HEADROOM_PROVIDER_TARGET_URL=https://api.z.ai/api/anthropic
+# HEADROOM_PROVIDER_PORT=8788
+
+# --- docker-compose.bedrock.yml (AWS Bedrock) ---
+# AWS_REGION is required by the bedrock overlay. AWS_PROFILE defaults to "default".
+# Credentials come from the host ~/.aws mount (static keys, aws sso login, or aws login).
+# AWS_REGION=us-east-1
+# AWS_PROFILE=default
+# HEADROOM_BEDROCK_PORT=8789

--- a/docker-compose.bedrock.yml
+++ b/docker-compose.bedrock.yml
@@ -1,0 +1,65 @@
+# Overlay: compress traffic to AWS Bedrock (Claude models) with Headroom.
+#
+# Unlike GLM/DeepSeek (Anthropic-compatible — see docker-compose.provider.yml),
+# Bedrock is a different API: SigV4 auth + the converse request shape. Headroom
+# translates and signs via its litellm backend (HEADROOM_BACKEND=bedrock), so
+# the proxy itself needs working AWS credentials.
+#
+# Credentials: this overlay bind-mounts your host ~/.aws into the container so
+# botocore can use whatever you already have — static keys, `aws sso login`, or
+# `aws login`. Because that bind mount is owned by your host user, the proxy
+# runs as root (user "0:0") and HOME points at the mount root so botocore finds
+# ~/.aws there. (The base/provider overlays don't need this — they use a named
+# volume with no host-UID coupling.)
+#
+# Prerequisites:
+#   - Build with the bedrock extra so boto3 + botocore[crt] are present:
+#       HEADROOM_EXTRAS=proxy,code,bedrock   (or build the image with [all])
+#   - Valid AWS credentials on the host (`aws sts get-caller-identity` works).
+#   - For `aws login`/SSO, keep the host session alive; the container reads the
+#     shared token cache from the mounted ~/.aws.
+#
+# Usage:
+#   1. Set AWS_REGION (+ optional AWS_PROFILE, HEADROOM_BEDROCK_PORT) in .env.
+#   2. docker compose -f docker-compose.yml -f docker-compose.bedrock.yml up -d
+#   3. Point your client at the proxy:
+#        ANTHROPIC_BASE_URL=http://localhost:${HEADROOM_BEDROCK_PORT}
+#        ANTHROPIC_MODEL=<bedrock model id or inference-profile ARN>
+#      (do NOT set CLAUDE_CODE_USE_BEDROCK — that bypasses the proxy and talks
+#       to AWS directly, so nothing gets compressed.)
+#
+# Model id may be a short Claude id (claude-sonnet-4-...), a region/global
+# inference profile, or a full inference-profile ARN. Append [1m] to the model
+# id to request the 1M context window (forwarded as the context-1m beta).
+services:
+  headroom-proxy-bedrock:
+    build:
+      context: .
+      args:
+        HEADROOM_EXTRAS: proxy,code,bedrock
+    # Root + HOME at the mount root so botocore reads the bind-mounted ~/.aws.
+    user: "0:0"
+    command: ["--host", "0.0.0.0", "--memory", "--backend", "bedrock"]
+    environment:
+      - HEADROOM_HOST=0.0.0.0
+      - HEADROOM_BACKEND=bedrock
+      - HEADROOM_BEDROCK_REGION=${AWS_REGION:?set AWS_REGION in .env}
+      - AWS_REGION=${AWS_REGION}
+      - AWS_PROFILE=${AWS_PROFILE:-default}
+      - HOME=/home/nonroot
+    ports:
+      - "${HEADROOM_BEDROCK_PORT:-8789}:8787"
+    volumes:
+      - headroom_workspace:/home/nonroot/.headroom
+      # Host AWS credentials (read-only mount; the SSO/login cache is refreshed
+      # on the host, the container only reads it).
+      - ${HOME}/.aws:/home/nonroot/.aws:ro
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://127.0.0.1:8787/readyz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    depends_on:
+      - qdrant
+      - neo4j

--- a/docker-compose.provider.yml
+++ b/docker-compose.provider.yml
@@ -1,0 +1,43 @@
+# Overlay: route Headroom at any Anthropic-compatible upstream (GLM/z.ai,
+# DeepSeek, Moonshot, or your own gateway) instead of api.anthropic.com.
+#
+# These providers speak the Anthropic Messages wire format, so Headroom just
+# forwards to a different base URL — no translation needed (that's the litellm
+# path, see docker-compose.bedrock.yml). The client still sends its own auth
+# token (ANTHROPIC_AUTH_TOKEN) which Headroom forwards upstream.
+#
+# Usage:
+#   1. Copy .env.example to .env and set HEADROOM_PROVIDER_TARGET_URL (+ port).
+#   2. docker compose -f docker-compose.yml -f docker-compose.provider.yml up -d
+#   3. Point your client at the proxy:
+#        ANTHROPIC_BASE_URL=http://localhost:${HEADROOM_PROVIDER_PORT}
+#        ANTHROPIC_AUTH_TOKEN=<your provider key>
+#        ANTHROPIC_MODEL=<provider model, e.g. glm-5.2 or deepseek-v4-pro>
+#
+# Examples for HEADROOM_PROVIDER_TARGET_URL:
+#   GLM (z.ai):  https://api.z.ai/api/anthropic
+#   DeepSeek:    https://api.deepseek.com/anthropic
+#
+# Custom context limits / pricing for non-Anthropic models: mount a
+# models.json (see README) — the named volume already persists ~/.headroom.
+services:
+  headroom-proxy-provider:
+    build: .
+    command: ["--host", "0.0.0.0", "--memory"]
+    environment:
+      - HEADROOM_HOST=0.0.0.0
+      # Upstream Anthropic-compatible endpoint (required). Set in .env.
+      - ANTHROPIC_TARGET_API_URL=${HEADROOM_PROVIDER_TARGET_URL:?set HEADROOM_PROVIDER_TARGET_URL in .env}
+    ports:
+      - "${HEADROOM_PROVIDER_PORT:-8788}:8787"
+    volumes:
+      - headroom_workspace:/home/nonroot/.headroom
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://127.0.0.1:8787/readyz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    depends_on:
+      - qdrant
+      - neo4j

--- a/docs/bedrock-cli-setup.md
+++ b/docs/bedrock-cli-setup.md
@@ -1,0 +1,111 @@
+# Headroom Bedrock Proxy — CLI Setup (no Docker)
+
+Run the Headroom compression proxy in front of AWS Bedrock from the CLI —
+the non-Docker equivalent of `docker-compose.bedrock.yml`. Claude Code points
+at the local proxy, the proxy translates + SigV4-signs to Bedrock via its
+LiteLLM backend, and your traffic gets compressed on the way through.
+
+> Uses the Python `headroom proxy --backend bedrock` path (LiteLLM converse +
+> SigV4). This is distinct from the native Rust `headroom-proxy` binary
+> documented in [`bedrock.md`](./bedrock.md).
+
+## 1. Prerequisites (install once)
+
+```sh
+# Rust toolchain — headroom compiles a native extension (headroom/_core.so) on install
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+
+# uv (Python project/runtime manager)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# AWS CLI v2 — for credentials (skip if already installed)
+```
+
+## 2. Clone the repo and check out the branch
+
+```sh
+git clone https://github.com/KennethWKZ/headroom.git
+cd headroom
+git checkout feat/bedrock-inference-profile-arn
+```
+
+## 3. Install headroom with Bedrock support
+
+```sh
+uv tool install ".[proxy,code,bedrock]"
+headroom --version   # verify it is on PATH
+```
+
+The `bedrock` extra pulls in `boto3` and `botocore[crt]` (the latter is required
+for the `aws login` / SSO credential providers).
+
+## 4. Get AWS credentials working
+
+Use whatever your org uses, then confirm before starting the proxy:
+
+```sh
+aws login --profile default       # or: aws sso login --profile default
+aws sts get-caller-identity        # must return your account — the proxy needs this
+```
+
+The proxy reads `~/.aws` directly (no mount needed — that is a Docker-only concern).
+
+## 5. Start the Bedrock proxy
+
+```sh
+headroom proxy \
+  --backend bedrock \
+  --region ap-southeast-1 \
+  --bedrock-profile default \
+  --memory \
+  --port 8789
+```
+
+Leave it running. By default it binds `127.0.0.1` — fine for local dev. Add
+`--host 0.0.0.0` only if another machine must reach it.
+
+## 6. Point Claude Code at the proxy
+
+Set these in your client (e.g. a ccs `bedrock.settings.json`, or plain env):
+
+```sh
+ANTHROPIC_BASE_URL=http://localhost:8789
+ANTHROPIC_MODEL=arn:aws:bedrock:ap-southeast-1:<ACCOUNT_ID>:application-inference-profile/<PROFILE_ID>[1m]
+```
+
+- The model id may be a short Claude id (`claude-sonnet-4-...`), a
+  region/global inference profile, or a full inference-profile ARN.
+- Append `[1m]` to request the 1M context window (forwarded as the
+  `context-1m-2025-08-07` beta).
+- **Do NOT set `CLAUDE_CODE_USE_BEDROCK`.** That makes Claude Code talk to AWS
+  directly, bypassing the proxy — nothing gets compressed.
+
+Then launch Claude Code as usual.
+
+## CLI ↔ docker-compose.bedrock.yml mapping
+
+| `docker-compose.bedrock.yml` | CLI equivalent |
+|---|---|
+| `command: --host 0.0.0.0 --memory --backend bedrock` | `--memory --backend bedrock` |
+| `HEADROOM_BEDROCK_REGION=${AWS_REGION}` | `--region ap-southeast-1` |
+| `AWS_PROFILE=default` | `--bedrock-profile default` |
+| `${HOME}/.aws:/home/nonroot/.aws:ro` mount | native — reads `~/.aws` directly |
+| port `8789:8787` | `--port 8789` |
+
+The CLI run is simpler than the container: no UID/HOME juggling and no bind
+mount, because the proxy runs as your own user and reads `~/.aws` in place.
+
+## Updating later
+
+A plain (non-editable) `uv tool install` is a snapshot. After `git pull`,
+reinstall to pick up changes:
+
+```sh
+git pull
+uv tool install --reinstall ".[proxy,code,bedrock]"
+```
+
+To develop against the source live instead, install editable
+(`uv tool install --editable ".[proxy,code,bedrock]"`) — then edits load without
+a reinstall.

--- a/headroom/backends/litellm.py
+++ b/headroom/backends/litellm.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -383,6 +384,20 @@ def _parse_tool_arguments(arguments: Any) -> Any:
     return arguments
 
 
+def _apply_anthropic_beta(kwargs: dict[str, Any], headers: dict[str, str]) -> None:
+    """Forward the client's ``anthropic-beta`` header into the LiteLLM call.
+
+    Without this, beta features negotiated by the client (notably the 1M
+    context window ``context-1m-2025-08-07``) never reach the upstream — the
+    Bedrock converse transform reads them from a ``headers`` kwarg, and
+    LiteLLM otherwise drops them. LiteLLM filters betas the provider does not
+    support, so passing the raw value through is safe.
+    """
+    beta = headers.get("anthropic-beta") or headers.get("Anthropic-Beta")
+    if beta:
+        kwargs.setdefault("headers", {})["anthropic-beta"] = beta
+
+
 class LiteLLMBackend(Backend):
     """Backend using LiteLLM for multi-provider support.
 
@@ -449,6 +464,18 @@ class LiteLLMBackend(Backend):
 
         # For Bedrock, try to normalize various input formats
         if self.provider == "bedrock":
+            # Full inference-profile ARNs must use the converse route; the bare
+            # ARN contains "/", so without this it falls through to the generic
+            # "/"-passthrough below and reaches litellm unprefixed (provider=None).
+            # Strip a trailing Claude Code context-window marker (e.g. "[1m]")
+            # in case a client forwards it on the model id rather than the
+            # anthropic-beta header.
+            if anthropic_model.startswith("arn:aws:bedrock:"):
+                arn = re.sub(r"\[[0-9]+m\]$", "", anthropic_model)
+                return f"bedrock/converse/{arn}"
+            if anthropic_model.startswith("bedrock/converse/"):
+                return anthropic_model
+
             normalized = _normalize_bedrock_profile_id(anthropic_model)
             if normalized and normalized in self._model_map:
                 return self._model_map[normalized]
@@ -695,6 +722,7 @@ class LiteLLMBackend(Backend):
             logger.debug(f"LiteLLM request: model={litellm_model}")
 
             # Make the call
+            _apply_anthropic_beta(kwargs, headers)
             response = await acompletion(**kwargs)
 
             # Convert to Anthropic format
@@ -817,6 +845,7 @@ class LiteLLMBackend(Backend):
             )
 
             # Stream content — blocks emitted dynamically based on response
+            _apply_anthropic_beta(kwargs, headers)
             response = await acompletion(**kwargs)
             output_tokens = 0
             current_block_index = -1
@@ -1023,6 +1052,7 @@ class LiteLLMBackend(Backend):
             logger.debug(f"LiteLLM OpenAI request: model={litellm_model}")
 
             # Make the call
+            _apply_anthropic_beta(kwargs, headers)
             response = await acompletion(**kwargs)
 
             # Build the usage block. LiteLLM normalizes prompt-cache stats from
@@ -1195,6 +1225,7 @@ class LiteLLMBackend(Backend):
                 elif headers.get("x-api-key"):
                     kwargs["api_key"] = headers["x-api-key"]
 
+            _apply_anthropic_beta(kwargs, headers)
             response = await acompletion(**kwargs)
 
             async for chunk in response:

--- a/headroom/providers/anthropic.py
+++ b/headroom/providers/anthropic.py
@@ -83,6 +83,8 @@ def sanitize_anthropic_model_metadata(value: Any) -> Any:
 # Anthropic model context limits
 # All Claude 3+ models have 200K context
 ANTHROPIC_CONTEXT_LIMITS: dict[str, int] = {
+    # Claude 4.8 (Opus 4.8) - 1M context
+    "claude-opus-4-8": 1000000,
     # Claude 4.7 (Opus 4.7) - 1M context
     "claude-opus-4-7": 1000000,
     # Claude 4.6 (Opus 4.6) - 1M context
@@ -112,6 +114,8 @@ ANTHROPIC_CONTEXT_LIMITS: dict[str, int] = {
 # NOTE: These are ESTIMATES. Always verify against actual Anthropic billing.
 # Last updated: 2025-01-14
 ANTHROPIC_PRICING: dict[str, dict[str, float]] = {
+    # Claude 4.8 (Opus tier pricing)
+    "claude-opus-4-8": {"input": 15.00, "output": 75.00, "cached_input": 1.50},
     # Claude 4.7 (Opus tier pricing)
     "claude-opus-4-7": {"input": 15.00, "output": 75.00, "cached_input": 1.50},
     # Claude 4.6 (Opus tier pricing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,10 @@ evals = [
 # AWS Bedrock backend
 bedrock = [
     "boto3>=1.28.0",
+    # `botocore[crt]` is required for the `aws login` (console-login / DPoP)
+    # credential provider; without awscrt botocore raises
+    # MissingDependencyException when resolving those credentials.
+    "botocore[crt]>=1.28.0",
 ]
 # HTML content extraction
 html = [
@@ -260,7 +264,7 @@ dev = [
 ]
 # All optional dependencies (everything you need)
 all = [
-    "headroom-ai[proxy,code,ml,memory,relevance,image,reports,otel,evals,voice,html,benchmark,mcp,spreadsheet]",
+    "headroom-ai[proxy,code,ml,memory,relevance,image,reports,otel,evals,voice,html,benchmark,mcp,spreadsheet,bedrock]",
 ]
 
 [project.scripts]

--- a/tests/test_bedrock_region.py
+++ b/tests/test_bedrock_region.py
@@ -13,6 +13,7 @@ importorskip_no_env_leak("litellm")
 
 from headroom.backends.litellm import (  # noqa: E402  (must follow importorskip)
     LiteLLMBackend,
+    _apply_anthropic_beta,
     _bedrock_profiles_cache,
     _bedrock_region_prefix,
     _build_bedrock_fallback_map,
@@ -352,3 +353,88 @@ class TestNormalizeBedrockProfileId:
         assert _normalize_bedrock_profile_id("claude-sonnet-4-20250514") == (
             "claude-sonnet-4-20250514"
         )
+
+
+# =============================================================================
+# Inference-profile ARN mapping (converse route)
+# =============================================================================
+
+
+class TestBedrockArnMapping:
+    """Full inference-profile ARNs must route through the converse handler.
+
+    A bare ARN contains ``/`` (``.../application-inference-profile/<id>``), so
+    without an explicit branch it falls through to the generic ``/``-passthrough
+    and reaches LiteLLM unprefixed, which fails with ``provider = None``.
+    """
+
+    def _backend(self):
+        with patch(
+            "headroom.backends.litellm._fetch_bedrock_inference_profiles",
+            return_value={},
+        ):
+            return LiteLLMBackend(provider="bedrock", region="ap-southeast-1")
+
+    def test_application_inference_profile_arn(self):
+        arn = (
+            "arn:aws:bedrock:ap-southeast-1:123456789012:application-inference-profile/abc123def456"
+        )
+        assert self._backend().map_model_id(arn) == f"bedrock/converse/{arn}"
+
+    def test_system_inference_profile_arn(self):
+        arn = (
+            "arn:aws:bedrock:us-east-1:123456789012:"
+            "inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        )
+        assert self._backend().map_model_id(arn) == f"bedrock/converse/{arn}"
+
+    def test_arn_strips_context_window_marker(self):
+        """A trailing [1m] marker on the model id must not break ARN routing."""
+        base = (
+            "arn:aws:bedrock:ap-southeast-1:123456789012:application-inference-profile/abc123def456"
+        )
+        assert self._backend().map_model_id(f"{base}[1m]") == f"bedrock/converse/{base}"
+
+    def test_converse_prefixed_arn_passthrough(self):
+        model = (
+            "bedrock/converse/arn:aws:bedrock:ap-southeast-1:123456789012:"
+            "application-inference-profile/abc123def456"
+        )
+        assert self._backend().map_model_id(model) == model
+
+
+# =============================================================================
+# anthropic-beta header forwarding (e.g. 1M context window)
+# =============================================================================
+
+
+class TestApplyAnthropicBeta:
+    """The client's ``anthropic-beta`` header must reach the LiteLLM call.
+
+    LiteLLM's Bedrock converse transform reads beta features (notably
+    ``context-1m-2025-08-07``) from a ``headers`` kwarg; without forwarding,
+    the 1M window silently caps at 200k.
+    """
+
+    def test_forwards_beta(self):
+        kwargs: dict = {}
+        _apply_anthropic_beta(kwargs, {"anthropic-beta": "context-1m-2025-08-07"})
+        assert kwargs["headers"]["anthropic-beta"] == "context-1m-2025-08-07"
+
+    def test_no_beta_is_noop(self):
+        kwargs: dict = {}
+        _apply_anthropic_beta(kwargs, {})
+        assert "headers" not in kwargs
+
+    def test_preserves_existing_headers(self):
+        kwargs: dict = {"headers": {"x-existing": "1"}}
+        _apply_anthropic_beta(kwargs, {"anthropic-beta": "context-1m-2025-08-07"})
+        assert kwargs["headers"] == {
+            "x-existing": "1",
+            "anthropic-beta": "context-1m-2025-08-07",
+        }
+
+    def test_titlecase_header_key(self):
+        kwargs: dict = {}
+        _apply_anthropic_beta(kwargs, {"Anthropic-Beta": "context-1m-2025-08-07"})
+        assert kwargs["headers"]["anthropic-beta"] == "context-1m-2025-08-07"

--- a/uv.lock
+++ b/uv.lock
@@ -336,6 +336,35 @@ wheels = [
 ]
 
 [[package]]
+name = "awscrt"
+version = "0.29.2"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/90/f985002a50859ea39841e66bc816c224b623c03f943b34bfe08fee17165c/awscrt-0.29.2.tar.gz", hash = "sha256:c78d81b1308d42fda1eb21d27fcf26579137b821043e528550f2cfc6c09ab9ff", size = 38013553, upload-time = "2025-12-04T00:16:36.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/d7/da6dd2261eca70595dc523df4ed69b59bde1728f4b629f55f55821bdbe5e/awscrt-0.29.2-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:924bd4d81c8a64618b7493d9705868b8a04214e3004fa4c501af99c9cc02015d", size = 3407798, upload-time = "2025-12-04T00:15:36.85Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/37/40d64128a983def95b623891d6553d108edf6a76d84f953c0d8a349217d4/awscrt-0.29.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2751af47cd24ecea59e8bab705bd709dd78e4b5bb585584264f0b615a3ab223f", size = 3855716, upload-time = "2025-12-04T00:15:39.598Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/69/b4c5d83de5efd497799358aaab4b5d461a95438d29767db2477306339f9e/awscrt-0.29.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aae54260b780ca32e73ea92528d649f1f9f892bc0da3fdf350889e0b577e45fa", size = 4128829, upload-time = "2025-12-04T00:15:41.255Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/56/a821230a9768f29a78700c5dd292d196ea60f494e80607ac10254839f345/awscrt-0.29.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:7b8dd8e2a8db9c1c42781b7c3e4ca79f1d71bad001f82e765bce217dc9560d8d", size = 3778484, upload-time = "2025-12-04T00:15:42.773Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/46/3bfb87921aab2bc8fde160e531742245b9ad0ece34be41cbc2016603c18c/awscrt-0.29.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6f652bf4ac5cf3ca5b8e6b13309a1d5795f61c84fe0554e1f230e263f900def0", size = 4005392, upload-time = "2025-12-04T00:15:44.694Z" },
+    { url = "https://files.pythonhosted.org/packages/97/14/f2a2580fa099d335d459483c1b5e565ed777af10e582c7114617a9b0cbdd/awscrt-0.29.2-cp310-cp310-win32.whl", hash = "sha256:39c0524a46e1d108065f7052b5689802304a41fe10c41d0741d42608a168baaf", size = 3961694, upload-time = "2025-12-04T00:15:46.325Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/73/f610409d5ad522e05ec41acf38c8be9e6f7bf40a2b1f9c149298e405c9c3/awscrt-0.29.2-cp310-cp310-win_amd64.whl", hash = "sha256:7e0c47e0cde4c52933c56cdafa2e3c59cdc2ec4a34d7f9ace77117416c66bfe5", size = 4092047, upload-time = "2025-12-04T00:15:47.898Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7f/9d7b3d3f72369f80730ee5a0e964a1cd6ccf83d8c117a4d1df629e3ed6f9/awscrt-0.29.2-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:3ff819a542acc5f11c46223204362c6b065031df0e4a37bf1ce2fc233a7145e4", size = 3407922, upload-time = "2025-12-04T00:15:49.071Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f2/3e61a4683ff8e9bc59871214e833bf3f67e9f08b1884aae9e1166ef06ac3/awscrt-0.29.2-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:aa3d2f7fc0218a04707384afd871a8c3e97251185038eb921ae2fae4f61b7d90", size = 3817179, upload-time = "2025-12-04T00:15:50.965Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/13/a7366b0465b998b1d05f8b3a05e5897a431ec101b9a389be6058fbbe5e26/awscrt-0.29.2-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f86d5a1a3c6d817dc0087d4e25abae1a7a1dd678d31fbcd226a15515719bdac", size = 4091388, upload-time = "2025-12-04T00:15:52.182Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/90/a34b1b29612d91baad1273ea1d4e31ab3a90e2db4e516345329fecfbaeb2/awscrt-0.29.2-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a6451a730c961b73b57dccdcf8599bf8058740053b531d3724efbf3a89e2d191", size = 3719628, upload-time = "2025-12-04T00:15:53.356Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/94/2d93803e93cff7da0f5c9b6422b9f919d86db83640cdfbae569bdf22e606/awscrt-0.29.2-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:66a82b0960d281e14e7bfb95e9d6934cbc8e949b3f3e829709736b14bf0e6760", size = 3945694, upload-time = "2025-12-04T00:15:54.879Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/26/e2517fe8eb2f565ba52274a59f301bc6fac25494e0d28b6257fde237190a/awscrt-0.29.2-cp311-abi3-win32.whl", hash = "sha256:c1c243a7d7b9ed9c1e10acfb44eaab81b88eec24b50915ce3db45a8ffa4f2edb", size = 3959540, upload-time = "2025-12-04T00:15:57.138Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/49/bc9f3bcf2d49c58b97dd357f617c8331c1be02e5907316eb0ac39096941d/awscrt-0.29.2-cp311-abi3-win_amd64.whl", hash = "sha256:cd7349596f8f7b05805e047d29bfceb2304f5f0277fe0088e13ea8fe41ac3064", size = 4092749, upload-time = "2025-12-04T00:15:58.414Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/41/a564e4537c8e56259d9a9a86239d6b89448a742a5a5769b8cb81e2db7b26/awscrt-0.29.2-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:2377b9adf0db47fcf74ad6c89afcd901f6cf97f24ba4f0e5e352f5ffe12affef", size = 3406616, upload-time = "2025-12-04T00:15:59.966Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/4f88475ea7a9e4954871ebe188bfc9b5d29a60e1101e50a984afde904c3b/awscrt-0.29.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e0cb67ce813577679dab7ab56cc8bb16a546328589db87a55f7b52314f54504f", size = 3809168, upload-time = "2025-12-04T00:16:01.288Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/f08b3b646198d9a5fb45bc411e6a102ec976efc4acc34c01ac86cf557216/awscrt-0.29.2-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb7d44ed31baeb1b5720674a0249f48d8d6e548ea544ddfb93000b6bff559f34", size = 4084414, upload-time = "2025-12-04T00:16:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/40/fd45b53bfc5486a31080a767947396f717534dde0ace1c9ee48b96c079b9/awscrt-0.29.2-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e455776fd0a04929c586a66e590c6eb6f2ca08b96ec13323bfb087ee17fd6e99", size = 3710752, upload-time = "2025-12-04T00:16:04.777Z" },
+    { url = "https://files.pythonhosted.org/packages/53/25/179278c03b84e09332ef4a7770878b93b43f10564b6a94a82faa8d9329e6/awscrt-0.29.2-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:70fd197fe83b78c25c2c57293466808df6f63287a480984834b4af7b9d18d4c0", size = 3939687, upload-time = "2025-12-04T00:16:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5c/8330d3f8f5f080a85dc79c376c7125f24579dfb9c4e200224292062a36bb/awscrt-0.29.2-cp313-abi3-win32.whl", hash = "sha256:b3c46e4808ce7cfb6a63878e45b30b3410f5c314e352396d1210380787cafee2", size = 3954574, upload-time = "2025-12-04T00:16:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8f/630f3083d07a75e258aae67c0d06c7ed69098d4ca85550e9cd344d3f613d/awscrt-0.29.2-cp313-abi3-win_amd64.whl", hash = "sha256:74f8944e04bfc1508cce784b75927b4fb9895ff6a57310abb523c4b446b4f34f", size = 4085860, upload-time = "2025-12-04T00:16:08.752Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -388,6 +417,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/b7/a02a9db7f5267547da79a28e0832059f87b7e8f275423b4384891d53bf3b/botocore-1.42.38.tar.gz", hash = "sha256:eb36d09b5c61b3ede6129f7b54630049f3eeeccf1327a32cf8944563027a4002", size = 14918119, upload-time = "2026-01-29T20:39:28.055Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/c1/5db0d5f9a57d5e72dd3b18c7279b0005adaf5ffe5915803ae6216fe86cec/botocore-1.42.38-py3-none-any.whl", hash = "sha256:b67e0c4989a6bdd459cb49274df05003179165567b7789d8d920cdbdc6c2661f", size = 14590772, upload-time = "2026-01-29T20:39:25.165Z" },
+]
+
+[package.optional-dependencies]
+crt = [
+    { name = "awscrt" },
 ]
 
 [[package]]
@@ -1477,6 +1511,8 @@ agno = [
 ]
 all = [
     { name = "anthropic" },
+    { name = "boto3" },
+    { name = "botocore", extra = ["crt"] },
     { name = "datasets" },
     { name = "fastapi" },
     { name = "fastembed" },
@@ -1519,6 +1555,7 @@ anyllm = [
 ]
 bedrock = [
     { name = "boto3" },
+    { name = "botocore", extra = ["crt"] },
 ]
 benchmark = [
     { name = "anthropic" },
@@ -1677,6 +1714,7 @@ requires-dist = [
     { name = "any-llm-sdk", marker = "python_full_version >= '3.11' and extra == 'anyllm'", specifier = ">=1.0.0" },
     { name = "ast-grep-cli", specifier = ">=0.30.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.28.0" },
+    { name = "botocore", extras = ["crt"], marker = "extra == 'bedrock'", specifier = ">=1.28.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "datasets", marker = "extra == 'evals'", specifier = ">=2.14.0" },
     { name = "datasets", marker = "extra == 'voice-train'", specifier = ">=2.14.0" },
@@ -1685,7 +1723,7 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'relevance'", specifier = ">=0.4.0" },
     { name = "gunicorn", marker = "sys_platform != 'win32' and extra == 'proxy-prod'", specifier = ">=21.0.0" },
     { name = "headroom-ai", extras = ["proxy"], marker = "extra == 'proxy-prod'" },
-    { name = "headroom-ai", extras = ["proxy", "code", "ml", "memory", "relevance", "image", "reports", "otel", "evals", "voice", "html", "benchmark", "mcp", "spreadsheet"], marker = "extra == 'all'" },
+    { name = "headroom-ai", extras = ["proxy", "code", "ml", "memory", "relevance", "image", "reports", "otel", "evals", "voice", "html", "benchmark", "mcp", "spreadsheet", "bedrock"], marker = "extra == 'all'" },
     { name = "headroom-ai", extras = ["voice"], marker = "extra == 'voice-train'" },
     { name = "hnswlib", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "hnswlib", marker = "extra == 'memory'", specifier = ">=0.8.0" },


### PR DESCRIPTION
## Description

Two fixes on the LiteLLM backend so AWS Bedrock works with the request shape Claude Code actually sends, plus the deps and compose overlays to run it.

When `ANTHROPIC_MODEL` is a full inference-profile ARN, requests failed with `litellm.BadRequestError: LLM Provider NOT provided` (provider=None). And on the Bedrock path the 1M context window never engaged because the client's `anthropic-beta` header was dropped before the upstream call.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **`map_model_id` ARN routing** (`headroom/backends/litellm.py`): route full inference-profile ARNs through the `bedrock/converse/` prefix (application- and system-defined, regional or `global.`). A bare ARN contains `/`, so it previously fell through to the generic passthrough and reached LiteLLM unprefixed. Also strips a trailing `[1m]` context-window marker if a client forwards it on the model id.
- **Forward `anthropic-beta`** (`_apply_anthropic_beta`): pass the client's beta header into all four `acompletion` calls. LiteLLM's converse transform reads beta features (notably `context-1m-2025-08-07`) from a `headers` kwarg; without this the 1M window silently capped at 200k. LiteLLM filters provider-unsupported betas, so forwarding the raw value is safe.
- **Deps** (`pyproject.toml`, `uv.lock`): add `botocore[crt]` to the `bedrock` extra (required by the AWS console-login / SSO credential provider, which raises `MissingDependencyException` without awscrt) and include `bedrock` in the `all` extra.
- **Compose overlays**: `docker-compose.bedrock.yml` (AWS Bedrock, mounts host `~/.aws` read-only) and `docker-compose.provider.yml` (generic Anthropic-compatible upstream — GLM/z.ai, DeepSeek, etc. via `.env`). Base `docker-compose.yml` is unchanged; both overlays are opt-in. New vars documented in `.env.example`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

\`\`\`text
$ uv run --extra dev --with litellm pytest tests/test_bedrock_region.py -q
tests/test_bedrock_region.py ...................................         [100%]
35 passed in 1.32s

$ uv run --extra dev ruff check headroom/backends/litellm.py tests/test_bedrock_region.py
All checks passed!
\`\`\`

11 new cases cover ARN mapping (application/system/global ARNs, `[1m]` strip, converse passthrough) and `anthropic-beta` forwarding (forward, no-op, preserve-existing, title-case key).

## Real Behavior Proof

- **Environment:** macOS, Python 3.13, AWS Bedrock `ap-southeast-1`, credentials via `aws login` (console-login / SSO), Claude Code via local proxy (`ANTHROPIC_BASE_URL`, no `CLAUDE_CODE_USE_BEDROCK`).
- **Exact steps:** ran the proxy with `--backend bedrock --bedrock-region ap-southeast-1`; sent a request with `ANTHROPIC_MODEL` set to a full `application-inference-profile` ARN (and separately a `global.` inference-profile ARN).
- **Observed result:** before the fix, HTTP 500 `LLM Provider NOT provided`. After, HTTP 200 with a real Bedrock completion. Global inference-profile ARN also returns 200. GLM/DeepSeek via the provider overlay return 200 against their Anthropic-compatible endpoints.
- **Not tested:** a true >200k-token request to physically confirm the 1M window extends end-to-end (mechanism traced and unit-tested: LiteLLM's converse transform accepts `context-1m` from the forwarded header).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

- `mypy` not run locally; happy to address any type findings from CI.
- CHANGELOG.md left untouched — let me know if you'd like an entry.
- The Bedrock overlay runs the container as root with `HOME=/home/nonroot` only because it bind-mounts the host `~/.aws`; the base and provider overlays use a named volume and need neither.