### PR TITLE
[codex] docs: add savings alias route

### DIFF
--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -7,6 +7,7 @@
     "docker-install",
     "persistent-installs",
     "community-savings",
+    "savings",
     "---Compression---",
     "how-compression-works",
     "smart-crusher",

--- a/docs/content/docs/savings.mdx
+++ b/docs/content/docs/savings.mdx
@@ -1,0 +1,11 @@
+---
+title: Savings
+description: Alias page for the community savings dashboard and aggregate proxy savings metrics.
+---
+
+This route exists as a short alias for the community savings view.
+
+- [Community Savings](/docs/community-savings)
+- [Metrics](/docs/metrics)
+
+Use this page when links or bookmarks expect `/docs/savings`.


### PR DESCRIPTION
## Description

The docs site was 404ing on `/docs/savings`, so this adds a short alias page that points users at the existing community savings content.

Closes #1759

## Type of Change

- [x] Documentation update

## Changes Made

- Added `docs/content/docs/savings.mdx` as an alias route.
- Added `savings` to the docs nav metadata.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
Docs-only verification:
- Reviewed route and nav diff for the new alias page.
- Confirmed alias targets existing `community-savings` and metrics docs instead of a dead route.
```

## Real Behavior Proof

- Environment: GitHub PR diff review for docs-only route alias.
- Exact command / steps: Compared new `savings` page and nav entry against existing community savings docs and metrics references.
- Observed result: `/docs/savings` now has a dedicated alias page instead of pointing users at a 404.
- Not tested: Live deployed docs site after publish in this verification pass.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
