### PR TITLE
fix(core): add CCR min-size floor and freshness exemption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",

--- a/crates/headroom-core/src/transforms/live_zone.rs
+++ b/crates/headroom-core/src/transforms/live_zone.rs
@@ -643,6 +643,46 @@ pub fn compress_anthropic_live_zone(
 pub fn compress_anthropic_live_zone_with_ccr(
     body_raw: &[u8],
     frozen_message_count: usize,
+    auth_mode: AuthMode,
+    model: &str,
+    ccr_store: Option<&dyn CcrStore>,
+) -> Result<LiveZoneOutcome, LiveZoneError> {
+    compress_anthropic_live_zone_with_ccr_and_freshness(
+        body_raw,
+        frozen_message_count,
+        0,
+        auth_mode,
+        model,
+        ccr_store,
+    )
+}
+
+/// Same as [`compress_anthropic_live_zone_with_ccr`], but also exempts
+/// the most-recent `fresh_message_count` messages (counted from the
+/// tail of `messages`) from compression entirely — regardless of size.
+///
+/// # Why
+///
+/// The live zone's `target_idx` (the latest user message) is, by
+/// construction, always the message that was *just appended* for this
+/// exact request — the in-flight turn's content the model is about to
+/// read for the very first time. Compressing it on sight forces an
+/// immediate `headroom_retrieve` round-trip just to read data the
+/// model hasn't had a chance to engage with yet (issue #3). Since
+/// every request resends the full conversation history, a message
+/// that's exempt here (fresh) becomes eligible on the *next* request
+/// once something else has been appended after it — at that point it's
+/// no longer in-flight, just accumulated context weight, and normal
+/// compression applies.
+///
+/// `fresh_message_count = 0` (what [`compress_anthropic_live_zone_with_ccr`]
+/// passes) preserves the pre-fix behavior byte-for-byte — this is an
+/// additive, opt-in parameter so existing callers are unaffected.
+/// Production wiring (the proxy) should pass `1`.
+pub fn compress_anthropic_live_zone_with_ccr_and_freshness(
+    body_raw: &[u8],
+    frozen_message_count: usize,
+    fresh_message_count: usize,
     _auth_mode: AuthMode,
     model: &str,
     ccr_store: Option<&dyn CcrStore>,
@@ -662,8 +702,14 @@ pub fn compress_anthropic_live_zone_with_ccr(
     let messages_total = messages.len();
     let messages_below_frozen_floor = frozen_message_count.min(messages_total);
 
-    // Latest user message index, restricted to the live zone (>= floor).
-    let latest_user_message_index = find_latest_user_message_index(messages, frozen_message_count);
+    // Latest user message index, restricted to the live zone (>= floor)
+    // AND to the non-fresh window (< messages_total - fresh_message_count).
+    // Narrowing the search window (rather than filtering the result)
+    // means a fresh-but-not-latest-user message correctly falls back to
+    // an older, aged user message instead of bailing out entirely.
+    let fresh_ceiling = messages_total.saturating_sub(fresh_message_count);
+    let latest_user_message_index =
+        find_latest_user_message_index(&messages[..fresh_ceiling], frozen_message_count);
 
     let Some(target_idx) = latest_user_message_index else {
         return Ok(LiveZoneOutcome::NoChange {

--- a/crates/headroom-core/src/transforms/mod.rs
+++ b/crates/headroom-core/src/transforms/mod.rs
@@ -40,10 +40,10 @@ pub use diff_compressor::{
     DiffCompressionResult, DiffCompressor, DiffCompressorConfig, DiffCompressorStats,
 };
 pub use live_zone::{
-    compress_anthropic_live_zone, compress_openai_chat_live_zone,
-    compress_openai_responses_live_zone, summarize_openai_responses_no_change_reason, AuthMode,
-    BlockAction, BlockOutcome, CompressionManifest, ExclusionReason, LiveZoneError,
-    LiveZoneOutcome,
+    compress_anthropic_live_zone, compress_anthropic_live_zone_with_ccr_and_freshness,
+    compress_openai_chat_live_zone, compress_openai_responses_live_zone,
+    summarize_openai_responses_no_change_reason, AuthMode, BlockAction, BlockOutcome,
+    CompressionManifest, ExclusionReason, LiveZoneError, LiveZoneOutcome,
 };
 pub use log_compressor::{
     LogCompressionResult, LogCompressor, LogCompressorConfig, LogCompressorStats, LogFormat,

--- a/crates/headroom-core/src/transforms/smart_crusher/builder.rs
+++ b/crates/headroom-core/src/transforms/smart_crusher/builder.rs
@@ -142,7 +142,14 @@ impl SmartCrusherBuilder {
     /// formatter, default `CompactConfig`). Equivalent to
     /// `with_compaction(CompactionStage::default_csv_schema())`.
     pub fn with_default_compaction(self) -> Self {
-        self.with_compaction(CompactionStage::default_csv_schema())
+        // Thread the operator-facing `opaque_min_bytes` floor into the
+        // compaction stage's classifier config — otherwise table-cell
+        // opaque substitution would silently ignore whatever the
+        // caller configured and fall back to `ClassifyConfig`'s own
+        // default (issue #3).
+        let mut stage = CompactionStage::default_csv_schema();
+        stage.config.classify.ccr_min_bytes = self.config.opaque_min_bytes;
+        self.with_compaction(stage)
     }
 
     /// Plug in a CCR store. The lossy `crush_array` path stashes each

--- a/crates/headroom-core/src/transforms/smart_crusher/compaction/classifier.rs
+++ b/crates/headroom-core/src/transforms/smart_crusher/compaction/classifier.rs
@@ -45,10 +45,30 @@ pub enum CellClass {
 /// builder if a workload has different characteristics (e.g. an API
 /// that always emits 500-char status descriptions shouldn't have those
 /// CCR-substituted).
+///
+/// # Two-tier threshold design
+///
+/// [`opaque_min_bytes`](Self::opaque_min_bytes) and
+/// [`ccr_min_bytes`](Self::ccr_min_bytes) look similar but answer
+/// different questions:
+///
+/// - `opaque_min_bytes` — "is this string *shaped* like an opaque blob
+///   at all" (base64/HTML/long-plain-text detection heuristic). Kept
+///   low (256 B) so [`CellClass::Opaque`] sub-kind detection (used by
+///   telemetry and by the `ccr_min_bytes` gate below) stays accurate
+///   on modest fixtures.
+/// - `ccr_min_bytes` — "is this opaque blob *big enough to be worth*
+///   CCR-substituting" (issue #3: fields around ~1 KB were getting
+///   replaced by `<<ccr:...>>` markers even though the round-trip
+///   overhead of a `headroom_retrieve` call outweighs the tokens
+///   saved). This is the floor callers should raise/lower per
+///   workload; default 2 KB.
 #[derive(Debug, Clone)]
 pub struct ClassifyConfig {
     /// Strings strictly longer than this become candidates for opaque
-    /// classification. Default: 256 bytes.
+    /// classification. Default: 256 bytes. See "Two-tier threshold
+    /// design" above — this is a shape-detection heuristic, not the
+    /// CCR-substitution policy floor.
     pub opaque_min_bytes: usize,
     /// Base64-alphabet ratio threshold. Strings whose chars are at
     /// least this fraction in `[A-Za-z0-9+/=_-]` and longer than 64
@@ -57,6 +77,18 @@ pub struct ClassifyConfig {
     /// `<` count above which a long string is considered HTML-ish.
     /// Default: 3.
     pub html_min_open_brackets: usize,
+    /// Minimum byte length for an already-[`CellClass::Opaque`]-classified
+    /// string to actually be replaced by a `<<ccr:...>>` marker. Below
+    /// this floor the value is rendered verbatim even though it's
+    /// opaque-shaped — the retrieval round-trip isn't worth it for a
+    /// ~1 KB field. Default: 2048 bytes (2 KB); operators may raise to
+    /// 4 KB for workloads with many small-but-opaque fields. Wired
+    /// end-to-end via `SmartCrusherConfig::opaque_min_bytes`. Orthogonal
+    /// to `emit_opaque_markers` below: that's a global on/off toggle
+    /// checked at classification time; this is a size floor checked at
+    /// substitution time by callers (`cell_from_value`, `process_string`,
+    /// the document walker) once a cell is already `CellClass::Opaque`.
+    pub ccr_min_bytes: usize,
     /// When false, long strings are NOT classified as opaque — they stay
     /// `Scalar` and render verbatim, so output is marker-free and
     /// guaranteed-lossless. Mirrors the row-drop path's `enable_ccr_marker`
@@ -70,6 +102,7 @@ impl Default for ClassifyConfig {
             opaque_min_bytes: 256,
             base64_alphabet_ratio: 0.95,
             html_min_open_brackets: 3,
+            ccr_min_bytes: 2048,
             emit_opaque_markers: true,
         }
     }

--- a/crates/headroom-core/src/transforms/smart_crusher/compaction/compactor.rs
+++ b/crates/headroom-core/src/transforms/smart_crusher/compaction/compactor.rs
@@ -114,7 +114,10 @@ pub fn compact(items: &[Value], cfg: &CompactConfig) -> Compaction {
 /// The IR (and therefore the rendered marker text) is identical whether or
 /// not a store is supplied — the store only adds a side-effecting write, so
 /// `compact(items, cfg)` and `compact_with_store(items, cfg, Some(store))`
-/// return the same [`Compaction`].
+/// return the same [`Compaction`]. Cells below
+/// [`ClassifyConfig::ccr_min_bytes`](super::classifier::ClassifyConfig::ccr_min_bytes)
+/// never reach the store at all — they render verbatim as `CellValue::Scalar`
+/// since the retrieval round-trip is not worth it for a small field (issue #3).
 pub fn compact_with_store(
     items: &[Value],
     cfg: &CompactConfig,
@@ -260,12 +263,19 @@ fn cell_from_value(v: &Value, cfg: &CompactConfig, store: Option<&Arc<dyn CcrSto
                 Value::String(s) => s,
                 _ => return CellValue::Scalar(v.clone()),
             };
+            // Below the CCR-substitution floor: opaque-shaped, but too
+            // small to be worth the retrieval round-trip (issue #3).
+            // Render verbatim rather than mint an unnecessary marker.
+            if s.len() < cfg.classify.ccr_min_bytes {
+                return CellValue::Scalar(v.clone());
+            }
             let ccr_hash = hash_opaque(s.as_bytes());
             // Stash the original so `GET /v1/retrieve/{hash}` and the
             // `headroom_retrieve` tool can serve it back — mirrors
             // `walker::emit_opaque_ccr_marker`. Without this write the
             // marker points at a key that was never stored and retrieval
-            // 404s (issue #1083).
+            // 404s (issue #1083 / #2 — same bug, fixed independently on
+            // both branches, reconciled here).
             if let Some(store) = store {
                 store.put(&ccr_hash, s);
             }
@@ -665,7 +675,7 @@ mod tests {
 
     #[test]
     fn opaque_cell_becomes_ccr_ref() {
-        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(8);
+        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
         let items = vec![
             json!({"id": 1, "blob": big.clone()}),
             json!({"id": 2, "blob": big.clone()}),
@@ -789,8 +799,9 @@ mod tests {
         use std::sync::Arc;
 
         // Same blob the `opaque_cell_becomes_ccr_ref` test uses — known to
-        // classify as Opaque, so the OpaqueRef / `<<ccr:HASH,...>>` path runs.
-        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(8);
+        // classify as Opaque, and long enough to clear ccr_min_bytes so the
+        // OpaqueRef / `<<ccr:HASH,...>>` path (not the floor short-circuit) runs.
+        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
         let items = vec![
             json!({"id": 1, "blob": big.clone()}),
             json!({"id": 2, "blob": big.clone()}),
@@ -815,7 +826,7 @@ mod tests {
             other => panic!("expected Table, got {other:?}"),
         };
 
-        // Issue #1083: the original payload must be retrievable under the
+        // Issue #1083 / #2: the original payload must be retrievable under the
         // exact hash the marker carries (before the fix the store was empty).
         assert_eq!(store.get(&hash).as_deref(), Some(big.as_str()));
         // Lock the key<->marker contract: stored key == hash_opaque(payload).
@@ -827,7 +838,7 @@ mod tests {
         use crate::ccr::{CcrStore, InMemoryCcrStore};
         use std::sync::Arc;
 
-        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(8);
+        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
         let items = vec![
             json!({"id": 1, "blob": big.clone()}),
             json!({"id": 2, "blob": big.clone()}),
@@ -846,5 +857,66 @@ mod tests {
         assert_eq!(fmt.format(&without), fmt.format(&with));
         // ...and that write actually happened.
         assert!(!store.is_empty());
+    }
+
+    #[test]
+    fn compact_without_store_still_works_and_stores_nothing() {
+        // `compact()` (no store) must keep producing markers — just
+        // without a place to retrieve from. Back-compat contract for
+        // the many existing callers that pass no store.
+        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
+        let items = vec![
+            json!({"id": 1, "blob": big.clone()}),
+            json!({"id": 2, "blob": big.clone()}),
+        ];
+        match compact(&items, &cfg()) {
+            Compaction::Table { rows, schema, .. } => {
+                let blob_idx = schema
+                    .fields
+                    .iter()
+                    .position(|f| f.name == "blob")
+                    .expect("blob col");
+                assert!(matches!(&rows[0].0[blob_idx], CellValue::OpaqueRef { .. }));
+            }
+            other => panic!("expected Table, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opaque_table_cell_below_ccr_floor_renders_verbatim_and_stores_nothing() {
+        // Issue #3 at the compactor/table-cell level: an opaque-shaped
+        // string that does not clear `ccr_min_bytes` must render as a
+        // plain Scalar (not OpaqueRef) and must never reach the store,
+        // even though it would otherwise classify as Opaque.
+        use crate::ccr::{CcrStore, InMemoryCcrStore};
+        use std::sync::Arc;
+
+        // Long enough to classify Opaque (> opaque_min_bytes=256) but short
+        // of the 2048-byte ccr_min_bytes substitution floor.
+        let small = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(8);
+        let items = vec![
+            json!({"id": 1, "blob": small.clone()}),
+            json!({"id": 2, "blob": small.clone()}),
+        ];
+
+        let store: Arc<dyn CcrStore> = Arc::new(InMemoryCcrStore::new());
+        match compact_with_store(&items, &cfg(), Some(&store)) {
+            Compaction::Table { rows, schema, .. } => {
+                let blob_idx = schema
+                    .fields
+                    .iter()
+                    .position(|f| f.name == "blob")
+                    .expect("blob col");
+                match &rows[0].0[blob_idx] {
+                    CellValue::Scalar(v) => assert_eq!(v.as_str(), Some(small.as_str())),
+                    other => panic!("expected Scalar (below floor), got {other:?}"),
+                }
+            }
+            other => panic!("expected Table, got {other:?}"),
+        }
+        assert!(
+            store.is_empty(),
+            "below-floor cell must not write to the store"
+        );
     }
 }

--- a/crates/headroom-core/src/transforms/smart_crusher/compaction/formatter.rs
+++ b/crates/headroom-core/src/transforms/smart_crusher/compaction/formatter.rs
@@ -681,7 +681,7 @@ mod tests {
 
     #[test]
     fn csv_formatter_emits_ccr_marker() {
-        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(8);
+        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
         let items = vec![
             json!({"id": 1, "blob": big.clone()}),
             json!({"id": 2, "blob": big.clone()}),
@@ -865,7 +865,7 @@ mod tests {
 
     #[test]
     fn markdown_kv_emits_ccr_marker() {
-        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(8);
+        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
         let items = vec![
             json!({"id": 1, "blob": big.clone()}),
             json!({"id": 2, "blob": big.clone()}),

--- a/crates/headroom-core/src/transforms/smart_crusher/compaction/mod.rs
+++ b/crates/headroom-core/src/transforms/smart_crusher/compaction/mod.rs
@@ -111,9 +111,7 @@ impl CompactionStage {
     /// [`Compaction`] tree (so callers can inspect kept/total row
     /// counts) alongside the rendered bytes.
     pub fn run(&self, items: &[serde_json::Value]) -> (Compaction, String) {
-        let c = compact(items, &self.config);
-        let rendered = self.formatter.format(&c);
-        (c, rendered)
+        self.run_with_store(items, None)
     }
 
     /// Like [`Self::run`], but stash every opaque-blob payload into `store`

--- a/crates/headroom-core/src/transforms/smart_crusher/compaction/walker.rs
+++ b/crates/headroom-core/src/transforms/smart_crusher/compaction/walker.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 use serde_json::{Map, Value};
 
 use super::classifier::{classify_cell, CellClass};
-use super::compactor::{compact, CompactConfig};
+use super::compactor::{compact_with_store, CompactConfig};
 use super::formatter::{CsvSchemaFormatter, Formatter};
 use super::ir::OpaqueKind;
 use crate::ccr::CcrStore;
@@ -117,7 +117,7 @@ fn walk_array(items: Vec<Value>, ctx: &DocumentCompactor) -> Value {
     let inner: Vec<Value> = items.into_iter().map(|i| walk(i, ctx)).collect();
 
     // Then try the array as a whole.
-    let c = compact(&inner, &ctx.config);
+    let c = compact_with_store(&inner, &ctx.config, ctx.ccr_store.as_ref());
     if c.was_compacted() {
         Value::String(ctx.formatter.format(&c))
     } else {
@@ -139,9 +139,13 @@ fn walk_string(s: String, ctx: &DocumentCompactor) -> Value {
 
     // Long opaque blob: substitute with CCR marker (and stash the
     // original in the store if one is configured, so retrieval works).
+    // Below `ccr_min_bytes`, the value is opaque-shaped but too small
+    // to be worth the retrieval round-trip — render verbatim (issue #3).
     if let CellClass::Opaque(kind) = classify_cell(&Value::String(s.clone()), &ctx.config.classify)
     {
-        return Value::String(emit_opaque_ccr_marker(&s, &kind, ctx.ccr_store.as_ref()));
+        if s.len() >= ctx.config.classify.ccr_min_bytes {
+            return Value::String(emit_opaque_ccr_marker(&s, &kind, ctx.ccr_store.as_ref()));
+        }
     }
 
     Value::String(s)
@@ -290,7 +294,7 @@ mod tests {
 
     #[test]
     fn long_opaque_string_at_top_level_becomes_ccr_marker() {
-        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(8);
+        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
         let out = dc().compact(Value::String(big));
         match out {
             Value::String(s) => assert!(
@@ -302,8 +306,24 @@ mod tests {
     }
 
     #[test]
+    fn opaque_string_below_ccr_floor_passes_through_verbatim() {
+        // Regression for issue #3, DocumentCompactor path: a ~1 KB
+        // opaque-shaped string (above the 256 B shape threshold, below
+        // the 2 KB ccr_min_bytes floor) must render verbatim.
+        let one_kb = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(15);
+        assert!(one_kb.len() > 256 && one_kb.len() < 2048);
+        let doc = json!({"id": 1, "blob": one_kb.clone()});
+        let out = dc().compact(doc);
+        assert_eq!(
+            out.pointer("/blob").and_then(|v| v.as_str()),
+            Some(one_kb.as_str()),
+            "sub-floor opaque field must pass through unchanged"
+        );
+    }
+
+    #[test]
     fn long_opaque_string_inside_object_field_becomes_ccr_marker() {
-        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(8);
+        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
         let doc = json!({"id": 1, "blob": big});
         let out = dc().compact(doc);
         let blob = out.pointer("/blob").and_then(|v| v.as_str()).unwrap();
@@ -393,5 +413,41 @@ mod tests {
         let doc = json!({"payload": "{not valid json"});
         let out = dc().compact(doc.clone());
         assert_eq!(out, doc);
+    }
+
+    #[test]
+    fn opaque_table_cell_with_ccr_store_is_retrievable_end_to_end() {
+        // Regression for issue #2, exercised through the real
+        // production entry point (`DocumentCompactor` with a wired CCR
+        // store — what `SmartCrusher`/live-zone actually use), not just
+        // the lower-level `compact_with_store` unit test. An array of
+        // objects where a field is a long opaque string gets tabulated;
+        // the opaque cell must be retrievable from the store by the
+        // hash embedded in its `<<ccr:HASH,KIND,SIZE>>` marker.
+        use crate::ccr::backends::InMemoryCcrStore;
+
+        let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
+        let doc = json!([
+            {"id": 1, "blob": big.clone()},
+            {"id": 2, "blob": big.clone()},
+        ]);
+        let store: Arc<dyn CcrStore> = Arc::new(InMemoryCcrStore::new());
+        let compactor = DocumentCompactor::new().with_ccr_store(store.clone());
+        let out = compactor.compact(doc);
+
+        let rendered = out.as_str().expect("array compacted to a rendered string");
+        let hash = extract_table_cell_hash(rendered).expect("marker must embed hash");
+        let retrieved = store
+            .get(&hash)
+            .expect("opaque table cell must be retrievable from the CCR store");
+        assert_eq!(retrieved, big);
+    }
+
+    /// Pull the hash out of a `<<ccr:HASH,KIND,SIZE>>` table-cell marker.
+    fn extract_table_cell_hash(s: &str) -> Option<String> {
+        let i = s.find("<<ccr:")?;
+        let after = &s[i + 6..];
+        let end = after.find(',')?;
+        Some(after[..end].to_string())
     }
 }

--- a/crates/headroom-core/src/transforms/smart_crusher/config.rs
+++ b/crates/headroom-core/src/transforms/smart_crusher/config.rs
@@ -77,9 +77,23 @@ pub struct SmartCrusherConfig {
     ///
     /// Scope: gates only the `crush_array` row-drop path. Stage-3c.2
     /// opaque-string CCR substitutions (in `walker::process_value`)
-    /// still emit always; they have no Python equivalent and no
-    /// production caller has asked for them to be suppressed.
+    /// still emit always, subject to the size floor below
+    /// (`opaque_min_bytes`).
     pub enable_ccr_marker: bool,
+    /// Minimum byte length an opaque-shaped string (base64/HTML/long
+    /// plain text) must clear before it's actually replaced by a
+    /// `<<ccr:...>>` marker. Below this floor the value renders
+    /// verbatim — the `headroom_retrieve` round-trip isn't worth it
+    /// for a small field. Wired into
+    /// [`ClassifyConfig::ccr_min_bytes`](super::compaction::ClassifyConfig::ccr_min_bytes)
+    /// at every substitution site (top-level opaque string fields and
+    /// table cells alike). Default: 2048 bytes (2 KB). Rust-only, no
+    /// Python counterpart — issue #3 fix (fields around ~1 KB were
+    /// getting CCR-substituted on their very first, same-turn read).
+    /// Orthogonal to `lossless_only` below: that's a global on/off
+    /// switch, this is a size floor that applies whenever markers are
+    /// otherwise allowed.
+    pub opaque_min_bytes: usize,
     /// Strict lossless mode. When `true`, lossless tabular compaction
     /// still applies, but any path that would otherwise need a CCR
     /// marker — the lossy row-drop sentinel AND opaque-blob offload —
@@ -113,14 +127,16 @@ pub struct SmartCrusherConfig {
 impl SmartCrusherConfig {
     /// Whether opaque blobs should be offloaded to a `<<ccr:…>>` marker.
     ///
-    /// Single source of truth for the opaque-marker gate. Markers are
-    /// emitted only when CCR markers are enabled AND strict lossless
+    /// Single source of truth for the opaque-marker on/off gate. Markers
+    /// are emitted only when CCR markers are enabled AND strict lossless
     /// mode is off — `lossless_only` forbids any offload because the
     /// marker would break the marker-free / byte-recoverable guarantee.
     /// Both compaction-stage construction (`new` /
     /// `with_compaction_format`) and the top-level `process_string` path
     /// derive `ClassifyConfig::emit_opaque_markers` from this method so
-    /// the three call sites can never drift apart.
+    /// the call sites can never drift apart. This does not cover the
+    /// size floor — see `opaque_min_bytes` /
+    /// `ClassifyConfig::ccr_min_bytes`, checked separately downstream.
     pub fn opaque_markers_enabled(&self) -> bool {
         self.enable_ccr_marker && !self.lossless_only
     }
@@ -150,6 +166,7 @@ impl Default for SmartCrusherConfig {
             relevance_threshold: 0.3,
             lossless_min_savings_ratio: 0.15,
             enable_ccr_marker: true,
+            opaque_min_bytes: 2048,
             lossless_only: false,
             compaction_core_field_fraction: 0.8,
             compaction_heterogeneous_core_ratio: 0.6,
@@ -188,6 +205,7 @@ mod tests {
         assert_eq!(c.relevance_threshold, 0.3);
         assert_eq!(c.lossless_min_savings_ratio, 0.15);
         assert!(c.enable_ccr_marker);
+        assert_eq!(c.opaque_min_bytes, 2048);
         assert!(!c.lossless_only);
         assert_eq!(c.compaction_core_field_fraction, 0.8);
         assert_eq!(c.compaction_heterogeneous_core_ratio, 0.6);

--- a/crates/headroom-core/src/transforms/smart_crusher/crusher.rs
+++ b/crates/headroom-core/src/transforms/smart_crusher/crusher.rs
@@ -603,16 +603,28 @@ impl SmartCrusher {
         // 2. Opaque blob: substitute with CCR marker AND stash the
         // original in the store (PR8) so retrieval works. Hash + format
         // identical to walker.rs via the shared helper — zero drift.
-        // Gated by `enable_ccr_marker` so disabling markers stays lossless
-        // here too (#1091).
+        //
+        // `opaque_min_bytes` used to be hardcoded via
+        // `ClassifyConfig::default()`, silently ignoring
+        // `self.config.opaque_min_bytes` — every caller got the 256 B
+        // shape-detection default regardless of what they configured.
+        // Build from `self.config` so the operator-facing floor is
+        // actually honored (issue #3). Also gated by `enable_ccr_marker`
+        // (via `opaque_markers_enabled()`) so disabling markers stays
+        // lossless here too (#1091).
         let cfg = ClassifyConfig {
+            ccr_min_bytes: self.config.opaque_min_bytes,
             emit_opaque_markers: self.config.opaque_markers_enabled(),
             ..ClassifyConfig::default()
         };
         if let CellClass::Opaque(kind) = classify_cell(&Value::String(s.to_string()), &cfg) {
-            let marker = emit_opaque_ccr_marker(s, &kind, self.ccr_store.as_ref());
-            let kind_label = opaque_kind_label(&kind);
-            return (Value::String(marker), format!("string_ccr:{kind_label}"));
+            // Below the CCR-substitution floor: opaque-shaped, but not
+            // worth the retrieval round-trip. Render verbatim.
+            if s.len() >= cfg.ccr_min_bytes {
+                let marker = emit_opaque_ccr_marker(s, &kind, self.ccr_store.as_ref());
+                let kind_label = opaque_kind_label(&kind);
+                return (Value::String(marker), format!("string_ccr:{kind_label}"));
+            }
         }
 
         // 3. Plain string — passthrough.
@@ -675,7 +687,7 @@ impl SmartCrusher {
         if let Some(stage) = &self.compaction {
             // Thread the CCR store so opaque-blob `<<ccr:HASH,...>>` markers
             // emitted by lossless:table compaction are actually retrievable
-            // (issue #1083); the row-drop lossy path below stores its own
+            // (issue #1083 / #2); the row-drop lossy path below stores its own
             // payload separately.
             let (c, rendered) = stage.run_with_store(items, self.ccr_store.as_ref());
             if c.was_compacted() {
@@ -1593,12 +1605,56 @@ mod tests {
     #[test]
     fn process_string_opaque_blob_becomes_ccr_marker() {
         let c = SmartCrusher::new(SmartCrusherConfig::default());
-        let big_b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(8);
+        // 32 repeats of the 67-char alphabet = 2144 bytes — comfortably
+        // above the 2 KB default ccr_min_bytes floor.
+        let big_b64 =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
         let doc = json!({"id": 1, "blob": big_b64});
         let (out, _info) = c.process_value(&doc, 0, "", 1.0);
         let blob = out.pointer("/blob").and_then(|v| v.as_str()).unwrap();
         assert!(blob.starts_with("<<ccr:"), "got: {blob}");
         assert!(blob.contains(",base64,"));
+    }
+
+    #[test]
+    fn process_string_opaque_but_below_ccr_floor_passes_through_verbatim() {
+        // Regression for issue #3: a ~1 KB opaque-shaped string (well
+        // above the 256 B shape-detection threshold, but below the
+        // 2 KB ccr_min_bytes substitution floor) must render verbatim
+        // — no marker, no retrieval round-trip forced on the model for
+        // fresh, modestly-sized tool output.
+        let c = SmartCrusher::new(SmartCrusherConfig::default());
+        let one_kb_b64 =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(15);
+        assert!(one_kb_b64.len() > 256 && one_kb_b64.len() < 2048);
+        let doc = json!({"id": 1, "blob": one_kb_b64.clone()});
+        let (out, _info) = c.process_value(&doc, 0, "", 1.0);
+        assert_eq!(
+            out.pointer("/blob").and_then(|v| v.as_str()),
+            Some(one_kb_b64.as_str()),
+            "sub-floor opaque field must pass through unchanged"
+        );
+    }
+
+    #[test]
+    fn process_string_ccr_floor_is_configurable() {
+        // Same ~1 KB payload as above, but with a custom, lower
+        // opaque_min_bytes — proves the floor is actually wired end to
+        // end, not just a hardcoded default that ignores config.
+        let config = SmartCrusherConfig {
+            opaque_min_bytes: 100,
+            ..SmartCrusherConfig::default()
+        };
+        let c = SmartCrusher::new(config);
+        let one_kb_b64 =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(15);
+        let doc = json!({"id": 1, "blob": one_kb_b64});
+        let (out, _info) = c.process_value(&doc, 0, "", 1.0);
+        let blob = out.pointer("/blob").and_then(|v| v.as_str()).unwrap();
+        assert!(
+            blob.starts_with("<<ccr:"),
+            "a lowered floor must still substitute a >100B opaque field, got: {blob}"
+        );
     }
 
     #[test]
@@ -1720,7 +1776,7 @@ mod tests {
         // With `enable_ccr_marker = false` it must render inline instead,
         // so no configuration leaks markers into a "lossless-only" prompt.
         let rows: Vec<Value> = (0..10)
-            .map(|i| json!({"path": "a.py", "line": i, "content": "x".repeat(300)}))
+            .map(|i| json!({"path": "a.py", "line": i, "content": "x".repeat(2200)}))
             .collect();
 
         // ratio 0.0 forces the lossless table to ship, exercising the
@@ -1739,7 +1795,7 @@ mod tests {
             "opaque marker leaked despite enable_ccr_marker=false: {rendered_off}"
         );
         assert!(
-            rendered_off.contains(&"x".repeat(300)),
+            rendered_off.contains(&"x".repeat(2200)),
             "blob should be inline when markers are off: {rendered_off}"
         );
 

--- a/crates/headroom-core/tests/ccr_roundtrip.rs
+++ b/crates/headroom-core/tests/ccr_roundtrip.rs
@@ -296,7 +296,7 @@ fn opaque_string_in_object_emits_marker_and_stores_original() {
 
     // 64-char base64 alphabet repeated → tripping the opaque-blob
     // detector deterministically.
-    let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(8);
+    let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
     let doc = json!({"id": 1, "blob": big.clone()});
 
     let result = crusher.crush(&doc.to_string(), "", 1.0);
@@ -352,7 +352,7 @@ fn document_walker_with_store_roundtrips_opaque_blob() {
     let store: Arc<dyn CcrStore> = Arc::new(InMemoryCcrStore::new());
     let dc = DocumentCompactor::new().with_ccr_store(store.clone());
 
-    let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(8);
+    let big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=".repeat(32);
     let out = dc.compact(json!({"id": 1, "blob": big.clone()}));
     let blob = out.pointer("/blob").and_then(|v| v.as_str()).unwrap();
     assert!(blob.starts_with("<<ccr:"));

--- a/crates/headroom-core/tests/live_zone_freshness.rs
+++ b/crates/headroom-core/tests/live_zone_freshness.rs
@@ -1,0 +1,200 @@
+//! Freshness exemption — integration tests for issue #3.
+//!
+//! `compress_anthropic_live_zone_with_ccr_and_freshness` must never
+//! compress the most-recent `fresh_message_count` messages (counted
+//! from the tail) regardless of size — that content is in-flight,
+//! about to be read by the model for the very first time this exact
+//! request. Older, non-frozen messages remain fully eligible.
+
+use headroom_core::transforms::live_zone::{
+    compress_anthropic_live_zone_with_ccr, compress_anthropic_live_zone_with_ccr_and_freshness,
+    DEFAULT_MODEL,
+};
+use headroom_core::transforms::{AuthMode, BlockAction, LiveZoneOutcome};
+use serde_json::{json, Value};
+
+fn body_of(value: Value) -> Vec<u8> {
+    serde_json::to_vec(&value).unwrap()
+}
+
+fn large_json_array_payload() -> String {
+    let items: Vec<Value> = (0..400)
+        .map(|i| {
+            json!({
+                "id": i,
+                "kind": "row",
+                "status": "ok",
+                "value": format!("repeat-{}", i % 5),
+            })
+        })
+        .collect();
+    let payload = serde_json::to_string(&items).unwrap();
+    assert!(
+        payload.len() >= 10_000,
+        "fixture must clear the byte threshold"
+    );
+    payload
+}
+
+fn manifest_of(out: &LiveZoneOutcome) -> &headroom_core::transforms::CompressionManifest {
+    match out {
+        LiveZoneOutcome::NoChange { manifest } => manifest,
+        LiveZoneOutcome::Modified { manifest, .. } => manifest,
+    }
+}
+
+#[test]
+fn large_fresh_tool_result_passes_through_verbatim() {
+    // Single user message, large tool_result — but it's the ONLY
+    // (hence tail, hence in-flight/fresh) message. With
+    // fresh_message_count=1 the dispatcher must find no compressible
+    // target at all and emit NoChange, no matter how large the
+    // payload is.
+    let payload = large_json_array_payload();
+    let body = body_of(json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_fresh",
+                "content": payload,
+            }],
+        }],
+    }));
+
+    let out = compress_anthropic_live_zone_with_ccr_and_freshness(
+        &body,
+        0,
+        1,
+        AuthMode::Payg,
+        DEFAULT_MODEL,
+        None,
+    )
+    .expect("dispatcher returns Ok on valid bodies");
+
+    assert!(
+        matches!(out, LiveZoneOutcome::NoChange { .. }),
+        "fresh (tail) message must never be compressed, regardless of size"
+    );
+    assert_eq!(
+        manifest_of(&out).latest_user_message_index,
+        None,
+        "the only user message is fresh — no compression target should be found"
+    );
+}
+
+#[test]
+fn same_body_without_freshness_gate_does_compress() {
+    // Sanity/contrast: the exact same body, dispatched through the
+    // freshness-unaware entry point (fresh_message_count=0 baked in),
+    // DOES get compressed. Proves the freshness param — not something
+    // else — is what caused the exemption above.
+    let payload = large_json_array_payload();
+    let body = body_of(json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_fresh",
+                "content": payload,
+            }],
+        }],
+    }));
+
+    let out = compress_anthropic_live_zone_with_ccr(&body, 0, AuthMode::Payg, DEFAULT_MODEL, None)
+        .expect("dispatcher returns Ok on valid bodies");
+
+    let manifest = manifest_of(&out);
+    assert_eq!(manifest.latest_user_message_index, Some(0));
+    let action = manifest
+        .block_outcomes
+        .iter()
+        .find(|b| b.block_type == "tool_result")
+        .expect("tool_result present")
+        .action
+        .clone();
+    match action {
+        BlockAction::Compressed { .. } | BlockAction::RejectedNotSmaller { .. } => {}
+        other => panic!("expected the dispatcher to attempt compression, got {other:?}"),
+    }
+}
+
+#[test]
+fn large_aged_tool_result_still_compresses_while_fresh_tail_is_untouched() {
+    // Three messages: [aged user tool_result (large), assistant text,
+    // fresh user tool_result (tail, large)]. With fresh_message_count=1
+    // the dispatcher must target the AGED message (index 0) — the
+    // fresh tail (index 2) is excluded from the search window
+    // entirely and stays byte-identical.
+    let aged_payload = large_json_array_payload();
+    let fresh_payload = large_json_array_payload();
+    let body = body_of(json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "max_tokens": 64,
+        "messages": [
+            {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_aged",
+                    "content": aged_payload,
+                }],
+            },
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "ok, one more lookup"}],
+            },
+            {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_fresh",
+                    "content": fresh_payload,
+                }],
+            },
+        ],
+    }));
+
+    let out = compress_anthropic_live_zone_with_ccr_and_freshness(
+        &body,
+        0,
+        1,
+        AuthMode::Payg,
+        DEFAULT_MODEL,
+        None,
+    )
+    .expect("dispatcher returns Ok on valid bodies");
+
+    let manifest = manifest_of(&out);
+    assert_eq!(
+        manifest.latest_user_message_index,
+        Some(0),
+        "dispatcher must target the aged message, skipping the fresh tail entirely"
+    );
+    let action = manifest
+        .block_outcomes
+        .iter()
+        .find(|b| b.block_type == "tool_result")
+        .expect("tool_result present")
+        .action
+        .clone();
+    match action {
+        BlockAction::Compressed { .. } | BlockAction::RejectedNotSmaller { .. } => {}
+        other => panic!("expected the aged message to attempt compression, got {other:?}"),
+    }
+
+    // The fresh tail's payload must survive byte-identical in the
+    // output (if the body was rewritten at all).
+    if let LiveZoneOutcome::Modified { new_body, .. } = &out {
+        let new_body_str = new_body.get();
+        assert!(
+            new_body_str.contains(&fresh_payload.replace('"', "\\\""))
+                || new_body_str.contains(&fresh_payload),
+            "fresh tail payload must be untouched in the rewritten body"
+        );
+    }
+}

--- a/crates/headroom-parity/src/lib.rs
+++ b/crates/headroom-parity/src/lib.rs
@@ -404,9 +404,20 @@ impl TransformComparator for SmartCrusherComparator {
                 .get("enable_ccr_marker")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(defaults.enable_ccr_marker),
-            // Compaction heuristics are moot here: this comparator uses
-            // `without_compaction` (fixtures were recorded against the
-            // lossy-only path). Take the defaults wholesale.
+            // Rust-only issue-#3 knob — legacy fixtures predate the
+            // ccr_min_bytes floor and their expected outputs assume
+            // opaque strings substitute unconditionally once
+            // classified Opaque (equivalent to floor = 0), not the
+            // new 2 KB default.
+            opaque_min_bytes: config
+                .get("opaque_min_bytes")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(0),
+            // Compaction heuristics (lossless_only, compaction_*) are moot
+            // here: this comparator uses `without_compaction` (fixtures
+            // were recorded against the lossy-only path). Take the
+            // defaults wholesale for every other new field.
             ..defaults
         };
 

--- a/crates/headroom-proxy/src/compression/live_zone_anthropic.rs
+++ b/crates/headroom-proxy/src/compression/live_zone_anthropic.rs
@@ -19,10 +19,13 @@
 //!    the body is parsed at all — when disabled, floor=0 without
 //!    inspection.
 //! 2. Hand the buffered body bytes to
-//!    [`headroom_core::transforms::compress_anthropic_live_zone`].
-//!    The dispatcher inspects the live zone (latest user message),
-//!    detects per-block content type, dispatches each block to the
-//!    matching compressor (SmartCrusher / LogCompressor /
+//!    [`headroom_core::transforms::compress_anthropic_live_zone_with_ccr_and_freshness`]
+//!    with `fresh_message_count = 1`, exempting the tail (in-flight)
+//!    message from compression — it's about to be read by the model
+//!    for the first time this exact request (issue #3).
+//!    The dispatcher inspects the live zone (latest non-fresh user
+//!    message), detects per-block content type, dispatches each block
+//!    to the matching compressor (SmartCrusher / LogCompressor /
 //!    SearchCompressor / DiffCompressor), and rewrites the body
 //!    via byte-range surgery so unmodified bytes round-trip
 //!    byte-equal.
@@ -42,7 +45,8 @@ use bytes::Bytes;
 use headroom_core::auth_mode::AuthMode as RequestAuthMode;
 use headroom_core::transforms::live_zone::DEFAULT_MODEL;
 use headroom_core::transforms::{
-    compress_anthropic_live_zone, BlockAction, ExclusionReason, LiveZoneError, LiveZoneOutcome,
+    compress_anthropic_live_zone_with_ccr_and_freshness, BlockAction, ExclusionReason,
+    LiveZoneError, LiveZoneOutcome,
 };
 use serde_json::Value;
 
@@ -355,7 +359,19 @@ pub fn compress_anthropic_request(
     // getting compression, not losing it). The plumbing here lets
     // F2.2 vary per-block thresholds by mode without touching this
     // call site again.
-    match compress_anthropic_live_zone(&dispatch_body, frozen_count, auth_mode.into(), model) {
+    // `fresh_message_count = 1`: the tail (most-recent) message is the
+    // live zone itself — the content the model is about to read for the
+    // first time this exact request. Exempting it from CCR/opaque-blob
+    // substitution matches the freshness contract documented on
+    // `compress_anthropic_live_zone_with_ccr_and_freshness` (issue #3).
+    match compress_anthropic_live_zone_with_ccr_and_freshness(
+        &dispatch_body,
+        frozen_count,
+        1,
+        auth_mode.into(),
+        model,
+        None,
+    ) {
         Ok(LiveZoneOutcome::NoChange { manifest }) => {
             let block_count = manifest.block_outcomes.len();
             let blocks_excluded = manifest
@@ -1306,6 +1322,121 @@ mod tests {
             other => {
                 panic!("expected Compressed (E3 fires) for already-sorted tools, got {other:?}")
             }
+        }
+    }
+
+    // Issue #3 regression: the freshness exemption must actually be wired
+    // into the proxy's production call site (`fresh_message_count = 1`),
+    // not just exercised by the library-level tests in
+    // `headroom-core/tests/live_zone_freshness.rs`.
+
+    fn large_json_array_payload() -> String {
+        let items: Vec<serde_json::Value> = (0..400)
+            .map(|i| {
+                serde_json::json!({
+                    "id": i,
+                    "kind": "row",
+                    "status": "ok",
+                    "value": format!("repeat-{}", i % 5),
+                })
+            })
+            .collect();
+        let payload = serde_json::to_string(&items).unwrap();
+        assert!(
+            payload.len() >= 10_000,
+            "fixture must clear the byte threshold"
+        );
+        payload
+    }
+
+    #[test]
+    fn fresh_tail_message_is_not_compressed_through_proxy_entry_point() {
+        // Single user message, large tool_result — it's the ONLY (hence
+        // tail, hence in-flight/fresh) message. Before this fix, the
+        // proxy called `compress_anthropic_live_zone` (fresh_message_count
+        // implicitly 0) and would compress it anyway. Now the proxy must
+        // exempt it, yielding NoCompression.
+        let payload = large_json_array_payload();
+        let body = body_of(serde_json::json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_fresh",
+                    "content": payload,
+                }],
+            }],
+        }));
+        let out = compress_anthropic_request(
+            &body,
+            CompressionMode::LiveZone,
+            CacheControlAutoFrozen::Disabled,
+            RequestAuthMode::Payg,
+            "req-freshness-1",
+        );
+        match out {
+            Outcome::NoCompression => {}
+            other => panic!(
+                "expected NoCompression — fresh tail message must never be compressed \
+                 through the proxy entry point, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn aged_message_still_compresses_while_fresh_tail_is_untouched_through_proxy() {
+        // Three messages: [aged user tool_result (large), assistant text,
+        // fresh user tool_result (tail, large)]. The proxy must still
+        // compress the aged message — the freshness exemption only
+        // excludes the tail, it doesn't disable compression entirely.
+        let aged_payload = large_json_array_payload();
+        let fresh_payload = large_json_array_payload();
+        let body = body_of(serde_json::json!({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_aged",
+                        "content": aged_payload,
+                    }],
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "ok, one more lookup"}],
+                },
+                {
+                    "role": "user",
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_fresh",
+                        "content": fresh_payload,
+                    }],
+                },
+            ],
+        }));
+        let out = compress_anthropic_request(
+            &body,
+            CompressionMode::LiveZone,
+            CacheControlAutoFrozen::Disabled,
+            RequestAuthMode::Payg,
+            "req-freshness-2",
+        );
+        match out {
+            Outcome::Compressed { body, .. } => {
+                let new_body_str = String::from_utf8_lossy(&body);
+                assert!(
+                    new_body_str.contains(&fresh_payload)
+                        || new_body_str.contains(&fresh_payload.replace('"', "\\\"")),
+                    "fresh tail payload must survive byte-identical in the rewritten body"
+                );
+            }
+            other => panic!(
+                "expected Compressed — aged (non-fresh) message must still compress, \
+                 got {other:?}"
+            ),
         }
     }
 }

--- a/crates/headroom-py/src/lib.rs
+++ b/crates/headroom-py/src/lib.rs
@@ -480,12 +480,13 @@ impl PySmartCrusherConfig {
         relevance_threshold = 0.3,
         lossless_min_savings_ratio = 0.15,
         enable_ccr_marker = true,
-        lossless_only = false,
-        compaction_core_field_fraction = 0.8,
-        compaction_heterogeneous_core_ratio = 0.6,
-        compaction_max_flatten_inner_keys = 6,
-        compaction_min_buckets = 2,
-        compaction_max_buckets = 8,
+    opaque_min_bytes = 2048,
+    lossless_only = false,
+    compaction_core_field_fraction = 0.8,
+    compaction_heterogeneous_core_ratio = 0.6,
+    compaction_max_flatten_inner_keys = 6,
+    compaction_min_buckets = 2,
+    compaction_max_buckets = 8,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -507,6 +508,7 @@ impl PySmartCrusherConfig {
         relevance_threshold: f64,
         lossless_min_savings_ratio: f64,
         enable_ccr_marker: bool,
+        opaque_min_bytes: usize,
         lossless_only: bool,
         compaction_core_field_fraction: f64,
         compaction_heterogeneous_core_ratio: f64,
@@ -534,6 +536,7 @@ impl PySmartCrusherConfig {
                 relevance_threshold,
                 lossless_min_savings_ratio,
                 enable_ccr_marker,
+                opaque_min_bytes,
                 lossless_only,
                 compaction_core_field_fraction,
                 compaction_heterogeneous_core_ratio,
@@ -611,6 +614,10 @@ impl PySmartCrusherConfig {
     #[getter]
     fn enable_ccr_marker(&self) -> bool {
         self.inner.enable_ccr_marker
+    }
+    #[getter]
+    fn opaque_min_bytes(&self) -> usize {
+        self.inner.opaque_min_bytes
     }
     #[getter]
     fn lossless_only(&self) -> bool {

--- a/tests/test_smart_crusher_toin_attachment.py
+++ b/tests/test_smart_crusher_toin_attachment.py
@@ -210,7 +210,7 @@ def test_ccr_inject_marker_false_suppresses_opaque_blob_markers(fresh_toin):
 
     # Distinct >256-byte string cells trigger the opaque-blob path.
     payload = json.dumps(
-        [{"id": i, "name": f"row{i}", "blob": f"sentinel{i}_" + "x" * 400} for i in range(60)]
+        [{"id": i, "name": f"row{i}", "blob": f"sentinel{i}_" + "x" * 2200} for i in range(60)]
     )
 
     on = SmartCrusher(

--- a/tests/test_transforms/test_smart_crusher_ccr_roundtrip.py
+++ b/tests/test_transforms/test_smart_crusher_ccr_roundtrip.py
@@ -267,7 +267,7 @@ def test_opaque_blob_in_object_emits_marker_and_stores_native() -> None:
     from headroom._core import SmartCrusher
 
     crusher = SmartCrusher()
-    big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=" * 8
+    big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=" * 32
     raw = json.dumps({"id": 1, "blob": big})
 
     result = crusher.crush(raw, "", 1.0)
@@ -290,7 +290,7 @@ def test_compact_document_json_via_pyo3() -> None:
 
     crusher = SmartCrusher()
     starting = crusher.ccr_len()
-    big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=" * 8
+    big = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=" * 32
     doc = {"id": 1, "blob": big}
 
     out = crusher.compact_document_json(json.dumps(doc))


### PR DESCRIPTION
## Description
<!-- Briefly explain the change and why it's needed. -->
Closes #3

SmartCrusher's opaque-blob CCR substitution used only `opaque_min_bytes` (256 bytes, a shape-detection heuristic) to decide whether a string gets replaced with a `<<ccr:HASH,...>>` marker. In practice this meant fields as small as ~1KB were substituted on their very first, same-turn read — the `headroom_retrieve` round-trip cost outweighs any token savings for a field that small, and same-turn tool results shouldn't be swapped out before the model has a chance to read them. Additionally, the live proxy's `/v1/messages` compression path called the freshness-unaware `compress_anthropic_live_zone` (`fresh_message_count` implicitly `0`), so even the freshness fix itself was never exercised by real traffic — only by headroom-core's own tests.

## Type of Change
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made
- Added `ccr_min_bytes` (`ClassifyConfig`) / `opaque_min_bytes` (`SmartCrusherConfig`): a substitution-policy floor, separate from the existing `opaque_min_bytes` shape-detection threshold (256 bytes). Cells/strings that classify as opaque but don't clear this floor (default 2048 bytes) render verbatim instead of getting a marker. Wired through `process_string`, the table-cell compactor (`cell_from_value`), and the document walker's opaque-string path, so all three CCR substitution sites agree.
- Added `fresh_message_count` exemption in the live-zone dispatcher: the most recent N messages in a turn are exempt from CCR substitution regardless of size, so an in-flight/just-produced tool result can't be swapped out for a marker before the model reads it.
- Wired `crates/headroom-proxy`'s real `/v1/messages` call site to `compress_anthropic_live_zone_with_ccr_and_freshness` with `fresh_message_count = 1`, matching the function's own doc comment ("Production wiring (the proxy) should pass 1"). This was the production gap flagged in review — the size-floor + freshness logic existed but wasn't reachable from real traffic before this change.
- Bumped two existing test fixtures (`test_smart_crusher_toin_attachment.py`, `test_transforms/test_smart_crusher_ccr_roundtrip.py`) whose blobs were sized just above the old 256-byte threshold but below the new 2048-byte floor, so they stay above both.

## Testing
<!-- Check what you actually ran, then paste the real command output below. -->
- [x] Unit tests pass (`cargo test -p headroom-core -p headroom-proxy`)
- [x] Linting passes (`cargo clippy -p headroom-core -p headroom-proxy`, `cargo fmt --all -- --check`)
- [x] Type checking passes (`mypy headroom --ignore-missing-imports`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
cargo test -p headroom-core --test live_zone_freshness
cargo test -p headroom-proxy fresh_tail_message_is_not_compressed_through_proxy_entry_point
cargo test -p headroom-proxy aged_message_still_compresses_while_fresh_tail_is_untouched_through_proxy
cargo check -p headroom-proxy
cargo fmt --all -- --check
-> all green (confirmed independently by @JerrettDavis on commit abd66a1 per review)
```

## Real Behavior Proof
- Environment: local `cargo test`/`clippy`/`fmt` against `crates/headroom-core` and `crates/headroom-proxy`, scoped (not full workspace) to avoid unrelated crate churn.
- Exact command / steps: see Test Output above — `live_zone_freshness.rs` exercises the dispatcher directly; the two new `headroom-proxy` tests exercise it through the public `compress_anthropic_request` entry point, i.e. the same call path real `/v1/messages` traffic takes.
- Observed result: a lone fresh tail message with a large opaque blob is left byte-identical; an aged message earlier in the same request still compresses normally with a CCR marker.
- Not tested: this crate (`crates/headroom-proxy`) is not currently what the deployed/live proxy runs — the live proxy is the pure-Python entrypoint (`headroom.cli.proxy`), which goes through `headroom/transforms/content_router.py` instead. The equivalent Python-side freshness fix is tracked separately in #2088.

## Review Readiness
- [x] I performed a self-review
- [x] This PR is ready for human review

## Checklist
- [x] My code follows this project's style guidelines
- [x] I performed a self-review of my own code
- [x] I commented my code, particularly in hard-to-understand areas
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I updated CHANGELOG.md if applicable

## Additional Notes
<!-- Mention any N/A checklist items, tradeoffs, follow-ups, or maintainer context. -->
No CHANGELOG entry: this crate isn't currently wired into the deployed proxy (see "Not tested" above), so there's no user-facing behavior change yet. Companion PR #2088 covers the code path that's actually live.