### PR TITLE
fix(proxy): include orjson in Headroom proxy extra for LiteLLM MCP compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,14 @@ proxy = [
     "httpx[http2]>=0.24.0",
     "openai>=2.14.0",             # OpenAI API format support
     "mcp>=1.0.0",                 # MCP server (headroom_compress, retrieve, stats)
+    # LiteLLM's proxy/MCP auth stack imports proxy.common_utils.http_parsing_utils,
+    # which hard-imports orjson at module import time. Headroom depends on plain
+    # litellm (not litellm[proxy]), so we need to carry this proxy-only dependency
+    # explicitly or /mcp can fail at runtime in published proxy images.
+    # TODO: Revisit the dependency boundary here. Headroom's proxy extra manually
+    # mirrors part of LiteLLM's proxy/runtime dependency set, which can drift as
+    # LiteLLM adds new proxy-only imports.
+    "orjson>=3.11.6,<4.0",
     "magika>=0.6.0",              # ML content detection for ContentRouter
     "zstandard>=0.20.0",          # Decompress zstd request bodies (Codex, etc.)
     "websockets>=13.0",           # WebSocket proxy for /v1/responses (Codex gpt-5.4+)


### PR DESCRIPTION
## Description

Add `orjson` to Headroom's `proxy` extra to close a packaging gap in the LiteLLM proxy dependency surface used by Headroom.

Headroom installs plain `litellm`, then layers a manually curated set of proxy dependencies on top. LiteLLM proxy utilities import `litellm.proxy.common_utils.http_parsing_utils`, which hard-imports `orjson` at module import time. In the published proxy image I inspected, `orjson` was not installed even though LiteLLM declares it under its `proxy` extra.

This PR keeps the fix intentionally narrow and also documents the broader dependency-drift risk with a TODO comment.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / internal cleanup

## Changes Made

- Added `orjson>=3.11.6,<4.0` to the `proxy` extra in `pyproject.toml`
- Added an inline TODO noting that Headroom's proxy extra currently mirrors part of LiteLLM's proxy/runtime dependency set and can drift as LiteLLM changes

## Testing

- [x] Verified the running container package set and LiteLLM dependency metadata
- [x] Verified the LiteLLM proxy/MCP auth import path that reaches `orjson`
- [x] Temporarily installed `orjson` into the running pod to validate the dependency gap
- [ ] Rebuilt the image with this patch
- [ ] Retested a rebuilt image end-to-end

### Test Output

```text
Running deployment image:
ghcr.io/chopratejas/headroom@sha256:e86f664eca715ca53505f3f2c73a66d82aa56d3d09b39bb2b75f6b131f3e1568

Installed package versions in the inspected pod before temporary install:
{
  "headroom-ai": "0.27.0",
  "litellm": "1.89.3",
  "mcp": "1.28.0",
  "orjson": null,
  "fastapi": "0.138.0",
  "uvicorn": "0.49.0"
}

LiteLLM metadata in the same pod includes:
orjson>=3.11.6,<4.0 ; extra == 'proxy'

LiteLLM proxy utility imports:
import orjson

Temporary live validation:
Successfully installed orjson-3.11.9
```

## Real Behavior Proof

### Environment

- Kubernetes deployment
- Deployment: `headroom`
- Image: `ghcr.io/chopratejas/headroom:code`
- Running digest: `ghcr.io/chopratejas/headroom@sha256:e86f664eca715ca53505f3f2c73a66d82aa56d3d09b39bb2b75f6b131f3e1568`

### Exact command / steps

1. Inspect installed package versions in the running pod
2. Inspect LiteLLM dependency metadata and proxy utility imports in the same pod
3. Temporarily install `orjson` into the running pod for live validation
4. Retest the MCP endpoint:
   `POST http://192.168.100.249:30107/mcp/`

### Observed result

- Before temporary install, the runtime had `litellm` and `mcp` installed, but `orjson` missing
- LiteLLM's proxy/MCP auth path imports proxy utilities that hard-import `orjson`
- Temporary installation of `orjson` into the running pod succeeded
- `/mcp` still returned:
  `{"error":"MCP request failed","details":""}`

### Not tested

- [x] I did not rebuild and rerun the container with this patch in the target cluster
- [x] I did not verify end-to-end `/mcp` success after applying this patch to a rebuilt image
- [x] This PR does not claim to fully resolve the live `/mcp` failure by itself

## Review Readiness

- [x] I have performed a self-review before requesting human review
- [x] This PR is ready for human review or I will convert it back to draft if more work is needed

## Notes

This PR is a minimal packaging fix, not a confirmed full root-cause fix for the current MCP runtime failure.

It fixes a real dependency inconsistency:
- LiteLLM proxy code expects `orjson`
- Headroom's `proxy` extra did not install it

The remaining `/mcp` failure appears to have an additional cause and is being investigated separately.

Follow-up worth considering separately:
- depend more directly on LiteLLM's proxy dependency set
- or add CI/build validation that exercises MCP/proxy import paths in the published image