### PR TITLE
fix(release): build and publish Windows x86_64 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,15 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             manylinux: ""
+          # Windows x86_64 (MSVC). Unlike the macOS Intel case above,
+          # `ort-sys` DOES ship prebuilt ONNX Runtime binaries for
+          # `x86_64-pc-windows-msvc`, so no source build / CMake needed
+          # here. Fixes #1144: no Windows wheel has ever been published,
+          # so `headroom._core` is silently missing and every compressor
+          # falls back to a no-op on Windows installs.
+          - os: windows-2022
+            target: x86_64-pc-windows-msvc
+            manylinux: ""
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -499,6 +508,9 @@ jobs:
           # ship today (Intel macOS dropped in PR #371 — ort-sys
           # has no x86_64-apple-darwin prebuilts).
           - { runner: macos-14, image: "", python: "3.13", wheel_target: aarch64-apple-darwin, wheel_artifact: wheels-macos-14-aarch64-apple-darwin, glibc_label: "" }
+          # Windows x86_64 — runs natively on the host runner; no
+          # container, no glibc floor. See #1144.
+          - { runner: windows-2022, image: "", python: "3.12", wheel_target: x86_64-pc-windows-msvc, wheel_artifact: wheels-windows-2022-x86_64-pc-windows-msvc, glibc_label: "" }
 
     steps:
       - name: Download wheels artifact for this target
@@ -525,6 +537,7 @@ jobs:
         #    YAML `run: |` level (uniform strip), the docker container
         #    sees it as a read-only mount, and macOS host runs the
         #    same script — no quoting drift between paths.
+        shell: bash
         run: |
           cat > "${RUNNER_TEMP}/smoke_import.py" <<'PY'
           import sys
@@ -640,7 +653,7 @@ jobs:
             '
 
       - name: Smoke-import wheel on macOS host
-        if: matrix.image == ''
+        if: matrix.image == '' && runner.os == 'macOS'
         env:
           PYTHON_VERSION: ${{ matrix.python }}
         run: |
@@ -676,6 +689,37 @@ jobs:
           # Same staged smoke script as the Linux container path uses,
           # invoked directly on the macOS host (no docker mount needed).
           /tmp/venv/bin/python "${RUNNER_TEMP}/smoke_import.py"
+
+      - name: Smoke-import wheel on Windows host
+        if: matrix.image == '' && runner.os == 'Windows'
+        shell: pwsh
+        env:
+          PYTHON_VERSION: ${{ matrix.python }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $pyTag = "cp" + $env:PYTHON_VERSION.Replace(".", "")
+
+          # Windows wheels are tagged win_amd64.
+          $whl = Get-ChildItem -Path dist -Filter "headroom_ai-*-$pyTag-$pyTag-win_amd64.whl" -File | Select-Object -First 1
+          if (-not $whl) {
+            # Stable-ABI (abi3) fallback — see the Linux/macOS paths above.
+            $pyMinor = [int]($env:PYTHON_VERSION -split '\.')[1]
+            $abi3 = Get-ChildItem -Path dist -Filter "headroom_ai-*-abi3-win_amd64.whl" -File | Select-Object -First 1
+            if ($abi3 -and $abi3.Name -match 'cp3(\d+)-abi3') {
+              if ([int]$Matches[1] -le $pyMinor) { $whl = $abi3 }
+            }
+          }
+          if (-not $whl) {
+            Write-Error "no Windows wheel matching python=$env:PYTHON_VERSION"
+            Get-ChildItem -Path dist -File | ForEach-Object { $_.Name }
+            exit 1
+          }
+          Write-Host "Installing: $($whl.FullName)"
+
+          py -$env:PYTHON_VERSION -m venv .venv-smoke
+          .venv-smoke\Scripts\python.exe -m pip install --quiet --upgrade pip
+          .venv-smoke\Scripts\python.exe -m pip install --quiet "$($whl.FullName)"
+          .venv-smoke\Scripts\python.exe "$env:RUNNER_TEMP\smoke_import.py"
 
   publish-pypi:
     needs: [collect-dist, smoke-import-wheels]


### PR DESCRIPTION
## Summary
- `release.yml`'s wheel matrix never had a Windows target — only `linux x86_64/arm64` and `macOS arm64` wheels are built. No Windows wheel has ever shipped, so `pip install headroom-ai` on Windows falls back to source (or fails outright), leaving `headroom._core` missing and every compressor silently no-op'ing (`compress()` catches `ModuleNotFoundError` and returns input unchanged).
- Rust side is already Windows-ready: dynamic ORT loading via `ort-load-dynamic` on `cfg(windows)` landed for the AVX2 SIGILL fix (#1715), and `ort-sys` ships prebuilt ONNX Runtime binaries for `x86_64-pc-windows-msvc` — no CMake/source build needed the way `x86_64-apple-darwin` requires.
- Adds a `windows-2022` / `x86_64-pc-windows-msvc` row to `build-wheels`, plus a matching `smoke-import-wheels` entry (PowerShell) that installs the built wheel into a clean venv and imports `headroom._core`, gating publish the same way the Linux/macOS rows do.

Fixes #1144 (Bug 1 — missing Windows wheel).

Bug 2 in that issue (`headroom --help` crashing with `ModuleNotFoundError: fastapi` on a core-only install) is already fixed on `main`: `headroom.proxy.server` is lazily imported inside the `proxy` command, not at CLI module load time. Verified locally by invoking `headroom --help` with `fastapi` import blocked via a meta-path finder — exits 0.

## Test plan
- [x] `tests/test_release_workflows.py` — 28 passed, 1 pre-existing unrelated failure (`test_no_native_tls_in_wheel_build_tree`, reproduces on clean `main` too — local `cargo tree` environment issue)
- [x] `.github/workflows/release.yml` parses as valid YAML
- [x] Verified `headroom --help` doesn't require `fastapi` on current `main` (Bug 2 already fixed)
- [ ] CI run of the new `build-wheels` / `smoke-import-wheels` Windows matrix rows on this PR (release.yml triggers a dry-run on PRs touching `crates/headroom-py/**`... this PR only touches `release.yml` itself, which is also in the path filter, so the dry-run should fire)