### PR TITLE
fix(issue-1679): detect OpenCode Go CLI and warn routing is ineffective

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -115,7 +115,12 @@ from headroom.providers.openclaw import (
 from headroom.providers.openclaw import (
     normalize_gateway_provider_ids as _normalize_openclaw_gateway_provider_ids_impl,
 )
-from headroom.providers.opencode import build_launch_env as _build_opencode_launch_env
+from headroom.providers.opencode import (
+    build_launch_env as _build_opencode_launch_env,
+)
+from headroom.providers.opencode import (
+    detect_opencode_kind,
+)
 from headroom.providers.opencode.config import (
     _MCP_MARKER_END,  # noqa: F401
     _MCP_MARKER_START,
@@ -5568,6 +5573,22 @@ def opencode(
         click.echo("Error: 'opencode' not found in PATH.")
         click.echo("Install OpenCode: https://opencode.ai")
         raise SystemExit(1)
+
+    if detect_opencode_kind(opencode_bin) == "go-cli":
+        click.echo()
+        click.echo("  Warning: Detected the OpenCode Go CLI.")
+        click.echo(
+            "  The Go CLI ignores OPENCODE_CONFIG_CONTENT plugin routing, provider "
+            "options.baseURL overrides, and OPENAI_BASE_URL/ANTHROPIC_BASE_URL for "
+            "the hardcoded opencode-go provider."
+        )
+        click.echo("  LLM traffic will bypass the Headroom proxy (0 inbound LLM requests).")
+        click.echo(
+            "  To route traffic, use the OpenCode Node SDK / a compatible OpenCode "
+            "build, or track upstream support for baseURL on opencode-go."
+        )
+        click.echo("  Continuing to launch so you can see this diagnostic alongside your session.")
+        click.echo()
 
     env, env_vars_display = _build_opencode_launch_env(
         port, os.environ, project=_project_name_from_cwd(), include_mcp=not no_mcp

--- a/headroom/providers/opencode/__init__.py
+++ b/headroom/providers/opencode/__init__.py
@@ -11,7 +11,12 @@ from .config import (
     strip_opencode_headroom_blocks,
 )
 from .install import apply_provider_scope, build_install_env, revert_provider_scope
-from .runtime import build_launch_env, build_opencode_config_content, proxy_base_url
+from .runtime import (
+    build_launch_env,
+    build_opencode_config_content,
+    detect_opencode_kind,
+    proxy_base_url,
+)
 
 __all__ = [
     "_MCP_MARKER_END",
@@ -22,6 +27,7 @@ __all__ = [
     "build_install_env",
     "build_launch_env",
     "build_opencode_config_content",
+    "detect_opencode_kind",
     "inject_opencode_provider_config",
     "opencode_config_paths",
     "proxy_base_url",

--- a/headroom/providers/opencode/runtime.py
+++ b/headroom/providers/opencode/runtime.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import subprocess
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -131,3 +133,71 @@ def build_launch_env(
         env["HEADROOM_PROJECT"] = project
 
     return env, display
+
+
+_OPENCODE_VERSION_TIMEOUT = 2
+
+# Go CLI builds (e.g. opencode v1.16.2) print a short standalone SemVer line
+# such as "v1.16.2" or "1.17.13". The Node SDK (verified against oclif-style
+# output) usually exposes Node/npm metadata like "node-v20.12.2" or
+# "@opencode-ai/cli". The heuristic is intentionally conservative: we only
+# classify "go-cli" when the output looks like a simple version string and
+# carries no Node/npm markers. If a future Go CLI changes its output, callers
+# should update this classifier or short-circuit via monkeypatching in tests.
+_RE_SIMPLE_VERSION = re.compile(
+    r"^(v?\d+\.\d+\.\d+(?:[-+.]?[A-Za-z0-9-]+)*)$",
+    re.IGNORECASE,
+)
+
+
+def _probe_version_output(binary: str) -> str:
+    """Run ``binary --version`` and combine stdout+stderr, or return empty string on any failure."""
+    try:
+        result = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=_OPENCODE_VERSION_TIMEOUT,
+            check=False,
+        )
+    except Exception:  # pragma: no cover - defensive timeout/filesystem safety
+        return ""
+    return f"{result.stdout or ''}{result.stderr or ''}".strip()
+
+
+def _classify_version_output(output: str) -> str:
+    """Classify a ``--version`` probe result as ``go-cli``, ``node-sdk`` or ``unknown``."""
+    if not output:
+        return "unknown"
+
+    output_lower = output.lower()
+    node_markers = ("node", "npm", "npx", "@opencode-ai", "package.json")
+    if any(marker in output_lower for marker in node_markers):
+        return "node-sdk"
+
+    first_line = output.splitlines()[0].strip()
+    if _RE_SIMPLE_VERSION.match(first_line):
+        return "go-cli"
+
+    return "unknown"
+
+
+def detect_opencode_kind(binary: str | None) -> str:
+    """Detect whether ``binary`` is the OpenCode Go CLI or the Node SDK.
+
+    Returns one of:
+
+    * ``"go-cli"`` — the binary looks like the Go CLI (simple SemVer output,
+      no Node/npm markers).
+    * ``"node-sdk"`` — the binary output contains Node/npm markers.
+    * ``"unknown"`` — the binary could not be probed or the output did not
+      match either signature.
+    * ``"missing"`` — ``binary`` is empty/None.
+
+    This function never raises; errors during probing are folded into
+    ``"unknown"``.
+    """
+    if not binary:
+        return "missing"
+    output = _probe_version_output(binary)
+    return _classify_version_output(output)

--- a/headroom/providers/opencode/runtime.py
+++ b/headroom/providers/opencode/runtime.py
@@ -137,15 +137,16 @@ def build_launch_env(
 
 _OPENCODE_VERSION_TIMEOUT = 2
 
-# Go CLI builds (e.g. opencode v1.16.2) print a short standalone SemVer line
-# such as "v1.16.2" or "1.17.13". The Node SDK (verified against oclif-style
-# output) usually exposes Node/npm metadata like "node-v20.12.2" or
-# "@opencode-ai/cli". The heuristic is intentionally conservative: we only
-# classify "go-cli" when the output looks like a simple version string and
-# carries no Node/npm markers. If a future Go CLI changes its output, callers
-# should update this classifier or short-circuit via monkeypatching in tests.
-_RE_SIMPLE_VERSION = re.compile(
-    r"^(v?\d+\.\d+\.\d+(?:[-+.]?[A-Za-z0-9-]+)*)$",
+# Go CLI builds (e.g. opencode v1.16.2) may print a bare SemVer ("v1.16.2")
+# or a cobra-style line ("opencode version v1.16.2"). The Node SDK (oclif)
+# surfaces Node/npm metadata ("node-v20.12.2", "@opencode-ai/cli"). We search
+# for a SemVer token anywhere in the first line, but only after excluding
+# Node/npm markers — the exclusion-first ordering prevents false-positives
+# when a Node-SDK output also contains a SemVer (e.g.
+# "@opencode-ai/cli/1.16.2 ... node-v20.12.2" has both, but the "node" marker
+# routes it to "node-sdk" before the SemVer check runs).
+_RE_VERSION_TOKEN = re.compile(
+    r"v?\d+\.\d+\.\d+(?:[-+.]?[A-Za-z0-9-]+)*",
     re.IGNORECASE,
 )
 
@@ -160,7 +161,7 @@ def _probe_version_output(binary: str) -> str:
             timeout=_OPENCODE_VERSION_TIMEOUT,
             check=False,
         )
-    except Exception:  # pragma: no cover - defensive timeout/filesystem safety
+    except Exception:  # defensive: TimeoutExpired, FileNotFoundError, PermissionError
         return ""
     return f"{result.stdout or ''}{result.stderr or ''}".strip()
 
@@ -176,7 +177,7 @@ def _classify_version_output(output: str) -> str:
         return "node-sdk"
 
     first_line = output.splitlines()[0].strip()
-    if _RE_SIMPLE_VERSION.match(first_line):
+    if _RE_VERSION_TOKEN.search(first_line):
         return "go-cli"
 
     return "unknown"

--- a/tests/test_cli/test_wrap_opencode.py
+++ b/tests/test_cli/test_wrap_opencode.py
@@ -11,6 +11,8 @@ from click.testing import CliRunner
 
 from headroom.cli import wrap as wrap_mod
 from headroom.cli.main import main
+from headroom.providers.opencode import detect_opencode_kind
+from headroom.providers.opencode import runtime as opencode_runtime_mod
 
 
 @pytest.fixture
@@ -51,10 +53,11 @@ def test_wrap_opencode_sets_config_content_env(
     with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
         with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
             with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
-                result = runner.invoke(
-                    main,
-                    ["wrap", "opencode", "--port", "9000", "--no-mcp", "--", "--model", "gpt-4o"],
-                )
+                with patch.object(wrap_mod, "detect_opencode_kind", return_value="node-sdk"):
+                    result = runner.invoke(
+                        main,
+                        ["wrap", "opencode", "--port", "9000", "--no-mcp", "--", "--model", "gpt-4o"],
+                    )
 
     assert result.exit_code == 0, result.output
     env = captured["env"]
@@ -89,13 +92,148 @@ def test_wrap_opencode_does_not_add_base_url_env_vars(
     with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
         with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
             with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
-                result = runner.invoke(main, ["wrap", "opencode", "--port", "9000", "--no-mcp"])
+                with patch.object(wrap_mod, "detect_opencode_kind", return_value="node-sdk"):
+                    result = runner.invoke(main, ["wrap", "opencode", "--port", "9000", "--no-mcp"])
 
     assert result.exit_code == 0, result.output
     env = captured["env"]
-    assert isinstance(env, dict)
     assert env["OPENAI_BASE_URL"] == "https://deepseek.example/v1"
+
     assert env["ANTHROPIC_BASE_URL"] == "https://anthropic.example"
+
+
+def test_wrap_opencode_warns_when_go_cli_detected(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scope A: emit an actionable diagnostic when the resolved binary is the Go CLI."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    _set_test_home(monkeypatch, tmp_path)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                with patch.object(wrap_mod, "detect_opencode_kind", return_value="go-cli"):
+                    result = runner.invoke(main, ["wrap", "opencode", "--port", "9000", "--no-mcp"])
+
+    assert result.exit_code == 0, result.output
+    assert "Detected the OpenCode Go CLI" in result.output
+    assert "0 inbound LLM requests" in result.output
+    assert "Node SDK" in result.output
+    assert captured["tool_label"] == "OPENCODE"
+    assert captured["args"] == ()
+
+
+def test_wrap_opencode_silent_when_node_sdk_detected(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No Go-CLI warning when the detector identifies the Node SDK runtime."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    _set_test_home(monkeypatch, tmp_path)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                with patch.object(wrap_mod, "detect_opencode_kind", return_value="node-sdk"):
+                    result = runner.invoke(main, ["wrap", "opencode", "--port", "9000", "--no-mcp"])
+
+    assert result.exit_code == 0, result.output
+    assert "Detected the OpenCode Go CLI" not in result.output
+    assert captured["tool_label"] == "OPENCODE"
+
+
+def test_wrap_opencode_silent_when_runtime_unknown(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the runtime cannot be probed, stay silent to avoid noisy false positives."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    _set_test_home(monkeypatch, tmp_path)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                with patch.object(wrap_mod, "detect_opencode_kind", return_value="unknown"):
+                    result = runner.invoke(main, ["wrap", "opencode", "--port", "9000", "--no-mcp"])
+
+    assert result.exit_code == 0, result.output
+    assert "Detected the OpenCode Go CLI" not in result.output
+    assert captured["tool_label"] == "OPENCODE"
+
+
+def test_wrap_opencode_unprobeable_binary_does_not_raise(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A probe failure does not escape _launch_opencode; launch continues with no diagnostic."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    _set_test_home(monkeypatch, tmp_path)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                with patch.object(wrap_mod, "detect_opencode_kind", return_value="unknown"):
+                    result = runner.invoke(main, ["wrap", "opencode", "--port", "9000", "--no-mcp"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["tool_label"] == "OPENCODE"
+
+
+def test_detect_opencode_kind_classifies_version_outputs() -> None:
+    """The version-probe classifier distinguishes Go CLI, Node SDK and unknown outputs."""
+    with patch.object(opencode_runtime_mod, "_probe_version_output", return_value="v1.16.2"):
+        assert detect_opencode_kind("opencode") == "go-cli"
+
+    with patch.object(
+        opencode_runtime_mod,
+        "_probe_version_output",
+        return_value="@opencode-ai/cli/1.16.2 linux-x64 node-v20.12.2",
+    ):
+        assert detect_opencode_kind("opencode") == "node-sdk"
+
+    with patch.object(opencode_runtime_mod, "_probe_version_output", return_value="some/odd output"):
+        assert detect_opencode_kind("opencode") == "unknown"
+
+    with patch.object(opencode_runtime_mod, "_probe_version_output", return_value=""):
+        assert detect_opencode_kind("opencode") == "unknown"
+
+
+def test_detect_opencode_kind_safe_on_missing_or_failing_binary() -> None:
+    """Detection never raises: missing/empty binary returns missing, probe errors return unknown."""
+    assert detect_opencode_kind(None) == "missing"
+    assert detect_opencode_kind("") == "missing"
+
+    with patch.object(opencode_runtime_mod, "_probe_version_output", return_value=""):
+        assert detect_opencode_kind("/does/not/exist") == "unknown"
 
 
 def test_wrap_opencode_missing_binary_errors_clearly(

--- a/tests/test_cli/test_wrap_opencode.py
+++ b/tests/test_cli/test_wrap_opencode.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -216,6 +217,20 @@ def test_detect_opencode_kind_classifies_version_outputs() -> None:
     with patch.object(
         opencode_runtime_mod,
         "_probe_version_output",
+        return_value="opencode version v1.16.2\n",
+    ):
+        assert detect_opencode_kind("opencode") == "go-cli"
+
+    with patch.object(
+        opencode_runtime_mod,
+        "_probe_version_output",
+        return_value="opencode v1.16.2 (Go binary)",
+    ):
+        assert detect_opencode_kind("opencode") == "go-cli"
+
+    with patch.object(
+        opencode_runtime_mod,
+        "_probe_version_output",
         return_value="@opencode-ai/cli/1.16.2 linux-x64 node-v20.12.2",
     ):
         assert detect_opencode_kind("opencode") == "node-sdk"
@@ -234,6 +249,30 @@ def test_detect_opencode_kind_safe_on_missing_or_failing_binary() -> None:
 
     with patch.object(opencode_runtime_mod, "_probe_version_output", return_value=""):
         assert detect_opencode_kind("/does/not/exist") == "unknown"
+
+
+def test_probe_version_output_catches_real_subprocess_errors() -> None:
+    """The never-raises safety net catches real subprocess exceptions (F2)."""
+    with patch.object(
+        opencode_runtime_mod.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired(cmd="opencode --version", timeout=2),
+    ):
+        assert opencode_runtime_mod._probe_version_output("opencode") == ""
+
+    with patch.object(
+        opencode_runtime_mod.subprocess,
+        "run",
+        side_effect=FileNotFoundError,
+    ):
+        assert opencode_runtime_mod._probe_version_output("/no/such/opencode") == ""
+
+    with patch.object(
+        opencode_runtime_mod.subprocess,
+        "run",
+        side_effect=PermissionError,
+    ):
+        assert detect_opencode_kind("/restricted/opencode") == "unknown"
 
 
 def test_wrap_opencode_missing_binary_errors_clearly(


### PR DESCRIPTION
## Description

`headroom wrap opencode` routes 0 LLM traffic to the proxy when the user runs the OpenCode **Go CLI** (`opencode` v1.16.2). The reporter verified four routing paths and all fail; their deeper comment establishes that a `provider.headroom` object is schema-valid in the Go CLI but cannot be selected as the active provider.

The Go binary's `net/http` traffic is never directed at the Headroom proxy. `headroom/providers/opencode/runtime.py:43` (`build_opencode_config_content`) emits `OPENCODE_CONFIG_CONTENT` with `provider.{anthropic,openai}.options.baseURL` overrides plus a `headroom` provider entry and an optional plugin path; `headroom/providers/opencode/runtime.py:101` (`build_launch_env`) serializes that into `OPENCODE_CONFIG_CONTENT` and `HEADROOM_PROXY_URL` (consumed only by the Node plugin); `headroom/cli/wrap.py:5572` (`_build_opencode_launch_env`) and `headroom/cli/wrap.py:5577` (`inject_opencode_provider_config`) wire it into the launch; none of it sets `HTTP_PROXY`/`HTTPS_PROXY`. For a Go binary this means: the hardcoded `opencode-go` provider ignores `options.baseURL` and `OPENAI_BASE_URL`/`ANTHROPIC_BASE_URL`; the transport plugin (`plugins/opencode/src/transport.ts:404`, `installHeadroomTransport`) patches Node's `fetch`/`http`/`https`/`http2`/`child_process`, none of which a Go binary traverses; and a `provider.headroom` object is definable but not selectable as active. Net effect: 0 inbound LLM requests to the proxy.

This PR implements the bounded, additive path: detect the Go CLI at launch and emit an actionable diagnostic instead of failing silently, leaving the Node-SDK routing layers intact for the SDK case and for future Go-CLI versions that may honor provider overrides.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/providers/opencode/runtime.py:185` — added `detect_opencode_kind(binary)`, a safe 2-second `opencode --version` probe that never raises (returns `go-cli` / `node-sdk` / `unknown` / `missing`). Node/npm markers in the output → `node-sdk`; a bare SemVer first line with no Node markers → `go-cli`; otherwise `unknown`.
- `headroom/providers/opencode/runtime.py:147` — `_RE_VERSION_TOKEN`, `_probe_version_output`, `_classify_version_output` helpers backing the detector. The SemVer token regex uses `search` (not anchored `match`) so cobra-style output like `opencode version v1.16.2` classifies as `go-cli`; node-marker exclusion is checked first to prevent false-positives on Node-SDK output that also contains a SemVer.
- `headroom/providers/opencode/__init__.py` — re-export `detect_opencode_kind` and add it to `__all__`.
- `headroom/cli/wrap.py:5577` — in `_launch_opencode`, after `shutil.which` resolves the binary and before `_launch_tool`, call the detector; when `go-cli` is detected, emit a multi-line `click.echo` diagnostic naming the three ineffective routing layers (`OPENCODE_CONFIG_CONTENT` plugin routing, `provider.*.options.baseURL` overrides, `OPENAI_BASE_URL`/`ANTHROPIC_BASE_URL` for the hardcoded `opencode-go` provider), stating the effect (0 inbound LLM requests to the proxy), and pointing to the actionable options (Node SDK / compatible build / upstream `baseURL` support on `opencode-go`). Launch proceeds — the diagnostic does not abort the session.
- `tests/test_cli/test_wrap_opencode.py` — 7 new tests (`test_wrap_opencode_warns_when_go_cli_detected`, `test_wrap_opencode_silent_when_node_sdk_detected`, `test_wrap_opencode_silent_when_runtime_unknown`, `test_wrap_opencode_unprobeable_binary_does_not_raise`, `test_detect_opencode_kind_classifies_version_outputs`, `test_detect_opencode_kind_safe_on_missing_or_failing_binary`, `test_probe_version_output_catches_real_subprocess_errors`) plus 2 existing tests adapted to patch the detector to `node-sdk` so the new probe is a no-op under them.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ uv run --extra dev mypy headroom
Success: no issues found in 406 source files

$ uv run --extra dev ruff check .
All checks passed!

$ uv run --extra dev pytest tests/test_cli/test_wrap_opencode.py
============================== 40 passed ==============================
```

## Real Behavior Proof

- Environment: branch `fix/issue-1679` (commits `5bf8c67b`, `9e6d2e06`); Python 3.13 via `uv` with `--extra dev`.
- Exact command / steps: `mypy headroom`, `ruff check .`, `pytest tests/test_cli/test_wrap_opencode.py`. The regression test `test_wrap_opencode_warns_when_go_cli_detected` mocks `detect_opencode_kind → "go-cli"` and asserts the diagnostic substrings (`Detected the OpenCode Go CLI`, `0 inbound LLM requests`, `Node SDK`) appear in output and that `_launch_tool` is still called (launch not aborted). `test_detect_opencode_kind_classifies_version_outputs` covers bare SemVer (`v1.16.2`), cobra-style (`opencode version v1.16.2`), and `(Go binary)` annotated output. `test_probe_version_output_catches_real_subprocess_errors` patches `subprocess.run` to raise `TimeoutExpired`/`FileNotFoundError`/`PermissionError`.
- Observed result: mypy clean (406 files); ruff clean; 40 tests passed. The diagnostic fires only for the `go-cli` classification and is silent for `node-sdk`/`unknown`; a missing or unprobeable binary does not raise out of `_launch_opencode`.
- Not tested: end-to-end against a live OpenCode Go CLI v1.16.2 binary (not installed locally). The routing mechanism is taken from the reporter's evidence — proxy `/stats` showing 0 requests, `OPENCODE_CONFIG_CONTENT` validation error proving the Go runtime reads the env var, and `curl` with `x-headroom-base-url` proving the proxy itself routes. The fix is validated by unit tests that mock the version probe, not by launching a real Go binary.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
