### PR TITLE
fix(wrap): use -P for the proxy subprocess to avoid cwd package shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `<headroom_proactive_expansion>` XML tags, giving downstream consumers
   (LLMs, loggers, attribution parsers) a machine-readable provenance
   boundary and preventing misattribution in multi-agent threads.
+- `headroom wrap <tool>` now launches its proxy subprocess with `-P`
+  (`PYTHONSAFEPATH`). Without it, running `headroom wrap` from inside a
+  checkout that has its own top-level `headroom/` package (e.g. this repo)
+  shadowed the installed package with the unbuilt source tree, dropping the
+  compiled `headroom._core` extension and failing with
+  `No module named 'headroom._core'`.
 
 ### Changed
 

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -398,7 +398,12 @@ def _start_proxy(
     `~/.headroom/logs/proxy-stdio.log`, to avoid pipe deadlock risk without
     competing with the rotating `proxy.log` runtime log.
     """
-    cmd = [sys.executable, "-m", "headroom.cli", "proxy", "--port", str(port)]
+    # -P (PYTHONSAFEPATH): don't prepend the launching process's cwd to
+    # sys.path. Without it, running `headroom wrap <tool>` from inside a
+    # checkout that happens to contain a top-level `headroom/` package (e.g.
+    # this repo) shadows the installed package with the unbuilt source tree,
+    # dropping the compiled `headroom._core` extension the proxy needs.
+    cmd = [sys.executable, "-P", "-m", "headroom.cli", "proxy", "--port", str(port)]
 
     # Forward HEADROOM_MODE env var so the proxy respects the user's mode choice
     headroom_mode = os.environ.get("HEADROOM_MODE")

--- a/tests/test_cli/test_wrap_proxy_detach.py
+++ b/tests/test_cli/test_wrap_proxy_detach.py
@@ -51,6 +51,30 @@ def _capture_popen_kwargs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> di
     return captured
 
 
+def test_start_proxy_uses_safe_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The proxy subprocess must run with -P so its cwd never shadows the
+    installed package -- e.g. `headroom wrap claude` invoked from inside a
+    checkout that has its own top-level `headroom/` package would otherwise
+    import that unbuilt source tree instead, dropping `headroom._core`."""
+    captured_cmd: list[Any] = []
+
+    def _fake_popen(cmd: Any, **kwargs: Any) -> _FakeProc:
+        captured_cmd.clear()
+        captured_cmd.extend(cmd)
+        return _FakeProc()
+
+    monkeypatch.setattr(wrap_cli.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: True)
+    monkeypatch.setattr(wrap_cli.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_cli, "_resolve_wrap_proxy_timeout_seconds", lambda: 1)
+
+    wrap_cli._start_proxy(8787)
+
+    assert captured_cmd[0] == wrap_cli.sys.executable
+    assert captured_cmd[1] == "-P"
+
+
 def test_start_proxy_detaches_on_windows(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     # Force the Windows branch regardless of the host OS, and supply the
     # Windows-only ``subprocess`` constants the host lacks on POSIX.


### PR DESCRIPTION
## Description

`headroom wrap <tool>` starts its shared proxy via `python -m headroom.cli proxy` (`_start_proxy()` in `headroom/cli/wrap.py`). Because `-m` prepends the launching process's current working directory to `sys.path`, running `headroom wrap claude` (or any wrapped tool) from inside a checkout that has its own top-level `headroom/` package -- this repo itself -- shadows the properly `uv tool install`ed package with the local, unbuilt source tree. That local tree has no compiled `headroom._core` extension, so proxy startup fails with `No module named 'headroom._core'`.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `headroom/cli/wrap.py`: add `-P` (`PYTHONSAFEPATH`) to the proxy subprocess command in `_start_proxy()`, disabling the cwd-based `sys.path` insertion.
- `CHANGELOG.md`: note the fix under `Unreleased` / `Fixed`.
- `tests/test_cli/test_wrap_proxy_detach.py`: add `test_start_proxy_uses_safe_path`, asserting the spawned command includes `-P`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run --extra dev --extra proxy pytest -q tests/test_cli/test_wrap_proxy_detach.py
collected 5 items
tests/test_cli/test_wrap_proxy_detach.py .....                           [100%]
5 passed in 0.57s

$ uv run --extra dev --extra proxy ruff check headroom/cli/wrap.py tests/test_cli/test_wrap_proxy_detach.py
All checks passed!

$ uv run --extra dev --extra proxy ruff format --check headroom/cli/wrap.py tests/test_cli/test_wrap_proxy_detach.py
2 files already formatted

$ uv run --extra dev --extra proxy mypy headroom/cli/wrap.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- **Environment**: Linux, Python 3.14, `headroom-ai` installed via `uv tool install headroom-ai[all]` (published 0.28.0); this checkout is the 0.29.0-dev tree; repro run with `cwd` = repo root.
- **Exact command / steps**:
  1. From the repo root, run `headroom wrap claude --version` (or any `headroom wrap <tool>`).
  2. Before the fix, the spawned proxy subprocess crashes:
     `Error: Proxy dependencies not installed. Run: pip install headroom-ai[proxy]` / `Details: No module named 'headroom._core'`.
  3. Isolated the cause directly with the installed interpreter:
     ```
     $ cd <repo> && .../headroom-ai/bin/python -c "import headroom; print(headroom.__file__)"
     headroom module file: <repo>/headroom/__init__.py          # wrong copy, no _core

     $ cd <repo> && .../headroom-ai/bin/python -P -c "import headroom; print(headroom.__file__)"
     headroom module file: .../site-packages/headroom/__init__.py   # correct copy, _core OK
     ```
  4. After adding `-P` to `_start_proxy()`'s command and re-running `headroom wrap claude --version` from the same cwd: the proxy starts cleanly (`Proxy ready on http://127.0.0.1:8787`) and `claude --version` runs through it end to end.
- **Observed result**: proxy startup no longer depends on the launching shell's `cwd`; it consistently loads the installed package with the compiled `headroom._core` extension.
- **Not tested**: Windows/macOS (the fix is a portable CPython interpreter flag with no platform-specific behavior expected); `headroom/install/runtime.py`'s persistent-deployment path uses the same `python -m headroom.cli proxy` pattern and would benefit from the same fix, but that's left out of this PR's scope.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

`headroom/install/runtime.py`'s `build_runtime_command()` has the identical `[sys.executable, "-m", "headroom.cli", "proxy", ...]` pattern for the persistent-deployment `PYTHON` runtime kind, and would hit the same shadowing bug. Left out of this PR to keep the change minimal and single-purpose; happy to follow up separately.
