### PR TITLE
fix(proxy): repair Windows proxy startup crash from invalid uvicorn loop kwarg

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -4468,7 +4468,14 @@ def run_server(
         # ProactorEventLoop can close the listening socket on transient
         # AcceptEx failures (for example WinError 64 from keep-alive RSTs).
         # The selector loop keeps accept errors scoped to the connection.
-        uvicorn_kwargs["loop"] = "asyncio:SelectorEventLoop"
+        # uvicorn's `loop=` is a lookup key into LOOP_SETUPS ("none"/"auto"/
+        # "asyncio"/"uvloop"), not an import path -- "asyncio:SelectorEventLoop"
+        # raises KeyError in Config.setup_event_loop(). Also, uvicorn's own
+        # asyncio_setup() only forces WindowsSelectorEventLoopPolicy when
+        # use_subprocess=True (reload or workers>1), so routing through
+        # `loop=` wouldn't cover the default single-worker path anyway. Set
+        # the policy directly instead.
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     if workers > 1:
         # CompressionCache and PrefixTracker are always per-worker instance vars.
         # Python CompressionStore defaults to InMemoryBackend (per-process), so


### PR DESCRIPTION
## Summary
- On Windows, `run_server()` set `uvicorn_kwargs["loop"] = "asyncio:SelectorEventLoop"`, but uvicorn's `loop=` is a lookup key (`"none"|"auto"|"asyncio"|"uvloop"`), not an import path. `Config.setup_event_loop()` does `LOOP_SETUPS[self.loop]`, which raised `KeyError` on every Windows proxy startup.
- Even with a valid key, uvicorn's own `asyncio_setup()` only applies `WindowsSelectorEventLoopPolicy` when `use_subprocess=True` (i.e. `reload` or `workers>1`), so the intended selector-loop workaround (avoiding `ProactorEventLoop` `AcceptEx` failures, e.g. `WinError 64` from keep-alive RSTs) wouldn't have taken effect for the default single-worker path anyway.
- Fix: call `asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())` directly before starting uvicorn, instead of routing through the `loop=` kwarg.

## Test plan
- [x] Verified the bug reproduces on Windows: `python -m headroom.cli proxy --port <n>` crashed with `KeyError: 'asyncio:SelectorEventLoop'` before the fix.
- [x] Applied the fix locally and confirmed the proxy starts cleanly and serves traffic: `/livez` and `/readyz` return 200, with `rust_core: loaded`.
- [ ] CI (Linux/macOS) unaffected — this branch is gated on `sys.platform == "win32"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)