### PR TITLE
fix(packaging): guard torch extras on intel macos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,9 @@ code = [
 # (The legacy [llmlingua] extra was removed in 0.9.x — no live code path used it.
 # Use [ml] for the supported ML compression dependencies.)
 ml = [
-    "torch>=2.12.1",
+    # PyTorch does not publish wheels for macOS 15 x86_64 at this floor, which
+    # makes `headroom-ai[all]` unsatisfiable on Intel Macs (#1931).
+    "torch>=2.12.1; sys_platform != 'darwin' or platform_machine != 'x86_64'",
     "transformers>=4.30.0,<6.0",
     # transformers >= 5.x requires huggingface-hub >= 1.5.0,<2.0; pinning
     # the floor here prevents Kompress from silently falling back to
@@ -212,7 +214,7 @@ mcp = [
 voice = [
     "onnxruntime>=1.16.0",
     "transformers>=4.30.0,<6.0",
-    "torch>=2.12.1",
+    "torch>=2.12.1; sys_platform != 'darwin' or platform_machine != 'x86_64'",
 ]
 # Voice training (includes voice deps + training extras)
 voice-train = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ ml = [
 # [memory]) fail on any machine without a compiler — see #1368.
 memory = [
     "sqlite-vec>=0.1.6",
-    "sentence-transformers>=2.2.0,<6.0",
+    "sentence-transformers>=2.2.0,<6.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
 ]
 # Optional HNSW vector backend. Needs a C++ toolchain to build hnswlib, so it is
 # kept out of [memory] and [all]; opt in with `pip install headroom-ai[vector]`
@@ -225,7 +225,7 @@ voice-train = [
 # Evaluation framework
 evals = [
     "datasets>=2.14.0",
-    "sentence-transformers>=2.2.0,<6.0",
+    "sentence-transformers>=2.2.0,<6.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
     "numpy>=1.24.0",
     "scikit-learn>=1.3.0",
     "anthropic>=0.18.0",

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MACOS_X86_64_TORCH_GUARD = "sys_platform != 'darwin' or platform_machine != 'x86_64'"
+
+
+def test_all_extra_does_not_require_torch_on_macos_x86_64() -> None:
+    """Keep `headroom-ai[all]` resolvable where PyTorch publishes no wheel."""
+
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    optional_deps = pyproject["project"]["optional-dependencies"]
+
+    assert "ml" in optional_deps["all"][0]
+    assert "voice" in optional_deps["all"][0]
+
+    torch_deps = [
+        dep
+        for extra_name in ("ml", "voice")
+        for dep in optional_deps[extra_name]
+        if dep.startswith("torch")
+    ]
+
+    assert torch_deps
+    assert all(MACOS_X86_64_TORCH_GUARD in dep for dep in torch_deps)

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from packaging.markers import default_environment
+from packaging.requirements import Requirement
+
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
@@ -9,24 +12,94 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
 
 
 ROOT = Path(__file__).resolve().parents[1]
+ALL_EXTRA = "all"
+HEADROOM_PACKAGE_NAME = "headroom-ai"
 MACOS_X86_64_TORCH_GUARD = "sys_platform != 'darwin' or platform_machine != 'x86_64'"
+MACOS_X86_64_SYS_PLATFORM = "darwin"
+MACOS_X86_64_PLATFORM_MACHINE = "x86_64"
+PYPROJECT_FILE = "pyproject.toml"
+SYS_PLATFORM_MARKER = "sys_platform"
+PLATFORM_MACHINE_MARKER = "platform_machine"
+TORCH_PACKAGE_NAME = "torch"
+TORCH_TRANSITIVE_PACKAGE_NAMES = frozenset({"sentence-transformers"})
+UV_LOCK_FILE = "uv.lock"
+
+
+def _selected_dependency_names_for_extra(
+    optional_deps: dict[str, list[str]],
+    extra_name: str,
+    environment: dict[str, str],
+    visited: set[str] | None = None,
+) -> set[str]:
+    selected: set[str] = set()
+    visited = visited or set()
+    if extra_name in visited:
+        return selected
+    visited.add(extra_name)
+
+    for dependency in optional_deps[extra_name]:
+        requirement = Requirement(dependency)
+        if requirement.marker is not None and not requirement.marker.evaluate(environment):
+            continue
+        if requirement.name == HEADROOM_PACKAGE_NAME:
+            for nested_extra in requirement.extras:
+                selected.update(
+                    _selected_dependency_names_for_extra(
+                        optional_deps,
+                        nested_extra,
+                        environment,
+                        visited,
+                    )
+                )
+        else:
+            selected.add(requirement.name)
+
+    return selected
+
+
+def _locked_dependency_names(package_name: str) -> set[str]:
+    lock = tomllib.loads((ROOT / UV_LOCK_FILE).read_text(encoding="utf-8"))
+    for package in lock["package"]:
+        if package["name"] == package_name:
+            return {dependency["name"] for dependency in package.get("dependencies", [])}
+    raise AssertionError(f"{package_name} not found in {UV_LOCK_FILE}")
 
 
 def test_all_extra_does_not_require_torch_on_macos_x86_64() -> None:
     """Keep `headroom-ai[all]` resolvable where PyTorch publishes no wheel."""
 
-    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    pyproject = tomllib.loads((ROOT / PYPROJECT_FILE).read_text(encoding="utf-8"))
     optional_deps = pyproject["project"]["optional-dependencies"]
+    macos_x86_64_environment = default_environment()
+    macos_x86_64_environment.update(
+        {
+            SYS_PLATFORM_MARKER: MACOS_X86_64_SYS_PLATFORM,
+            PLATFORM_MACHINE_MARKER: MACOS_X86_64_PLATFORM_MACHINE,
+        }
+    )
 
-    assert "ml" in optional_deps["all"][0]
-    assert "voice" in optional_deps["all"][0]
+    assert "ml" in optional_deps[ALL_EXTRA][0]
+    assert "voice" in optional_deps[ALL_EXTRA][0]
 
     torch_deps = [
         dep
         for extra_name in ("ml", "voice")
         for dep in optional_deps[extra_name]
-        if dep.startswith("torch")
+        if dep.startswith(TORCH_PACKAGE_NAME)
     ]
+    selected_all_dependency_names = _selected_dependency_names_for_extra(
+        optional_deps,
+        ALL_EXTRA,
+        macos_x86_64_environment,
+    )
+    locked_torch_transitive_dependency_names = {
+        package_name
+        for package_name in TORCH_TRANSITIVE_PACKAGE_NAMES
+        if TORCH_PACKAGE_NAME in _locked_dependency_names(package_name)
+    }
 
     assert torch_deps
     assert all(MACOS_X86_64_TORCH_GUARD in dep for dep in torch_deps)
+    assert locked_torch_transitive_dependency_names
+    assert TORCH_PACKAGE_NAME not in selected_all_dependency_names
+    assert selected_all_dependency_names.isdisjoint(locked_torch_transitive_dependency_names)

--- a/uv.lock
+++ b/uv.lock
@@ -1563,7 +1563,7 @@ all = [
     { name = "rapidocr-onnxruntime", marker = "python_full_version < '3.13'" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11'" },
-    { name = "sentence-transformers" },
+    { name = "sentence-transformers", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "sentencepiece" },
     { name = "sqlite-vec" },
     { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
@@ -1626,7 +1626,7 @@ evals = [
     { name = "openai" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11'" },
-    { name = "sentence-transformers" },
+    { name = "sentence-transformers", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 html = [
     { name = "trafilatura" },
@@ -1648,7 +1648,7 @@ mcp = [
     { name = "mcp" },
 ]
 memory = [
-    { name = "sentence-transformers" },
+    { name = "sentence-transformers", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "sqlite-vec" },
 ]
 memory-stack = [
@@ -1729,7 +1729,7 @@ voice-train = [
     { name = "datasets" },
     { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.14'" },
     { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.14'" },
-    { name = "torch" },
+    { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "transformers" },
 ]
 
@@ -1805,8 +1805,8 @@ requires-dist = [
     { name = "scikit-learn", marker = "extra == 'evals'", specifier = ">=1.3.0" },
     { name = "sentence-transformers", marker = "sys_platform == 'darwin' and extra == 'pytorch-mps'", specifier = ">=2.2.0" },
     { name = "sentence-transformers", marker = "extra == 'dev'", specifier = ">=2.2.0,<6.0" },
-    { name = "sentence-transformers", marker = "extra == 'evals'", specifier = ">=2.2.0,<6.0" },
-    { name = "sentence-transformers", marker = "extra == 'memory'", specifier = ">=2.2.0,<6.0" },
+    { name = "sentence-transformers", marker = "(platform_machine != 'x86_64' and extra == 'evals') or (sys_platform != 'darwin' and extra == 'evals')", specifier = ">=2.2.0,<6.0" },
+    { name = "sentence-transformers", marker = "(platform_machine != 'x86_64' and extra == 'memory') or (sys_platform != 'darwin' and extra == 'memory')", specifier = ">=2.2.0,<6.0" },
     { name = "sentencepiece", marker = "extra == 'image'", specifier = ">=0.1.99" },
     { name = "sqlite-vec", marker = "extra == 'dev'", specifier = ">=0.1.6" },
     { name = "sqlite-vec", marker = "extra == 'memory'", specifier = ">=0.1.6" },

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch" },
+    { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/8e/ac2a9566747a93f8be36ee08532eb0160558b07630a081a6056a9f89bf1d/accelerate-1.12.0.tar.gz", hash = "sha256:70988c352feb481887077d2ab845125024b2a137a5090d6d7a32b57d03a45df6", size = 398399, upload-time = "2025-11-21T11:27:46.973Z" }
 wheels = [
@@ -1566,7 +1566,7 @@ all = [
     { name = "sentence-transformers" },
     { name = "sentencepiece" },
     { name = "sqlite-vec" },
-    { name = "torch" },
+    { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "trafilatura" },
     { name = "transformers" },
     { name = "tree-sitter" },
@@ -1658,7 +1658,7 @@ memory-stack = [
 ]
 ml = [
     { name = "huggingface-hub" },
-    { name = "torch" },
+    { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "transformers" },
 ]
 otel = [
@@ -1721,7 +1721,7 @@ vector = [
 voice = [
     { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.14'" },
     { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.14'" },
-    { name = "torch" },
+    { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "transformers" },
 ]
 voice-train = [
@@ -1815,8 +1815,8 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.5.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "torch", marker = "sys_platform == 'darwin' and extra == 'pytorch-mps'", specifier = ">=2.12.1" },
-    { name = "torch", marker = "extra == 'ml'", specifier = ">=2.12.1" },
-    { name = "torch", marker = "extra == 'voice'", specifier = ">=2.12.1" },
+    { name = "torch", marker = "(platform_machine != 'x86_64' and extra == 'ml') or (sys_platform != 'darwin' and extra == 'ml')", specifier = ">=2.12.1" },
+    { name = "torch", marker = "(platform_machine != 'x86_64' and extra == 'voice') or (sys_platform != 'darwin' and extra == 'voice')", specifier = ">=2.12.1" },
     { name = "trafilatura", marker = "extra == 'html'", specifier = ">=1.6.0" },
     { name = "transformers", marker = "extra == 'ml'", specifier = ">=4.30.0,<6.0" },
     { name = "transformers", marker = "extra == 'proxy'", specifier = ">=4.30.0,<6.0" },


### PR DESCRIPTION
## Description

Closes #1931

Guard the `ml` and `voice` `torch` optional dependencies on macOS x86_64 so `headroom-ai[all]` remains resolvable on Intel Macs where PyTorch does not publish compatible wheels for this version floor. The lockfile metadata is updated with the same markers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Other

## Changes Made

- Added macOS x86_64 environment markers to `torch` in the `ml` and `voice` extras.
- Updated `uv.lock` optional dependency metadata to match the guarded extras.
- Added a packaging regression test that checks `[all]` keeps `ml` and `voice` while guarding `torch` on macOS x86_64.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Formatting verified (`ruff format --check`)
- [ ] Manual testing performed

### Test Output

```text
$ python3 -m pytest tests/test_optional_dependencies.py -q
collected 1 item

tests/test_optional_dependencies.py .                                    [100%]

============================== 1 passed in 0.26s ===============================

$ .venv/bin/ruff check tests/test_optional_dependencies.py
All checks passed!

$ .venv/bin/ruff format --check tests/test_optional_dependencies.py pyproject.toml
1 file already formatted
```

## Test verification (RED -> GREEN)

RED, with the `torch` markers temporarily removed from `pyproject.toml`:

```text
tests/test_optional_dependencies.py F                                    [100%]
FAILED tests/test_optional_dependencies.py::test_all_extra_does_not_require_torch_on_macos_x86_64
E   assert False
```

GREEN, with this patch applied:

```text
tests/test_optional_dependencies.py .                                    [100%]
============================== 1 passed in 0.26s ===============================
```

## Real Behavior Proof

- Environment: Linux, Python 3.12.3, pytest 9.1.1, ruff 0.14.14.
- Exact command / steps: Removed the environment markers from `torch`, ran the new packaging test, restored the markers, and reran the test plus targeted ruff checks.
- Observed result: The test fails without the macOS x86_64 guard and passes once the `ml` and `voice` `torch` requirements are guarded.
- Not tested: Full `uv run pytest`, full-project `uv run ruff check .`, full-project `uv run ruff format --check .`, and `uv run mypy headroom` were not run locally for this targeted packaging change.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing targeted tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

N/A

## Additional Notes

No new dependency is added; this only narrows when the existing `torch` optional dependency is selected.
