### PR TITLE
fix(dashboard): clarify unavailable RTK stats in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     command: ["--host", "0.0.0.0"]
     environment:
       - HEADROOM_HOST=0.0.0.0
+      # RTK dashboard stats are read inside this container. A host/WSL2
+      # `rtk` on PATH is not visible here unless you mount its binary and
+      # state into the container; otherwise the dashboard marks RTK stats
+      # unavailable instead of importing host `rtk gain`.
       # if you want to use a custom OpenAI-compatible API endpoint,
       # uncomment and set the following line with the desired URL
       # - OPENAI_TARGET_API_URL=https://api.x.ai

--- a/docker/docker-compose.native.yml
+++ b/docker/docker-compose.native.yml
@@ -29,6 +29,9 @@ services:
     environment:
       HOME: /tmp/headroom-home
       HEADROOM_HOST: 0.0.0.0
+      # RTK dashboard stats are read by this proxy container. Host-only RTK
+      # installs are not visible unless their binary/state live under the
+      # mounted HEADROOM_HOST_HOME paths below.
       # Canonical Headroom filesystem contract (issue #175). See `cli` service
       # above for rationale.
       HEADROOM_WORKSPACE_DIR: /tmp/headroom-home/.headroom

--- a/docs/content/docs/docker-install.mdx
+++ b/docs/content/docs/docker-install.mdx
@@ -137,6 +137,10 @@ docker compose -f docker/docker-compose.native.yml up -d proxy
 
 This is a supported persistent-Docker path when you want the proxy managed explicitly through Compose instead of the installed wrapper.
 
+<Callout type="info" title="RTK stats and Docker">
+The dashboard reads RTK stats from the Headroom proxy process. In Docker, that means the container must be able to run `rtk gain` against the same mounted state that your wrapped host tools use. A host-only or WSL2-only `rtk` install on `PATH` is not visible inside the proxy container; in that case the dashboard reports RTK stats as unavailable rather than importing host telemetry.
+</Callout>
+
 <Callout type="info" title="HEADROOM_WORKSPACE vs HEADROOM_WORKSPACE_DIR">
 These are two different variables — both are set by the compose file, and both are retained for backward compatibility:
 

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -220,7 +220,12 @@
                 <div class="mt-1 text-xs text-gray-500 leading-relaxed">
                     <span x-text="'Proxy ' + formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' (' + proxyShareOfTotal.toFixed(1) + '%)'"></span>
                     <span class="mx-1 text-gray-600">/</span>
-                    <span x-text="cliFilteringLabel + ' ' + formatNumber(cliFilteringSaved) + ' this session (' + cliFilteringSessionPctDisplay.toFixed(1) + '%)'"></span>
+                    <template x-if="cliFilteringStatsAvailable">
+                        <span x-text="cliFilteringLabel + ' ' + formatNumber(cliFilteringSaved) + ' this session (' + cliFilteringSessionPctDisplay.toFixed(1) + '%)'"></span>
+                    </template>
+                    <template x-if="!cliFilteringStatsAvailable">
+                        <span class="text-amber-400" x-text="cliFilteringStatusText" :title="cliFilteringStatusTitle"></span>
+                    </template>
                 </div>
                 <div class="mt-1 text-xs text-gray-600 leading-relaxed">
                     <span x-text="'Of total wire: ' + (stats.tokens?.savings_percent || 0).toFixed(2) + '%'" title="Savings as fraction of all input tokens including frozen prefix"></span>
@@ -1030,9 +1035,15 @@
                     </div>
                     <div class="flex justify-between items-center">
                         <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
-                        <span class="font-mono text-sm text-emerald-400" x-text="formatNumber(cliFilteringSaved)"></span>
+                        <span class="font-mono text-sm text-emerald-400"
+                              x-show="cliFilteringStatsAvailable"
+                              x-text="formatNumber(cliFilteringSaved)"></span>
+                        <span class="font-mono text-sm text-amber-400"
+                              x-show="!cliFilteringStatsAvailable"
+                              x-text="'Unavailable'"
+                              :title="cliFilteringStatusTitle"></span>
                     </div>
-                    <div class="flex justify-between items-center" x-show="cliFilteringLifetime > 0">
+                    <div class="flex justify-between items-center" x-show="cliFilteringStatsAvailable && cliFilteringLifetime > 0">
                         <span class="text-sm text-gray-500" x-text="cliFilteringLabel + ' Filtered (lifetime)'"></span>
                         <span class="font-mono text-sm text-emerald-400/70" x-text="formatNumber(cliFilteringLifetime)"></span>
                     </div>
@@ -1402,7 +1413,7 @@
                         <div class="mt-2 text-xs text-gray-500">Based on persisted weekly buckets</div>
                     </div>
 
-                    <template x-if="historyStats.cli_filtering">
+                    <template x-if="historyStats.cli_filtering && historyCliFilteringStatsAvailable">
                         <div class="bg-surface rounded-lg p-4 border border-border">
                             <div class="text-xs text-gray-500 uppercase tracking-wide mb-1"
                                  x-text="(historyStats.cli_filtering?.label || cliFilteringLabel) + ' Lifetime Saved'"></div>
@@ -1411,6 +1422,16 @@
                                       x-text="formatNumber(historyStats.cli_filtering?.lifetime?.tokens_saved || 0)"></span>
                             </div>
                             <div class="mt-2 text-xs text-gray-500">CLI output filtering (lifetime)</div>
+                        </div>
+                    </template>
+                    <template x-if="historyStats.cli_filtering && !historyCliFilteringStatsAvailable">
+                        <div class="bg-surface rounded-lg p-4 border border-border">
+                            <div class="text-xs text-gray-500 uppercase tracking-wide mb-1"
+                                 x-text="(historyStats.cli_filtering?.label || cliFilteringLabel) + ' Stats'"></div>
+                            <div class="flex items-baseline gap-2">
+                                <span class="text-2xl font-light tabular-nums text-amber-400">Unavailable</span>
+                            </div>
+                            <div class="mt-2 text-xs text-gray-500" x-text="historyCliFilteringStatusText"></div>
                         </div>
                     </template>
                 </div>
@@ -2532,6 +2553,27 @@
                     return String(raw);
                 },
 
+                get cliFilteringStatsAvailable() {
+                    const layer = this.stats.savings?.by_layer?.cli_filtering;
+                    const tool = this.stats.context_tool;
+                    const available = tool?.stats_available
+                        ?? layer?.stats_available
+                        ?? tool?.available
+                        ?? layer?.available;
+                    return available !== false;
+                },
+
+                get cliFilteringStatusText() {
+                    return `${this.cliFilteringLabel} stats unavailable to this proxy`;
+                },
+
+                get cliFilteringStatusTitle() {
+                    const reason = this.stats.context_tool?.unavailable_reason
+                        || this.stats.savings?.by_layer?.cli_filtering?.unavailable_reason;
+                    const suffix = reason ? ` Reason: ${reason}.` : '';
+                    return `${this.cliFilteringLabel} stats are read by the Headroom proxy process.${suffix}`;
+                },
+
                 get cliFilteringSaved() {
                     return this.stats.tokens?.cli_filtering_saved
                         ?? this.stats.tokens?.cli_tokens_avoided
@@ -2552,6 +2594,19 @@
                 get cliFilteringSessionPctDisplay() {
                     const p = this.stats.savings?.by_layer?.cli_filtering?.session_savings_pct;
                     return (p === null || p === undefined) ? this.cliFilteringShareOfTotal : p;
+                },
+
+                get historyCliFilteringStatsAvailable() {
+                    const stats = this.historyStats.cli_filtering;
+                    if (!stats) return false;
+                    const available = stats.stats_available ?? stats.available;
+                    return available !== false;
+                },
+
+                get historyCliFilteringStatusText() {
+                    const stats = this.historyStats.cli_filtering;
+                    const label = stats?.label || this.cliFilteringLabel;
+                    return `${label} stats were unavailable when /stats-history was fetched.`;
                 },
 
                 // --- Headline savings percent ---

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -1102,6 +1102,8 @@ def _context_tool_summary_payload(
     installed: bool,
     scope: str | None = None,
     summary: dict[str, Any] | None = None,
+    stats_available: bool = True,
+    unavailable_reason: str | None = None,
 ) -> dict[str, Any]:
     """Normalize RTK/lean-ctx lifetime gain output into one schema.
 
@@ -1173,6 +1175,9 @@ def _context_tool_summary_payload(
         "tool": tool,
         "label": _context_tool_label(tool),
         "installed": installed,
+        "stats_available": stats_available,
+        "status": "ok" if stats_available else ("unavailable" if not installed else "error"),
+        "unavailable_reason": unavailable_reason,
         "scope": scope or _context_tool_default_scope(tool),
         "total_commands": _coerce_int(
             _first_value(
@@ -1203,12 +1208,18 @@ def _context_tool_zero_payload(
     tool: str,
     installed: bool,
     scope: str | None = None,
+    stats_available: bool | None = None,
+    unavailable_reason: str | None = None,
 ) -> dict[str, Any]:
+    if stats_available is None:
+        stats_available = installed
     return _context_tool_summary_payload(
         tool=tool,
         installed=installed,
         scope=scope,
         summary={},
+        stats_available=stats_available,
+        unavailable_reason=unavailable_reason,
     )
 
 
@@ -1224,6 +1235,8 @@ def _read_rtk_lifetime_stats() -> dict[str, Any] | None:
             tool=_CONTEXT_TOOL_RTK,
             installed=False,
             scope=scope,
+            stats_available=False,
+            unavailable_reason="not_installed",
         )
 
     try:
@@ -1257,6 +1270,8 @@ def _read_rtk_lifetime_stats() -> dict[str, Any] | None:
                 tool=_CONTEXT_TOOL_RTK,
                 installed=True,
                 scope=scope,
+                stats_available=False,
+                unavailable_reason="subprocess_failed",
             )
     except Exception as exc:
         # PR-G2 remediation (H2): log the exception path too. Reason is the
@@ -1271,6 +1286,8 @@ def _read_rtk_lifetime_stats() -> dict[str, Any] | None:
             tool=_CONTEXT_TOOL_RTK,
             installed=True,
             scope=scope,
+            stats_available=False,
+            unavailable_reason=type(exc).__name__,
         )
 
     return payload
@@ -1283,9 +1300,19 @@ def _read_lean_ctx_lifetime_stats() -> dict[str, Any] | None:
 
     lean_ctx_path = get_lean_ctx_path()
     if not lean_ctx_path:
-        return _context_tool_zero_payload(tool=_CONTEXT_TOOL_LEAN_CTX, installed=False)
+        return _context_tool_zero_payload(
+            tool=_CONTEXT_TOOL_LEAN_CTX,
+            installed=False,
+            stats_available=False,
+            unavailable_reason="not_installed",
+        )
 
-    base_payload = _context_tool_zero_payload(tool=_CONTEXT_TOOL_LEAN_CTX, installed=True)
+    base_payload = _context_tool_zero_payload(
+        tool=_CONTEXT_TOOL_LEAN_CTX,
+        installed=True,
+        stats_available=False,
+        unavailable_reason="stats_unavailable",
+    )
 
     try:
         result = run(
@@ -1295,12 +1322,16 @@ def _read_lean_ctx_lifetime_stats() -> dict[str, Any] | None:
             timeout=5,
         )
         if result.returncode != 0 or not result.stdout.strip():
-            return dict(base_payload)
+            payload = dict(base_payload)
+            payload["unavailable_reason"] = "subprocess_failed"
+            return payload
 
         data = json.loads(result.stdout)
         summary = data.get("summary", data) if isinstance(data, dict) else {}
         if not isinstance(summary, dict):
-            return dict(base_payload)
+            payload = dict(base_payload)
+            payload["unavailable_reason"] = "malformed_output"
+            return payload
 
         return _context_tool_summary_payload(
             tool=_CONTEXT_TOOL_LEAN_CTX,

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -3031,6 +3031,28 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         cli_filtering_label = (
             str(cli_filtering_stats.get("label", "RTK")) if cli_filtering_stats else "RTK"
         )
+        context_tool_installed = bool(
+            cli_filtering_stats and cli_filtering_stats.get("installed", True)
+        )
+        context_tool_stats_available = bool(
+            cli_filtering_stats
+            and cli_filtering_stats.get("stats_available", context_tool_installed)
+        )
+        default_context_tool_status = (
+            "ok"
+            if context_tool_stats_available
+            else ("error" if context_tool_installed else "unavailable")
+        )
+        context_tool_status = (
+            str(cli_filtering_stats.get("status", default_context_tool_status))
+            if cli_filtering_stats
+            else "unavailable"
+        )
+        context_tool_unavailable_reason = (
+            cli_filtering_stats.get("unavailable_reason")
+            if cli_filtering_stats
+            else "not_installed"
+        )
         cli_tokens_avoided = (
             cli_filtering_stats.get("tokens_saved", 0) if cli_filtering_stats else 0
         )
@@ -3156,6 +3178,10 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                     "cli_filtering": {
                         "tool": cli_filtering_tool,
                         "label": cli_filtering_label,
+                        "available": context_tool_installed,
+                        "stats_available": context_tool_stats_available,
+                        "status": context_tool_status,
+                        "unavailable_reason": context_tool_unavailable_reason,
                         "tokens": cli_tokens_avoided,
                         "tokens_saved": cli_tokens_avoided,
                         "session": cli_filtering_session,
@@ -3424,9 +3450,10 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
             "context_tool": {
                 "configured": cli_filtering_tool,
                 "label": cli_filtering_label,
-                "available": bool(
-                    cli_filtering_stats and cli_filtering_stats.get("installed", False)
-                ),
+                "available": context_tool_installed,
+                "stats_available": context_tool_stats_available,
+                "status": context_tool_status,
+                "unavailable_reason": context_tool_unavailable_reason,
                 "stats": cli_filtering_stats,
             },
             "cli_filtering": cli_filtering_stats,
@@ -3550,9 +3577,10 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         The JSON payload also carries a ``cli_filtering`` key with live RTK
         stats. This is a curated subset (``tool``, ``label``, ``lifetime``,
         ``session``) tailored to the Historical tab, not the full
-        ``_get_context_tool_stats()`` payload that ``/stats`` exposes. It is
-        ``None`` when RTK is absent or its stats cannot be read, so the tab
-        simply hides the card rather than erroring.
+        ``_get_context_tool_stats()`` payload that ``/stats`` exposes. When
+        the selected context tool is absent or unreadable, the subset carries
+        ``stats_available=false`` so the tab can render an honest unavailable
+        state instead of a fake zero.
         """
         if format == "csv":
             filename = f"headroom-stats-history-{series}.csv"
@@ -3576,9 +3604,16 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
             logger.debug("stats-history: RTK stats unavailable", exc_info=True)
             cli_stats = None
         if cli_stats:
+            installed = bool(cli_stats.get("installed", True))
+            stats_available = bool(cli_stats.get("stats_available", installed))
+            default_status = "ok" if stats_available else ("error" if installed else "unavailable")
             history["cli_filtering"] = {
                 "tool": str(cli_stats.get("tool", "rtk")),
                 "label": str(cli_stats.get("label", "RTK")),
+                "available": installed,
+                "stats_available": stats_available,
+                "status": str(cli_stats.get("status", default_status)),
+                "unavailable_reason": cli_stats.get("unavailable_reason"),
                 "lifetime": cli_stats.get("lifetime", {}),
                 "session": cli_stats.get("session", {}),
             }

--- a/tests/test_proxy_dashboard_stats_cache.py
+++ b/tests/test_proxy_dashboard_stats_cache.py
@@ -99,6 +99,8 @@ def test_get_rtk_stats_memoizes_subprocess_calls(monkeypatch: pytest.MonkeyPatch
     assert first["tool"] == "rtk"
     assert first["label"] == "RTK"
     assert first["installed"] is True
+    assert first["stats_available"] is True
+    assert first["status"] == "ok"
     assert first["scope"] == "global"
     assert first["total_commands"] == 0
     assert first["input_tokens"] == 0
@@ -186,6 +188,8 @@ def test_get_rtk_stats_can_read_project_scoped_gain(monkeypatch: pytest.MonkeyPa
 
     assert payload is not None
     assert payload["scope"] == "project"
+    assert payload["stats_available"] is True
+    assert payload["status"] == "ok"
     assert payload["total_commands"] == 1
     assert payload["tokens_saved"] == 25
     assert calls["run"] == 1
@@ -219,6 +223,22 @@ def test_get_rtk_stats_invalid_scope_defaults_to_global(
     assert calls["run"] == 1
     warning_calls = " ".join(str(call) for call in mock_warning.call_args_list)
     assert "event=rtk_gain_scope_invalid" in warning_calls
+
+
+def test_get_rtk_stats_marks_missing_binary_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("headroom.rtk.get_rtk_path", lambda: None)
+
+    payload = proxy_helpers._read_rtk_lifetime_stats()
+
+    assert payload is not None
+    assert payload["tool"] == "rtk"
+    assert payload["installed"] is False
+    assert payload["stats_available"] is False
+    assert payload["status"] == "unavailable"
+    assert payload["unavailable_reason"] == "not_installed"
+    assert payload["tokens_saved"] == 0
 
 
 def test_get_context_tool_stats_reads_lean_ctx_gain(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -266,6 +286,8 @@ def test_get_context_tool_stats_reads_lean_ctx_gain(monkeypatch: pytest.MonkeyPa
     assert first["tool"] == "lean-ctx"
     assert first["label"] == "lean-ctx"
     assert first["installed"] is True
+    assert first["stats_available"] is True
+    assert first["status"] == "ok"
     assert first["total_commands"] == 0
     assert first["tokens_saved"] == 0
     assert first["avg_savings_pct"] == 40.0
@@ -445,6 +467,77 @@ def test_stats_reports_lean_ctx_as_selected_cli_filter(monkeypatch: pytest.Monke
     assert payload["savings"]["by_layer"]["compression"]["lean_ctx_tokens"] == 9
 
 
+def test_stats_marks_unavailable_context_tool_without_counting_fake_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    import headroom.proxy.server as server
+    from headroom.proxy.server import ProxyConfig, create_app
+
+    monkeypatch.setattr(
+        server,
+        "get_compression_store",
+        lambda: _StatsStub({"store": 0}, "store", {}),
+    )
+    monkeypatch.setattr(
+        server,
+        "get_telemetry_collector",
+        lambda: _StatsStub({"telemetry": 0}, "telemetry", {}),
+    )
+    monkeypatch.setattr(
+        server,
+        "get_compression_feedback",
+        lambda: _StatsStub({"feedback": 0}, "feedback", {}),
+    )
+    monkeypatch.setattr(
+        server,
+        "_get_context_tool_stats",
+        lambda: {
+            "tool": "rtk",
+            "label": "RTK",
+            "installed": False,
+            "stats_available": False,
+            "status": "unavailable",
+            "unavailable_reason": "not_installed",
+            "tokens_saved": 0,
+            "session": {"tokens_saved": 0},
+            "lifetime": {"tokens_saved": 0},
+        },
+    )
+    monkeypatch.setattr(server, "get_toin", lambda: _ToinStub())
+
+    app = create_app(
+        ProxyConfig(
+            optimize=False,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=False,
+            log_requests=False,
+            ccr_inject_tool=False,
+            ccr_handle_responses=False,
+            ccr_context_tracking=False,
+            http2=False,
+        )
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/stats")
+
+    payload = response.json()
+    assert response.status_code == 200
+    assert payload["context_tool"]["configured"] == "rtk"
+    assert payload["context_tool"]["available"] is False
+    assert payload["context_tool"]["stats_available"] is False
+    assert payload["context_tool"]["status"] == "unavailable"
+    assert payload["context_tool"]["unavailable_reason"] == "not_installed"
+    assert payload["savings"]["by_layer"]["cli_filtering"]["stats_available"] is False
+    assert payload["savings"]["by_layer"]["cli_filtering"]["unavailable_reason"] == "not_installed"
+    assert payload["tokens"]["cli_filtering_saved"] == 0
+    assert payload["tokens"]["rtk_saved"] == 0
+
+
 def test_cost_merge_uses_generic_cli_filtering_name() -> None:
     from headroom.proxy.cost import merge_cost_stats
 
@@ -603,6 +696,10 @@ def test_dashboard_uses_cached_stats_and_lazy_history_feed_polling() -> None:
     assert "Context Tool" in html
     assert "cliFilteringLabel + ' Filtered (this session)'" in html
     assert "cliFilteringLabel + ' Filtered (lifetime)'" in html
+    assert "cliFilteringStatsAvailable" in html
+    assert "cliFilteringStatusText" in html
+    assert "stats unavailable to this proxy" in html
+    assert "historyCliFilteringStatsAvailable" in html
 
 
 def test_dashboard_session_metrics_do_not_repeat_proxy_tokens_without_new_context() -> None:

--- a/tests/test_proxy_savings_history.py
+++ b/tests/test_proxy_savings_history.py
@@ -1296,6 +1296,7 @@ def test_stats_history_includes_cli_filtering(tmp_path, monkeypatch):
         cache_enabled=False,
         rate_limit_enabled=False,
         log_requests=False,
+        http2=False,
     )
 
     with TestClient(create_app(config)) as client:
@@ -1307,7 +1308,51 @@ def test_stats_history_includes_cli_filtering(tmp_path, monkeypatch):
     assert data["cli_filtering"] is not None
     assert data["cli_filtering"]["tool"] == "rtk"
     assert data["cli_filtering"]["label"] == "RTK"
+    assert data["cli_filtering"]["available"] is True
+    assert data["cli_filtering"]["stats_available"] is True
+    assert data["cli_filtering"]["status"] == "ok"
     assert data["cli_filtering"]["lifetime"]["tokens_saved"] == 999
+
+
+def test_stats_history_marks_cli_filtering_unavailable(tmp_path, monkeypatch):
+    """Absent RTK stats must be explicit, not a misleading lifetime 0 card."""
+    import headroom.proxy.server as server
+
+    savings_path = tmp_path / "proxy_savings.json"
+    monkeypatch.setenv("HEADROOM_SAVINGS_PATH", str(savings_path))
+    monkeypatch.setattr(
+        server,
+        "_get_context_tool_stats",
+        lambda: {
+            "tool": "rtk",
+            "label": "RTK",
+            "installed": False,
+            "stats_available": False,
+            "status": "unavailable",
+            "unavailable_reason": "not_installed",
+            "session": {"tokens_saved": 0},
+            "lifetime": {"tokens_saved": 0},
+        },
+    )
+
+    config = ProxyConfig(
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        log_requests=False,
+        http2=False,
+    )
+
+    with TestClient(create_app(config)) as client:
+        response = client.get("/stats-history")
+        assert response.status_code == 200
+        data = response.json()
+
+    assert data["cli_filtering"]["tool"] == "rtk"
+    assert data["cli_filtering"]["available"] is False
+    assert data["cli_filtering"]["stats_available"] is False
+    assert data["cli_filtering"]["status"] == "unavailable"
+    assert data["cli_filtering"]["unavailable_reason"] == "not_installed"
+    assert data["cli_filtering"]["lifetime"]["tokens_saved"] == 0
 
 
 def test_coercion_helpers_reject_non_finite_values():


### PR DESCRIPTION
## Description

Closes #1831.

Dockerized Headroom can only report RTK stats that are visible to the Headroom proxy process. A host-only or WSL2-only `rtk gain` database is outside the container unless the RTK binary/state is mounted into the container. Before this change, the proxy represented missing or unreadable RTK stats as a zero-valued payload, so the dashboard made an unavailable integration look like a real `0` token / `0%` result.

This PR keeps the scope honest: it does not invent host-container telemetry. It adds explicit availability metadata, renders unavailable RTK stats as unavailable in the dashboard, and documents the Docker boundary.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add `stats_available`, `status`, and `unavailable_reason` to normalized RTK/CLI context-tool stats.
- Preserve legacy payload compatibility: existing stats payloads without `installed` are treated as available unless they explicitly say otherwise.
- Surface the availability metadata through `/stats`, `savings.by_layer.cli_filtering`, `context_tool`, and `/stats-history`.
- Update the dashboard to show RTK/context-tool stats as `Unavailable` instead of `0 this session` when the proxy cannot read them.
- Add Docker Compose comments and Docker-native docs explaining that RTK dashboard stats are read inside the proxy container.
- Add regression coverage for missing RTK binaries, `/stats`, `/stats-history`, and dashboard template branches.

## Testing

- [x] Unit tests pass (`pytest`) — focused local tests and full CI test matrix passed
- [x] Linting passes (`ruff check .`) — local Ruff and CI lint passed
- [x] Type checking passes (`mypy headroom`) — local mypy and CI lint passed
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
rtk proxy env HEADROOM_REQUIRE_RUST_CORE=false PYTHONPATH=/tmp/headroom-1831-shim:/Users/vinaygupta/Desktop/git/headroom-fix-1831-rtk-docker-dashboard pytest tests/test_proxy_dashboard_stats_cache.py::test_get_rtk_stats_memoizes_subprocess_calls tests/test_proxy_dashboard_stats_cache.py::test_get_rtk_stats_can_read_project_scoped_gain tests/test_proxy_dashboard_stats_cache.py::test_get_rtk_stats_marks_missing_binary_unavailable tests/test_proxy_dashboard_stats_cache.py::test_get_context_tool_stats_reads_lean_ctx_gain tests/test_proxy_dashboard_stats_cache.py::test_stats_marks_unavailable_context_tool_without_counting_fake_zero tests/test_proxy_dashboard_stats_cache.py::test_dashboard_uses_cached_stats_and_lazy_history_feed_polling tests/test_proxy_savings_history.py::test_stats_history_includes_cli_filtering tests/test_proxy_savings_history.py::test_stats_history_marks_cli_filtering_unavailable -q

8 passed, 2 warnings in 2.31s

rtk proxy uvx ruff check headroom/proxy/helpers.py headroom/proxy/server.py tests/test_proxy_dashboard_stats_cache.py tests/test_proxy_savings_history.py

All checks passed!

rtk git diff --check

<no output>
```

Full `uv run pytest ...` was not run successfully in this local checkout: the editable build hit the known native `esaxx-rs` failure (`fatal error: 'cstdint' file not found`) before tests could start. The focused pytest command above used a temporary in-memory `headroom._core` shim, matching the local workaround documented in the handover.

## Real Behavior Proof

- Environment: local TestClient with RTK stats stubbed as unavailable (`installed=false`, `stats_available=false`, `unavailable_reason=not_installed`).
- Exact command / steps: the focused pytest command above exercises `_read_rtk_lifetime_stats`, `/stats`, `/stats-history`, and dashboard template rendering paths.
- Observed result: unavailable RTK stats are carried as explicit metadata and the dashboard has an unavailable branch instead of rendering the RTK line as a real zero.
- Not tested: a live Docker Compose session with a host-only WSL2 RTK install; this PR intentionally avoids importing host `rtk gain` from the container.

## Review Readiness

- [x] I have performed a self-review
- [ ] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

- The fix is deliberately an unavailable-state/disclaimer, not host-container telemetry.
- CHANGELOG is not updated because this is a narrow bug fix.
- All non-skipped GitHub Actions checks are green after the rebase onto `main`; skipped jobs are path-gated.

