### PR TITLE
fix(wrap): use valid Serena context for opencode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- `headroom wrap opencode` no longer fails to start Serena. It passed
+  `--context opencode` to `serena start-mcp-server`, but Serena ships no
+  `opencode` context, so Serena aborted with `FileNotFoundError: Context
+  opencode not found`. The wrap now uses Serena's generic `agent` context
+  ([#1549](https://github.com/headroomlabs-ai/headroom/issues/1549)).
 - Proactive expansion blocks injected into user turns are now wrapped in
   `<headroom_proactive_expansion>` XML tags, giving downstream consumers
   (LLMs, loggers, attribution parsers) a machine-readable provenance

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -5394,7 +5394,12 @@ def opencode(
     if not no_serena:
         from headroom.mcp_registry import OpencodeRegistrar
 
-        _setup_serena_mcp(OpencodeRegistrar(), context="opencode", verbose=verbose, force=True)
+        # Serena has no "opencode" context — passing one makes
+        # `serena start-mcp-server --context opencode` abort with
+        # FileNotFoundError, so the whole `wrap opencode` flow fails to
+        # start (#1549). Fall back to Serena's generic "agent" context,
+        # which is valid for any coding agent without a dedicated context.
+        _setup_serena_mcp(OpencodeRegistrar(), context="agent", verbose=verbose, force=True)
     else:
         from headroom.mcp_registry import OpencodeRegistrar
 

--- a/tests/test_cli/test_wrap_opencode.py
+++ b/tests/test_cli/test_wrap_opencode.py
@@ -69,6 +69,37 @@ def test_wrap_opencode_sets_config_content_env(
     assert captured["args"] == ("--model", "gpt-4o")
 
 
+def test_wrap_opencode_uses_valid_serena_context(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`wrap opencode` must hand Serena a real context (#1549).
+
+    Serena ships no "opencode" context, so passing one makes
+    `serena start-mcp-server --context opencode` abort with
+    FileNotFoundError and the whole wrap fails to start. The wrap must use
+    a valid generic context instead.
+    """
+    monkeypatch.chdir(tmp_path)
+    _set_test_home(monkeypatch, tmp_path)
+
+    captured: dict[str, object] = {}
+
+    def fake_setup_serena(registrar, *, context, verbose=False, force=False):  # noqa: ANN001
+        captured["context"] = context
+
+    with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
+        with patch.object(wrap_mod, "_launch_tool"):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                with patch.object(wrap_mod, "_setup_serena_mcp", side_effect=fake_setup_serena):
+                    result = runner.invoke(main, ["wrap", "opencode", "--port", "9000", "--no-mcp"])
+
+    assert result.exit_code == 0, result.output
+    assert captured.get("context") == "agent"
+    assert captured["context"] != "opencode"
+
+
 def test_wrap_opencode_does_not_add_base_url_env_vars(
     runner: CliRunner,
     tmp_path: Path,


### PR DESCRIPTION
## Description

`headroom wrap opencode` fails to start Serena. The OpenCode wrap path registers Serena with `context="opencode"` (`headroom/cli/wrap.py`), which becomes `serena start-mcp-server --context opencode`. Serena ships no `opencode` context, so it aborts on startup:

```
FileNotFoundError: Context opencode not found in ...serena/resources/config/contexts.
Available contexts: ['agent', 'antigravity', 'chatgpt', 'claude-code', 'codex',
'context.template', 'copilot-cli', 'desktop-app', 'ide', 'jb-ai-assistant',
'jb-copilot-plugin', 'junie', 'oaicompat-agent', 'vscode']
```

The other wrap targets already pass valid Serena contexts (`claude` → `claude-code`, `codex` → `codex`); OpenCode is the only one passing a name Serena doesn't have. Fix: use Serena's generic `agent` context, which is valid for any coding agent without a dedicated context. (Happy to switch to `oaicompat-agent` or `ide` if maintainers prefer — any valid context resolves the crash.)

Closes #1549

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `headroom/cli/wrap.py`: OpenCode wrap now registers Serena with `context="agent"` instead of the non-existent `"opencode"` context.
- `tests/test_cli/test_wrap_opencode.py`: regression test `test_wrap_opencode_uses_valid_serena_context` asserting the wrap hands Serena a valid context (and not `"opencode"`).
- `CHANGELOG.md`: note under Unreleased → Fixed.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`, `ruff format --check`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

Regression test fails before the fix (wrap passes `opencode`), passes after (`agent`):

```text
# before fix (context="opencode")
FAILED tests/test_cli/test_wrap_opencode.py::test_wrap_opencode_uses_valid_serena_context
E     - agent
E     + opencode

# after fix (context="agent")
tests/test_cli/test_wrap_opencode.py .................................. [100%]
34 passed, 1 warning in 0.36s
```

`ruff check` / `ruff format --check` on the changed files: clean.

## Real Behavior Proof

- Environment: macOS (arm64), Python venv, editable install (`pip install -e .`), `pytest`.
- Exact command / steps: `python -m pytest tests/test_cli/test_wrap_opencode.py`. (1) Reverted the line to `context="opencode"` and ran the new test → it failed with the wrap passing `opencode` to Serena (output above). (2) Applied the fix (`context="agent"`). (3) Re-ran → 34 passed. The test drives the real `headroom wrap opencode` CLI path and captures the exact context handed to `_setup_serena_mcp` (the value that becomes `serena start-mcp-server --context <…>`).
- Observed result: the wrap now hands Serena `agent` — a context present in Serena's own available-contexts list (quoted from the issue's `FileNotFoundError`), so `serena start-mcp-server` no longer aborts. `opencode` is absent from that list, which is exactly why the original crashed.
- Not tested: I did not launch the real Serena binary locally (it is fetched/run via `uvx --from git+https://github.com/oraios/serena`, blocked in my sandbox), so the proof rests on (a) Serena's own emitted available-contexts list confirming `agent` is valid and `opencode` is not, and (b) the CLI-level test verifying the wrap now passes `agent`.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md
