### PR TITLE
fix(learn): honor CLAUDE_CONFIG_DIR when locating Claude logs and memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- `headroom learn` now honors `CLAUDE_CONFIG_DIR`. It resolved the Claude
+  config directory as `~/.claude` and wrote global memory to
+  `~/.claude/CLAUDE.md`, so users who relocate their Claude config via that
+  env var had `learn` scan the wrong directory and detect no projects. The
+  scanner and memory writer now read/write the configured directory
+  ([#1630](https://github.com/headroomlabs-ai/headroom/issues/1630)).
 - Proactive expansion blocks injected into user turns are now wrapped in
   `<headroom_proactive_expansion>` XML tags, giving downstream consumers
   (LLMs, loggers, attribution parsers) a machine-readable provenance

--- a/headroom/learn/_shared.py
+++ b/headroom/learn/_shared.py
@@ -6,9 +6,24 @@ used across all scanner plugins.
 
 from __future__ import annotations
 
+import os
 import re
+from pathlib import Path
 
 from .models import ErrorCategory
+
+
+def claude_config_dir() -> Path:
+    """Resolve the Claude Code config directory, honoring ``CLAUDE_CONFIG_DIR``.
+
+    Claude Code relocates its config (including ``projects/`` logs and the
+    global ``CLAUDE.md``) when ``CLAUDE_CONFIG_DIR`` is set. ``headroom learn``
+    must read and write the same directory, mirroring the override already
+    honored in ``subscription`` and ``mcp_registry``. Falls back to
+    ``~/.claude``.
+    """
+    base = os.environ.get("CLAUDE_CONFIG_DIR")
+    return Path(base) if base else Path.home() / ".claude"
 
 # =============================================================================
 # Error Classification

--- a/headroom/learn/_shared.py
+++ b/headroom/learn/_shared.py
@@ -25,6 +25,7 @@ def claude_config_dir() -> Path:
     base = os.environ.get("CLAUDE_CONFIG_DIR")
     return Path(base) if base else Path.home() / ".claude"
 
+
 # =============================================================================
 # Error Classification
 # =============================================================================

--- a/headroom/learn/plugins/claude.py
+++ b/headroom/learn/plugins/claude.py
@@ -10,7 +10,7 @@ import logging
 import re
 from pathlib import Path, PureWindowsPath
 
-from .._shared import classify_error, is_error_content
+from .._shared import classify_error, claude_config_dir, is_error_content
 from ..base import ConversationScanner, LearnPlugin
 from ..models import (
     ErrorCategory,
@@ -33,7 +33,7 @@ class ClaudeCodePlugin(LearnPlugin, ConversationScanner):
     """
 
     def __init__(self, claude_dir: Path | None = None):
-        self.claude_dir = claude_dir or Path.home() / ".claude"
+        self.claude_dir = claude_dir or claude_config_dir()
         self.projects_dir = self.claude_dir / "projects"
 
     # --- LearnPlugin identity ---

--- a/headroom/learn/writer.py
+++ b/headroom/learn/writer.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from pathlib import Path
 
+from ._shared import claude_config_dir
 from .models import (
     ProjectInfo,
     Recommendation,
@@ -274,10 +275,11 @@ class ClaudeCodeWriter(ContextWriter):
         if self._context_target is not None:
             target = Path(self._context_target).expanduser()
             return target if target.is_absolute() else project.project_path / target
-        # The home directory's CLAUDE.md (~/.claude/CLAUDE.md) is the user's
-        # personal global memory, not a team-shared file, so keep writing there.
+        # The home directory's CLAUDE.md (~/.claude/CLAUDE.md, or
+        # $CLAUDE_CONFIG_DIR/CLAUDE.md) is the user's personal global memory,
+        # not a team-shared file, so keep writing there.
         if project.project_path == Path.home():
-            return Path.home() / ".claude" / "CLAUDE.md"
+            return claude_config_dir() / "CLAUDE.md"
         # Project level: default to the gitignored, personal CLAUDE.local.md so
         # we never pollute the team-shared CLAUDE.md (issue #1072).
         return project.project_path / "CLAUDE.local.md"

--- a/tests/test_learn/test_claude_config_dir.py
+++ b/tests/test_learn/test_claude_config_dir.py
@@ -1,0 +1,54 @@
+"""Regression tests: `headroom learn` honors CLAUDE_CONFIG_DIR (issue #1630).
+
+Claude Code relocates its config (conversation logs under ``projects/`` and the
+global ``CLAUDE.md``) when ``CLAUDE_CONFIG_DIR`` is set. The learn scanner and
+memory writer previously hardcoded ``~/.claude``, so they scanned/wrote the
+wrong directory and detected no projects for such users.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from headroom.learn._shared import claude_config_dir
+from headroom.learn.models import ProjectInfo
+from headroom.learn.plugins.claude import ClaudeCodePlugin
+from headroom.learn.writer import ClaudeCodeWriter
+
+
+def test_config_dir_honors_env(tmp_path, monkeypatch) -> None:
+    custom = tmp_path / "custom-claude"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+    assert claude_config_dir() == custom
+
+
+def test_config_dir_defaults_to_home(monkeypatch) -> None:
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    assert claude_config_dir() == Path.home() / ".claude"
+
+
+def test_plugin_scans_config_dir_override(tmp_path, monkeypatch) -> None:
+    custom = tmp_path / "custom-claude"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+    plugin = ClaudeCodePlugin()
+    assert plugin.claude_dir == custom
+    assert plugin.projects_dir == custom / "projects"
+
+
+def test_plugin_explicit_dir_wins_over_env(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "env"))
+    explicit = tmp_path / "explicit"
+    plugin = ClaudeCodePlugin(claude_dir=explicit)
+    assert plugin.claude_dir == explicit
+
+
+def test_writer_home_memory_follows_config_dir(tmp_path, monkeypatch) -> None:
+    custom = tmp_path / "custom-claude"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+    writer = ClaudeCodeWriter()
+    project = ProjectInfo(
+        name="home",
+        project_path=Path.home(),
+        data_path=custom / "projects",
+    )
+    assert writer._resolve_context_path(project) == custom / "CLAUDE.md"


### PR DESCRIPTION
## Description

`headroom learn` ignored `CLAUDE_CONFIG_DIR`. `ClaudeCodePlugin.__init__` resolved the Claude config directory as `~/.claude`, and the memory writer wrote the global `CLAUDE.md` to `~/.claude/CLAUDE.md`. A user who relocates their Claude config with that env var had `learn` scan the wrong directory and detect no projects.

Other parts of the codebase already honor the override (`subscription/client.py`, `subscription/session_tracking.py`, `mcp_registry/claude.py`); the `learn` path was the outlier.

Closes #1630

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Add `claude_config_dir()` to `headroom/learn/_shared.py` — returns `$CLAUDE_CONFIG_DIR` when set, else `~/.claude` (via `Path.home()`, matching the existing override elsewhere).
- `ClaudeCodePlugin.__init__` now defaults `claude_dir` to `claude_config_dir()` instead of a hardcoded `~/.claude` (an explicit `claude_dir=` argument still wins).
- `ClaudeCodeWriter._resolve_context_path` writes the home-directory global memory to `claude_config_dir() / "CLAUDE.md"` instead of `~/.claude/CLAUDE.md`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/test_learn/test_claude_config_dir.py tests/test_learn/test_writer.py -q
35 passed, 1 warning in 0.18s

$ ruff check headroom/learn/ tests/test_learn/test_claude_config_dir.py
All checks passed!

$ mypy headroom/learn/_shared.py headroom/learn/plugins/claude.py headroom/learn/writer.py
Success: no issues found in 3 source files
```

## Real Behavior Proof

- Environment: macOS (arm64), Python 3.14 venv, editable install of this branch.
- Exact command / steps: ran `python -c "from headroom.learn.plugins.claude import ClaudeCodePlugin; print(ClaudeCodePlugin().projects_dir)"` with and without `CLAUDE_CONFIG_DIR=/tmp/altclaude` set, then `pytest tests/test_learn/ tests/test_cli_learn.py`.
- Observed result: default prints `/Users/<me>/.claude/projects`; with `CLAUDE_CONFIG_DIR=/tmp/altclaude` it prints `/tmp/altclaude/projects` (before this change the second still printed `~/.claude/projects`). Test suite: 226 passed, 3 skipped. New regression tests cover the plugin scan dir, explicit-arg precedence, and the writer's home-memory path.
- Not tested: end-to-end `headroom learn` against a real relocated log tree with live Claude Code transcripts — verified at the plugin/writer resolution layer plus the existing scanner suite.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Additional Notes

The identical hardcode also exists at `headroom/cli/mcp.py:21` (`CLAUDE_CONFIG_DIR = Path.home() / ".claude"`), but that is a separate command outside this issue's scope, so I left it for a follow-up to keep this PR to one issue.
