### PR TITLE
Resolve MCP server command to absolute path

### DIFF
--- a/e2e/init/run.py
+++ b/e2e/init/run.py
@@ -22,6 +22,7 @@ from ``e2e/init/Dockerfile``).
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -111,6 +112,13 @@ def _verify_claude_local(ctx: CaseContext) -> None:
     # being dead pointers for users who never ran `headroom mcp install`).
     # The `-e HEADROOM_PROXY_URL=…` arg is only emitted when the proxy
     # port differs from the 8787 default; this case uses --port 9011.
+    # The MCP server command is resolved to the absolute path of the running
+    # `headroom` executable so GUI clients with a minimal PATH can spawn it, so
+    # compare that segment by basename rather than the full venv path.
+    normalized = [
+        [os.path.basename(arg) if arg.endswith("/headroom") else arg for arg in argv]
+        for argv in claude_calls
+    ]
     expected = [
         ["plugin", "marketplace", "add", str(REPO_ROOT_IN_CONTAINER)],
         ["plugin", "install", "headroom@headroom-marketplace", "--scope", "local"],
@@ -128,7 +136,7 @@ def _verify_claude_local(ctx: CaseContext) -> None:
             "serve",
         ],
     ]
-    if claude_calls != expected:
+    if normalized != expected:
         raise AssertionError(f"Unexpected Claude install commands: {claude_calls}")
 
 

--- a/headroom/mcp_registry/claude.py
+++ b/headroom/mcp_registry/claude.py
@@ -10,17 +10,44 @@ available, and reads the underlying JSON files directly for compare /
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
 from .base import MCPRegistrar, RegisterResult, RegisterStatus, ServerSpec
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_command(spec: ServerSpec) -> ServerSpec:
+    """Rewrite a bare ``headroom`` command to an absolute path.
+
+    Claude Code spawns the MCP server as a subprocess with the minimal PATH
+    a GUI app inherits, which excludes the venv bin dir where the ``headroom``
+    console script lives. A bare command name then fails to exec and the
+    server shows as "failed" in ``/mcp`` with no way to reconnect. Resolve it
+    to the running executable's absolute path (the script sits next to
+    ``sys.executable``), falling back to ``argv[0]`` then PATH lookup.
+    """
+    if spec.command != "headroom":
+        return spec
+    candidate = Path(sys.executable).with_name("headroom")
+    if not candidate.exists():
+        argv0 = Path(sys.argv[0])
+        if argv0.name == "headroom" and argv0.exists():
+            candidate = argv0.resolve()
+        else:
+            which = shutil.which("headroom")
+            if which is None:
+                return spec
+            candidate = Path(which)
+    return dataclasses.replace(spec, command=str(candidate))
 
 
 class ClaudeRegistrar(MCPRegistrar):
@@ -73,6 +100,7 @@ class ClaudeRegistrar(MCPRegistrar):
         return None
 
     def register_server(self, spec: ServerSpec, *, force: bool = False) -> RegisterResult:
+        spec = _resolve_command(spec)
         existing = self.get_server(spec.name)
         if existing is not None:
             if _specs_equivalent(existing, spec):

--- a/headroom/mcp_registry/claude.py
+++ b/headroom/mcp_registry/claude.py
@@ -37,10 +37,12 @@ def _resolve_command(spec: ServerSpec) -> ServerSpec:
     """
     if spec.command != "headroom":
         return spec
-    candidate = Path(sys.executable).with_name("headroom")
+    # On Windows the console script is ``headroom.exe``; elsewhere ``headroom``.
+    exe_name = "headroom.exe" if os.name == "nt" else "headroom"
+    candidate = Path(sys.executable).with_name(exe_name)
     if not candidate.exists():
         argv0 = Path(sys.argv[0])
-        if argv0.name == "headroom" and argv0.exists():
+        if argv0.stem == "headroom" and argv0.exists():
             candidate = argv0.resolve()
         else:
             which = shutil.which("headroom")

--- a/tests/test_mcp_registry/test_claude_registrar.py
+++ b/tests/test_mcp_registry/test_claude_registrar.py
@@ -10,7 +10,13 @@ from unittest.mock import patch
 import pytest
 
 from headroom.mcp_registry.base import RegisterStatus, ServerSpec
-from headroom.mcp_registry.claude import ClaudeRegistrar
+from headroom.mcp_registry.claude import ClaudeRegistrar, _resolve_command
+
+# Command as it lands in config after resolution to an absolute path (the bare
+# "headroom" name a GUI-spawned client cannot exec on its minimal PATH).
+RESOLVED_COMMAND = _resolve_command(
+    ServerSpec(name="headroom", command="headroom", args=("mcp", "serve"))
+).command
 
 
 def _make_registrar(
@@ -136,9 +142,9 @@ def test_register_via_cli_calls_claude_mcp_add(tmp_path: Path) -> None:
         "-s",
         "user",
     ]
-    assert add_cmd[-3:] == ["--", "headroom", "mcp"] or add_cmd[-4:] == [
+    assert add_cmd[-4:] == [
         "--",
-        "headroom",
+        RESOLVED_COMMAND,
         "mcp",
         "serve",
     ]
@@ -168,7 +174,7 @@ def test_register_writes_file_when_no_cli(tmp_path: Path) -> None:
     cfg = tmp_path / ".claude" / ".claude.json"
     data = json.loads(cfg.read_text())
     assert "headroom" in data["mcpServers"]
-    assert data["mcpServers"]["headroom"]["command"] == "headroom"
+    assert data["mcpServers"]["headroom"]["command"] == RESOLVED_COMMAND
     assert data["mcpServers"]["headroom"]["args"] == ["mcp", "serve"]
 
 
@@ -194,7 +200,7 @@ def test_register_writes_to_claude_config_dir(
     assert result.status == RegisterStatus.REGISTERED
     cfg = tmp_path / ".claude.json"
     data = json.loads(cfg.read_text())
-    assert data["mcpServers"]["headroom"]["command"] == "headroom"
+    assert data["mcpServers"]["headroom"]["command"] == RESOLVED_COMMAND
     assert not (tmp_path / ".claude" / ".claude.json").exists()
 
 
@@ -207,7 +213,9 @@ def test_register_already_when_spec_matches(tmp_path: Path) -> None:
     cfg = tmp_path / ".claude" / ".claude.json"
     cfg.parent.mkdir()
     cfg.write_text(
-        json.dumps({"mcpServers": {"headroom": {"command": "headroom", "args": ["mcp", "serve"]}}})
+        json.dumps(
+            {"mcpServers": {"headroom": {"command": RESOLVED_COMMAND, "args": ["mcp", "serve"]}}}
+        )
     )
     reg = _make_registrar(tmp_path, cli="/usr/local/bin/claude")
     with patch("subprocess.run") as run_mock:
@@ -224,7 +232,7 @@ def test_register_mismatch_when_spec_differs_no_force(tmp_path: Path) -> None:
             {
                 "mcpServers": {
                     "headroom": {
-                        "command": "headroom",
+                        "command": RESOLVED_COMMAND,
                         "args": ["mcp", "serve"],
                         "env": {"HEADROOM_PROXY_URL": "http://127.0.0.1:9999"},
                     }

--- a/tests/test_mcp_registry/test_claude_registrar.py
+++ b/tests/test_mcp_registry/test_claude_registrar.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import types
 from pathlib import Path
 from unittest.mock import patch
 
@@ -35,6 +36,41 @@ def _spec() -> ServerSpec:
         args=("mcp", "serve"),
         env={},
     )
+
+
+# ----------------------------------------------------------------------
+# _resolve_command()
+# ----------------------------------------------------------------------
+
+
+def test_resolve_command_uses_sibling_of_interpreter(monkeypatch, tmp_path: Path) -> None:
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "headroom").write_text("#!/bin/sh\n")
+    monkeypatch.setattr("headroom.mcp_registry.claude.os.name", "posix")
+    monkeypatch.setattr("sys.executable", str(bin_dir / "python"))
+    spec = _resolve_command(_spec())
+    assert spec.command == str(bin_dir / "headroom")
+
+
+def test_resolve_command_windows_exe_suffix(monkeypatch, tmp_path: Path) -> None:
+    scripts = tmp_path / "Scripts"
+    scripts.mkdir()
+    (scripts / "headroom.exe").write_text("")
+    # Swap only the module's os reference so the resolver sees name="nt" while
+    # pathlib keeps the host flavour (real os.name="nt" would make Path build a
+    # WindowsPath, which cannot be instantiated on a POSIX test host).
+    monkeypatch.setattr(
+        "headroom.mcp_registry.claude.os", types.SimpleNamespace(name="nt")
+    )
+    monkeypatch.setattr("sys.executable", str(scripts / "python.exe"))
+    spec = _resolve_command(_spec())
+    assert spec.command == str(scripts / "headroom.exe")
+
+
+def test_resolve_command_leaves_non_headroom_untouched() -> None:
+    spec = ServerSpec(name="other", command="uvx", args=("x",))
+    assert _resolve_command(spec) is spec
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Description

Claude Code spawns the Headroom MCP server as a subprocess with the minimal `PATH` a GUI app inherits, which excludes the venv `bin` dir where the `headroom` console script lives. The Claude registrar wrote the server entry with a bare `command: "headroom"`, so the client cannot exec it: the server shows up as **failed** in `/mcp` with no way to reconnect, and the memory tools (`memory_search` / `memory_save`) never appear.

This resolves the command to the absolute path of the running `headroom` executable, in the Claude registrar only. Codex (a terminal flow where `headroom` is reliably on PATH) is intentionally left unchanged.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add `_resolve_command()` in `headroom/mcp_registry/claude.py`: rewrites a bare `headroom` command to the absolute path of the running executable (the console script next to `sys.executable`), falling back to `argv[0]`, then `shutil.which("headroom")`, then the bare name. Applied at the top of `ClaudeRegistrar.register_server` so both the CLI (`claude mcp add`) and direct-JSON write paths emit the resolved path.
- Update `tests/test_mcp_registry/test_claude_registrar.py` to assert the resolved command (derived via `_resolve_command`, so it is environment-independent).
- Update `e2e/init/run.py` to compare the MCP server command by basename rather than the hardcoded bare name.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ pytest tests/test_mcp_registry/ tests/test_cli/test_wrap_codex.py -q
136 passed in 5.69s

$ ruff check headroom/mcp_registry/claude.py tests/test_mcp_registry/test_claude_registrar.py e2e/init/run.py
All checks passed!

$ mypy headroom/mcp_registry/claude.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: macOS, Python 3.12, Headroom installed under `~/Library/Application Support/Headroom/.../venv`.
- Exact command / steps: inspected the registered entry in `~/.claude/mcp.json` (`command: "headroom"`); confirmed `command -v headroom` returns nothing even in a login shell, since the binary lives only in the venv bin dir; reproduced the `/mcp` "failed" state in Claude Code. The init e2e confirms the resolved command lands as `/opt/headroom-venv/bin/headroom` in the `claude mcp add` invocation.
- Observed result: with the fix, the Claude MCP entry's command is the absolute path to the venv's `headroom`, which the client can exec regardless of inherited PATH.
- Not tested: end-to-end relaunch of a real Claude Code session against a freshly built release bundle (verified at unit + init-e2e level).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

- Documentation / CHANGELOG: N/A — internal registrar behavior, no user-facing API change.
- Scoped to the Claude registrar deliberately: `build_headroom_spec` (shared with the Codex TOML writer) is unchanged, so Codex wrap output and its e2e are unaffected.
- Follow-up (out of scope): the registrar can still write to the legacy `~/.claude/mcp.json`, which Claude Code >=2.x does not read. That path-vs-file issue is separate from this command-resolution fix.
