### PR TITLE
fix(proxy): populate contribution USD savings

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -4426,16 +4426,26 @@ class AnthropicHandlerMixin:
                         if _auth_header.startswith("Bearer ") and not _auth_header.startswith(
                             "Bearer sk-ant-api"
                         ):
+                            from headroom.proxy.savings_tracker import (
+                                estimate_request_savings_usd,
+                            )
                             from headroom.subscription.tracker import (
                                 get_subscription_tracker as _get_sub_tracker,
                             )
 
                             _sub_tracker = _get_sub_tracker()
                             if _sub_tracker is not None:
+                                _savings_usd = estimate_request_savings_usd(
+                                    model,
+                                    compression_tokens_saved=tokens_saved,
+                                    cache_read_tokens=cr_tokens,
+                                )
                                 _sub_tracker.update_contribution(
                                     tokens_submitted=optimized_tokens,
                                     tokens_saved_compression=tokens_saved,
                                     tokens_saved_cache_reads=cr_tokens,
+                                    compression_savings_usd=_savings_usd["compression"],
+                                    cache_savings_usd=_savings_usd["provider_cache"],
                                 )
 
                         # The pre-refactor PERF emit (above) read raw usage

--- a/tests/test_anthropic_stage_timings.py
+++ b/tests/test_anthropic_stage_timings.py
@@ -257,6 +257,37 @@ def test_anthropic_http_happy_path_emits_stage_timings(stage_log_capture):
     assert "total_pre_upstream" in emitted
 
 
+def test_subscription_contribution_receives_request_savings_usd(monkeypatch):
+    request = _build_request(
+        {
+            "model": "claude-3-5-sonnet-latest",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        {"authorization": "Bearer oauth-test"},
+    )
+    handler = _DummyAnthropicHandler()
+    captured: dict[str, object] = {}
+    tracker = SimpleNamespace(
+        notify_active=lambda token: None,
+        update_contribution=lambda **kwargs: captured.update(kwargs),
+    )
+
+    monkeypatch.setattr("headroom.tokenizers.get_tokenizer", lambda model: _DummyTokenizer())
+    monkeypatch.setattr(
+        "headroom.subscription.tracker.get_subscription_tracker",
+        lambda: tracker,
+    )
+    monkeypatch.setattr(
+        "headroom.proxy.savings_tracker.estimate_request_savings_usd",
+        lambda model, **kwargs: {"compression": 1.25, "provider_cache": 2.5},
+    )
+
+    anyio.run(handler.handle_anthropic_messages, request)
+
+    assert captured["compression_savings_usd"] == 1.25
+    assert captured["cache_savings_usd"] == 2.5
+
+
 def test_anthropic_no_optimize_preserves_client_tool_order():
     tools = [
         {


### PR DESCRIPTION
## Description

Populate Anthropic subscription contribution USD totals for compression and provider cache reads.

The handler already records saved-token counts, while the subscription model also exposes dollar fields. This change prices the same request through Headroom's centralized savings calculator and passes those values into `update_contribution()` instead of leaving them at zero.

Closes #1751

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `headroom/proxy/handlers/anthropic.py`: price the request's compression and provider-cache savings through `estimate_request_savings_usd()`, then populate both subscription contribution USD fields.
- `tests/test_anthropic_stage_timings.py`: exercise the real non-streaming Anthropic handler with subscription OAuth and assert both calculated USD values reach the tracker.
- Rebased the submission onto current `main`; the older duplicate cache-pricing helper was removed because current Headroom already centralizes that logic.

## Testing

- [x] Unit tests pass
- [x] Linting passes
- [x] Type checking passes
- [x] New tests added for new functionality
- [ ] Manual upstream testing performed

### Test Output

```text
uv run --frozen --extra dev pytest tests/test_anthropic_stage_timings.py tests/test_subscription_tracker.py -q
16 passed

uv run --frozen ruff check headroom/proxy/handlers/anthropic.py tests/test_anthropic_stage_timings.py
All checks passed

Repository commit hooks:
Ruff, formatting, mypy, merge-conflict checks: passed
```

## Real Behavior Proof

- The handler regression sends a non-streaming Anthropic request using subscription-style OAuth.
- The centralized savings calculator is stubbed with distinct compression and cache values.
- The subscription tracker receives those values as `compression_savings_usd` and `cache_savings_usd`.
- A live Anthropic subscription request was not used in this maintenance pass.

## Review Readiness

- [x] Self-review completed
- [x] Branch is based on current main
- [x] Focused behavioral regression passes
- [x] Ready for human review

## Checklist

- [x] Code follows project style
- [x] Existing centralized pricing logic is reused
- [x] No manual CHANGELOG.md edit
- [x] New and relevant existing tests pass