### PR TITLE
fix(router): stop protecting passing build/test output as error traces

### DIFF
--- a/.github/pr-images/issue-1696-error-protection-fix.svg
+++ b/.github/pr-images/issue-1696-error-protection-fix.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" font-family="Segoe UI, Helvetica, Arial, sans-serif">
+  <rect x="0" y="0" width="1200" height="900" fill="#ffffff"/>
+  <text x="600" y="36" text-anchor="middle" font-size="22" font-weight="700" fill="#111827">Headroom: Error-Output Protection False-Positive Fix (#1696)</text>
+
+  <!-- Box 1: pipeline -->
+  <g>
+    <rect x="20" y="60" width="560" height="190" rx="10" fill="#eff6ff" stroke="#2563eb"/>
+    <text x="36" y="88" font-size="15" font-weight="700" fill="#1d4ed8">1. THE GATE</text>
+    <text x="36" y="112" font-size="13" fill="#111827">content_router.py routes every message/content-block through</text>
+    <text x="36" y="130" font-size="13" fill="#111827">content_has_strong_error_indicators() before deciding whether</text>
+    <text x="36" y="148" font-size="13" fill="#111827">to compress it or protect it (pass through untouched).</text>
+    <text x="36" y="176" font-size="13" fill="#111827">Rule: if the text contains 2+ DISTINCT keywords from</text>
+    <text x="36" y="194" font-size="13" font-family="Consolas, monospace" fill="#b91c1c">[error, fail, exception, traceback, fatal, panic, crash]</text>
+    <text x="36" y="218" font-size="13" fill="#111827">the block is protected — assumed to be a real failure trace.</text>
+  </g>
+
+  <!-- Box 2: the bug -->
+  <g>
+    <rect x="620" y="60" width="560" height="190" rx="10" fill="#fef2f2" stroke="#dc2626"/>
+    <text x="636" y="88" font-size="15" font-weight="700" fill="#b91c1c">2. THE BUG</text>
+    <text x="636" y="112" font-size="13" fill="#111827">Passing build/test output mentions BOTH words without failing:</text>
+    <text x="636" y="136" font-size="13" font-family="Consolas, monospace" fill="#111827">tsc:   "Found 0 errors"</text>
+    <text x="636" y="156" font-size="13" font-family="Consolas, monospace" fill="#111827">jest:  "0 failures, 42 passed"</text>
+    <text x="636" y="184" font-size="13" fill="#111827">→ 2 distinct keyword hits ("error" + "fail") on a CLEAN run</text>
+    <text x="636" y="202" font-size="13" font-weight="700" fill="#b91c1c">→ wrongly protected, forever, from compression.</text>
+  </g>
+
+  <!-- Box 3: impact -->
+  <g>
+    <rect x="20" y="270" width="1160" height="150" rx="10" fill="#fff7ed" stroke="#ea580c"/>
+    <text x="36" y="298" font-size="15" font-weight="700" fill="#c2410c">3. OBSERVED IMPACT (issue #1696 stats.json)</text>
+    <text x="36" y="324" font-size="13" fill="#111827">In a long multi-turn JS/TS coding session (KiloCode via headroom proxy), "router:protected:error_output" fired on</text>
+    <text x="36" y="344" font-size="13" fill="#111827">nearly every request. Combined with tool-output exclusion and small-block skips, only a sliver of tokens were ever</text>
+    <text x="36" y="364" font-size="13" fill="#111827">eligible for compression.</text>
+    <rect x="900" y="325" width="60" height="60" fill="#fecaca"/>
+    <text x="930" y="360" text-anchor="middle" font-size="16" font-weight="700" fill="#7f1d1d">0.3%</text>
+    <text x="930" y="400" text-anchor="middle" font-size="11" fill="#111827">actual</text>
+    <rect x="980" y="285" width="60" height="100" fill="#bbf7d0"/>
+    <text x="1010" y="340" text-anchor="middle" font-size="14" font-weight="700" fill="#14532d">60-95%</text>
+    <text x="1010" y="400" text-anchor="middle" font-size="11" fill="#111827">expected</text>
+  </g>
+
+  <!-- Box 4: the fix -->
+  <g>
+    <rect x="20" y="440" width="560" height="200" rx="10" fill="#ecfdf5" stroke="#059669"/>
+    <text x="36" y="468" font-size="15" font-weight="700" fill="#047857">4. THE FIX</text>
+    <text x="36" y="494" font-size="13" fill="#111827">Strip common zero-result phrases before the keyword scan:</text>
+    <text x="36" y="516" font-size="13" font-family="Consolas, monospace" fill="#111827">"0 error(s)", "no error(s)", "0 failing",</text>
+    <text x="36" y="536" font-size="13" font-family="Consolas, monospace" fill="#111827">"0 failure(s)", "no failure(s)"</text>
+    <text x="36" y="562" font-size="13" fill="#111827">headroom/transforms/error_detection.py</text>
+    <text x="36" y="582" font-size="13" fill="#111827">content_has_strong_error_indicators()</text>
+    <text x="36" y="608" font-size="13" font-weight="700" fill="#047857">→ clean tool output no longer trips protection.</text>
+  </g>
+
+  <!-- Box 5: still safe -->
+  <g>
+    <rect x="620" y="440" width="560" height="200" rx="10" fill="#f5f3ff" stroke="#7c3aed"/>
+    <text x="636" y="468" font-size="15" font-weight="700" fill="#6d28d9">5. REAL FAILURES STILL PROTECTED</text>
+    <text x="636" y="494" font-size="13" font-family="Consolas, monospace" fill="#111827">Traceback (most recent call last):</text>
+    <text x="636" y="512" font-size="13" font-family="Consolas, monospace" fill="#111827">  ...</text>
+    <text x="636" y="530" font-size="13" font-family="Consolas, monospace" fill="#111827">ValueError: fatal error during load</text>
+    <text x="636" y="558" font-size="13" fill="#111827">"traceback" + "fatal" (+ "error") — 2+ distinct hits</text>
+    <text x="636" y="576" font-size="13" fill="#111827">outside a stripped zero-result phrase</text>
+    <text x="636" y="602" font-size="13" font-weight="700" fill="#6d28d9">→ still protected, correctly.</text>
+  </g>
+
+  <!-- Box 6: tests -->
+  <g>
+    <rect x="20" y="660" width="1160" height="140" rx="10" fill="#f8fafc" stroke="#334155"/>
+    <text x="36" y="688" font-size="15" font-weight="700" fill="#1e293b">6. TEST COVERAGE ADDED (tests/test_error_detection.py — none existed before)</text>
+    <text x="36" y="714" font-size="13" fill="#111827">✓ real error/traceback text is still flagged      ✓ single keyword mention is not flagged</text>
+    <text x="36" y="736" font-size="13" fill="#111827">✓ passing tsc summary ("Found 0 errors") is not flagged      ✓ passing eslint summary is not flagged</text>
+    <text x="36" y="758" font-size="13" fill="#111827">✓ "0 errors" text does not mask a real second indicator elsewhere in the same blob</text>
+    <text x="36" y="782" font-size="13" fill="#111827">All 5 new tests + full existing content_router suite (86 tests total) pass.</text>
+  </g>
+
+  <text x="600" y="850" text-anchor="middle" font-size="12" fill="#6b7280">Fixes GitHub issue #1696 · headroomlabs-ai/headroom</text>
+</svg>

--- a/headroom/transforms/error_detection.py
+++ b/headroom/transforms/error_detection.py
@@ -158,7 +158,10 @@ def content_has_error_indicators(text: str) -> bool:
 # scrubber must strip all of them too, not just the forms literally named
 # "failing"/"failure(s)".
 _ZERO_RESULT_PATTERN = re.compile(
+    # "0 errors" / "no failed" — count-first forms.
     r"\b(?:0|no)\s+(?:errors?|fail(?:ed|ing|ures?)?)\b"
+    # "Errors: 0" / "failed=0" — label:value / label=value forms used by
+    # other CI/test tools' summary lines.
     r"|\b(?:errors?|fail(?:ed|ing|ures?)?)\s*[:=]\s*0\b",
     re.IGNORECASE,
 )
@@ -180,6 +183,14 @@ def content_has_strong_error_indicators(text: str) -> bool:
     ``crash``), while passing mentions rarely do. Misses here are
     safe — downstream compressors (LogCompressor) still preserve
     error lines.
+
+    Before scanning, ``_ZERO_RESULT_PATTERN`` strips zero-result
+    summary phrases (``"0 errors"``, ``"failed: 0"``, ...) so a
+    passing build/test/lint run doesn't trip the two-keyword
+    threshold just because its PASS summary happens to mention both
+    "error" and "fail" at count zero (see issue #1696 — this was
+    firing on nearly every request in a long JS/TS coding session
+    and defeating compression almost entirely).
     """
     lowered = _ZERO_RESULT_PATTERN.sub(" ", text.lower())
     hits = 0

--- a/headroom/transforms/error_detection.py
+++ b/headroom/transforms/error_detection.py
@@ -145,6 +145,17 @@ def content_has_error_indicators(text: str) -> bool:
     return bool(_rust_content_has_error_indicators(text))
 
 
+# Success-summary phrases from common build/test/lint tools that legitimately
+# pair two indicator keywords (`error` + `fail`) while reporting a PASS, e.g.
+# tsc's "Found 0 errors", jest's "0 failing" / "0 failures", eslint's
+# "0 problems (0 errors, 0 warnings)". Stripped before the keyword scan below
+# so a clean JS/TS toolchain run doesn't get permanently protected from
+# compression for the rest of a long coding session (issue #1696).
+_ZERO_RESULT_PATTERN = re.compile(
+    r"\b(?:0|no)\s+(?:error|errors|failing|failure|failures)\b", re.IGNORECASE
+)
+
+
 def content_has_strong_error_indicators(text: str) -> bool:
     """Stricter triage for compression-protection gates.
 
@@ -162,7 +173,7 @@ def content_has_strong_error_indicators(text: str) -> bool:
     safe — downstream compressors (LogCompressor) still preserve
     error lines.
     """
-    lowered = text.lower()
+    lowered = _ZERO_RESULT_PATTERN.sub(" ", text.lower())
     hits = 0
     for keyword in ERROR_INDICATOR_KEYWORDS:
         if keyword in lowered:

--- a/headroom/transforms/error_detection.py
+++ b/headroom/transforms/error_detection.py
@@ -147,12 +147,20 @@ def content_has_error_indicators(text: str) -> bool:
 
 # Success-summary phrases from common build/test/lint tools that legitimately
 # pair two indicator keywords (`error` + `fail`) while reporting a PASS, e.g.
-# tsc's "Found 0 errors", jest's "0 failing" / "0 failures", eslint's
-# "0 problems (0 errors, 0 warnings)". Stripped before the keyword scan below
-# so a clean JS/TS toolchain run doesn't get permanently protected from
+# tsc's "Found 0 errors", jest's "0 failing" / "0 failures" / "0 failed",
+# eslint's "0 problems (0 errors, 0 warnings)", or label:value summaries like
+# "Failures: 0", "failed: 0", "Errors=0". Stripped before the keyword scan
+# below so a clean JS/TS toolchain run doesn't get permanently protected from
 # compression for the rest of a long coding session (issue #1696).
+#
+# `fail(?:ed|ing|ures?)?` covers fail/failed/failing/failure/failures — the
+# keyword scan below matches the "fail" substring inside all of them, so the
+# scrubber must strip all of them too, not just the forms literally named
+# "failing"/"failure(s)".
 _ZERO_RESULT_PATTERN = re.compile(
-    r"\b(?:0|no)\s+(?:error|errors|failing|failure|failures)\b", re.IGNORECASE
+    r"\b(?:0|no)\s+(?:errors?|fail(?:ed|ing|ures?)?)\b"
+    r"|\b(?:errors?|fail(?:ed|ing|ures?)?)\s*[:=]\s*0\b",
+    re.IGNORECASE,
 )
 
 

--- a/tests/test_error_detection.py
+++ b/tests/test_error_detection.py
@@ -1,0 +1,38 @@
+"""Regression tests for the error/importance detection triage helpers."""
+
+from __future__ import annotations
+
+from headroom.transforms.error_detection import content_has_strong_error_indicators
+
+
+def test_real_error_output_is_detected() -> None:
+    text = "Traceback (most recent call last):\n  ...\nValueError: fatal error during load"
+    assert content_has_strong_error_indicators(text)
+
+
+def test_single_keyword_mention_is_not_flagged() -> None:
+    # Only one distinct indicator keyword ("error") — should not trip the
+    # two-keyword threshold.
+    text = 'Wrote error_handler.py with an "errors": [] field.'
+    assert not content_has_strong_error_indicators(text)
+
+
+def test_tsc_passing_summary_is_not_flagged() -> None:
+    # Regression for issue #1696: a clean `tsc` run mentions both "error"
+    # and (via "0 failures" in a paired test run) "fail" while reporting
+    # success. Previously this tripped the two-keyword heuristic and got
+    # the message permanently protected from compression.
+    text = "Found 0 errors. Watching for file changes.\nTests: 0 failures, 42 passed"
+    assert not content_has_strong_error_indicators(text)
+
+
+def test_eslint_passing_summary_is_not_flagged() -> None:
+    text = "0 problems (0 errors, 0 warnings)\nno failing tests"
+    assert not content_has_strong_error_indicators(text)
+
+
+def test_zero_result_phrase_does_not_mask_a_real_second_error() -> None:
+    # "0 errors" is stripped, but a genuine second distinct indicator
+    # elsewhere in the same blob must still trigger protection.
+    text = "0 errors from linter, but the build crashed with a fatal signal"
+    assert content_has_strong_error_indicators(text)

--- a/tests/test_error_detection.py
+++ b/tests/test_error_detection.py
@@ -36,3 +36,23 @@ def test_zero_result_phrase_does_not_mask_a_real_second_error() -> None:
     # elsewhere in the same blob must still trigger protection.
     text = "0 errors from linter, but the build crashed with a fatal signal"
     assert content_has_strong_error_indicators(text)
+
+
+def test_zero_failed_form_is_not_flagged() -> None:
+    # Reviewer regression (PR #1740): "0 failed" wasn't covered by the
+    # original pattern (only "failing"/"failure(s)"), so "failed" still
+    # contributed a "fail" keyword hit alongside "0 errors" and tripped
+    # the false positive this fix targets.
+    text = "Found 0 errors\nTests: 0 failed, 42 passed"
+    assert not content_has_strong_error_indicators(text)
+
+
+def test_label_value_summary_formats_are_not_flagged() -> None:
+    # Broader CI summary formats (not just "N word" / "word N"): label:value
+    # and label=value pairs, in either error/fail order.
+    for text in (
+        "Failures: 0, Errors: 0",
+        "failed: 0, errors: 0",
+        "Errors=0 Failures=0",
+    ):
+        assert not content_has_strong_error_indicators(text), text


### PR DESCRIPTION
## Description

![Error output protection false-positive fix](https://raw.githubusercontent.com/ashishpatel26/headroom/fix/1696-error-protection-false-positive/.github/pr-images/issue-1696-error-protection-fix.svg)

`content_has_strong_error_indicators()` (`headroom/transforms/error_detection.py`) protects any message/content-block from compression when it contains 2+ distinct indicator keywords (`error`, `fail`, `exception`, `traceback`, `fatal`, `panic`, `crash`). That heuristic false-positives on **passing** build/test tool output: `tsc`'s `"Found 0 errors"` plus a passing test run's `"0 failures"` trips both `error` and `fail` — 2 distinct hits — despite nothing failing. In a long JS/TS coding session this fired on nearly every request (confirmed against the `stats.json` attached to #1696), permanently protecting legitimate tool output from ever being compressed and explaining the reported 0.3% savings vs. the advertised 60-95%.

Closes #1696

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/transforms/error_detection.py`: strip common zero-result phrases before the 2-keyword scan in `content_has_strong_error_indicators()` — both `"N word"`/`"word N"` forms (`"0 errors"`, `"no failures"`) and `"label:value"`/`"label=value"` forms (`"Failures: 0"`, `"errors=0"`), covering `error(s)` and `fail`/`failed`/`failing`/`failure(s)` (the scan matches `fail` by substring, so all inflections needed covering).
- `tests/test_error_detection.py` (new file — no prior coverage existed): 7 tests covering real error/traceback detection, single-keyword safety, `tsc`/`eslint` passing summaries, the `"0 failed"` regression a reviewer caught, label:value formats, and that a genuine second indicator elsewhere in the same blob still triggers protection.
- `.github/pr-images/issue-1696-error-protection-fix.svg`: diagram explaining the mechanism (embedded above).

## Testing

- [x] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`) — not run locally, CI `lint` check is green
- [ ] Type checking passes (`mypy headroom`) — not run locally, CI is green
- [x] New tests added for new functionality
- [x] Manual testing performed (see Real Behavior Proof)

### Test Output

```text
$ .venv/Scripts/python -m pytest tests/test_error_detection.py tests/test_transforms/test_content_router.py tests/test_transforms_content_router.py -q
tests\test_error_detection.py .......                                    [  7%]
tests\test_transforms\test_content_router.py ........................... [ 34%]
...........................                                              [ 62%]
tests\test_transforms_content_router.py ................................ [ 94%]
.....                                                                    [100%]
============================= 98 passed in 1.21s ==============================
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.14.5, local venv, `headroom._core` built via `maturin develop --release` (not prebuilt in a fresh checkout)
- Exact command / steps: ran the reporter's exact scenario patterns (`"Found 0 errors\nTests: 0 failures, 42 passed"`, eslint's `"0 problems (0 errors, 0 warnings)"`) through `content_has_strong_error_indicators()` directly, before and after the fix
- Observed result: before → `True` (wrongly protected); after → `False` (correctly compressible). Real failure text (`Traceback... fatal error`) still returns `True` after the fix.
- Not tested: have not reproduced the full KiloCode/proxy session end-to-end locally (no access to the reporter's actual traffic) — root cause was confirmed via the `stats.json` they attached to the issue, which shows `router:protected:error_output` firing on nearly every request in their session.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A — internal heuristic, no user-facing docs reference it)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable (release-please generates this automatically from commit messages)

## Screenshots (if applicable)

See the diagram embedded in Description above.

## Additional Notes

**Investigation trail**: ruled out `protect_recent_reads_fraction` (proxy already overrides its `0.0` dataclass default to `0.3` in token mode, the default) before confirming the error-protection false-positive via the reporter's `stats.json`.

**Response to review comments** (@AbelVM, @sparkbugz): prose mentions like `"Fix the errors in the code."` or `"console.error(...)"` contain only 1 distinct indicator keyword and were already safe under the pre-existing 2-keyword threshold — not something this PR changes. The broader concern about other CI summary formats is addressed above (label:value forms). A case like genuine prose that happens to mention *two* distinct keywords together (e.g. "there are errors and it failed") is a known limitation of a keyword-substring heuristic in general, predates this PR, and is out of scope here — downstream compressors (LogCompressor) still preserve real error lines even when a block isn't gate-protected, so the failure mode there is "slightly stricter than ideal," not data loss.

**Response to @JerrettDavis's CHANGES_REQUESTED**: fixed in the follow-up commit — `"0 failed"` is now stripped (previously only `failing`/`failure(s)` were), with a regression test for the exact reproduction given.