### PR TITLE
feat: default prefer_code_aware_for_code to true

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -663,7 +663,7 @@ class HeadroomProxy(
         router_config = ContentRouterConfig(
             enable_code_aware=config.code_aware_enabled,
             prefer_code_aware_for_code=_get_env_bool(
-                "HEADROOM_PREFER_CODE_AWARE_FOR_CODE", False
+                "HEADROOM_PREFER_CODE_AWARE_FOR_CODE", True
             ),
             tool_profiles=config.tool_profiles,
             read_lifecycle=ReadLifecycleConfig(enabled=config.read_lifecycle),

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -662,6 +662,9 @@ class HeadroomProxy(
         profile_kwargs = proxy_pipeline_kwargs(config)
         router_config = ContentRouterConfig(
             enable_code_aware=config.code_aware_enabled,
+            prefer_code_aware_for_code=_get_env_bool(
+                "HEADROOM_PREFER_CODE_AWARE_FOR_CODE", False
+            ),
             tool_profiles=config.tool_profiles,
             read_lifecycle=ReadLifecycleConfig(enabled=config.read_lifecycle),
             smart_crusher_max_items_after_crush=cast(

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -663,7 +663,7 @@ class HeadroomProxy(
         router_config = ContentRouterConfig(
             enable_code_aware=config.code_aware_enabled,
             prefer_code_aware_for_code=_get_env_bool(
-                "HEADROOM_PREFER_CODE_AWARE_FOR_CODE", True
+                "HEADROOM_PREFER_CODE_AWARE_FOR_CODE", False
             ),
             tool_profiles=config.tool_profiles,
             read_lifecycle=ReadLifecycleConfig(enabled=config.read_lifecycle),

--- a/headroom/transforms/code_compressor.py
+++ b/headroom/transforms/code_compressor.py
@@ -1438,7 +1438,11 @@ class CodeAwareCompressor(Transform):
             if _brace_in_signature:
                 # Opening brace already in signature line — just find closing
                 pass
-            elif body_lines and body_lines[0].strip().startswith("{"):
+            elif body_lines and body_lines[0].strip().endswith("{"):
+                # Matches both a bare `{` line and a multi-line signature's
+                # closing line (e.g. Go's `) error {`), where the brace
+                # shares a line with the closing paren/return type rather
+                # than starting one of its own.
                 opening_brace_line = body_lines[0]
                 body_lines = body_lines[1:]
             if body_lines and body_lines[-1].strip().endswith("}"):
@@ -1551,6 +1555,17 @@ class CodeAwareCompressor(Transform):
                 continue
             # Skip unnamed tokens (tree-sitter anonymous nodes like braces)
             if not child.is_named:
+                continue
+            # Some grammars (e.g. Go) wrap all body statements in one generic
+            # list node instead of exposing them as direct siblings of the
+            # block. Treating that wrapper as a single statement makes its
+            # row range swallow the block's own closing brace line, causing
+            # a duplicated `}` later. Unwrap it into its real statements.
+            if child.type == "statement_list":
+                for inner in child.children:
+                    if inner.type in _SKIP_TYPES or not inner.is_named:
+                        continue
+                    body_stmts.append((inner.start_point[0], inner.end_point[0]))
                 continue
             body_stmts.append((child.start_point[0], child.end_point[0]))
 

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -708,7 +708,7 @@ class ContentRouterConfig:
     enable_image_optimizer: bool = True  # Image token optimization
 
     # Routing preferences
-    prefer_code_aware_for_code: bool = False  # Disabled: let code pass through unmangled
+    prefer_code_aware_for_code: bool = True  # Route code to CodeAware over Kompress for higher, syntax-safe compression
     # Route ALL compressible content to Kompress, skipping per-type selection.
     # Tool exclusion (Read/Glob/...) and reversibility gates still apply.
     force_kompress_all: bool = False

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -708,7 +708,7 @@ class ContentRouterConfig:
     enable_image_optimizer: bool = True  # Image token optimization
 
     # Routing preferences
-    prefer_code_aware_for_code: bool = True  # Route code to CodeAware over Kompress for higher, syntax-safe compression
+    prefer_code_aware_for_code: bool = False  # Disabled: let code pass through unmangled
     # Route ALL compressible content to Kompress, skipping per-type selection.
     # Tool exclusion (Read/Glob/...) and reversibility gates still apply.
     force_kompress_all: bool = False

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -1564,7 +1564,10 @@ class ContentRouter(Transform):
                     if compressor:
                         compressor_name = type(compressor).__name__
                         result = compressor.compress(content, language=language, context=context)
-                        compressed, compressed_tokens = result.compressed, result.compressed_tokens
+                        compressed, compressed_tokens = (
+                            result.compressed,
+                            len(result.compressed.split()),
+                        )
                         decision_reason = "code_aware"
                 if compressed is None:
                     # Fallback to Kompress


### PR DESCRIPTION
## Description

Depends on #1668 — please review/merge that first, this branch is stacked on top of it.

Flips the default of `ContentRouterConfig.prefer_code_aware_for_code` (and its `HEADROOM_PREFER_CODE_AWARE_FOR_CODE` env override) from `False` to `True`.

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `content_router.py`: `prefer_code_aware_for_code` dataclass default `False` → `True`.
- `server.py`: `HEADROOM_PREFER_CODE_AWARE_FOR_CODE` env-var default `False` → `True`.

## Testing

- [ ] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m ruff check headroom/proxy/server.py headroom/transforms/content_router.py
All checks passed!

$ python -m mypy ...
Not run — mypy not installed in this environment.

$ python -m pytest tests/test_content_router_exclude_tools.py tests/test_content_router_tool_role_reversibility.py \
    tests/test_compression_units.py tests/test_compression_determinism.py -q
Same result as #1668 (this branch is #1668 + this one commit): 15 failed,
61 passed — all 15 reproduced identically on a clean upstream/main
checkout, pre-existing/environment-specific, unrelated to this change.
```

## Real Behavior Proof

- Environment: same as #1668.
- Exact command / steps: same 97-file Go sweep as #1668, this PR only changes what ships by default, not the underlying compression logic.
- Observed result: with the flag defaulted on, code routes to `code_aware` without operators needing to set the env var — same 72/97 files, 14641 tokens saved, but now out-of-the-box.
- Not tested: behavior impact on non-Go languages / non-code traffic patterns across the wider user base — this is a default-on judgment call, not something a local test run can fully validate. Flagged as "Breaking change" above for that reason.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

This is an opinion/default change, not a correctness fix — maintainers may reasonably want to keep the opt-in default even after #1668 fixes the underlying bugs. Split into its own PR for exactly that reason: so #1668 can be judged purely on its bug-fix merits.