### PR TITLE
fix(deps): bump transformers 5.0.0→5.12.1 (CVE-2026-4372)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -6187,7 +6187,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.3.0"
+version = "5.12.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -6201,9 +6201,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/1a/70e830d53ecc96ce69cfa8de38f163712d2b43ac52fbd743f39f56025c31/transformers-5.3.0.tar.gz", hash = "sha256:009555b364029da9e2946d41f1c5de9f15e6b1df46b189b7293f33a161b9c557", size = 8830831, upload-time = "2026-03-04T17:41:46.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/7c/8240f612819718100a9346dc28dea6a11370c3ca9c8c6eabadd3dea4ef29/transformers-5.12.1.tar.gz", hash = "sha256:679ee731c8225347889ad4fb3b2c926a62e9da3b7d284e9d12c791da7272466b", size = 8924054, upload-time = "2026-06-15T17:27:50.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/88/ae8320064e32679a5429a2c9ebbc05c2bf32cefb6e076f9b07f6d685a9b4/transformers-5.3.0-py3-none-any.whl", hash = "sha256:50ac8c89c3c7033444fb3f9f53138096b997ebb70d4b5e50a2e810bf12d3d29a", size = 10661827, upload-time = "2026-03-04T17:41:42.722Z" },
+    { url = "https://files.pythonhosted.org/packages/df/56/bbd60dd8668055803bf8ba55a81f9b8a8b31497f620109a9671d26a2076d/transformers-5.12.1-py3-none-any.whl", hash = "sha256:2a5e109d2021265df7098ffbb738295acaf5ad256f12cbc586db2ea4dcbb1a8a", size = 11150587, upload-time = "2026-06-15T17:27:46.679Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Bump `transformers` from 5.3.0 to 5.12.1 to fix CVE-2026-4372 — a critical RCE vulnerability in HuggingFace Transformers that allows arbitrary code execution via a malicious `config.json` when loading models with `from_pretrained()`.

pyproject.toml constraint (`>=4.30.0,<6.0`) already permits this version; only the lock file needs updating.

## Type of Change

- [x] Bug fix (dependency version bump to address a CVE)

## Changes Made

- Ran `uv lock --upgrade-package "transformers>=5.3.0"` to update the lock file
- transformers upgraded 5.3.0 → 5.12.1

## Testing

- [x] `uv lock` resolved without errors
- [x] `uv export --frozen --no-dev --no-emit-project --no-hashes --extra all --format requirements-txt` produces a valid requirements file

### Test Output

```text
$ uv lock --upgrade-package "transformers>=5.3.0"
Resolved 256 packages in 9.25s
Updated transformers v5.3.0 -> v5.12.1

$ git diff --stat uv.lock
 uv.lock | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

## Real Behavior Proof

- Environment: Ubuntu 24.04, Python 3.12.3, uv
- Exact command / steps: `uv lock --upgrade-package "transformers>=5.3.0"` on latest upstream/main
- Observed result: transformers updated to 5.12.1, only uv.lock changed, 3 insertions / 3 deletions
- Not tested: Runtime integration tests with Kompress (transformers is used as a tokenizer only in headroom; the CVE's RCE path via `from_pretrained()` is not exercised by headroom's code path)

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
