### PR TITLE
fix(learn): Windows compatibility for verbosity and session discovery

### DIFF
--- a/headroom/learn/analyzer.py
+++ b/headroom/learn/analyzer.py
@@ -573,20 +573,38 @@ def _call_claude_cli_streaming(
     Threads (rather than ``select``) drain stdout/stderr so the watchdog works
     on Windows too, where ``select`` does not support pipe handles.
     """
-    try:
-        proc = Popen(
-            cmd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,  # line-buffered
-        )
-    except FileNotFoundError:
+    # On Windows, raw scripts (e.g. `claude` with a bash shebang from an npm
+    # global install) can't be executed directly by CreateProcess — they need
+    # the `.cmd`/`.exe` shim. Try the bare name first; on FileNotFoundError fall
+    # back to <name>.cmd (and <name>.exe) so npm-global CLIs work on Windows.
+    candidates = [cmd]
+    if os.name == "nt" and "/" not in cmd[0] and "\\" not in cmd[0]:
+        base = cmd[0]
+        for ext in (".cmd", ".exe", ".bat"):
+            candidates.append([base + ext] + cmd[1:])
+
+    proc = None
+    last_exc: Exception | None = None
+    for candidate in candidates:
+        try:
+            proc = Popen(
+                candidate,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,  # line-buffered
+            )
+            break
+        except FileNotFoundError as exc:
+            last_exc = exc
+            continue
+
+    if proc is None:
         raise RuntimeError(
             f"`{cmd[0]}` not found in PATH. Install it or use a different backend "
             "with --model <litellm-model-name>."
-        ) from None
+        ) from last_exc
 
     assert proc.stdin is not None and proc.stdout is not None and proc.stderr is not None
     try:

--- a/headroom/learn/plugins/claude.py
+++ b/headroom/learn/plugins/claude.py
@@ -70,12 +70,18 @@ class ClaudeCodePlugin(LearnPlugin, ConversationScanner):
 
             project_path = _decode_project_path(entry.name)
             if project_path is None:
-                fallback_parts = entry.name[1:].split("-")
-                if len(fallback_parts[0]) == 1 and fallback_parts[0].isalpha():
-                    drive = fallback_parts[0].upper()
-                    project_path = Path(f"{drive}:\\" + "\\".join(fallback_parts[1:]))
+                # Handle "D--work-DPJ" → "D:\work\DPJ" (drive letter + -- = :\)
+                if len(entry.name) >= 3 and entry.name[1:3] == "--" and entry.name[0].isalpha():
+                    drive = entry.name[0].upper()
+                    rest = entry.name[3:]
+                    project_path = Path(f"{drive}:\\{rest.replace('-', '\\')}")
                 else:
-                    project_path = Path("/" + entry.name[1:].replace("-", "/"))
+                    fallback_parts = entry.name[1:].split("-")
+                    if len(fallback_parts[0]) == 1 and fallback_parts[0].isalpha():
+                        drive = fallback_parts[0].upper()
+                        project_path = Path(f"{drive}:\\" + "\\".join(fallback_parts[1:]))
+                    else:
+                        project_path = Path("/" + entry.name[1:].replace("-", "/"))
 
             name = _project_display_name(project_path, entry.name)
 
@@ -93,6 +99,32 @@ class ClaudeCodePlugin(LearnPlugin, ConversationScanner):
             jsonl_files = list(entry.glob("*.jsonl"))
             if not jsonl_files:
                 continue
+
+            # The directory-name → path decoding is ambiguous when a project
+            # name itself contains '-' (e.g. "vibe-remote" decodes to both
+            # D:\work\vibe-remote and D:\work\vibe\remote). Resolve the TRUE
+            # project path by reading the `cwd` field recorded inside the
+            # session transcripts. Fall back to the decoded guess only if no
+            # jsonl yields a cwd (e.g. empty/corrupt files, or non-disk roots
+            # like Claude desktop which don't record a windows cwd).
+            resolved = project_path
+            for jf in jsonl_files[:3]:
+                try:
+                    with open(jf, encoding="utf-8") as fh:
+                        for line in fh:
+                            try:
+                                d = json.loads(line)
+                            except (json.JSONDecodeError, ValueError):
+                                continue
+                            cwd = d.get("cwd")
+                            if cwd and isinstance(cwd, str) and len(cwd) >= 3 and cwd[1:3] == ":\\":
+                                resolved = Path(cwd)
+                                break
+                    if resolved != project_path:
+                        break
+                except OSError:
+                    continue
+            project_path = resolved
 
             projects.append(
                 ProjectInfo(

--- a/headroom/learn/verbosity.py
+++ b/headroom/learn/verbosity.py
@@ -144,7 +144,7 @@ class VerbosityProfile:
     @classmethod
     def load(cls, path: Path) -> VerbosityProfile | None:
         try:
-            d = json.loads(Path(path).read_text())
+            d = json.loads(Path(path).read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError, ValueError):
             return None
         return cls(
@@ -208,7 +208,7 @@ def _parse_session(path: Path) -> tuple[list[_Response], list[_HumanMsg], bool]:
     recent_context: list[str] = []
 
     try:
-        lines = path.read_text().splitlines()
+        lines = path.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeDecodeError):
         return [], [], False
 
@@ -282,7 +282,7 @@ def _ordered_events(path: Path) -> list[tuple[float | None, str, _Response | _Hu
     """
     out: list[tuple[float | None, str, Any]] = []
     try:
-        lines = path.read_text().splitlines()
+        lines = path.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeDecodeError):
         return out
     responses, humans, _ = _parse_session(path)


### PR DESCRIPTION
## Summary

Fixes three bugs that prevented `headroom learn --verbosity` from working on Windows, and fixes `headroom learn --agent codex` failing to invoke the `claude` CLI.

Closes #1624 (issues 1-3)

## Changes

### `headroom/learn/verbosity.py` — UTF-8 encoding fix

`Path.read_text()` without encoding defaults to GBK on Windows. Session JSONL files are UTF-8, so non-ASCII characters (Chinese, Japanese, etc.) cause `UnicodeDecodeError`, which is silently caught — returning empty results for all projects.

Added `encoding="utf-8"` to all three `read_text()` calls (lines 147, 211, 285).

### `headroom/learn/plugins/claude.py` — Windows drive-letter path decoding + cwd resolution

Two fixes:

1. **Drive-letter path decoding:** The `D--work-DPJ` format (where `--` encodes `:\`) was not handled by the existing fallback. Added detection for `X--rest` prefix before the existing fallback logic.

2. **cwd reverse lookup:** When a project name contains hyphens (e.g. `vibe-remote`), the directory name `D--work-vibe-remote` is ambiguous. Added logic to read the `cwd` field from session JSONL files to resolve the true project path.

### `headroom/learn/analyzer.py` — Windows .cmd shim fallback

On Windows, npm-installed global CLIs (e.g. `claude`) are bash script shims that `CreateProcess` cannot invoke directly. The actual executables are `.cmd` / `.exe` shims.

Added fallback logic: after `Popen()` fails with `FileNotFoundError` on Windows, try `<name>.cmd`, `<name>.exe`, and `<name>.bat` before raising an error.

## Testing

Ran `test_learn/test_analyzer.py` and `test_verbosity_controller.py` — **87 passed, 1 pre-existing failure** (`test_includes_project_info` expects Linux path `/tmp/test-project` but gets Windows path `\\tmp\test-project`). That failure is unrelated to this PR.

Verified the cwd reverse lookup resolves correctly:
```
D--work-vibe-remote → reads cwd: D:\work\vibe-remote ✓
D--work-DPJ → reads cwd: D:\work\DPJ ✓
```
