### PR TITLE
fix(proxy): handle content-part outputs in Codex Responses compression

### DIFF
--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -1366,11 +1366,7 @@ class OpenAIHandlerMixin:
                     # can still be losslessly compacted. Reuse the router helper
                     # so the Responses path matches the chat/Anthropic behavior.
                     excl_out = _responses_part_text(item.get("output"))
-                    fold = (
-                        router._lossless_compact_excluded(excl_out)
-                        if excl_out
-                        else None
-                    )
+                    fold = router._lossless_compact_excluded(excl_out) if excl_out else None
                     if fold is not None:
                         lossless_excluded.append((idx, ("output", None), fold[0], excl_out))
                     if debug_enabled:

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -546,6 +546,15 @@ def _responses_input_item_text_bytes(item: Any) -> int:
     output = item.get("output")
     if isinstance(output, str):
         return len(output.encode("utf-8", errors="replace"))
+    if isinstance(output, list):
+        total = 0
+        for part in output:
+            if isinstance(part, str):
+                total += len(part.encode("utf-8", errors="replace"))
+            elif isinstance(part, dict) and isinstance(part.get("text"), str):
+                total += len(part["text"].encode("utf-8", errors="replace"))
+        if total > 0:
+            return total
 
     content = item.get("content")
     if isinstance(content, str):
@@ -1256,9 +1265,9 @@ class OpenAIHandlerMixin:
             # remain as defense-in-depth.
             type_tag = item.get("type")
             if type_tag in self.OPENAI_RESPONSES_OUTPUT_TYPES:
-                output = item.get("output")
-                if isinstance(output, str):
-                    return output, ("output", None)
+                output_text = _responses_part_text(item.get("output"))
+                if output_text:
+                    return output_text, ("output", None)
             return None
 
         def _set_slot_text(
@@ -1356,10 +1365,10 @@ class OpenAIHandlerMixin:
                     # Protected from lossy compression — but grep/log/json output
                     # can still be losslessly compacted. Reuse the router helper
                     # so the Responses path matches the chat/Anthropic behavior.
-                    excl_out = item.get("output")
+                    excl_out = _responses_part_text(item.get("output"))
                     fold = (
                         router._lossless_compact_excluded(excl_out)
-                        if isinstance(excl_out, str)
+                        if excl_out
                         else None
                     )
                     if fold is not None:

--- a/tests/test_openai_responses_compression_units.py
+++ b/tests/test_openai_responses_compression_units.py
@@ -176,6 +176,46 @@ def test_openai_responses_adapter_compresses_custom_tool_call_output():
     assert strategy_chain == []
 
 
+def test_openai_responses_adapter_compresses_output_content_parts():
+    router = ContentRouter()
+
+    def compress(self, content: str, **_kwargs):
+        return RouterCompressionResult(
+            compressed="content part output summary",
+            original=content,
+            strategy_used=CompressionStrategy.KOMPRESS,
+        )
+
+    router.compress = MethodType(compress, router)
+    handler = _handler_with_router(router)
+    long_text = " ".join(f"part{i}" for i in range(180))
+    payload = {
+        "model": "gpt-5",
+        "input": [
+            {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": [{"type": "output_text", "text": long_text}],
+            }
+        ],
+    }
+
+    new_payload, modified, saved, transforms, units_by_category, strategy_chain, _attempted = (
+        handler._compress_openai_responses_live_text_units_with_router(
+            payload,
+            model="gpt-5",
+            request_id="req_content_parts",
+        )
+    )
+
+    assert modified is True
+    assert saved > 0
+    assert new_payload["input"][0]["output"] == "content part output summary"
+    assert "router:openai:responses:function_call_output:kompress" in transforms
+    assert units_by_category == {"applied": 1}
+    assert strategy_chain == []
+
+
 def test_openai_responses_adapter_reuses_exact_tool_output_cache():
     router = ContentRouter()
     calls = {"count": 0}
@@ -488,6 +528,45 @@ def test_openai_responses_adapter_losslessly_folds_excluded_grep_output():
     folded = new_payload["input"][1]["output"]
     assert len(folded) < len(grep_out)  # byte-smaller (real guarantee)
     assert search_unheading(folded) == grep_out  # byte-exact recovery
+
+
+def test_openai_responses_adapter_losslessly_folds_excluded_output_content_parts():
+    from headroom.transforms.lossless_compaction import search_unheading
+
+    router = ContentRouter()
+    router.config.exclude_tools = {"grep"}
+    handler = _handler_with_router(router)
+    grep_out = "".join(
+        f"src/part_{f}.py:{ln}:matching content in a content part\n"
+        for f in range(8)
+        for ln in range(6)
+    )
+    payload = {
+        "model": "gpt-5",
+        "input": [
+            {"type": "function_call", "call_id": "call_1", "name": "grep", "arguments": "{}"},
+            {
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": [{"type": "output_text", "text": grep_out}],
+            },
+        ],
+    }
+
+    new_payload, modified, saved, transforms, _units, _chain, _attempted = (
+        handler._compress_openai_responses_live_text_units_with_router(
+            payload,
+            model="gpt-5",
+            request_id="req_content_part_fold",
+        )
+    )
+
+    assert modified is True
+    assert saved >= 0
+    assert "router:excluded:lossless" in transforms
+    folded = new_payload["input"][1]["output"]
+    assert len(folded) < len(grep_out)
+    assert search_unheading(folded) == grep_out
 
 
 def test_openai_responses_adapter_excludes_tool_case_insensitively_with_debug(monkeypatch):


### PR DESCRIPTION
## Description

Fixes 0% savings when wrapping Codex (Closes #2050).  `_slot_text` and the
lossless-excluded fold in the OpenAI Responses compression path only handled
`function_call_output` items whose `output` field is a plain string, silently
skipping items whose `output` is an array of content parts (valid per OpenAI
spec).  Use `_responses_part_text()` — which already handles both — so these
items reach the ContentRouter and accrue compression savings.

Also extend `_responses_input_item_text_bytes` to count text bytes inside
content-part arrays in the `output` field, matching its existing treatment of
the `content` field.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `_slot_text()` (openai.py:1260): use `_responses_part_text()` instead of
  `isinstance(output, str)` to extract text from both string and content-part
  outputs
- Lossless excluded fold (openai.py:1362): same change — use
  `_responses_part_text()` so excluded-tool outputs with content parts can
  still be losslessly compacted
- `_responses_input_item_text_bytes()` (openai.py:547): extend byte counting
  to handle content-part arrays in the `output` field, matching existing
  `content` field handling

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Manual testing performed

### Test Output

```text
$ uv run pytest tests/test_openai_responses_compression_units.py -x -q
16 passed in 1.19s

$ uv run pytest tests/ -k "openai and responses and compress" -x -q
19 passed, 14 skipped in 18.17s

$ uv run ruff check headroom/proxy/handlers/openai.py
All checks passed!
```

## Real Behavior Proof

- Environment: Linux (6.8.0-124-generic), Python 3.12.3, headroom main @ 868b88bc
- Exact command / steps: checkout branch, run `uv run pytest tests/test_openai_responses_compression_units.py -x -q`, run `uv run pytest tests/ -k "openai and responses and compress" -x -q`, run `uv run ruff check headroom/proxy/handlers/openai.py`
- Observed result: All 35 tests pass (16 units + 19 integration), ruff clean, no regressions
- Not tested: Live Codex WS end-to-end with actual content-part outputs (requires Codex Desktop and a session that produces content-part tool outputs)

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
