### PR TITLE
ci(opencode): compile + test the OpenCode plugin on changes

### DIFF
--- a/.github/workflows/opencode-plugin.yml
+++ b/.github/workflows/opencode-plugin.yml
@@ -1,0 +1,41 @@
+name: OpenCode Plugin
+
+# The OpenCode plugin (plugins/opencode) is the routing shim that carries
+# `headroom wrap opencode` traffic through the proxy, yet nothing in CI ever
+# compiled it — so TypeScript / @types/node major bumps and source changes had
+# zero build evidence. This gate runs the plugin's own typecheck + build + test
+# whenever it (or this workflow) changes.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "plugins/opencode/**"
+      - ".github/workflows/opencode-plugin.yml"
+  push:
+    branches: [main]
+    paths:
+      - "plugins/opencode/**"
+      - ".github/workflows/opencode-plugin.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: typecheck + build + test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: plugins/opencode
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: plugins/opencode/package-lock.json
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run build
+      - run: npm test


### PR DESCRIPTION
The OpenCode plugin (`plugins/opencode`) is the routing shim that carries `headroom wrap opencode` traffic through the proxy — but **no CI job ever compiled it**. It has `typecheck`/`build`/`test` scripts that only ran locally, so:
- TypeScript 6.x (#1687) and @types/node 26 (#1688) major-bump PRs had **zero build evidence** (why they're held).
- Any source edit to the plugin could silently break the build.

This adds a path-gated workflow that runs `npm ci → typecheck → build → test` whenever `plugins/opencode/**` (or this workflow) changes. Matches repo conventions (`setup-node@v6`, node 20, npm cache).

**Verified green locally on main:** `tsc --noEmit` clean, `tsup` build ok, 13 vitest tests pass.

Unblocks safe evaluation of the held dependency-bump PRs and protects the routing plugin going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)