### PR TITLE
feat(wrap): allow project RTK instruction opt-out

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -5903,6 +5903,11 @@ def openclaw(
     is_flag=True,
     help="Skip CLI context-tool setup",
 )
+@click.option(
+    "--no-project-rtk",
+    is_flag=True,
+    help="Skip rtk instruction injection into the project AGENTS.md",
+)
 @click.option("--no-mcp", is_flag=True, help="Skip headroom MCP server registration")
 @click.option("--no-serena", is_flag=True, help="Skip Serena MCP server registration")
 @click.option(
@@ -5924,6 +5929,7 @@ def openclaw(
 def opencode(
     port: int,
     no_rtk: bool,
+    no_project_rtk: bool,
     no_mcp: bool,
     no_serena: bool,
     code_graph: bool,
@@ -5949,6 +5955,7 @@ def opencode(
         headroom wrap opencode                         # Start proxy + context tool + opencode
         headroom wrap opencode -- "fix the bug"        # Pass prompt to opencode
         headroom wrap opencode --no-context-tool       # Skip CLI context-tool setup
+        headroom wrap opencode --no-project-rtk        # Keep project AGENTS.md unchanged
         headroom wrap opencode --no-mcp                # Skip MCP retrieve tool registration
         headroom wrap opencode --no-serena             # Skip Serena MCP registration
         headroom wrap opencode --port 9999             # Custom proxy port
@@ -5968,9 +5975,9 @@ def opencode(
             click.echo("  Setting up rtk for OpenCode...")
             rtk_path = _ensure_rtk_binary(verbose=verbose)
             if rtk_path:
-                # Inject into project AGENTS.md
-                project_agents = Path.cwd() / "AGENTS.md"
-                _inject_rtk_instructions(project_agents, verbose=verbose)
+                if not no_project_rtk:
+                    project_agents = Path.cwd() / "AGENTS.md"
+                    _inject_rtk_instructions(project_agents, verbose=verbose)
                 # Inject into global OpenCode AGENTS.md
                 global_agents = _opencode_home_dir() / "AGENTS.md"
                 _inject_rtk_instructions(global_agents, verbose=verbose)

--- a/tests/test_cli/test_wrap_opencode.py
+++ b/tests/test_cli/test_wrap_opencode.py
@@ -241,6 +241,39 @@ def test_wrap_opencode_injects_rtk_into_agents_md(
     assert wrap_mod._RTK_MARKER in project_agents.read_text(encoding="utf-8")
 
 
+def test_wrap_opencode_no_project_rtk_only_skips_project_agents_md(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    _set_test_home(monkeypatch, tmp_path)
+    project_agents = tmp_path / "AGENTS.md"
+    project_agents.write_text("# Team instructions\n", encoding="utf-8")
+
+    with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=SystemExit(0)):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                result = runner.invoke(
+                    main,
+                    [
+                        "wrap",
+                        "opencode",
+                        "--no-project-rtk",
+                        "--no-proxy",
+                        "--port",
+                        "9000",
+                        "--no-mcp",
+                    ],
+                )
+
+    assert result.exit_code == 0, result.output
+    assert project_agents.read_text(encoding="utf-8") == "# Team instructions\n"
+    global_agents = tmp_path / ".config" / "opencode" / "AGENTS.md"
+    assert wrap_mod._RTK_MARKER in global_agents.read_text(encoding="utf-8")
+
+
 def test_wrap_opencode_idempotent_no_duplicate_block(
     runner: CliRunner,
     tmp_path: Path,


### PR DESCRIPTION
## Description

Add an opt-out for project-level RTK guidance when wrapping OpenCode, so teams can preserve an existing repository `AGENTS.md` while still installing RTK and its global OpenCode instructions.

Closes #1980

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- add `--no-project-rtk` to `headroom wrap opencode`
- leave the repository `AGENTS.md` untouched when requested
- continue installing RTK and its global OpenCode guidance
- cover preservation of existing team instructions

## Testing

- [x] Focused unit test passes (`pytest`)
- [x] Touched-file linting passes (`ruff check`)
- [ ] Type checking passes (`mypy headroom`) — not run
- [x] New test added for new functionality
- [ ] Manual testing performed

### Test Output

```text
uv run pytest tests/test_cli/test_wrap_opencode.py::test_wrap_opencode_no_project_rtk_only_skips_project_agents_md -q
1 passed

uv run ruff check headroom/cli/wrap.py tests/test_cli/test_wrap_opencode.py
All checks passed!

uv run ruff format --check headroom/cli/wrap.py tests/test_cli/test_wrap_opencode.py
2 files already formatted
```

## Real Behavior Proof

- Environment: local Python test environment
- Exact command / steps: invoke the focused OpenCode wrapper test with an existing project `AGENTS.md` and project RTK guidance disabled
- Observed result: the existing project instructions remain byte-for-byte untouched while the global RTK guidance path still runs
- Not tested: manual OpenCode launch or the full repository test suite

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings in the scoped checks
- [x] I have added a test that proves the feature works
- [x] Relevant existing and new unit coverage passes locally
- [ ] Documentation and changelog updates — not applicable for this self-documenting CLI option

## Additional Notes

The opt-out is deliberately narrow: it suppresses only the project `AGENTS.md` mutation, not RTK installation or global OpenCode configuration.
