### PR TITLE
ci: add Windows smoke test — surfaces compatibility issues

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -1,0 +1,46 @@
+name: windows-smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'headroom/install/**'
+      - 'headroom/paths.py'
+      - 'headroom/cli/**'
+  pull_request:
+    paths:
+      - 'headroom/install/**'
+      - 'headroom/paths.py'
+      - 'headroom/cli/**'
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Verify CLI Version
+        run: headroom --version
+
+      - name: Verify Proxy Command
+        run: headroom proxy --help
+
+      - name: Verify Wrap Command
+        run: headroom wrap --help


### PR DESCRIPTION
## Problem

Discord user **tommy** reports Headroom not working on Windows. We have Windows support code but no CI.

## Solution

Add `windows-smoke.yml` — runs `headroom --version`, `headroom proxy --help`, `headroom wrap --help` on `windows-latest`.

Closes #1466