### PR TITLE
fix(deps): bump pyo3 0.24 -> 0.29 to close RUSTSEC-2026-0176/0177

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,15 +2393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,15 +2679,6 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -3219,37 +3201,32 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3257,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.12.4"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45192e5e4a4d2505587e27806c7b710c231c40c56f3bfc19535d0bb25df52264"
+checksum = "f64083bd3a16a353d9d62335808e8e13d0552d2a2b83fdb084496192dcfa9fcd"
 dependencies = [
  "arc-swap",
  "log",
@@ -3268,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3280,13 +3257,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -4640,12 +4616,6 @@ dependencies = [
  "encoding_rs",
  "regex",
 ]
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unit-prefix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,10 +59,10 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 axum = "0.7"
 tower = "0.5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-pyo3 = { version = "0.24", features = ["abi3-py310"] }
+pyo3 = { version = "0.29", features = ["abi3-py310"] }
 # Forwards Rust `log` records (incl. tracing events via the `log` compat
 # feature above) into Python's `logging` inside the _core extension module.
-pyo3-log = "0.12"
+pyo3-log = "0.13"
 # Phase D PR-D1: AWS SigV4 signing for native Bedrock InvokeModel route.
 # `aws-sigv4` provides the canonical-request + signing-key implementation;
 # `aws-config` resolves credentials from the standard provider chain

--- a/crates/headroom-py/src/lib.rs
+++ b/crates/headroom-py/src/lib.rs
@@ -97,7 +97,7 @@ fn build_crush_array_dict<'py>(
 /// Defaults match Python; constructor accepts every field as a kwarg with
 /// the same name and type as the Python dataclass for drop-in
 /// compatibility.
-#[pyclass(name = "DiffCompressorConfig", module = "headroom._core")]
+#[pyclass(name = "DiffCompressorConfig", module = "headroom._core", from_py_object)]
 #[derive(Clone)]
 struct PyDiffCompressorConfig {
     inner: DiffCompressorConfig,
@@ -417,7 +417,7 @@ impl PyDiffCompressor {
     fn compress(&self, py: Python<'_>, content: &str, context: &str) -> PyDiffCompressionResult {
         let content = content.to_string();
         let context = context.to_string();
-        let inner = py.allow_threads(|| self.inner.compress(&content, &context));
+        let inner = py.detach(|| self.inner.compress(&content, &context));
         PyDiffCompressionResult { inner }
     }
 
@@ -435,7 +435,7 @@ impl PyDiffCompressor {
         let content = content.to_string();
         let context = context.to_string();
         let (result, stats) =
-            py.allow_threads(|| self.inner.compress_with_stats(&content, &context));
+            py.detach(|| self.inner.compress_with_stats(&content, &context));
         (
             PyDiffCompressionResult { inner: result },
             PyDiffCompressorStats { inner: stats },
@@ -449,7 +449,7 @@ impl PyDiffCompressor {
 /// Defaults match Python's dataclass byte-for-byte. The constructor
 /// accepts every field as a kwarg with the same name and type so the
 /// Python shim can pass `SmartCrusherConfig(**asdict(py_cfg))`.
-#[pyclass(name = "SmartCrusherConfig", module = "headroom._core")]
+#[pyclass(name = "SmartCrusherConfig", module = "headroom._core", from_py_object)]
 #[derive(Clone)]
 struct PySmartCrusherConfig {
     inner: RustSmartCrusherConfig,
@@ -761,7 +761,7 @@ impl PySmartCrusher {
     fn crush(&self, py: Python<'_>, content: &str, query: &str, bias: f64) -> PyCrushResult {
         let content = content.to_string();
         let query = query.to_string();
-        let inner = py.allow_threads(|| self.inner.crush(&content, &query, bias));
+        let inner = py.detach(|| self.inner.crush(&content, &query, bias));
         PyCrushResult { inner }
     }
 
@@ -780,7 +780,7 @@ impl PySmartCrusher {
     ) -> (String, bool, String) {
         let content = content.to_string();
         let query = query.to_string();
-        py.allow_threads(|| self.inner.smart_crush_content(&content, &query, bias))
+        py.detach(|| self.inner.smart_crush_content(&content, &query, bias))
     }
 
     /// Crush a JSON array directly and return the structured result.
@@ -813,7 +813,7 @@ impl PySmartCrusher {
         let items_json = items_json.to_string();
         let query = query.to_string();
         let (kept_json, ccr_hash, dropped_summary, strategy_info, compacted, compaction_kind) = py
-            .allow_threads(|| {
+            .detach(|| {
                 let parsed: serde_json::Value = serde_json::from_str(&items_json)
                     .unwrap_or_else(|e| panic!("items_json must be JSON: {e}"));
                 let items = match parsed {
@@ -860,7 +860,7 @@ impl PySmartCrusher {
         // Heavy: JSON parse + recursive walker + tabular compaction +
         // re-serialize. None of it touches Python; release the GIL.
         let doc_json = doc_json.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             let parsed: serde_json::Value = serde_json::from_str(&doc_json)
                 .unwrap_or_else(|e| panic!("doc_json must be JSON: {e}"));
             let mut dc = DocumentCompactor::new().with_config(CompactConfig {
@@ -913,7 +913,7 @@ impl PySmartCrusher {
 /// `content_type` is exposed as the lowercase string tag (e.g.
 /// `"json_array"`). The Python wrapper translates it back into the
 /// `ContentType` enum so the call-site looks identical.
-#[pyclass(name = "DetectionResult", module = "headroom._core")]
+#[pyclass(name = "DetectionResult", module = "headroom._core", from_py_object)]
 #[derive(Clone)]
 struct PyDetectionResult {
     inner: RustDetectionResult,
@@ -994,7 +994,7 @@ impl PyDetectionResult {
 #[pyfunction]
 fn detect_content_type(py: Python<'_>, content: &str) -> PyDetectionResult {
     let owned = content.to_string();
-    let content_type = py.allow_threads(move || rust_detect_chain(&owned));
+    let content_type = py.detach(move || rust_detect_chain(&owned));
     PyDetectionResult {
         inner: RustDetectionResult {
             content_type,
@@ -1009,7 +1009,7 @@ fn detect_content_type(py: Python<'_>, content: &str) -> PyDetectionResult {
 #[pyfunction]
 fn is_json_array_of_dicts(py: Python<'_>, content: &str) -> bool {
     let owned = content.to_string();
-    py.allow_threads(move || rust_is_json_array_of_dicts(&owned))
+    py.detach(move || rust_is_json_array_of_dicts(&owned))
 }
 
 // Suppress unused-import warning when ContentType isn't referenced
@@ -1118,7 +1118,7 @@ fn keyword_registry_snapshot(py: Python<'_>) -> Py<PyDict> {
 // store. This avoids dragging a second CCR backend into Rust before the
 // Phase 3g pipeline formalization owns CCR end-to-end.
 
-#[pyclass(name = "SearchCompressorConfig", module = "headroom._core")]
+#[pyclass(name = "SearchCompressorConfig", module = "headroom._core", from_py_object)]
 #[derive(Clone)]
 struct PySearchCompressorConfig {
     inner: RustSearchConfig,
@@ -1274,7 +1274,7 @@ impl PySearchCompressor {
         // wants persistence beyond the request lifecycle.
         let owned = content.to_string();
         let owned_ctx = context.to_string();
-        let (result, stats) = py.allow_threads(move || {
+        let (result, stats) = py.detach(move || {
             let store = headroom_core::ccr::InMemoryCcrStore::new();
             let (r, s) = self
                 .inner
@@ -1312,7 +1312,7 @@ fn parse_search_lines(content: &str) -> Vec<(String, u64, String)> {
 // pattern as search_compressor: Rust emits a `cache_key`, Python shim
 // writes the original to the production `CompressionStore`.
 
-#[pyclass(name = "LogCompressorConfig", module = "headroom._core")]
+#[pyclass(name = "LogCompressorConfig", module = "headroom._core", from_py_object)]
 #[derive(Clone)]
 struct PyLogCompressorConfig {
     inner: RustLogConfig,
@@ -1461,7 +1461,7 @@ impl PyLogCompressor {
     #[pyo3(signature = (content, bias = 1.0))]
     fn compress(&self, py: Python<'_>, content: &str, bias: f64) -> PyLogCompressionResult {
         let owned = content.to_string();
-        let (result, stats) = py.allow_threads(move || {
+        let (result, stats) = py.detach(move || {
             let store = headroom_core::ccr::InMemoryCcrStore::new();
             let (r, s) = self.inner.compress_with_store(&owned, bias, Some(&store));
             (r, s)
@@ -1510,7 +1510,7 @@ fn protect_tags(
     compress_tagged_content: bool,
 ) -> (String, Vec<(String, String)>) {
     let owned = text.to_string();
-    py.allow_threads(move || {
+    py.detach(move || {
         let (cleaned, blocks, _stats) = rust_protect_tags(&owned, compress_tagged_content);
         (cleaned, blocks)
     })
@@ -1521,7 +1521,7 @@ fn protect_tags(
 #[pyfunction]
 fn restore_tags(py: Python<'_>, text: &str, blocks: Vec<(String, String)>) -> String {
     let owned = text.to_string();
-    py.allow_threads(move || rust_restore_tags(&owned, &blocks))
+    py.detach(move || rust_restore_tags(&owned, &blocks))
 }
 
 /// Case-insensitive HTML5 tag check. The Python shim uses this to
@@ -1643,7 +1643,7 @@ fn compress_openai_responses_live_zone(
 
 // --- TextCrusher (Phase 2, #1171): fast extractive prose compressor ---
 
-#[pyclass(name = "TextCrusherConfig", module = "headroom._core")]
+#[pyclass(name = "TextCrusherConfig", module = "headroom._core", from_py_object)]
 #[derive(Clone)]
 struct PyTextCrusherConfig {
     inner: RustTextCrusherConfig,
@@ -1775,7 +1775,7 @@ impl PyTextCrusher {
     ) -> PyTextCrusherResult {
         let content = content.to_string();
         let context = context.to_string();
-        let inner = py.allow_threads(|| self.inner.compress(&content, &context, target_ratio));
+        let inner = py.detach(|| self.inner.compress(&content, &context, target_ratio));
         PyTextCrusherResult { inner }
     }
 }


### PR DESCRIPTION

## Description

Bumps `pyo3 0.24.2 → 0.29.0` (and `pyo3-log 0.12 → 0.13`) to clear two `cargo audit`
advisories against the Rust core: **RUSTSEC-2026-0176** (High, OOB read in
`PyList`/`PyTuple` `nth`/`nth_back`) and **RUSTSEC-2026-0177** (Moderate, missing `Sync`
bound on `PyCFunction::new_closure`). Both are fixed in pyo3 0.29.0. The migration is
mechanical and confined to `crates/headroom-py`; no public Python API change.

Closes #1453

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `Cargo.toml` (workspace deps): `pyo3 0.24 → 0.29` (keeps `abi3-py310`), `pyo3-log 0.12 → 0.13`.
- `crates/headroom-py/src/lib.rs`:
  - 13× `Python::allow_threads` → `Python::detach` (renamed in pyo3 0.25).
  - `from_py_object` opt-in on the 6 `#[pyclass] + Clone` types (`DiffCompressorConfig`,
    `SmartCrusherConfig`, `DetectionResult`, `SearchCompressorConfig`,
    `LogCompressorConfig`, `TextCrusherConfig`) whose implicit `FromPyObject`-by-clone
    derive is deprecated in 0.27 — this keeps the existing extraction behavior unchanged.
- `Cargo.lock`: regenerated. pyo3 0.29 also drops 3 transitive deps (`indoc`,
  `memoffset`, `unindent`) — no new install surface.

The heavy `Bound<>` migration (pyo3 0.23) was already paid at 0.24.2, so no
reference-API churn was needed.

### Dependency justification (CONTRIBUTING — supply chain)

- **Why this package:** already a direct dependency; this is a version bump only.
- **Who maintains it:** the PyO3 project — active, regular releases, security-advisory hygiene.
- **Install surface:** no new transitive deps; net **−3** (`indoc`, `memoffset`, `unindent` removed). No new native code or network at install/runtime.
- **Why this version:** **security patch** — pyo3 0.29.0 is the first release fixing both advisories (`Solution: Upgrade to >=0.29.0`).

## Testing

- [ ] Unit tests pass (`pytest`)  — see note in Additional Notes (focused smoke only on the fork)
- [ ] Linting passes (`ruff check .`)  — N/A, no Python source changed
- [ ] Type checking passes (`mypy headroom`)  — N/A, no Python source changed
- [ ] New tests added for new functionality  — N/A, dependency bump
- [x] Manual testing performed

### Test Output

The before/after check for a dependency advisory is `cargo audit` (fails before, passes after):

```console
# BEFORE (pyo3 0.24.2)
$ cargo audit
... RUSTSEC-2026-0176  (pyo3 0.24.2)  Solution: Upgrade to >=0.29.0
... RUSTSEC-2026-0177  (pyo3 0.24.2)  Solution: Upgrade to >=0.29.0
error: 2 vulnerabilities found!

# AFTER (pyo3 0.29.0)
$ cargo audit
    Scanning Cargo.lock for vulnerabilities (526 crate dependencies)
# no RUSTSEC-2026-0176 / RUSTSEC-2026-0177; exit code 0

$ cargo clippy -p headroom-py --features extension-module --all-targets -- -D warnings
    Finished — 0 warnings, exit code 0

$ maturin build --features extension-module
📦 Built wheel for abi3 Python ≥ 3.10 → headroom_ai-0.27.0-cp310-abi3-manylinux_2_35_x86_64.whl
```

## Real Behavior Proof

- Environment: Zorin OS (Linux 6.17, x86_64), Rust 1.96.0, Python 3.12.3,
  maturin 1.14.1, pyo3 0.29.0 (`abi3-py310`). Built and installed the recompiled abi3 wheel into a clean venv.
- Exact command / steps: after applying the patch — (1) `cargo audit`;
  (2) `maturin build --features extension-module`; (3) `pip install` the wheel into a
  fresh venv; (4) `pytest` a `compress()` smoke that feeds a ~400-row JSON tool-output
  through `headroom.compress(messages, model="claude-sonnet-4-5-20250929")`.
- Observed result: `cargo audit` no longer reports RUSTSEC-2026-0176/0177 (exit 0);
  clippy `-D warnings` clean; abi3 wheel built; the `compress()` smoke passed and the
  engine compressed the payload (`tokens_saved = 6039`) — i.e. the recompiled
  extension loads and runs end-to-end, not a passthrough.
- Not tested: the full upstream `pytest` suite (the smoke is one focused
  `compress()` case); non-Linux builds (Windows/macOS); the proxy server path. Happy to
  run more if you'd like a specific scenario covered.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas  *(N/A — mechanical rename + attribute opt-in)*
- [ ] I have made corresponding changes to the documentation  *(N/A — no doc-facing change)*
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works  *(the `cargo audit` before/after is the proof; see note)*
- [x] New and existing unit tests pass locally with my changes  *(the `compress()` pytest smoke)*
- [ ] I have updated the CHANGELOG.md if applicable  *(see Additional Notes)*

### Additional Notes

- **CHANGELOG:** not hand-edited. The `fix(deps):` commit is Conventional, so
  release-please will surface this under **Bug Fixes** in the generated `## Unreleased`
  section at release time — keeping the diff to the 3 files the bump strictly needs
  (`Cargo.toml`, `Cargo.lock`, `lib.rs`). Happy to also add an explicit `### Security`
  line to `## Unreleased` now if you'd prefer it pre-release.
- **Tests:** there is no unit test to assert a dependency advisory; `cargo audit` is the
  before/after gate. I ran a focused `compress()` smoke rather than the full `pytest`
  suite on the fork (which expects the Node/commit-msg dev hooks); the maintainer CI will
  run the full suite. The unchecked `ruff`/`mypy` items are Python-only and no Python
  source changed.
- Note: `cargo audit` in CI is currently soft-fail, so this wasn't surfaced as a CI gate.
