### PR TITLE
fix(kompress): surface model-not-ready state via logs and health endpoint

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2423,7 +2423,9 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
 
     def _health_payload(*, include_config: bool) -> dict[str, Any]:
         checks = _health_checks()
-        ready = all(check["ready"] for check in checks.values())
+        # Kompress is an optional soft component: model downloads lazily on
+        # first use, so "not ready" (cold cache) must not degrade overall health.
+        ready = all(check["ready"] for name, check in checks.items() if name != "kompress")
         payload: dict[str, Any] = {
             "service": "headroom-proxy",
             "status": "healthy" if ready else "unhealthy",

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2320,6 +2320,11 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                 url=_upstream_check_cache["url"],
                 error=_upstream_check_cache["error"],
             ),
+            "kompress": _component_health(
+                enabled=not config.disable_kompress,
+                ready=proxy.warmup.kompress.status == "loaded",
+                backend=proxy.warmup.kompress.info.get("backend", None),
+            ),
         }
 
     def _runtime_payload() -> dict[str, Any]:

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -2362,6 +2362,16 @@ class ContentRouter(Transform):
             if compressor:
                 if not compressor.is_ready():
                     compressor.ensure_background_load()
+                    # Surface: warn once per ContentRouter instance so operators
+                    # know compression is degraded — model not cached, or
+                    # HuggingFace unreachable (corporate firewall, SSL, etc.).
+                    if not getattr(self, "_kompress_warned", False):
+                        logger.warning(
+                            "Kompress model not ready; requests will not be "
+                            "compressed. Check HuggingFace connectivity or "
+                            "pre-download: headroom-ai[ml] + first-run warmup."
+                        )
+                        self._kompress_warned = True
                 else:
                     try:
                         result = compressor.compress(
@@ -2713,9 +2723,10 @@ class ContentRouter(Transform):
                     try:
                         backend = compressor.preload(allow_download=False)
                     except KompressModelNotCached:
-                        logger.info(
-                            "Kompress model not cached; deferring download to "
-                            "first use to keep startup non-blocking"
+                        logger.warning(
+                            "Kompress model not cached; compression disabled "
+                            "until model is downloaded. Ensure HuggingFace is "
+                            "accessible or pre-download with headroom-ai[ml]."
                         )
                         status["kompress"] = "deferred"
                     else:


### PR DESCRIPTION
## Description

Kompress model download failures (HuggingFace unreachable, corporate firewall, SSL errors) previously caused **silent 0% compression** — the model isn't loaded, `is_ready()` returns `False`, and the proxy passes through with no warning, no health indicator, nothing. Operators cannot detect degraded operation without manually comparing `x-headroom-tokens-before` vs `x-headroom-tokens-after` headers.

Closes #2029

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

Three surfaces where silent failure is now visible:

- **Request-time (hot path)**: `ContentRouter.compress_text()` now logs a WARNING once per router instance when `is_ready()` is False and the model is not cached. Rate-limited to one log per session to avoid spam.

- **Startup (eager preload)**: `ContentRouter.eager_load_compressors()` now logs WARNING (was INFO) when `KompressModelNotCached` is raised, with actionable guidance ("Check HuggingFace connectivity or pre-download with headroom-ai[ml]").

- **Health endpoint**: `/health` response now includes a `kompress` component with the standard `enabled`/`ready`/`status`/`backend` fields. Kompress is treated as **optional** in the aggregate readiness check — a cold model cache does NOT degrade the overall proxy health status (matching the semantics of `cache` and `rate_limiter` which report `ready=True` when disabled).

## Testing

- [x] **Existing tests**: 13/13 pass in `test_kompress_preload_deferral.py` + `test_proxy_disable_kompress.py` + `test_proxy_ccr.py` + `test_proxy_debug_endpoints.py`
- [x] **Adversarial**: 5 endpoint-level tests verify `/health`, `/healthz`, `/livez`, `/readyz` all return 200 even when kompress model is not cached
- [x] **PBT (Hypothesis)**: 3 properties × 136 random combinations confirm aggregate readiness ignores kompress, `_component_health()` invariants hold, and kompress is never the sole cause of `unhealthy`
- [x] **Lint**: `ruff check` and `ruff format --check` pass on all changed files

```text
$ uv run pytest tests/test_kompress_preload_deferral.py tests/test_proxy_disable_kompress.py \
    tests/test_proxy_ccr.py::TestCCRIntegration::test_health_endpoint \
    tests/test_proxy_debug_endpoints.py::test_existing_health_routes_unchanged -q
.............                              [100%]
13 passed in 2.90s

$ uv run pytest /tmp/adversarial_kompress_health.py -q
.....                                      [100%]
5 passed in 9.60s
# Includes: /healthz, /livez, /readyz all 200; disable_kompress=True → status=disabled

$ uv run pytest /tmp/pbt_kompress_health.py -q
...                                        [100%]
3 passed in 0.56s
# Hypothesis: 128 aggregate combos + 4 invariant combos + 4 isolation combos
```

## Real Behavior Proof

- Environment: Linux, Python 3.12, headroom main @ a617455f
- Exact command / steps: `uv run pytest tests/test_kompress_preload_deferral.py tests/test_proxy_disable_kompress.py -q` → 13 passed; adversarial 5/5; PBT 3/3 (136 combos); `uv run ruff format --check headroom/transforms/content_router.py headroom/proxy/server.py` → 2 files already formatted
- Observed result: Startup warning fires when model not cached. Request-time warning fires once when `is_ready()` returns False. `/health` returns `kompress` with `enabled`, `ready`, and `backend` fields. Overall proxy health remains `healthy` regardless of kompress cold-cache state.
- Not tested: Full E2E with HuggingFace blocked (network simulation). Manual testing recommended for operators behind corporate firewalls.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
