### PR TITLE
chore: add CODEOWNERS with maintainer catch-all

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS — default reviewers for this repository.
+# Docs: https://docs.github.com/articles/about-code-owners
+#
+# Owners listed here are auto-requested for review on matching pull requests.
+# When branch protection requires code-owner review, any one of them can
+# satisfy it. Owners must have write access to the repo or the line is ignored.
+#
+# Order matters: the last matching pattern wins.
+
+# Catch-all: the maintainers own everything by default.
+* @chopratejas @JerrettDavis @DevanshiVyas


### PR DESCRIPTION
## Description

Adds `.github/CODEOWNERS` so pull requests auto-request review from the repository maintainers. A single catch-all rule assigns all matching paths to the three accounts that actually have write access — the only accounts GitHub accepts as code owners.

Closes # N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update <!-- repo governance/config; closest category -->
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add `.github/CODEOWNERS` with a catch-all: `* @chopratejas @JerrettDavis @DevanshiVyas`.
- Header comment documents the semantics (auto-request, last-match-wins, owners need write access).

## Testing

<!-- No code changed, so ruff/mypy/pytest are N/A. Validated the file with GitHub's own CODEOWNERS checker instead. -->

- [ ] Unit tests pass (`pytest`) — N/A (no code)
- [ ] Linting passes (`ruff check`) — N/A (no Python)
- [ ] Type checking passes (`mypy`) — N/A (no Python)
- [ ] New tests added for new functionality — N/A
- [x] Manual testing performed (GitHub CODEOWNERS validation API)

### Test Output

```text
# All 3 listed owners have write access (required, else the line is ignored):
$ gh api 'repos/headroomlabs-ai/headroom/collaborators?permission=push' --jq '.[].login'
JerrettDavis
chopratejas
DevanshiVyas

# GitHub's authoritative CODEOWNERS validation on this branch — zero errors:
$ gh api 'repos/headroomlabs-ai/headroom/codeowners/errors?ref=chore/add-codeowners'
{"errors":[]}
```

## Real Behavior Proof

- **Environment:** GitHub repo `headroomlabs-ai/headroom`, branch `chore/add-codeowners`.
- **Exact command / steps:** `gh api repos/headroomlabs-ai/headroom/codeowners/errors?ref=chore/add-codeowners`.
- **Observed result:** `{"errors":[]}` — every owner in the file resolves to a valid account with repo access, so the rule is live (no silently-ignored lines).
- **Not tested:** Whether branch protection is set to *require* code-owner review — that's a separate repo setting, not part of this file. See Additional Notes.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (this file is self-documenting via its header)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my feature works — N/A (config file; validated via GitHub API)
- [ ] New and existing unit tests pass locally with my changes — N/A (no code)
- [ ] I have updated the CHANGELOG.md if applicable — N/A (`chore:` is excluded from the Release Please changelog)

## Additional Notes

- **Owner selection:** only `@chopratejas`, `@JerrettDavis`, `@DevanshiVyas` have write access, so they are the only valid code owners. High-volume contributors without push access were intentionally omitted — GitHub silently ignores owners that lack write access.
- **Why one catch-all with all three (not per-path, not solo):** any single owner can satisfy a required code-owner review, and listing three avoids the solo-maintainer deadlock (a PR author can't self-satisfy their own code-owner review). No per-subsystem rules were added because commit history doesn't cleanly map owners to subsystems — happy to add them if you want to define that.
- **Enforcement is opt-in:** this file only *auto-requests* reviewers today. It becomes blocking only if branch protection enables "Require review from Code Owners." If you turn that on, the three-owner setup is what keeps everyone's PRs mergeable.
