### PR TITLE
fix(anthropic): align Claude 4.x fallback pricing & context limits to current rates

### DIFF
--- a/headroom/providers/anthropic.py
+++ b/headroom/providers/anthropic.py
@@ -112,14 +112,15 @@ ANTHROPIC_CONTEXT_LIMITS: dict[str, int] = {
 
 # Fallback pricing - LiteLLM is preferred source
 # NOTE: These are ESTIMATES. Always verify against actual Anthropic billing.
-# Last updated: 2025-01-14
+# Last updated: 2026-06-27
 ANTHROPIC_PRICING: dict[str, dict[str, float]] = {
-    # Claude 4.8 (Opus tier pricing)
-    "claude-opus-4-8": {"input": 15.00, "output": 75.00, "cached_input": 1.50},
-    # Claude 4.7 (Opus tier pricing)
-    "claude-opus-4-7": {"input": 15.00, "output": 75.00, "cached_input": 1.50},
-    # Claude 4.6 (Opus tier pricing)
-    "claude-opus-4-6": {"input": 15.00, "output": 75.00, "cached_input": 1.50},
+    # Claude 4.8 — current Opus tier (anthropic.com/pricing): $5 in / $25 out,
+    # prompt-cache read = 0.1x input ($0.50).
+    "claude-opus-4-8": {"input": 5.00, "output": 25.00, "cached_input": 0.50},
+    # Claude 4.7 (current Opus tier)
+    "claude-opus-4-7": {"input": 5.00, "output": 25.00, "cached_input": 0.50},
+    # Claude 4.6 (current Opus tier)
+    "claude-opus-4-6": {"input": 5.00, "output": 25.00, "cached_input": 0.50},
     # Claude 4.5 (Opus tier pricing)
     "claude-opus-4-5-20251101": {"input": 15.00, "output": 75.00, "cached_input": 1.50},
     # Claude 4 (Sonnet/Haiku tier pricing)

--- a/headroom/providers/anthropic.py
+++ b/headroom/providers/anthropic.py
@@ -83,6 +83,8 @@ def sanitize_anthropic_model_metadata(value: Any) -> Any:
 # Anthropic model context limits
 # All Claude 3+ models have 200K context
 ANTHROPIC_CONTEXT_LIMITS: dict[str, int] = {
+    # Claude 4.8 (Opus 4.8) - 1M context
+    "claude-opus-4-8": 1000000,
     # Claude 4.7 (Opus 4.7) - 1M context
     "claude-opus-4-7": 1000000,
     # Claude 4.6 (Opus 4.6) - 1M context
@@ -112,6 +114,8 @@ ANTHROPIC_CONTEXT_LIMITS: dict[str, int] = {
 # NOTE: These are ESTIMATES. Always verify against actual Anthropic billing.
 # Last updated: 2025-01-14
 ANTHROPIC_PRICING: dict[str, dict[str, float]] = {
+    # Claude 4.8 (Opus tier pricing)
+    "claude-opus-4-8": {"input": 15.00, "output": 75.00, "cached_input": 1.50},
     # Claude 4.7 (Opus tier pricing)
     "claude-opus-4-7": {"input": 15.00, "output": 75.00, "cached_input": 1.50},
     # Claude 4.6 (Opus tier pricing)

--- a/headroom/providers/anthropic.py
+++ b/headroom/providers/anthropic.py
@@ -91,6 +91,10 @@ ANTHROPIC_CONTEXT_LIMITS: dict[str, int] = {
     "claude-opus-4-6": 1000000,
     # Claude 4.5 (Opus 4.5)
     "claude-opus-4-5-20251101": 200000,
+    # Claude Sonnet 4.6 — 1M context window (long-context pricing tier)
+    "claude-sonnet-4-6": 1000000,
+    # Claude Sonnet 4.5
+    "claude-sonnet-4-5": 200000,
     # Claude 4 (Sonnet 4, Haiku 4)
     "claude-sonnet-4-20250514": 200000,
     "claude-haiku-4-5-20251001": 200000,
@@ -121,8 +125,11 @@ ANTHROPIC_PRICING: dict[str, dict[str, float]] = {
     "claude-opus-4-7": {"input": 5.00, "output": 25.00, "cached_input": 0.50},
     # Claude 4.6 (current Opus tier)
     "claude-opus-4-6": {"input": 5.00, "output": 25.00, "cached_input": 0.50},
-    # Claude 4.5 (Opus tier pricing)
-    "claude-opus-4-5-20251101": {"input": 15.00, "output": 75.00, "cached_input": 1.50},
+    # Claude 4.5 (current Opus tier — same rates as 4.6–4.8)
+    "claude-opus-4-5-20251101": {"input": 5.00, "output": 25.00, "cached_input": 0.50},
+    # Claude Sonnet 4.6 / 4.5 (current Sonnet tier): $3 in / $15 out, cache read $0.30
+    "claude-sonnet-4-6": {"input": 3.00, "output": 15.00, "cached_input": 0.30},
+    "claude-sonnet-4-5": {"input": 3.00, "output": 15.00, "cached_input": 0.30},
     # Claude 4 (Sonnet/Haiku tier pricing)
     "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00, "cached_input": 0.30},
     "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00, "cached_input": 0.08},

--- a/headroom/providers/anthropic.py
+++ b/headroom/providers/anthropic.py
@@ -132,7 +132,7 @@ ANTHROPIC_PRICING: dict[str, dict[str, float]] = {
     "claude-sonnet-4-5": {"input": 3.00, "output": 15.00, "cached_input": 0.30},
     # Claude 4 (Sonnet/Haiku tier pricing)
     "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00, "cached_input": 0.30},
-    "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00, "cached_input": 0.08},
+    "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00, "cached_input": 0.10},
     # Claude 3.5
     "claude-3-5-sonnet-20241022": {"input": 3.00, "output": 15.00, "cached_input": 0.30},
     "claude-3-5-sonnet-latest": {"input": 3.00, "output": 15.00, "cached_input": 0.30},

--- a/tests/test_providers/test_anthropic.py
+++ b/tests/test_providers/test_anthropic.py
@@ -77,6 +77,9 @@ class TestAnthropicModelLimits:
     def test_get_context_limit_strips_ansi_model_suffix(self, anthropic_provider):
         assert anthropic_provider.get_context_limit("claude-opus-4-7[1m]") == 1000000
 
+    def test_get_context_limit_claude_opus_4_8(self, anthropic_provider):
+        assert anthropic_provider.get_context_limit("claude-opus-4-8") == 1000000
+
     def test_supports_model_known(self, anthropic_provider):
         assert anthropic_provider.supports_model("claude-3-5-sonnet-20241022")
 
@@ -108,5 +111,10 @@ class TestAnthropicCostEstimation:
 
     def test_pricing_lookup_strips_ansi_model_suffix(self, anthropic_provider):
         assert anthropic_provider._get_pricing("claude-opus-4-7[1m]") == (
+            anthropic_provider._get_pricing("claude-opus-4-7")
+        )
+
+    def test_opus_4_8_pricing_matches_opus_tier(self, anthropic_provider):
+        assert anthropic_provider._get_pricing("claude-opus-4-8") == (
             anthropic_provider._get_pricing("claude-opus-4-7")
         )

--- a/tests/test_providers/test_anthropic.py
+++ b/tests/test_providers/test_anthropic.py
@@ -114,7 +114,12 @@ class TestAnthropicCostEstimation:
             anthropic_provider._get_pricing("claude-opus-4-7")
         )
 
-    def test_opus_4_8_pricing_matches_opus_tier(self, anthropic_provider):
-        assert anthropic_provider._get_pricing("claude-opus-4-8") == (
-            anthropic_provider._get_pricing("claude-opus-4-7")
-        )
+    @pytest.mark.parametrize("model", ["claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8"])
+    def test_current_opus_tier_pricing(self, anthropic_provider, model):
+        # Opus 4.6–4.8 share the same current-tier rates per anthropic.com/pricing
+        # (verified 2026-06-27): $5/MTok input, $25/MTok output, cache read = 0.1x input ($0.50).
+        assert anthropic_provider._get_pricing(model) == {
+            "input": 5.00,
+            "output": 25.00,
+            "cached_input": 0.50,
+        }

--- a/tests/test_providers/test_anthropic.py
+++ b/tests/test_providers/test_anthropic.py
@@ -142,3 +142,13 @@ class TestAnthropicCostEstimation:
             "output": 15.00,
             "cached_input": 0.30,
         }
+
+    def test_current_haiku_tier_pricing(self, anthropic_provider):
+        # Haiku 4.5 (current Haiku tier, verified 2026-06-27): $1/MTok input,
+        # $5/MTok output, cache read = 0.1x input ($0.10). Was previously stored
+        # with Haiku 3.5 rates ($0.80/$4/$0.08).
+        assert anthropic_provider._get_pricing("claude-haiku-4-5-20251001") == {
+            "input": 1.00,
+            "output": 5.00,
+            "cached_input": 0.10,
+        }

--- a/tests/test_providers/test_anthropic.py
+++ b/tests/test_providers/test_anthropic.py
@@ -80,6 +80,10 @@ class TestAnthropicModelLimits:
     def test_get_context_limit_claude_opus_4_8(self, anthropic_provider):
         assert anthropic_provider.get_context_limit("claude-opus-4-8") == 1000000
 
+    def test_get_context_limit_claude_sonnet_4_6(self, anthropic_provider):
+        # Sonnet 4.6 ships with the 1M context window (long-context pricing tier).
+        assert anthropic_provider.get_context_limit("claude-sonnet-4-6") == 1000000
+
     def test_supports_model_known(self, anthropic_provider):
         assert anthropic_provider.supports_model("claude-3-5-sonnet-20241022")
 
@@ -114,12 +118,27 @@ class TestAnthropicCostEstimation:
             anthropic_provider._get_pricing("claude-opus-4-7")
         )
 
-    @pytest.mark.parametrize("model", ["claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8"])
+    @pytest.mark.parametrize(
+        "model",
+        ["claude-opus-4-5-20251101", "claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8"],
+    )
     def test_current_opus_tier_pricing(self, anthropic_provider, model):
-        # Opus 4.6–4.8 share the same current-tier rates per anthropic.com/pricing
+        # Opus 4.5–4.8 share the same current-tier rates per anthropic.com/pricing
         # (verified 2026-06-27): $5/MTok input, $25/MTok output, cache read = 0.1x input ($0.50).
         assert anthropic_provider._get_pricing(model) == {
             "input": 5.00,
             "output": 25.00,
             "cached_input": 0.50,
+        }
+
+    @pytest.mark.parametrize(
+        "model", ["claude-sonnet-4-5", "claude-sonnet-4-6", "claude-sonnet-4-20250514"]
+    )
+    def test_current_sonnet_tier_pricing(self, anthropic_provider, model):
+        # Sonnet 4 / 4.5 / 4.6 all sit at the current Sonnet tier per anthropic.com/pricing
+        # (verified 2026-06-27): $3/MTok input, $15/MTok output, cache read = 0.1x input ($0.30).
+        assert anthropic_provider._get_pricing(model) == {
+            "input": 3.00,
+            "output": 15.00,
+            "cached_input": 0.30,
         }


### PR DESCRIPTION
## Summary

Aligns the Anthropic fallback pricing and context-limit tables in `headroom/providers/anthropic.py` with the current [anthropic.com/pricing](https://docs.anthropic.com/en/docs/about-claude/pricing) rates (verified 2026-06-27). Several Claude 4.x entries were carrying stale or incorrect rates, and the newer Sonnet 4.5 / 4.6 models had no fallback metadata at all.

## Changes

All values `$ / MTok`; `cached_input` = prompt-cache read = 0.1× input.

| Tier | Model | Before | After | Context |
|---|---|---|---|---|
| Opus | `claude-opus-4-8` | $15 / $75 / $1.50 | $5 / $25 / $0.50 | 1M |
| Opus | `claude-opus-4-7` | $15 / $75 / $1.50 | $5 / $25 / $0.50 | 1M |
| Opus | `claude-opus-4-6` | $15 / $75 / $1.50 | $5 / $25 / $0.50 | 1M |
| Opus | `claude-opus-4-5-20251101` | $15 / $75 / $1.50 | $5 / $25 / $0.50 | 200K |
| Sonnet | `claude-sonnet-4-6` | — *(new)* | $3 / $15 / $0.30 | **1M** |
| Sonnet | `claude-sonnet-4-5` | — *(new)* | $3 / $15 / $0.30 | 200K |
| Haiku | `claude-haiku-4-5-20251001` | $0.80 / $4 / $0.08 *(3.5 rates)* | $1 / $5 / $0.10 | 200K |

`claude-sonnet-4-20250514` and all Claude 3.x / 3.5.x entries were already correct — left unchanged.

The **Sonnet 4.6** entry is functional, not cosmetic: it ships in the long-context pricing tier (1M window), and without an explicit entry the `sonnet` pattern default would report 200K.

## Tests

Replaced the original fragile parity-with-Opus-4.7 assertion with parametrized absolute-value tier checks:

- `test_current_opus_tier_pricing` — Opus 4.5–4.8
- `test_current_sonnet_tier_pricing` — Sonnet 4 / 4.5 / 4.6
- `test_current_haiku_tier_pricing` — Haiku 4.5
- `test_get_context_limit_claude_sonnet_4_6` — pins the 1M context window

Full suite: 24 passed, ruff clean.

## Notes

- `_PATTERN_DEFAULTS` (the `opus` / `sonnet` / `haiku` regex fallbacks for *unknown* models) are intentionally left unchanged — they are conservative heuristics, not model-specific entries. Happy to retune in a follow-up.
- Source of truth: https://docs.anthropic.com/en/docs/about-claude/pricing
