### PR TITLE
docs(changelog): remove unresolved merge-conflict markers from Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-<<<<<<< pr/503-proactive-expansion-xml-tag
 ### Fixed
 - Proactive expansion blocks injected into user turns are now wrapped in
   `<headroom_proactive_expansion>` XML tags, giving downstream consumers
   (LLMs, loggers, attribution parsers) a machine-readable provenance
   boundary and preventing misattribution in multi-agent threads.
 
-=======
->>>>>>> main
 ### Changed
 
 * **telemetry:** anonymous usage telemetry is now **opt-in** (off by default) instead of opt-out. Nothing is collected or sent unless you set `HEADROOM_TELEMETRY=on` or pass `--telemetry` to `headroom proxy` / `headroom install apply`. `is_telemetry_enabled()` is fail-closed — only explicit on-values (`on`/`true`/`1`/`yes`/`enable`/`enabled`) enable it; unset, empty, or unrecognized values stay disabled. The existing `--no-telemetry` flag and `HEADROOM_TELEMETRY=off` remain accepted for back-compat, and install manifests now write the `HEADROOM_TELEMETRY` value explicitly so generated deployments are unambiguous.
@@ -45,12 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **proxy:** stop discarding a finished compression on very large requests. After the transform pipeline completed, a telemetry-only waste-signal re-parse of the *original* messages ran on the critical path; on huge Claude Code transcripts (~400k tokens) that parse could exceed the Anthropic compression timeout, so the proxy failed open and forwarded the uncompressed request despite "Pipeline complete" logging real savings (`tokens_saved: 0`, `transforms_applied: []`, ~31s latency). Waste-signal detection is now skipped above `MAX_WASTE_SIGNAL_DETECTION_TOKENS` (100k) so the compression result stays on the critical path ([#296](https://github.com/chopratejas/headroom/issues/296)).
 * **codex:** retag existing Codex threads when `headroom init` injects the `headroom` provider, so Codex Desktop history stays visible. Codex filters its sidebar/search by the active `model_provider`; the init path set `model_provider = "headroom"` without retagging, so existing native `openai` threads disappeared from the menu (data was never deleted, only hidden). `_ensure_codex_provider` now reconciles thread tags openai→headroom, matching what the install and `wrap` paths already do; `headroom unwrap codex` handles the revert direction ([#961](https://github.com/chopratejas/headroom/issues/961)).
 * **install:** stop duplicating the container ENTRYPOINT in the `persistent-docker` runtime command. The published image already runs `headroom proxy` as its ENTRYPOINT, but `build_runtime_command` re-added `headroom proxy` after the image name, so the container ran `headroom proxy headroom proxy --host 0.0.0.0 …` and Click aborted with "Got unexpected extra arguments (headroom proxy)" — the deployment never became ready and rollback left nothing running. The runtime command now appends only the proxy flags ([#833](https://github.com/chopratejas/headroom/issues/833)).
-<<<<<<< fix/gemini-offload
 * **gemini:** run compression off the asyncio event loop. The Gemini handlers (`generateContent`, Cloud Code stream, `countTokens`) ran the CPU-bound compression pipeline (Magika detection plus ML compression) synchronously on the loop, stalling every concurrent request for the duration of each Gemini request's compression. They now offload it via the shared compression executor, matching the existing OpenAI and Anthropic paths.
-=======
 * **proxy:** queue mid-turn user messages on non-Bedrock streaming path instead of silently dropping them — closes [#902](https://github.com/headroomlabs-ai/headroom/issues/902).
 * **proxy:** add `--protect-tool-results` / `HEADROOM_PROTECT_TOOL_RESULTS` to prevent lossy compression of exact-output tool results (e.g. `Bash cat`/`grep` results) — closes [#1307](https://github.com/headroomlabs-ai/headroom/issues/1307).
->>>>>>> main
 * **cli:** add `--rpm`/`--tpm` and `HEADROOM_RPM`/`HEADROOM_TPM` to the Click proxy command for rate-limit parity with the legacy CLI -- closes [#1350](https://github.com/headroomlabs-ai/headroom/issues/1350) (Problem 1).
 * **proxy:** register `ToolResultInterceptorTransform` in explicit transforms list when `HEADROOM_INTERCEPT_ENABLED` is set — closes [#829](https://github.com/headroomlabs-ai/headroom/issues/829).
 * **opencode:** write Headroom MCP config as a local stdio server instead of a remote `/mcp` URL, keep provider-only installs from adding MCP config, and allow `install apply --target opencode` ([#1380](https://github.com/headroomlabs-ai/headroom/issues/1380)).


### PR DESCRIPTION
## Description

`CHANGELOG.md` on `main` contains **unresolved Git merge-conflict markers** — literal `<<<<<<<` / `=======` / `>>>>>>>` lines committed into a tracked file. They render verbatim on the GitHub file view and in any Markdown/docs build of the changelog.

Two merged PRs each `git add`-ed the file with the markers still in place (the `## Unreleased` section is a constant conflict magnet because every PR appends to it):

- `cabf666b` — `fix(ccr): wrap proactive expansion injection in XML attribution tag (#1398)` → the `pr/503-proactive-expansion-xml-tag` vs `main` block.
- `615848eb` — `fix(gemini): offload compression to the executor (#1382)` → the `fix/gemini-offload` vs `main` block.

Nothing flagged them: there is no `check-merge-conflict` pre-commit hook, no workflow runs `pre-commit`, and `ruff`/`mypy`/`pytest` do not parse Markdown — so the markers slipped through review twice.

This PR removes the markers by taking the **union** of each side's content, so no changelog entries are lost.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Block 1 (top of `## Unreleased`): `main`'s side of the conflict was empty, so kept the `pr/503` side verbatim — the proactive-expansion `### Fixed` entry — and removed the three markers.
- Block 2 (inside `### Bug Fixes`): kept **all three** distinct bullets — the `fix/gemini-offload` gemini entry plus `main`'s two proxy entries (`queue mid-turn user messages`, `--protect-tool-results`) — and removed the three markers.
- Net diff is `6 deletions, 0 insertions` (only the six marker lines); every prose line is preserved.

## Testing

- [x] Linting passes (`ruff check .`)
- [x] Manual testing performed
- [ ] Unit tests pass (`pytest`) — N/A, Markdown-only change (no code touched)
- [ ] Type checking passes (`mypy headroom`) — N/A, Markdown-only change
- [ ] New tests added for new functionality — N/A (see Additional Notes re: a prevention hook)

### Test Output

```text
# Conflict markers before vs after (whole repo):
$ git grep -cE '^(<{7}|\|{7}|={7}|>{7})( |$)' upstream/main -- .
CHANGELOG.md:6
$ git grep -nE  '^(<{7}|\|{7}|={7}|>{7})( |$)' HEAD -- .
(no output) -> 0 markers

# Diff is only the marker lines — no prose changed:
$ git diff --stat upstream/main..HEAD
 CHANGELOG.md | 6 ------
 1 file changed, 6 deletions(-)

# Sanity (unaffected by a Markdown change):
$ ruff check .
All checks passed!
$ commitlint --from upstream/main --to HEAD   ->  0 problems, 0 warnings
```

## Real Behavior Proof

- Environment: the repo at this branch (`fix/changelog-merge-conflict-markers`), verified locally with `git grep`, `git diff`, `ruff 0.15.17`, and `commitlint` (`@commitlint/config-conventional`). No application runtime is involved — this is a tracked-content (Markdown) fix.
- Exact command / steps: scanned every tracked file for conflict markers before/after with `git grep -nE '^(<{7}|\|{7}|={7}|>{7})( |$)'`, then confirmed the change is marker-only with `git diff --stat upstream/main..HEAD` and reviewed the full `git diff` to confirm all changelog prose is preserved.
- Observed result: `upstream/main` had 6 marker lines across 2 conflict blocks in `CHANGELOG.md`; after the fix the whole repo has **0** conflict markers, the diff is exactly `6 deletions / 0 insertions`, every changelog entry from both sides is retained, and `## Unreleased` is now valid Markdown. `ruff check .` and `commitlint` stay green.
- Not tested: no code paths change, so there is no application behavior to exercise; the MkDocs site build and release-please changelog generation were not run locally (both only benefit from the markers being gone).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A — Markdown only)
- [x] I have made corresponding changes to the documentation (this *is* the docs change)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — see Additional Notes)
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

- Resolution intent: I preserved both sides' content verbatim rather than re-editing wording or relocating entries. Block 1 leaves a `### Fixed` heading (Keep-a-Changelog style) alongside the `### Bug Fixes` (release-please) section; folding it in is an editorial call I left to maintainers so this PR stays a pure marker removal.
- Prevention follow-up (happy to do as a separate PR if wanted): add the `check-merge-conflict` hook from `pre-commit/pre-commit-hooks` to `.pre-commit-config.yaml` and/or a one-line CI `git grep` guard, so a committed conflict marker fails fast instead of merging silently.
