### PR TITLE
docs(readme): fix lean-ctx Reversible column — it ships 5 recovery paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Headroom runs **locally**, covers **every** content type, works with every major
 |------------------------------------------------------------------------------|------------------------------------------------|------------------------------------|:-----:|:----------:|
 | **Headroom**                                                                 | All context — tools, RAG, logs, files, history | Proxy · library · middleware · MCP | Yes   | Yes        |
 | [RTK](https://github.com/rtk-ai/rtk)                                        | CLI command outputs                            | CLI wrapper                        | Yes   | No         |
-| [lean-ctx](https://github.com/yvgude/lean-ctx)                               | CLI commands, MCP tools, editor rules          | CLI wrapper · MCP                  | Yes   | No         |
+| [lean-ctx](https://github.com/yvgude/lean-ctx)                               | CLI commands, MCP tools, editor rules          | CLI wrapper · MCP                  | Yes   | Yes        |
 | [Compresr](https://compresr.ai), [Token Co.](https://thetokencompany.ai)    | Text sent to their API                         | Hosted API call                    | No    | No         |
 | OpenAI Compaction                                                            | Conversation history                           | Provider-native                    | No    | No         |
 


### PR DESCRIPTION
## Description

lean-ctx compression is reversible by design — content is never discarded, it moves to a content-addressable store with 5 recovery paths. The "Compared to" table in the README incorrectly listed lean-ctx as `Reversible: No`. This PR corrects it to `Yes`.

Reported by lean-ctx maintainer @davidmiller in #1675.

## Type of Change

- [x] Documentation update

## Changes Made

- `README.md` — lean-ctx row in comparison table: `Reversible: No` → `Yes` (1 character change)

## Testing

- [x] No code changes — docs-only PR
- [x] Table alignment verified (column widths maintained)
- [x] Link URL unchanged (`https://github.com/yvgude/lean-ctx`)

### Test Output

```text
$ git diff upstream/main...HEAD
diff --git a/README.md b/README.md
-| [lean-ctx](https://github.com/yvgude/lean-ctx) | CLI commands, MCP tools, editor rules | CLI wrapper · MCP | Yes   | No         |
+| [lean-ctx](https://github.com/yvgude/lean-ctx) | CLI commands, MCP tools, editor rules | CLI wrapper · MCP | Yes   | Yes        |
```

## Real Behavior Proof

- Environment: Any text editor (docs-only change)
- Exact command / steps: `git show -- README.md | grep "lean-ctx"`
- Observed result: Reversible column shows `Yes` for lean-ctx
- Not tested: N/A — single-character table cell edit

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
