### PR TITLE
Install using uv tool globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ headroom perf
 headroom dashboard                      # live savings dashboard (proxy must be running)
 ```
 
-When wrapping a coding agent, headroom starts a local proxy, sets up an MCP server that provides tools such as rtk and tokensave, and launches a coding agent session configured to proxy requests to headroom. This is a one-time setup step.
+To use headroom, it is recommended you launch a wrapped agent session each time so that all necessary setup is completed. When wrapping a coding agent, headroom starts a local proxy, sets up an MCP server that provides tools such as rtk and tokensave, and launches a coding agent session configured to proxy requests to headroom. 
 
 The `headroom` CLI ships **only** via the PyPI package. The npm `headroom-ai` is the TypeScript SDK — a library you import (`import { compress } from 'headroom-ai'`), not a CLI, so it provides no `headroom` command.
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ Headroom compresses everything your AI agent reads — tool outputs, logs, RAG c
 
 ```bash
 # 1 — Install
+uv tool install "headroom-ai[all]"      # Install `headroom` CLI as a global tool in self-contained virtual env
 pip install "headroom-ai[all]"          # Python — ships the `headroom` CLI
 npm install headroom-ai                 # TypeScript SDK only — no `headroom` CLI
 
-# 2 — Pick your mode  (the `headroom` commands below come from the pip install)
+# 2 — Pick your mode  (the `headroom` commands below come from the uv or pip install)
 headroom wrap claude                    # wrap a coding agent
 headroom proxy --port 8787              # drop-in proxy, zero code changes
 # or: from headroom import compress      # inline library
@@ -100,6 +101,8 @@ headroom doctor                         # health check — confirms routing is w
 headroom perf
 headroom dashboard                      # live savings dashboard (proxy must be running)
 ```
+
+When wrapping a coding agent, headroom starts a local proxy, sets up an MCP server that provides tools such as rtk and tokensave, and launches a coding agent session configured to proxy requests to headroom. This is a one-time setup step.
 
 The `headroom` CLI ships **only** via the PyPI package. The npm `headroom-ai` is the TypeScript SDK — a library you import (`import { compress } from 'headroom-ai'`), not a CLI, so it provides no `headroom` command.
 


### PR DESCRIPTION
Resolves headroomlabs-ai/headroom#768

## Description

Explain how to install using `uv tool` as a global tool.  This should be the preferred option for installation so that headroom is setup as a global tool within a self-contained virtual env and the binary on the user's path.

That way, a wrapped coding agent can correctly invoke headroom within the virtual env to avoid python package import issues.

For example, `~/.claude.json`:

```json
  "mcpServers": {
    "headroom": {
      "type": "stdio",
      "command": "/Users/USERNAME/.local/bin/headroom",
      "args": [
        "mcp",
        "serve"
      ],
      "env": {}
    },
```

uses the command path based on `command -v headroom`.


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Updated README.md

## Testing

<!-- Check what you actually ran, then paste the real command output below. -->

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```sh
uv tool install "headroom-ai[all]"
```

```sh
command -v headroom
/Users/dustin/.local/bin/headroom
```

```sh
headroom wrap claude                                                                                                                                                                                          
  ╔═══════════════════════════════════════════════╗
  ║            HEADROOM WRAP: CLAUDE              ║
  ╚═══════════════════════════════════════════════╝

  Starting Headroom proxy on port 8787...
  Logs: /Users/dustin/.headroom/logs/proxy.log
  Proxy ready on http://127.0.0.1:8787
  Dashboard:    http://127.0.0.1:8787/dashboard
  Setting up rtk...
  Code graph: indexed (tokensave)

  Launching Claude Code (API routed through Headroom)...
  ANTHROPIC_BASE_URL=http://127.0.0.1:8787
  Remote Control: Claude Code may hide the Remote Control menu while ANTHROPIC_BASE_URL points at a custom endpoint (the wrapped Claude session's ANTHROPIC_BASE_URL); launch Claude without Headroom for sessions that need this feature.

  ENABLE_TOOL_SEARCH=true (on-demand tool loading kept on; issue #746)
```

## Real Behavior Proof

- Environment: See below
- Exact command / steps: See test output section above
- Observed result: Headroom installed as expected, Claude coding agent successfully had headroom MCP available
- Not tested: Coding agents other than Claude.  OS other than Mac.


```sh
uname -a                                                                                                                                                                                                      
Darwin mac.lan 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:41:26 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T8132 arm64

claude --version                                                                                                                                                                                              2.1.201 (Claude Code)

headroom --version                                                                                                                                                                                           
headroom, version 0.30.0
```

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [ ] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

<!-- Mention any N/A checklist items, tradeoffs, follow-ups, or maintainer context. -->
