### PR TITLE
fix(proxy): use selector loop on Windows

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -4043,6 +4043,11 @@ def run_server(
 
     app_target: Any
     uvicorn_kwargs: dict[str, Any] = {}
+    if sys.platform == "win32":
+        # ProactorEventLoop can close the listening socket on transient
+        # AcceptEx failures (for example WinError 64 from keep-alive RSTs).
+        # The selector loop keeps accept errors scoped to the connection.
+        uvicorn_kwargs["loop"] = "asyncio:SelectorEventLoop"
     if workers > 1:
         # CompressionCache and PrefixTracker are always per-worker instance vars.
         # Python CompressionStore defaults to InMemoryBackend (per-process), so

--- a/tests/test_proxy_scalability.py
+++ b/tests/test_proxy_scalability.py
@@ -276,3 +276,39 @@ class TestWorkerConfiguration:
             # value and re-restores it on teardown, leaking the config into
             # later tests (e.g. _proxy_config_from_env then ignores HEADROOM_*).
             os.environ.pop(_MULTI_WORKER_CONFIG_ENV, None)
+
+    def test_run_server_uses_selector_loop_on_windows(self, monkeypatch):
+        from headroom.proxy import server as server_mod
+        from headroom.proxy.models import ProxyConfig
+
+        captured = {}
+
+        def fake_run(app, **kwargs):
+            captured["app"] = app
+            captured["kwargs"] = kwargs
+
+        monkeypatch.setattr(server_mod.sys, "platform", "win32")
+        monkeypatch.setattr(server_mod, "create_app", lambda config: "app")
+
+        with patch("headroom.proxy.server.uvicorn.run", fake_run):
+            server_mod.run_server(ProxyConfig(), print_banner=False)
+
+        assert captured["app"] == "app"
+        assert captured["kwargs"]["loop"] == "asyncio:SelectorEventLoop"
+
+    def test_run_server_keeps_default_loop_off_windows(self, monkeypatch):
+        from headroom.proxy import server as server_mod
+        from headroom.proxy.models import ProxyConfig
+
+        captured = {}
+
+        def fake_run(app, **kwargs):
+            captured["kwargs"] = kwargs
+
+        monkeypatch.setattr(server_mod.sys, "platform", "linux")
+        monkeypatch.setattr(server_mod, "create_app", lambda config: "app")
+
+        with patch("headroom.proxy.server.uvicorn.run", fake_run):
+            server_mod.run_server(ProxyConfig(), print_banner=False)
+
+        assert "loop" not in captured["kwargs"]


### PR DESCRIPTION
## Description

Fixes the Windows proxy listener failure where `headroom proxy` can keep running while `127.0.0.1:8787` stops accepting connections after a transient `WinError 64` / AcceptEx failure.

On Windows, uvicorn's default single-process asyncio loop is ProactorEventLoop. If a keep-alive client resets a connection during accept, the Proactor accept path can close the listening socket and never re-arm accept. Passing uvicorn `loop="asyncio:SelectorEventLoop"` on Windows keeps accept failures scoped to the individual connection and leaves the listener registered.

Closes #1116

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Force `uvicorn.run(...)` to use `loop="asyncio:SelectorEventLoop"` when `sys.platform == "win32"`.
- Leave non-Windows uvicorn loop selection unchanged.
- Add regression tests that assert Windows receives the selector-loop kwarg and non-Windows does not.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$env:PYTHONPATH = (Get-Location).Path
python -m pytest tests/test_proxy_scalability.py::TestWorkerConfiguration -q

============================= test session starts =============================
platform win32 -- Python 3.13.1, pytest-9.1.1, pluggy-1.6.0
rootdir: E:\work\code\headroom
configfile: pyproject.toml
plugins: anyio-4.14.0
collected 5 items

tests\test_proxy_scalability.py .....                                    [100%]

======================== 5 passed, 1 warning in 0.79s =========================

$env:PYTHONPATH = (Get-Location).Path
python -m ruff check headroom/proxy/server.py tests/test_proxy_scalability.py
All checks passed!

$env:PYTHONPATH = (Get-Location).Path
python -m ruff format --check headroom/proxy/server.py tests/test_proxy_scalability.py
2 files already formatted
```

### CI Validation

GitHub Actions is green for this PR, including:

```text
build                         pass
build-wheel                   pass
commitlint                    pass
lint                          pass  # ruff check ., ruff format --check ., mypy headroom
test (1)                      pass
test (2)                      pass
test (3)                      pass
test (4)                      pass
test-extras                   pass
test-agno                     pass
test-dashboard-ui             pass
windows-native-wrapper        pass
macos-native-wrapper          pass
docker-native-e2e             pass
docker-init-e2e               pass
docker-wrap-e2e               pass
```

### Local Full-Suite Attempt

I also completed a local full Python test run on Windows after building the native extension locally and prefetching the HuggingFace model cache:

```text
maturin develop -m crates/headroom-py/Cargo.toml --features extension-module -v
$env:PYTHONPATH = (Get-Location).Path
$env:PYTHONUTF8 = '1'
$env:HF_HUB_OFFLINE = '1'
$env:TRANSFORMERS_OFFLINE = '1'
$env:HF_HUB_DISABLE_TELEMETRY = '1'
.\.venv\Scripts\python.exe -m pytest tests scripts/tests --tb=short -q --timeout=90 --timeout-method=thread
```

Result:

```text
50 failed, 7166 passed, 518 skipped, 5807 warnings, 131 errors in 283.41s
```

The local failures are outside this proxy event-loop change and are concentrated in existing Windows/local-environment issues:

- SQLite temp database cleanup errors on Windows (`PermissionError: [WinError 32] ... .db`) across memory, graph, and vector-index tests.
- Windows URI/path parsing for `sqlite:///C:/...` and `jsonl:///C:/...`, producing invalid `\\C:\...` paths in storage/cache integration tests.
- Missing/non-portable local external tooling such as `difftastic`.
- Windows-local process/runtime assumptions in a few installer, RTK, lock, and default-storage-path tests.

The PR-specific regression tests still pass locally, and the full GitHub Actions suite for this PR is green with the freshly built extension.

## Real Behavior Proof

- Environment: Windows 10.0.19045, CPython 3.13.1, uvicorn 0.49.0, Headroom 0.27.0 tool environment, local checkout on `PYTHONPATH`.
- Exact command / steps: ran `python -c "import asyncio, uvicorn; c=uvicorn.Config('headroom.proxy.server:create_app_from_env', loop='asyncio:SelectorEventLoop', factory=True); f=c.get_loop_factory(); loop=f(); print(type(loop).__name__); assert isinstance(loop, asyncio.SelectorEventLoop); loop.close()"` with `PYTHONPATH` pointed at this checkout.
- Observed result: command printed `_WindowsSelectorEventLoop`, proving uvicorn 0.49 resolves the configured loop string to the Windows selector event loop.
- Not tested: I did not run a long live Claude/Codex session against this source checkout because the checkout was not fully installed from source on this machine.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A.

## Additional Notes

- Documentation: N/A; this is an internal event-loop selection fix with no user-facing API change.
- CHANGELOG: not updated because this branch's `CHANGELOG.md` currently contains pre-existing conflict markers on `main`, and this PR intentionally avoids touching unrelated release-note state.