### PR TITLE
fix(bedrock): forward anthropic-beta header to LiteLLM (1M context)

### DIFF
--- a/headroom/backends/litellm.py
+++ b/headroom/backends/litellm.py
@@ -383,6 +383,20 @@ def _parse_tool_arguments(arguments: Any) -> Any:
     return arguments
 
 
+def _apply_anthropic_beta(kwargs: dict[str, Any], headers: dict[str, str]) -> None:
+    """Forward the client's ``anthropic-beta`` header into the LiteLLM call.
+
+    Without this, beta features negotiated by the client (notably the 1M
+    context window ``context-1m-2025-08-07``) never reach the upstream — the
+    Bedrock converse transform reads them from a ``headers`` kwarg, and
+    LiteLLM otherwise drops them. LiteLLM filters betas the provider does not
+    support, so passing the raw value through is safe.
+    """
+    beta = headers.get("anthropic-beta") or headers.get("Anthropic-Beta")
+    if beta:
+        kwargs.setdefault("headers", {})["anthropic-beta"] = beta
+
+
 class LiteLLMBackend(Backend):
     """Backend using LiteLLM for multi-provider support.
 
@@ -695,6 +709,7 @@ class LiteLLMBackend(Backend):
             logger.debug(f"LiteLLM request: model={litellm_model}")
 
             # Make the call
+            _apply_anthropic_beta(kwargs, headers)
             response = await acompletion(**kwargs)
 
             # Convert to Anthropic format
@@ -817,6 +832,7 @@ class LiteLLMBackend(Backend):
             )
 
             # Stream content — blocks emitted dynamically based on response
+            _apply_anthropic_beta(kwargs, headers)
             response = await acompletion(**kwargs)
             output_tokens = 0
             current_block_index = -1
@@ -1023,6 +1039,7 @@ class LiteLLMBackend(Backend):
             logger.debug(f"LiteLLM OpenAI request: model={litellm_model}")
 
             # Make the call
+            _apply_anthropic_beta(kwargs, headers)
             response = await acompletion(**kwargs)
 
             # Build the usage block. LiteLLM normalizes prompt-cache stats from
@@ -1195,6 +1212,7 @@ class LiteLLMBackend(Backend):
                 elif headers.get("x-api-key"):
                     kwargs["api_key"] = headers["x-api-key"]
 
+            _apply_anthropic_beta(kwargs, headers)
             response = await acompletion(**kwargs)
 
             async for chunk in response:

--- a/tests/test_bedrock_region.py
+++ b/tests/test_bedrock_region.py
@@ -13,6 +13,7 @@ importorskip_no_env_leak("litellm")
 
 from headroom.backends.litellm import (  # noqa: E402  (must follow importorskip)
     LiteLLMBackend,
+    _apply_anthropic_beta,
     _bedrock_profiles_cache,
     _bedrock_region_prefix,
     _build_bedrock_fallback_map,
@@ -352,3 +353,40 @@ class TestNormalizeBedrockProfileId:
         assert _normalize_bedrock_profile_id("claude-sonnet-4-20250514") == (
             "claude-sonnet-4-20250514"
         )
+
+
+# =============================================================================
+# anthropic-beta header forwarding (e.g. 1M context window)
+# =============================================================================
+
+
+class TestApplyAnthropicBeta:
+    """The client's ``anthropic-beta`` header must reach the LiteLLM call.
+
+    LiteLLM's Bedrock converse transform reads beta features (notably
+    ``context-1m-2025-08-07``) from a ``headers`` kwarg; without forwarding,
+    the 1M window silently caps at 200k.
+    """
+
+    def test_forwards_beta(self):
+        kwargs: dict = {}
+        _apply_anthropic_beta(kwargs, {"anthropic-beta": "context-1m-2025-08-07"})
+        assert kwargs["headers"]["anthropic-beta"] == "context-1m-2025-08-07"
+
+    def test_no_beta_is_noop(self):
+        kwargs: dict = {}
+        _apply_anthropic_beta(kwargs, {})
+        assert "headers" not in kwargs
+
+    def test_preserves_existing_headers(self):
+        kwargs: dict = {"headers": {"x-existing": "1"}}
+        _apply_anthropic_beta(kwargs, {"anthropic-beta": "context-1m-2025-08-07"})
+        assert kwargs["headers"] == {
+            "x-existing": "1",
+            "anthropic-beta": "context-1m-2025-08-07",
+        }
+
+    def test_titlecase_header_key(self):
+        kwargs: dict = {}
+        _apply_anthropic_beta(kwargs, {"Anthropic-Beta": "context-1m-2025-08-07"})
+        assert kwargs["headers"]["anthropic-beta"] == "context-1m-2025-08-07"


### PR DESCRIPTION
## Description

The client's `anthropic-beta` header (notably `context-1m-2025-08-07`) is dropped before the LiteLLM `acompletion` call, so the 1M context window silently caps at 200k on the Bedrock path.

Headroom's LiteLLM backend extracts only auth (`x-api-key`/`authorization`) from the incoming request headers. Beta features negotiated by the client never reach the upstream.

## Root cause (verified against LiteLLM source)

LiteLLM *does* support forwarding `context-1m` to Bedrock:

1. `context-1m-2025-08-07` is in LiteLLM's per-provider allowlist (`anthropic_beta_headers_config.json`, `bedrock_converse` section).
2. LiteLLM's Bedrock converse transform reads betas from the `headers`/`extra_headers` kwarg via `litellm.anthropic_beta_headers_manager`.
3. **But** Headroom never populates that kwarg — so the header is lost before LiteLLM sees it.

Without this change → header dropped → 1M never engages (200k cap).
With this change → header reaches LiteLLM → allowed for `bedrock_converse` → forwarded to Bedrock.

> Note: not yet physically exercised with a >200k-token request, but the full path is traced and confirmed against LiteLLM's real allowlist. Independent of model-id routing — works for short IDs and ARNs alike.

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

- Add `_apply_anthropic_beta(kwargs, headers)` in `headroom/backends/litellm.py`.
- Call it before all four `acompletion` sites: `send_message`, `stream_message`, `send_openai_message`, `stream_openai_message`.
- LiteLLM filters provider-unsupported betas, so forwarding the raw header value is safe.
- Add `TestApplyAnthropicBeta` (4 cases: forward, no-op, preserve-existing, title-case key).

Scoped to the beta-forwarding fix only. ARN→`bedrock/converse/` routing and named-profile forwarding are handled in #1456; this is complementary and touches neither.

## Testing

\`\`\`text
$ uv run --extra dev --with litellm pytest tests/test_bedrock_region.py -q
31 passed in 1.36s

$ uv run --extra dev --with litellm ruff check headroom/backends/litellm.py tests/test_bedrock_region.py
All checks passed!
\`\`\`

## Checklist

- [x] Self-review performed
- [x] New unit tests added
- [x] New + existing unit tests pass locally
- [x] Linting passes