### PR TITLE
docs(proxy): document --protect-tool-results side effect on protect_recent_reads_fraction

### DIFF
--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -285,6 +285,10 @@ def dashboard(port: int, no_open: bool) -> None:
     help=(
         "Comma-separated tool names whose results are never lossy-compressed, "
         "merged with the built-in defaults (e.g. Bash,WebFetch). "
+        "In token mode, this also resets protect_recent_reads_fraction "
+        "from 0.3 (only recent ~30% of results protected) to 0.0 (all "
+        "results protected indefinitely), which prevents older Read/Glob/"
+        "Grep/Edit tool results from being silently compressed. "
         "Env: HEADROOM_PROTECT_TOOL_RESULTS."
     ),
 )

--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -288,7 +288,7 @@ def dashboard(port: int, no_open: bool) -> None:
         "In token mode, this also resets protect_recent_reads_fraction "
         "from 0.3 (only recent ~30% of results protected) to 0.0 (all "
         "results protected indefinitely), which prevents older Read/Glob/"
-        "Grep/Edit tool results from being silently compressed. "
+        "Grep/Write/Edit tool results from being silently compressed. "
         "Env: HEADROOM_PROTECT_TOOL_RESULTS."
     ),
 )

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -761,6 +761,11 @@ class HeadroomProxy(
         if is_token_mode(config.mode):
             router_config.protect_recent_reads_fraction = 0.3
             router_config.search_group_by_file = True
+        # Note: protect_tool_results runs AFTER token mode (ordering matters).
+        # It resets protect_recent_reads_fraction from 0.3→0.0, restoring
+        # full protection for ALL excluded-tool results regardless of age.
+        # This means naming any tool with --protect-tool-results also
+        # protects Read/Glob/Grep/Write/Edit results indefinitely.
         if config.protect_tool_results:
             router_config.protect_recent_reads_fraction = 0.0
         # `--compress-user-messages` flips the router's default skip rule.


### PR DESCRIPTION
## Description

Documents the side effect of `--protect-tool-results`: in token mode, naming
any tool also resets `protect_recent_reads_fraction` from 0.3 to 0.0 (Closes
#1921).  Previously this interaction was only visible in the source code
ordering in server.py and led to user confusion.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cli/proxy.py`: extend `--protect-tool-results` CLI help text to
  explain that in token mode it also resets `protect_recent_reads_fraction`
  from 0.3 → 0.0, restoring full indefinite protection for all excluded-tool
  results (Read/Glob/Grep/Write/Edit)
- `headroom/proxy/server.py`: add inline comment documenting the ordering
  dependency (token mode runs first, protect_tool_results overrides after)

## Testing

- [x] Linting passes (`ruff check`)
- [x] No functional changes (docs only)
- [ ] N/A — no code logic changes

### Test Output

```text
$ uv run ruff check headroom/cli/proxy.py headroom/proxy/server.py
All checks passed!
```

## Real Behavior Proof

- Environment: Linux, headroom main @ 868b88bc
- Exact command / steps: (1) `headroom proxy --help` → verify `--protect-tool-results` shows new help text, (2) read server.py line ~764 to verify comment documents the ordering dependency
- Observed result: Help text now explains the fraction-reset side effect; server.py comment makes the ordering dependency explicit
- Not tested: N/A — documentation-only change

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review