### PR TITLE
fix(openclaw/release): ship responsive npm integrations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -810,6 +810,11 @@ jobs:
           node-version: "20"
           registry-url: ${{ env.NPM_REGISTRY_URL }}
 
+      - name: Verify npm publishing authentication
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami --registry "${NPM_REGISTRY_URL}"
+
       # No artifact download required: the publish steps below pack and
       # publish directly from the checked-out source tree (sdk/typescript
       # and plugins/openclaw) via `npm pack` + `npm publish`. The
@@ -825,12 +830,15 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           version="${{ needs.detect-version.outputs.npm_version }}"
+          if npm view "${NPM_SDK_PACKAGE}@${version}" version --registry "${NPM_REGISTRY_URL}" >/dev/null 2>&1; then
+            echo "${NPM_SDK_PACKAGE}@${version} is already published; continuing."
+            exit 0
+          fi
           cd sdk/typescript
           npm ci
           npm run build
           npm version "$version" --no-git-tag-version --allow-same-version
           npm publish --access public
-        continue-on-error: true
 
       - name: Publish ${{ env.NPM_OPENCLAW_PACKAGE }} to npmjs.org
         id: npm-openclaw-publish
@@ -838,6 +846,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           version="${{ needs.detect-version.outputs.npm_version }}"
+          if npm view "${NPM_OPENCLAW_PACKAGE}@${version}" version --registry "${NPM_REGISTRY_URL}" >/dev/null 2>&1; then
+            echo "${NPM_OPENCLAW_PACKAGE}@${version} is already published; continuing."
+            exit 0
+          fi
           cd plugins/openclaw
           npm ci
           npm run build
@@ -851,7 +863,6 @@ jobs:
           EOF
           node prepare-dist.mjs
           npm publish --access public
-        continue-on-error: true
 
       - name: Publish ${{ env.NPM_OPENCODE_PACKAGE }} to npmjs.org
         id: npm-opencode-publish
@@ -859,6 +870,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           version="${{ needs.detect-version.outputs.npm_version }}"
+          if npm view "${NPM_OPENCODE_PACKAGE}@${version}" version --registry "${NPM_REGISTRY_URL}" >/dev/null 2>&1; then
+            echo "${NPM_OPENCODE_PACKAGE}@${version} is already published; continuing."
+            exit 0
+          fi
           cd plugins/opencode
           npm ci
           npm run build
@@ -871,12 +886,6 @@ jobs:
           fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
           EOF
           npm publish --access public
-        continue-on-error: true
-
-      - name: npm publish notice
-        if: steps.npm-sdk-publish.outcome == 'failure' || steps.npm-openclaw-publish.outcome == 'failure' || steps.npm-opencode-publish.outcome == 'failure'
-        run: |
-          echo "::notice::One or more npm publishes failed. Set NPM_SKIP=true in repo Variables to skip npm publishes if tokens are not configured."
 
   publish-github-packages:
     needs: [detect-version, build]

--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -205,7 +205,8 @@ Compression is lossless via CCR (Compress-Cache-Retrieve): originals are stored 
 | `pythonPath` | auto-detected | Optional Python executable override for Python fallback launcher. |
 | `autoStart` | `false` | Opt-in auto-start for a local `headroom proxy` if not already running (local URLs only; ignored for remote proxies). Keep `false` when systemd owns the proxy. |
 | `startupTimeoutMs` | `20000` | Time to wait for auto-started proxy to become healthy |
-| `requestTimeoutMs` | `30000` | Maximum milliseconds to wait for a single `compress()` call. If the proxy hangs or is slow, the call is cancelled after this deadline and the original uncompressed messages are used as a fallback. |
+| `requestTimeoutMs` | `2000` | Maximum milliseconds to wait for a single `compress()` call. The SDK aborts the request at this deadline and the original messages are used as a fallback. |
+| `minContextChars` | `800` | Skip proxy compression below this approximate 200-token context floor. Large single tool results still qualify; set to `0` to disable the gate. |
 | `circuitBreakerThreshold` | `3` | Number of consecutive `assemble()` errors before the circuit breaker opens and all requests bypass the proxy. Prevents cascading failures when the proxy is unhealthy. |
 | `circuitBreakerCooldownMs` | `60000` | How long (ms) the circuit breaker stays open after the threshold is reached. After the cool-down the breaker resets automatically and the next request re-probes the proxy via `/health`. |
 | `routeCodexViaProxy` | `true` | Rewrite OpenClaw's built-in `openai-codex` provider to use the active Headroom proxy in memory so upstream Codex requests pass through Headroom. |

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -26,6 +26,10 @@
       "label": "Compression Request Timeout",
       "help": "Maximum milliseconds to wait for one compression request before returning the original messages."
     },
+    "minContextChars": {
+      "label": "Minimum Context Size",
+      "help": "Skip the proxy for smaller contexts that cannot produce meaningful savings. Set to 0 to disable."
+    },
     "circuitBreakerThreshold": {
       "label": "Circuit Breaker Threshold",
       "help": "Consecutive compression failures before temporarily bypassing Headroom."
@@ -84,7 +88,12 @@
       "requestTimeoutMs": {
         "type": "integer",
         "minimum": 1,
-        "default": 30000
+        "default": 2000
+      },
+      "minContextChars": {
+        "type": "integer",
+        "minimum": 0,
+        "default": 800
       },
       "circuitBreakerThreshold": {
         "type": "integer",

--- a/plugins/openclaw/src/engine.ts
+++ b/plugins/openclaw/src/engine.ts
@@ -11,20 +11,10 @@ import { compress } from "headroom-ai";
 import { ProxyManager, defaultLogger, type ProxyManagerConfig, type ProxyManagerLogger } from "./proxy-manager.js";
 import { agentToOpenAI, normalizeAgentMessages, openAIToAgent } from "./convert.js";
 
-/** Race a promise against a timeout and always release the timer. */
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  let timerId: ReturnType<typeof setTimeout> | undefined;
-  const timer = new Promise<never>((_, reject) => {
-    timerId = setTimeout(() => reject(new Error(`headroom compress() timed out after ${ms}ms`)), ms);
-  });
-  return Promise.race([promise, timer]).finally(() => {
-    if (timerId !== undefined) clearTimeout(timerId);
-  });
-}
-
 export interface HeadroomEngineConfig extends ProxyManagerConfig {
   enabled?: boolean;
   requestTimeoutMs?: number;
+  minContextChars?: number;
   circuitBreakerThreshold?: number;
   circuitBreakerCooldownMs?: number;
 }
@@ -117,20 +107,24 @@ export class HeadroomContextEngine {
       return { messages: normalizeAgentMessages(params.messages), estimatedTokens: 0 };
     }
 
-    try {
-      // Convert AgentMessage → OpenAI format
-      const openaiMessages = agentToOpenAI(params.messages);
+    const openaiMessages = agentToOpenAI(params.messages);
+    const minContextChars = this.config.minContextChars ?? 800;
+    if (minContextChars > 0 && countContextChars(openaiMessages) < minContextChars) {
+      this.logger.debug("[headroom] Context below compression threshold — using original messages");
+      return { messages: normalizeAgentMessages(params.messages), estimatedTokens: 0 };
+    }
 
+    try {
       // Compress via proxy — pass tokenBudget so RollingWindow enforces it
-      const result = await withTimeout(
-        compress(openaiMessages, {
-          model: params.model ?? "claude-sonnet-4-5",
-          baseUrl: this.proxyUrl,
-          fallback: true,
-          tokenBudget: params.tokenBudget,
-        } as any),
-        this.config.requestTimeoutMs ?? 30_000,
-      );
+      const result = await compress(openaiMessages, {
+        model: params.model ?? "claude-sonnet-4-5",
+        baseUrl: this.proxyUrl,
+        fallback: true,
+        tokenBudget: params.tokenBudget,
+        // The SDK applies this to AbortSignal.timeout(), so a timed-out call is
+        // cancelled instead of continuing in the background after fail-open.
+        timeout: this.config.requestTimeoutMs ?? 2_000,
+      } as any);
 
       if (!result.compressed || result.tokensSaved === 0) {
         this.resetCircuit();
@@ -348,4 +342,15 @@ export class HeadroomContextEngine {
       }
     }
   }
+}
+
+function countContextChars(messages: ReturnType<typeof agentToOpenAI>): number {
+  let total = 0;
+  for (const message of messages) {
+    total += message.content?.length ?? 0;
+    for (const toolCall of message.tool_calls ?? []) {
+      total += toolCall.function?.arguments?.length ?? 0;
+    }
+  }
+  return total;
 }

--- a/plugins/openclaw/test/engine.test.ts
+++ b/plugins/openclaw/test/engine.test.ts
@@ -199,40 +199,77 @@ describe("HeadroomContextEngine proxy startup helpers", () => {
     expect(mocked.start).toHaveBeenCalledTimes(1);
   });
 
-  it("clears the request timeout after successful compression", async () => {
-    vi.useFakeTimers();
-    try {
-      vi.mocked(compress).mockResolvedValue({
-        compressed: false,
-        messages: [{ role: "user", content: "hello" }],
-        tokensBefore: 5,
-        tokensAfter: 5,
-        tokensSaved: 0,
-      });
+  it("passes the configured request timeout to the aborting SDK client", async () => {
+    vi.mocked(compress).mockResolvedValue({
+      compressed: false,
+      messages: [{ role: "user", content: "hello" }],
+      tokensBefore: 5,
+      tokensAfter: 5,
+      tokensSaved: 0,
+    });
 
-      const engine = new HeadroomContextEngine({ requestTimeoutMs: 30_000 });
-      (engine as { proxyUrl: string | null }).proxyUrl = "http://127.0.0.1:8787";
+    const engine = new HeadroomContextEngine({ requestTimeoutMs: 1_234, minContextChars: 0 });
+    (engine as { proxyUrl: string | null }).proxyUrl = "http://127.0.0.1:8787";
 
-      await expect(
-        engine.assemble({
-          sessionId: "session-1",
-          messages: [{ role: "user", content: "hello" }],
-        }),
-      ).resolves.toEqual({
-        messages: [{ role: "user", content: "hello" }],
-        estimatedTokens: 5,
-      });
+    await engine.assemble({
+      sessionId: "session-1",
+      messages: [{ role: "user", content: "hello" }],
+    });
 
-      expect(vi.getTimerCount()).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(compress).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ timeout: 1_234 }),
+    );
+  });
+
+  it("skips proxy compression for short contexts with no meaningful savings", async () => {
+    const messages = [{ role: "user", content: "hello" }];
+    const engine = new HeadroomContextEngine();
+    (engine as { proxyUrl: string | null }).proxyUrl = "http://127.0.0.1:8787";
+
+    await expect(engine.assemble({ sessionId: "session-1", messages })).resolves.toEqual({
+      messages,
+      estimatedTokens: 0,
+    });
+    expect(compress).not.toHaveBeenCalled();
+  });
+
+  it("counts a single large tool result as eligible context", async () => {
+    const messages = [{ role: "toolResult", toolCallId: "call-1", content: "x".repeat(800) }];
+    vi.mocked(compress).mockResolvedValue({
+      compressed: false,
+      messages: [{ role: "tool", tool_call_id: "call-1", content: "x".repeat(800) }],
+      tokensBefore: 200,
+      tokensAfter: 200,
+      tokensSaved: 0,
+    });
+    const engine = new HeadroomContextEngine();
+    (engine as { proxyUrl: string | null }).proxyUrl = "http://127.0.0.1:8787";
+
+    await engine.assemble({ sessionId: "session-1", messages });
+    expect(compress).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows the short-context gate to be disabled", async () => {
+    vi.mocked(compress).mockResolvedValue({
+      compressed: false,
+      messages: [{ role: "user", content: "hello" }],
+      tokensBefore: 2,
+      tokensAfter: 2,
+      tokensSaved: 0,
+    });
+    const engine = new HeadroomContextEngine({ minContextChars: 0 });
+    (engine as { proxyUrl: string | null }).proxyUrl = "http://127.0.0.1:8787";
+
+    await engine.assemble({ sessionId: "session-1", messages: [{ role: "user", content: "hello" }] });
+    expect(compress).toHaveBeenCalledTimes(1);
   });
 
   it("opens the circuit after consecutive compression failures", async () => {
     vi.mocked(compress).mockRejectedValue(new Error("proxy stalled"));
     const messages = [{ role: "user", content: "hello" }];
     const engine = new HeadroomContextEngine({
+      minContextChars: 0,
       circuitBreakerThreshold: 2,
       circuitBreakerCooldownMs: 60_000,
     });

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -788,7 +788,7 @@ def test_publish_npm_regenerates_openclaw_dist_metadata_after_version_and_depend
     content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
     start = content.index("name: Publish ${{ env.NPM_OPENCLAW_PACKAGE }} to npmjs.org")
-    end = content.index("continue-on-error: true", start)
+    end = content.index("name: Publish ${{ env.NPM_OPENCODE_PACKAGE }}", start)
     block = content[start:end]
 
     version = block.index('npm version "$version"')
@@ -804,7 +804,7 @@ def test_publish_npm_rewrites_opencode_dependency_after_version_and_before_publi
     content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
     start = content.index("name: Publish ${{ env.NPM_OPENCODE_PACKAGE }} to npmjs.org")
-    end = content.index("continue-on-error: true", start)
+    end = content.index("\n  publish-github-packages:", start)
     block = content[start:end]
 
     version = block.index('npm version "$version"')
@@ -812,6 +812,39 @@ def test_publish_npm_rewrites_opencode_dependency_after_version_and_before_publi
     publish = block.index("npm publish --access public")
 
     assert version < dependency < publish
+
+
+def test_publish_npm_authenticates_before_any_publish_and_fails_closed() -> None:
+    """An opted-in npm release must not silently succeed with stale packages."""
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    start = content.index("\n  publish-npm:")
+    end = content.index("\n  publish-github-packages:", start)
+    block = content[start:end]
+
+    auth = block.index("name: Verify npm publishing authentication")
+    first_publish = block.index("npm publish --access public")
+    assert auth < first_publish
+    assert 'npm whoami --registry "${NPM_REGISTRY_URL}"' in block
+    assert "NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}" in block
+    assert "continue-on-error: true" not in block
+    assert "npm publish notice" not in block
+
+
+def test_publish_npm_is_rerunnable_after_a_partial_release() -> None:
+    """Immutable versions already published by an earlier attempt must be skipped."""
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    start = content.index("\n  publish-npm:")
+    end = content.index("\n  publish-github-packages:", start)
+    block = content[start:end]
+
+    for package_var in ("NPM_SDK_PACKAGE", "NPM_OPENCLAW_PACKAGE", "NPM_OPENCODE_PACKAGE"):
+        lookup = (
+            f'npm view "${{{package_var}}}@${{version}}" version --registry "${{NPM_REGISTRY_URL}}"'
+        )
+        assert lookup in block
+        lookup_index = block.index(lookup)
+        publish_index = block.index("npm publish --access public", lookup_index)
+        assert lookup_index < publish_index
 
 
 def test_sdist_license_is_packaged_and_verified_before_upload() -> None:


### PR DESCRIPTION
## Description

Fixes #977 and #2353.

The v0.35.0 release built all three JavaScript packages successfully, but npm rejected every publish with ENEEDAUTH. Because each publish step used continue-on-error, the publish-npm job still concluded success. npm therefore remains on headroom-ai 0.22.4 and headroom-openclaw 0.1.0, while headroom-opencode is absent.

The checked-in OpenClaw source had already corrected the old strict-schema mismatch and added a circuit breaker, but its assemble hook still called compression for every tiny conversation and allowed a 30-second default wait. This PR completes both the runtime correction and the delivery path instead of merely exposing one failure.

## Changes

### OpenClaw runtime

- Skip proxy compression below an 800-character context floor (roughly 200 tokens), avoiding synchronous HTTP work on short conversations that cannot produce meaningful savings.
- Measure actual content, including tool-call arguments, so a single large tool result remains eligible.
- Allow operators to disable the floor with minContextChars=0.
- Lower the interactive request ceiling from 30 seconds to 2 seconds.
- Pass that timeout into the SDK, whose AbortSignal cancels the HTTP request, instead of racing a promise while the fetch continues in the background.
- Preserve circuit-breaker fail-open behavior and document/schema the new defaults.

### npm release integrity

- Authenticate with npm before publishing any package, so a missing or invalid NPM_TOKEN fails before a partial release begins.
- Make SDK, OpenClaw, and OpenCode npm publish failures fatal when npm publishing is enabled.
- Preserve NPM_SKIP=true as the explicit opt-out.
- Make retries safe after partial publication by skipping only the exact package version already present, then continuing to missing packages.
- Remove the false-success notice path.

## Existing #977 corrections verified

- The current OpenClaw schema declares startupTimeoutMs, routeCodexViaProxy, gatewayProviderIds, request timeout, and circuit-breaker fields written/used by the installer and runtime.
- wrap defaults to the real published package name, headroom-openclaw.
- unwrap removes managed values while preserving unrelated user configuration.
- The coding savings profile uses protect_recent=0 paired with type-based recent-read protection, avoiding the old blanket short-session protection without weakening tool-result fidelity.

## Testing

- 80 OpenClaw plugin tests pass.
- TypeScript typecheck and production build pass.
- 123 OpenClaw wrap/provider, savings-profile, compress endpoint, and MCP contract tests pass.
- 47 release-workflow and MCP contract tests pass.
- The npm release asset builder installed/imported and verified the actual 0.35.1 SDK and OpenClaw tarballs.
- Workflow YAML parses; Ruff, format, and git diff checks pass.

## Required repository action

A maintainer must replace or restore the npm publishing credential in NPM_TOKEN, then rerun the v0.35.0 release workflow (or publish the next version). This PR makes that failure visible and safely rerunnable; repository code cannot provision the external npm credential.

Co-authored with @liuyongcheng0000, whose original PR identified the masked npm failures.