### PR TITLE
[codex] docs: add pipeline extension recipe

### DIFF
--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -182,6 +182,39 @@ response = client.chat.completions.create(
 
 The `RollingWindowConfig`, `IntelligentContextConfig`, and `ScoringWeights` classes were removed in 0.9.x. Context management now happens automatically inside the pipeline.
 
+## Pipeline Extensions
+
+Use a `headroom.pipeline_extension` entry point when you need to normalize or annotate requests before they leave Headroom. The `PRE_SEND` stage is the right place for provider-specific request cleanup, such as turning `content: null` into `content: ""` for upstreams that reject OpenAI-spec tool-call messages.
+
+```python
+from headroom.pipeline import PipelineEvent, PipelineStage
+
+
+class NormalizeNullContent:
+    def on_pipeline_event(self, event: PipelineEvent) -> PipelineEvent:
+        if event.stage is not PipelineStage.PRE_SEND or not event.messages:
+            return event
+
+        for message in event.messages:
+            if (
+                message.get("role") == "assistant"
+                and message.get("content") is None
+                and message.get("tool_calls")
+            ):
+                message["content"] = ""
+
+        return event
+```
+
+Register it in `pyproject.toml`:
+
+```toml
+[project.entry-points."headroom.pipeline_extension"]
+normalize_null_content = "my_pkg.normalize:NormalizeNullContent"
+```
+
+If the upstream base URL itself must vary per request, use the `x-headroom-base-url` override header in addition to the normalization hook.
+
 ## Proxy Configuration
 
 ### Command Line Options


### PR DESCRIPTION
## Description

Headroom already supports `headroom.pipeline_extension`, but request-normalization pattern was not documented. That leaves users guessing how to fix upstream quirks such as `content: null` tool-call payloads.

Closes #1758

## Type of Change

- [x] Documentation update

## Changes Made

- Added a `Pipeline Extensions` section to `configuration.mdx`.
- Documented the `PRE_SEND` hook as the right place for request cleanup.
- Included a minimal `NormalizeNullContent` example and entry-point registration.
- Mentioned `x-headroom-base-url` as the per-request routing override.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
Docs-only verification:
- Reviewed docs diff for API names, hook names, and placement.
- Confirmed example uses public `headroom.pipeline` contract and matches existing header-routing terminology.
```

## Real Behavior Proof

- Environment: GitHub PR diff review for docs-only extension recipe.
- Exact command / steps: Compared new configuration docs against public pipeline-extension and per-request routing interfaces already exposed by Headroom.
- Observed result: Docs now show concrete request-cleanup extension pattern without requiring a fork.
- Not tested: Live extension package execution in this verification pass.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
