### PR TITLE
[codex] docs: add Codex install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ headroom perf
 
 Granular extras: `[proxy]`, `[mcp]`, `[ml]`, `[code]`, `[memory]`, `[relevance]`, `[image]`, `[agno]`, `[langchain]`, `[evals]`, `[pytorch-mps]` (Apple-GPU memory-embedder offload — set `HEADROOM_EMBEDDER_RUNTIME=pytorch_mps`). Requires **Python 3.10+**.
 
+### Codex / global install
+
+If Codex or another MCP client cannot inherit a shell `PATH` reliably, install Headroom as a persistent uv tool and point the client at the absolute binary path:
+
+```bash
+uv tool install "headroom-ai[all]"
+command -v headroom
+```
+
+Then use the returned path in MCP config:
+
+```toml
+[mcp_servers.headroom]
+command = "/absolute/path/from/command-v/headroom"
+args = ["mcp", "serve"]
+```
+
+`command = "headroom"` only works when the client starts with a `PATH` that already includes the uv tool directory.
+
 ## Proof
 
 **Savings on real agent workloads:**


### PR DESCRIPTION
## Description

README lacked a practical note for Codex and other MCP clients that cannot reliably inherit a shell PATH. That makes `command = "headroom"` brittle for uv-installed setups.

Closes #1757

## Type of Change

- [x] Documentation update

## Changes Made

- Added a short Codex/global-install section to README.
- Documented `uv tool install "headroom-ai[all]"` and `command -v headroom`.
- Showed the absolute-path MCP config pattern.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
Docs-only verification:
- Reviewed README diff for command syntax and placement.
- Cross-checked the documented flow against the existing uv install pattern and absolute-path MCP config example.
```

## Real Behavior Proof

- Environment: GitHub PR diff review for docs-only install guidance.
- Exact command / steps: Compared new README note against documented `uv` tool install flow and absolute-path MCP launch pattern.
- Observed result: Docs now give Codex/MCP users a stable binary-path setup instead of relying on ambient PATH inheritance.
- Not tested: Fresh uv install on a clean machine in this verification pass.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
