### PR TITLE
ci(devcontainers): free runner disk on the default variant too

### DIFF
--- a/.github/workflows/devcontainers.yml
+++ b/.github/workflows/devcontainers.yml
@@ -32,20 +32,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # The memory-stack devcontainer brings up Neo4j + Postgres +
-      # Redis + Qdrant on top of the Docker base. PR #495 surfaced
-      # that the GitHub-hosted runner now ships with too little
-      # headroom for that stack: the runner's diagnostic log writer
-      # hit "No space left on device" mid-smoke-test, killing the
-      # job before `devcontainer exec` could finish. The default
-      # devcontainer is light enough to pass on the same image.
+      # Both variants exhaust the GitHub runner's disk, so free space up front
+      # on every variant. memory-stack brings up Neo4j + Postgres + Redis +
+      # Qdrant (PR #495: the diagnostic log writer hit "No space left on device"
+      # mid-smoke-test). The default variant's post-create `uv sync` fills the
+      # disk installing the ML wheel set — it failed copying numpy into the venv
+      # with "No space left on device" (os error 28). Previously this ran only
+      # on memory-stack, which left the default variant with no cushion.
       #
-      # Reclaim ~14 GB by stripping preinstalled tools none of the
-      # devcontainer paths use (Android SDK, .NET, Haskell). Run
-      # ONLY on memory-stack — the default validate is fast and
-      # benefits from the preinstalled toolcache.
-      - name: Free runner disk (memory-stack only)
-        if: matrix.name == 'memory-stack'
+      # Reclaim ~14 GB by stripping preinstalled tools none of the devcontainer
+      # paths use (Android SDK, .NET, Haskell).
+      - name: Free runner disk
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true


### PR DESCRIPTION
## Description

The **Dev Containers → `validate (default)`** job failed on `main` with:

```
error: Failed to install: numpy-2.4.1-...whl
  Caused by: ... No space left on device (os error 28)
postCreateCommand from devcontainer.json failed with exit code 2
```

The failing step was `Start default` → the devcontainer's `post-create.sh` runs `uv sync`, which fills the runner's disk installing the ML wheel set (numpy et al.).

The workflow already has a `Free runner disk` step (reclaims ~14 GB), but it was gated `if: matrix.name == 'memory-stack'` — so the **default** variant had no disk cushion and tipped over. This drops the gate so **both** variants free disk before the container build.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Remove the `matrix.name == 'memory-stack'` gate on the `Free runner disk` step in `.github/workflows/devcontainers.yml` so it runs for the `default` variant too; reword the comment to note the default variant's `uv sync` disk exhaustion.

## Testing

- [x] Linting passes (`ruff check .`) — n/a (workflow YAML)
- [x] Manual testing performed (YAML validated; step now ungated)

### Test Output

```text
$ python -c "import yaml; ... 'Free runner disk' steps: 1 | has if-gate: False"
Free runner disk steps: 1 | has if-gate: False
```

## Real Behavior Proof

- Environment: local macOS; edited CI workflow only.
- Exact command / steps: removed the `if: matrix.name == 'memory-stack'` gate on the `Free runner disk` step; validated the YAML parses and the step is now ungated.
- Observed result: `Free runner disk` runs for every `validate` matrix variant, reclaiming ~14 GB before the devcontainer build so `uv sync` no longer exhausts the disk on the default variant.
- Not tested: the live CI run (the fix's effect is only observable when the Dev Containers workflow next runs on this PR / main). The `default` failure was a runner disk-exhaustion flake, not a code issue.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings