### PR TITLE
fix(wrap): restore Codex config after headroom sessions

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -1707,6 +1707,43 @@ def _ensure_rtk_binary(verbose: bool = False) -> Path | None:
     return None
 
 
+def _expose_rtk_on_path(rtk_path: Path, verbose: bool = False) -> bool:
+    """Make Headroom-managed rtk available as a bare ``rtk`` command.
+
+    Codex consumes RTK through instructions in ``~/.codex/AGENTS.md``. Unlike
+    Claude hooks, those instructions ask the agent to run ``rtk`` directly, so
+    the binary must live in a directory Codex already has on PATH. Avoid
+    overwriting a user-managed ``rtk``; if one exists, leave it alone.
+    """
+    existing = shutil.which("rtk")
+    if existing:
+        if verbose:
+            click.echo(f"  rtk already available on PATH at {existing}")
+        return True
+
+    home = Path.home()
+    target_dir = home / ".local" / "bin" if (home / ".local").exists() else home / "bin"
+    target = target_dir / ("rtk.exe" if sys.platform == "win32" else "rtk")
+
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        if target.exists() or target.is_symlink():
+            if target.resolve() == rtk_path.resolve():
+                return True
+            click.echo(f"  Warning: {target} already exists; not replacing it")
+            return False
+        try:
+            target.symlink_to(rtk_path)
+        except OSError:
+            shutil.copy2(rtk_path, target)
+        if verbose:
+            click.echo(f"  rtk exposed on PATH at {target}")
+        return True
+    except Exception as e:
+        click.echo(f"  Warning: could not expose rtk on PATH: {e}")
+        return False
+
+
 def _prepare_wrap_rtk(verbose: bool = False, *, label: str | None = None) -> Path | None:
     """Ensure rtk is present for host-bridged wrap flows without host-specific setup."""
     if label:
@@ -4639,6 +4676,7 @@ def codex(
             click.echo("  Setting up rtk for Codex...")
             rtk_path = _ensure_rtk_binary(verbose=verbose)
             if rtk_path:
+                _expose_rtk_on_path(rtk_path, verbose=verbose)
                 # Keep RTK guidance local to the user's Codex configuration.
                 global_agents = _codex_home_dir() / "AGENTS.md"
                 _inject_rtk_instructions(global_agents, verbose=verbose)
@@ -4861,6 +4899,11 @@ def codex(
             region=region,
         )
     finally:
+        try:
+            _restore_codex_provider_config()
+        except Exception as e:
+            click.echo(f"  Warning: could not restore Codex config after wrap: {e}")
+
         # _launch_tool's internal cleanup unregisters this client marker,
         # but doesn't know about the proxy we started.  Terminate it when
         # no other clients remain.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -797,6 +797,41 @@ run_claude_rtk_init() {
   fi
 }
 
+expose_rtk_on_path() {
+  local rtk_bin="${HEADROOM_HOST_HOME}/.headroom/bin/rtk"
+  local target_dir
+  local target
+
+  if [[ ! -x "${rtk_bin}" ]]; then
+    warn "rtk was not installed at ${rtk_bin}; Codex PATH setup was skipped"
+    return
+  fi
+
+  if command -v rtk >/dev/null 2>&1; then
+    return
+  fi
+
+  if [[ -d "${HEADROOM_HOST_HOME}/.local" ]]; then
+    target_dir="${HEADROOM_HOST_HOME}/.local/bin"
+  else
+    target_dir="${HEADROOM_HOST_HOME}/bin"
+  fi
+  target="${target_dir}/rtk"
+
+  mkdir -p "${target_dir}"
+  if [[ -e "${target}" || -L "${target}" ]]; then
+    if [[ "$(readlink "${target}" 2>/dev/null || true)" == "${rtk_bin}" ]]; then
+      return
+    fi
+    warn "${target} already exists; not replacing it"
+    return
+  fi
+
+  if ! ln -s "${rtk_bin}" "${target}"; then
+    warn "Failed to expose rtk at ${target}; Codex may not find bare rtk commands"
+  fi
+}
+
 selected_context_tool() {
   local value="${HEADROOM_CONTEXT_TOOL:-rtk}"
   value="${value,,}"
@@ -1537,6 +1572,8 @@ main() {
 
       if [[ "${no_rtk}" -eq 0 && "${context_tool}" == "lean-ctx" ]]; then
         run_lean_ctx_init "${tool}"
+      elif [[ "${no_rtk}" -eq 0 && "${context_tool}" == "rtk" && "${tool}" == "codex" ]]; then
+        expose_rtk_on_path
       fi
 
       case "${tool}" in
@@ -1547,7 +1584,12 @@ main() {
           ANTHROPIC_BASE_URL="http://127.0.0.1:${port}" run_host_tool claude "${host_args[@]}"
           ;;
         codex)
+          set +e
           OPENAI_BASE_URL="http://127.0.0.1:${port}/v1" run_host_tool codex "${host_args[@]}"
+          local codex_status=$?
+          set -e
+          run_headroom unwrap codex --no-stop-proxy >/dev/null || warn "Failed to restore Codex config after wrap"
+          return "${codex_status}"
           ;;
         aider)
           OPENAI_API_BASE="http://127.0.0.1:${port}/v1" \

--- a/tests/test_cli/test_wrap_codex.py
+++ b/tests/test_cli/test_wrap_codex.py
@@ -1086,6 +1086,78 @@ def test_wrap_codex_injects_rtk_globally_without_changing_project_agents(
     assert wrap_mod._RTK_MARKER.encode() in global_agents.read_bytes()
 
 
+def test_wrap_codex_exposes_managed_rtk_as_bare_command(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_home(monkeypatch, tmp_path)
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    monkeypatch.setenv("PATH", str(local_bin))
+
+    rtk_path = tmp_path / ".headroom" / "bin" / "rtk"
+    rtk_path.parent.mkdir(parents=True)
+    rtk_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    rtk_path.chmod(0o755)
+
+    with patch(
+        "headroom.cli.wrap._ensure_rtk_binary",
+        return_value=rtk_path,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "wrap",
+                "codex",
+                "--prepare-only",
+                "--no-mcp",
+                "--no-serena",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    exposed = local_bin / "rtk"
+    assert exposed.exists()
+    assert exposed.resolve() == rtk_path
+
+
+def test_wrap_codex_restores_provider_config_after_launch(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_home(monkeypatch, tmp_path)
+    config_file = tmp_path / ".codex" / "config.toml"
+    config_file.parent.mkdir(parents=True)
+    original = 'model = "gpt-5"\n'
+    config_file.write_text(original, encoding="utf-8")
+
+    def assert_wrapped_then_exit(**kwargs: object) -> None:
+        del kwargs
+        content = config_file.read_text(encoding="utf-8")
+        assert 'model_provider = "headroom"' in content
+        raise SystemExit(0)
+
+    with (
+        patch("headroom.cli.wrap._ensure_rtk_binary", return_value=None),
+        patch("headroom.cli.wrap._ensure_proxy", return_value=(None, 8787)),
+        patch("headroom.cli.wrap.shutil.which", return_value="/usr/local/bin/codex"),
+        patch("headroom.cli.wrap._launch_tool", side_effect=assert_wrapped_then_exit),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "wrap",
+                "codex",
+                "--no-mcp",
+                "--no-serena",
+                "--port",
+                "8787",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert config_file.read_text(encoding="utf-8") == original
+    assert not (tmp_path / ".codex" / "config.toml.headroom-backup").exists()
+
+
 def test_unwrap_codex_without_codex_home_warns_on_ambiguous_noop(
     runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- restore Codex provider config after `headroom wrap codex` exits
- expose Headroom-managed `rtk` as a bare command for Codex instructions
- mirror the Codex cleanup behavior in the Docker-native wrapper
- add regression coverage for config restoration and `rtk` PATH exposure

## Validation

- `PYTHONPATH=/private/tmp/headroom-main-ship /Users/dan/Projects/others/headroom/.venv/bin/python -m pytest tests/test_cli/test_wrap_codex.py` passed before the temporary worktree was removed: 85 passed
- `bash -n scripts/install.sh`
- `bash -n /Users/dan/.local/bin/headroom`
