### PR TITLE
test(proxy): assert CCR hash route guard blocks valid hashes

### DIFF
--- a/tests/test_proxy_loopback_gating.py
+++ b/tests/test_proxy_loopback_gating.py
@@ -50,7 +50,7 @@ def _seed_ccr_entry() -> str:
     reset_compression_store()
     store = get_compression_store(backend=InMemoryBackend())
     return store.store(
-        "seeded-secret-content",
+        "seeded-ccr-content",
         "<<ccr:seeded>>",
         original_tokens=3,
         compressed_tokens=1,
@@ -96,7 +96,7 @@ def test_ccr_retrieve_hash_route_blocks_valid_hash_for_non_loopback() -> None:
         loopback = _loopback_client()
         loopback_resp = loopback.get(f"/v1/retrieve/{ccr_hash}")
         assert loopback_resp.status_code == 200, loopback_resp.text
-        assert loopback_resp.json()["original_content"] == "seeded-secret-content"
+        assert loopback_resp.json()["original_content"] == "seeded-ccr-content"
 
         network_resp = TestClient(_make_app()).get(f"/v1/retrieve/{ccr_hash}")
         assert network_resp.status_code == 404, network_resp.text

--- a/tests/test_proxy_loopback_gating.py
+++ b/tests/test_proxy_loopback_gating.py
@@ -14,6 +14,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from headroom.cache.backends import InMemoryBackend
+from headroom.cache.compression_store import get_compression_store, reset_compression_store
 from headroom.proxy.server import ProxyConfig, create_app
 
 GATED = [
@@ -42,6 +44,18 @@ def _loopback_client() -> TestClient:
     # A real loopback peer + a loopback Host header — passes both guard gates
     # (client-IP check and the DNS-rebinding Host-header check).
     return TestClient(_make_app(), base_url="http://127.0.0.1", client=("127.0.0.1", 12345))
+
+
+def _seed_ccr_entry() -> str:
+    reset_compression_store()
+    store = get_compression_store(backend=InMemoryBackend())
+    return store.store(
+        "seeded-secret-content",
+        "<<ccr:seeded>>",
+        original_tokens=3,
+        compressed_tokens=1,
+        tool_name="seeded-test",
+    )
 
 
 @pytest.mark.parametrize("method,path", GATED)
@@ -74,6 +88,20 @@ CCR_GATED = [
 def test_ccr_non_loopback_gets_404(method: str, path: str) -> None:
     resp = TestClient(_make_app()).request(method, path, json={})
     assert resp.status_code == 404, resp.text
+
+
+def test_ccr_retrieve_hash_route_blocks_valid_hash_for_non_loopback() -> None:
+    ccr_hash = _seed_ccr_entry()
+    try:
+        loopback = _loopback_client()
+        loopback_resp = loopback.get(f"/v1/retrieve/{ccr_hash}")
+        assert loopback_resp.status_code == 200, loopback_resp.text
+        assert loopback_resp.json()["original_content"] == "seeded-secret-content"
+
+        network_resp = TestClient(_make_app()).get(f"/v1/retrieve/{ccr_hash}")
+        assert network_resp.status_code == 404, network_resp.text
+    finally:
+        reset_compression_store()
 
 
 def test_dns_rebinding_host_header_rejected() -> None:


### PR DESCRIPTION
## Description

PR #1338 added loopback gating to the CCR retrieve/compress endpoints for #1227, but one regression case still had weak proof: `GET /v1/retrieve/{hash_key}` used a dummy hash. Since both the route guard and the missing-hash handler return `404`, that test could pass even if the route reached the handler.

This adds a seeded-hash regression so the test proves the security property directly.

Closes #1227 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [x] Add more testing

## Changes Made

- Seed a real CCR entry using an in-memory compression-store backend.
- Verify loopback can retrieve the seeded entry and see `original_content`.
- Verify a non-loopback caller gets `404` for the same valid hash.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
13 passed
```

## Testing Commands

```bash
.venv/bin/pytest tests/test_proxy_loopback_gating.py -q
.venv/bin/pytest tests/test_proxy_loopback_gating.py tests/test_proxy_cors.py tests/test_proxy_compress_endpoint.py -q
.venv/bin/ruff check tests/test_proxy_loopback_gating.py
```

## Real Behavior Proof

- Environment: macOS 25.4.0, Python 3.12
- Exact command / steps: `.venv/bin/pytest tests/test_proxy_loopback_gating.py -q`
`.venv/bin/pytest tests/test_proxy_loopback_gating.py tests/test_proxy_cors.py tests/test_proxy_compress_endpoint.py -q`
`.venv/bin/ruff check tests/test_proxy_loopback_gating.py`
- Not tested: NA

- Observed result: Pass

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

