### PR TITLE
docs(readme): correct lean-ctx comparison row

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Headroom runs **locally**, covers **every** content type, works with every major
 |------------------------------------------------------------------------------|------------------------------------------------|------------------------------------|:-----:|:----------:|
 | **Headroom**                                                                 | All context — tools, RAG, logs, files, history | Proxy · library · middleware · MCP | Yes   | Yes        |
 | [RTK](https://github.com/rtk-ai/rtk)                                        | CLI command outputs                            | CLI wrapper                        | Yes   | No         |
-| [lean-ctx](https://github.com/yvgude/lean-ctx)                               | CLI commands, MCP tools, editor rules          | CLI wrapper · MCP                  | Yes   | No         |
+| [lean-ctx](https://github.com/yvgude/lean-ctx)                               | Tool output, files, shell, history             | Proxy · library · middleware · MCP | Yes   | Yes        |
 | [Compresr](https://compresr.ai), [Token Co.](https://thetokencompany.ai)    | Text sent to their API                         | Hosted API call                    | No    | No         |
 | OpenAI Compaction                                                            | Conversation history                           | Provider-native                    | No    | No         |
 


### PR DESCRIPTION
## Description

Correct the `lean-ctx` row in the README comparison table.

The upstream project documents reversible recovery paths and broader deployment surfaces than the table previously reflected.

Closes #1754

## Type of Change

- [x] Documentation update

## Changes Made

- `README.md`: updated `lean-ctx` comparison row to match current documented capabilities and reversible behavior.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
Docs-only verification:
- Reviewed rendered README diff for the comparison row.
- Cross-checked updated row against current public lean-ctx docs covering deployment surfaces and reversible behavior.
```

## Real Behavior Proof

- Environment: GitHub PR diff review for docs-only comparison-table update.
- Exact command / steps: Compared new README row wording against current public lean-ctx documentation.
- Observed result: Comparison row now matches documented capabilities instead of understating recovery and deployment support.
- Not tested: Runtime commands; docs-only change.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
