### PR TITLE
fix(compress): freshness exemption for tool_result content in Python content router

### DIFF
--- a/benchmarks/proxy_mode_benchmark.py
+++ b/benchmarks/proxy_mode_benchmark.py
@@ -200,7 +200,11 @@ def _simulate_mode(turns: int, mode: str) -> ModeBenchmarkResult:
         forwarded = pipeline_result.messages
 
         if mode == PROXY_MODE_TOKEN:
-            comp_cache.update_from_result(messages, forwarded)
+            comp_cache.update_from_result(
+                messages,
+                forwarded,
+                protected_contents=pipeline_result.protected_tool_result_contents,
+            )
         if mode == PROXY_MODE_CACHE:
             forwarded, _ = AnthropicHandlerMixin._restore_frozen_prefix(
                 messages, forwarded, frozen_message_count=frozen

--- a/headroom/cache/compression_cache.py
+++ b/headroom/cache/compression_cache.py
@@ -13,6 +13,7 @@ import logging
 import threading
 import time
 from collections import OrderedDict
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -283,11 +284,30 @@ class CompressionCache:
                 result.append(msg)
             return result
 
-    def update_from_result(self, originals: list[dict], compressed: list[dict]) -> None:
+    def update_from_result(
+        self,
+        originals: list[dict],
+        compressed: list[dict],
+        protected_contents: Iterable[str] | None = None,
+    ) -> None:
         """Cache new compressions by comparing original and compressed messages.
 
         Index-aligned: for each position, if both are tool results and the
         content differs, store the mapping original_hash -> compressed_content.
+
+        Args:
+            protected_contents: Raw tool_result content left verbatim by
+                ContentRouter's freshness exemption this call (issue #3),
+                i.e. `TransformResult.protected_tool_result_contents`. Content
+                unchanged for this reason must NOT be marked stable below: it
+                was skipped only because it was the fresh tail this turn, not
+                because it's incompressible, so it needs to stay eligible for
+                compression once a later turn ages it out of the protection
+                window. Without this exclusion, `compute_frozen_count` would
+                treat it as part of the stable/frozen prefix as soon as it's
+                no longer the tail, and content_router would never see it
+                again to actually compress it -- permanently forfeiting the
+                compression, not just deferring it by one turn.
         """
         if len(originals) != len(compressed):
             logger.warning(
@@ -296,6 +316,10 @@ class CompressionCache:
                 len(compressed),
             )
             return
+
+        protected_hashes = (
+            {self.content_hash(c) for c in protected_contents} if protected_contents else set()
+        )
 
         # Single critical section: `store_compressed` re-acquires the lock
         # (RLock) safely.
@@ -306,8 +330,11 @@ class CompressionCache:
                 if orig_content is None or comp_content is None:
                     continue
                 if orig_content == comp_content:
+                    h = self.content_hash(orig_content)
+                    if h in protected_hashes:
+                        continue
                     # Content unchanged — mark as stable for frozen count walk
-                    self._stable_hashes.add(self.content_hash(orig_content))
+                    self._stable_hashes.add(h)
                     continue
                 h = self.content_hash(orig_content)
                 tokens_saved = len(orig_content) // 4 - len(comp_content) // 4

--- a/headroom/config.py
+++ b/headroom/config.py
@@ -722,6 +722,13 @@ class TransformResult:
     cache_metrics: CachePrefixMetrics | None = None  # Populated by CacheAligner
     timing: dict[str, float] = field(default_factory=dict)  # transform_name → ms
     waste_signals: WasteSignals | None = None  # Detected waste in original messages
+    # Raw content of tool_result blocks left verbatim by ContentRouter's
+    # freshness exemption (issue #3), this call only. CompressionCache uses
+    # this to avoid marking freshness-skipped content permanently "stable"
+    # (see CompressionCache.update_from_result) -- it was skipped because it
+    # was the fresh tail this turn, not because it's incompressible, so it
+    # must stay eligible for compression once it's no longer the tail.
+    protected_tool_result_contents: list[str] = field(default_factory=list)
 
     @property
     def transforms_summary(self) -> dict[str, int]:

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -1302,7 +1302,16 @@ class AnthropicHandlerMixin:
                                         **proxy_pipeline_kwargs(self.config),
                                     ),
                                     lambda bg_result: comp_cache.update_from_result(
-                                        messages, bg_result.messages
+                                        messages,
+                                        bg_result.messages,
+                                        # getattr default: pipeline results that
+                                        # predate this field (or non-TransformResult
+                                        # shims) degrade to old stable-marking
+                                        # behavior instead of crashing the
+                                        # fail-open proxy path.
+                                        protected_contents=getattr(
+                                            bg_result, "protected_tool_result_contents", None
+                                        ),
                                     ),
                                 )
 
@@ -1336,7 +1345,13 @@ class AnthropicHandlerMixin:
 
                             # Cache newly compressed messages (index-aligned diff)
                             if result.messages != working_messages:
-                                comp_cache.update_from_result(messages, result.messages)
+                                comp_cache.update_from_result(
+                                    messages,
+                                    result.messages,
+                                    protected_contents=getattr(
+                                        result, "protected_tool_result_contents", None
+                                    ),
+                                )
 
                             # Always use pipeline result — Zone 1 swaps are already applied
                             optimized_messages = result.messages

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -2486,7 +2486,17 @@ class OpenAIHandlerMixin:
                     )
 
                     if result.messages != working_messages:
-                        comp_cache.update_from_result(messages, result.messages)
+                        comp_cache.update_from_result(
+                            messages,
+                            result.messages,
+                            # getattr default: pipeline results that predate this
+                            # field (or non-TransformResult shims) degrade to old
+                            # stable-marking behavior instead of crashing the
+                            # fail-open proxy path.
+                            protected_contents=getattr(
+                                result, "protected_tool_result_contents", None
+                            ),
+                        )
 
                     # Always use pipeline result in token mode
                     optimized_messages = result.messages

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -1043,6 +1043,18 @@ class ContentRouterConfig:
     protect_recent_code: int = 4  # Don't compress CODE in last N messages (0 = disabled)
     protect_analysis_context: bool = True  # Detect "analyze/review" intent, protect code
 
+    # Protection: freshness exemption for tool_result content (issue #3).
+    # The most-recent N messages are content the model is about to read
+    # for the first time this exact request — SmartCrusher/CCR
+    # substitution there means the model never actually sees what it just
+    # asked for. This is distinct from `protect_recent_code` above, which
+    # only gates SOURCE_CODE-classified content on the plain-string
+    # (OpenAI-style flattened) message path; it does not cover general
+    # JSON/log/text tool_result content blocks (Anthropic-style), which is
+    # where SmartCrusher/CCR opaque-blob substitution actually happens for
+    # the typical MCP tool-output case. 0 disables this protection.
+    protect_recent_tool_results: int = 1
+
     # Protection: failed tool calls / error outputs stay verbatim (issue #847).
     # The model needs exact tracebacks and error text to recover; compressing
     # them measurably hurts agent recovery. Outputs above the size cap still
@@ -4404,6 +4416,37 @@ class ContentRouter(Transform):
                     if route_counts is not None:
                         route_counts.setdefault("error_protected", 0)
                         route_counts["error_protected"] += 1
+                    continue
+
+                # Protection: freshness exemption (issue #3). The most-recent
+                # `protect_recent_tool_results` messages carry content the
+                # model is about to read for the first time this exact
+                # request — SmartCrusher/CCR substitution here means the
+                # model never actually sees what it just asked for. Skip
+                # entirely (both lossless and lossy tiers below) rather than
+                # gating only the CCR-marker path, mirroring how the Rust
+                # live-zone dispatcher's `fresh_message_count` fully excludes
+                # the tail message from its search window. Unlike
+                # `protect_recent_code` above, this isn't gated on
+                # content-type classification — SmartCrusher's typical input
+                # (tool_result JSON/log/text) never classifies as
+                # SOURCE_CODE, so that older check doesn't reach it.
+                #
+                # `messages_from_end == 0` is the parameter's unset/"not
+                # applicable" sentinel (its own default), used by call sites
+                # (mainly unit tests) that invoke this method directly
+                # without wiring in real message position — real messages
+                # from `apply()`'s loop always pass `num_messages - i >= 1`.
+                # `0 < messages_from_end` excludes that sentinel so this
+                # protection stays opt-in to real position tracking instead
+                # of silently firing on every unpositioned call.
+                protect_recent_results = self.config.protect_recent_tool_results
+                if protect_recent_results > 0 and 0 < messages_from_end <= protect_recent_results:
+                    new_blocks.append(block)
+                    transforms_applied.append("router:protected:recent_tool_result")
+                    if route_counts is not None:
+                        route_counts.setdefault("recent_tool_result_protected", 0)
+                        route_counts["recent_tool_result_protected"] += 1
                     continue
 
                 # Only process string content. Blocks below the lossy min_chars

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -3330,6 +3330,11 @@ class ContentRouter(Transform):
         if runtime_read_protection_window is not None:
             read_protection_window = max(0, int(runtime_read_protection_window))
 
+        protect_recent_tool_results = self.config.protect_recent_tool_results
+        runtime_protect_recent_tool_results = kwargs.get("protect_recent_tool_results")
+        if runtime_protect_recent_tool_results is not None:
+            protect_recent_tool_results = max(0, int(runtime_protect_recent_tool_results))
+
         # Adaptive compression ratio: scale with context pressure
         if model_limit > 0:
             context_pressure = min(1.0, tokens_before / model_limit)
@@ -3375,6 +3380,10 @@ class ContentRouter(Transform):
             "content_blocks": 0,
         }
         compressed_details: list[str] = []  # e.g. ["code_aware:0.72", "kompress:0.65"]
+        # Raw content of tool_result blocks skipped by the freshness gate this
+        # call, surfaced on TransformResult so CompressionCache can avoid
+        # treating them as permanently "stable" (see TransformResult docstring).
+        protected_tool_result_contents: list[str] = []
 
         # Check for analysis intent in the most recent user message
         analysis_intent = False
@@ -3490,6 +3499,8 @@ class ContentRouter(Transform):
                     skip_user=skip_user,
                     skip_system=skip_system,
                     compress_assistant_text_blocks=compress_assistant_text_blocks,
+                    protect_recent_tool_results=protect_recent_tool_results,
+                    protected_tool_result_contents=protected_tool_result_contents,
                 )
                 result_slots[i] = transformed_message
                 route_counts["content_blocks"] += 1
@@ -3935,6 +3946,7 @@ class ContentRouter(Transform):
             markers_inserted=lifecycle_ccr_hashes,
             warnings=warnings,
             timing=compressor_timing,
+            protected_tool_result_contents=protected_tool_result_contents,
         )
 
     def _lossless_compact_excluded(self, content: Any) -> tuple[str, str] | None:
@@ -4193,6 +4205,8 @@ class ContentRouter(Transform):
         skip_user: bool = True,
         skip_system: bool = True,
         compress_assistant_text_blocks: bool = False,
+        protect_recent_tool_results: int = 1,
+        protected_tool_result_contents: list[str] | None = None,
     ) -> dict[str, Any]:
         """Process content blocks (Anthropic format) for compression.
 
@@ -4439,14 +4453,29 @@ class ContentRouter(Transform):
                 # from `apply()`'s loop always pass `num_messages - i >= 1`.
                 # `0 < messages_from_end` excludes that sentinel so this
                 # protection stays opt-in to real position tracking instead
-                # of silently firing on every unpositioned call.
-                protect_recent_results = self.config.protect_recent_tool_results
-                if protect_recent_results > 0 and 0 < messages_from_end <= protect_recent_results:
+                # of silently firing on every unpositioned call. Runtime-
+                # overridable via the `protect_recent_tool_results` kwarg
+                # (threaded down from `apply()`, mirroring `read_protection_window`)
+                # so callers that need to bypass it for an unrelated, narrow
+                # test/purpose (e.g. isolating `force_kompress` routing) can do
+                # so explicitly, the same way `read_protection_window=0` already
+                # opts out of the read-tool protection above.
+                if (
+                    protect_recent_tool_results > 0
+                    and 0 < messages_from_end <= protect_recent_tool_results
+                ):
                     new_blocks.append(block)
                     transforms_applied.append("router:protected:recent_tool_result")
                     if route_counts is not None:
                         route_counts.setdefault("recent_tool_result_protected", 0)
                         route_counts["recent_tool_result_protected"] += 1
+                    # Surface the raw content so CompressionCache (proxy layer)
+                    # doesn't mark it permanently "stable" -- it was skipped for
+                    # freshness this turn, not because it's incompressible, and
+                    # must stay eligible for compression once it ages out of the
+                    # protection window (see TransformResult docstring).
+                    if protected_tool_result_contents is not None and isinstance(tool_text, str):
+                        protected_tool_result_contents.append(tool_text)
                     continue
 
                 # Only process string content. Blocks below the lossy min_chars

--- a/headroom/transforms/pipeline.py
+++ b/headroom/transforms/pipeline.py
@@ -316,6 +316,7 @@ class TransformPipeline:
             all_markers: list[str] = []
             all_warnings: list[str] = []
             all_timing: dict[str, float] = {}  # transform_name → ms
+            all_protected_tool_result_contents: list[str] = []
 
             # Track transform diffs if enabled
             transform_diffs: list[TransformDiff] = []
@@ -400,6 +401,7 @@ class TransformPipeline:
                     all_markers.extend(result.markers_inserted)
                     all_warnings.extend(result.warnings)
                     all_timing[transform.name] = duration_ms
+                    all_protected_tool_result_contents.extend(result.protected_tool_result_contents)
 
                     # Merge sub-transform timing (e.g. ContentRouter's per-compressor breakdown)
                     if result.timing:
@@ -542,6 +544,7 @@ class TransformPipeline:
             diff_artifact=diff_artifact,
             timing=all_timing,
             waste_signals=waste_signals,
+            protected_tool_result_contents=all_protected_tool_result_contents,
         )
 
     def simulate(

--- a/tests/test_compression_cache.py
+++ b/tests/test_compression_cache.py
@@ -237,6 +237,51 @@ class TestCompressionCacheFrozenCount:
         ]
         assert cache.compute_frozen_count(messages) == 2
 
+    def test_update_from_result_freshness_protected_not_marked_stable(
+        self, cache: CompressionCache
+    ) -> None:
+        """Content left unchanged because it was freshness-protected (issue #3)
+        must NOT be marked stable — otherwise `compute_frozen_count` would freeze
+        it on the next turn and it would never get compressed once it ages out of
+        the protection window (permanently forfeiting the compression, not just
+        deferring it). This is the counterpart to
+        `test_update_from_result_identical_content_marks_stable`: identical
+        content, opposite outcome, distinguished by `protected_contents`."""
+        tool_content = "fresh tail tool output the model has not read yet"
+        originals = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": tool_content}],
+            },
+        ]
+        # Compressed is identical (freshness gate skipped it), and the router
+        # surfaced it via TransformResult.protected_tool_result_contents.
+        compressed = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": tool_content}],
+            },
+        ]
+        cache.update_from_result(originals, compressed, protected_contents=[tool_content])
+
+        h = CompressionCache.content_hash(tool_content)
+        assert h not in cache._stable_hashes
+
+        # Next turn: this tool_result is no longer the tail. Because it was NOT
+        # marked stable, the frozen walk stops at it (cache miss) rather than
+        # freezing it, keeping it in the live zone where it can be compressed.
+        messages = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": tool_content}],
+            },
+            {"role": "user", "content": "more stuff"},
+        ]
+        assert cache.compute_frozen_count(messages) == 1
+
     def test_mark_stable_from_messages(self, cache: CompressionCache) -> None:
         """mark_stable_from_messages records hashes for tool_results."""
         content_a = "tool output A"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -336,6 +336,7 @@ class TestTransformResult:
             "cache_metrics",
             "timing",
             "waste_signals",
+            "protected_tool_result_contents",
         }
         assert field_names == expected_fields
 

--- a/tests/test_proxy/test_anthropic_ccr_deferred_injection.py
+++ b/tests/test_proxy/test_anthropic_ccr_deferred_injection.py
@@ -61,7 +61,9 @@ class _FakeCompressionCache:
     def mark_stable_from_messages(self, messages, frozen_count) -> None:  # noqa: ARG002
         return None
 
-    def update_from_result(self, originals, compressed) -> None:  # noqa: ARG002
+    def update_from_result(  # noqa: ARG002
+        self, originals, compressed, protected_contents=None
+    ) -> None:
         return None
 
 

--- a/tests/test_proxy_anthropic_cache_stability.py
+++ b/tests/test_proxy_anthropic_cache_stability.py
@@ -354,7 +354,9 @@ def test_token_mode_freeze_is_capped_by_prefix_tracker() -> None:
             def compute_frozen_count(self, messages):  # noqa: ANN001
                 return 99
 
-            def update_from_result(self, originals, compressed):  # noqa: ANN001
+            def update_from_result(  # noqa: ANN001
+                self, originals, compressed, protected_contents=None
+            ):
                 return None
 
             def mark_stable_from_messages(self, messages, up_to):  # noqa: ANN001
@@ -814,7 +816,9 @@ def test_token_mode_does_not_force_freeze_all_previous_turns() -> None:
             def compute_frozen_count(self, messages):  # noqa: ANN001
                 return 0
 
-            def update_from_result(self, originals, compressed):  # noqa: ANN001
+            def update_from_result(  # noqa: ANN001
+                self, originals, compressed, protected_contents=None
+            ):
                 return None
 
             def mark_stable_from_messages(self, messages, up_to):  # noqa: ANN001
@@ -1243,7 +1247,9 @@ class _IssueFakeCompCache:
     def mark_stable_from_messages(self, messages, up_to):  # noqa: ANN001
         self.calls.append(("mark_stable_from_messages", (up_to,), {}))
 
-    def update_from_result(self, originals, compressed):  # noqa: ANN001
+    def update_from_result(  # noqa: ANN001
+        self, originals, compressed, protected_contents=None
+    ):
         self.calls.append(("update_from_result", (), {}))
 
     # Methods that should NOT be called in the post-fix code path. If any of

--- a/tests/test_proxy_mode_benchmark.py
+++ b/tests/test_proxy_mode_benchmark.py
@@ -10,10 +10,23 @@ def test_local_mode_benchmark_shows_compression_and_cache_tradeoff() -> None:
     token = results["token"]
     cache = results["cache"]
 
+    # TOKEN mode aggressively compresses aged tool_results. The fresh tail is
+    # exempt (freshness exemption, issue #3), but earlier results still compress
+    # once they age out of the freshness window, so it sends far fewer tokens
+    # than baseline.
     assert token.total_tokens_saved > 0
-    assert cache.total_tokens_saved > 0
     assert token.total_sent_tokens < baseline.total_sent_tokens
-    assert cache.total_sent_tokens < baseline.total_sent_tokens
 
-    # Cache mode should preserve prefix better than token mode.
+    # CACHE mode's live zone is only the final message, and the freshness
+    # exemption (issue #3) protects a fresh tail tool_result there — so CACHE
+    # mode does not compress tool output. Its value is prefix stability: send
+    # each result verbatim once, then keep it byte-identical in the frozen
+    # prefix so the provider serves it from cache on every later turn. It
+    # therefore sends more tokens than TOKEN mode but preserves the cached
+    # prefix better — the exact tradeoff this benchmark exists to surface.
+    # (Before the issue #3 fix, CACHE mode's only compression came from
+    # rewriting that fresh tail — the very anti-pattern the fix removes — so
+    # its former `total_tokens_saved > 0` was encoding buggy behavior.)
+    assert cache.total_sent_tokens <= baseline.total_sent_tokens
+    assert cache.total_sent_tokens >= token.total_sent_tokens
     assert cache.total_cache_read_tokens >= token.total_cache_read_tokens

--- a/tests/test_proxy_openai_cache_stability.py
+++ b/tests/test_proxy_openai_cache_stability.py
@@ -280,7 +280,9 @@ def test_issue_327_openai_handler_does_not_call_walker_functions() -> None:
             calls.append(("compute_frozen_count", (), {}))
             return 0
 
-        def update_from_result(self, originals, compressed):  # noqa: ANN001
+        def update_from_result(  # noqa: ANN001
+            self, originals, compressed, protected_contents=None
+        ):
             calls.append(("update_from_result", (), {}))
 
         def mark_stable_from_messages(self, messages, up_to):  # noqa: ANN001

--- a/tests/test_transforms/test_content_router.py
+++ b/tests/test_transforms/test_content_router.py
@@ -197,6 +197,10 @@ def test_force_kompress_routes_anthropic_tool_result_to_targeted_kompress(
         compress_user_messages=True,
         min_tokens_to_compress=10,
         read_protection_window=0,
+        # This test's single message is also the tail, so it would otherwise
+        # hit the freshness exemption (issue #3) by default -- disable it
+        # here to isolate what's actually under test: force_kompress routing.
+        protect_recent_tool_results=0,
     )
 
     assert result.messages[0]["content"][0]["content"] != tool_content

--- a/tests/test_transforms_content_router.py
+++ b/tests/test_transforms_content_router.py
@@ -606,7 +606,7 @@ def _make_router_with_mock_compress(monkeypatch: pytest.MonkeyPatch) -> ContentR
         return SimpleNamespace(
             compressed=content[: len(content) // 2] + "[compressed]",
             compression_ratio=0.5,
-            strategy_used=SimpleNamespace(value="text"),
+            strategy_used=CompressionStrategy.TEXT,
         )
 
     monkeypatch.setattr(router, "compress", fake_compress)
@@ -676,6 +676,133 @@ def test_tool_result_cache_control_protected(monkeypatch: pytest.MonkeyPatch) ->
     )
     # cache_control hard-skip applies to tool_result too
     assert result["content"][0]["content"] == long_text
+
+
+def test_fresh_tail_tool_result_protected_from_compression(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #3: the tail message (messages_from_end=1) is content the model
+    is about to read for the first time this exact request — SmartCrusher/
+    CCR substitution must not touch it, regardless of size or content type.
+    """
+    router = _make_router_with_mock_compress(monkeypatch)
+    long_text = "Z" * 1000
+    msg = {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "fresh", "content": long_text}],
+    }
+    counts: dict[str, int] = {}
+    result = router._process_content_blocks(
+        msg,
+        msg["content"],
+        "",
+        [],
+        set(),
+        route_counts=counts,
+        messages_from_end=1,
+    )
+    assert result["content"][0]["content"] == long_text
+    assert counts["recent_tool_result_protected"] == 1
+
+
+def _make_router_with_mock_smart_crusher_compress(
+    monkeypatch: pytest.MonkeyPatch, config: ContentRouterConfig | None = None
+) -> ContentRouter:
+    """Like `_make_router_with_mock_compress`, but the mocked `compress()`
+    reports `strategy_used=SMART_CRUSHER` — the strategy real tool_result
+    blocks actually route through. `TEXT`/`KOMPRESS`/`CODE_AWARE` are in
+    `LOSSY_UNMARKED_STRATEGIES`, which the reversibility guard (#1307)
+    rejects below `min_ratio` without a CCR marker present; `SMART_CRUSHER`
+    isn't in that set, so this mock's fixed 0.5 ratio doesn't trip it."""
+    router = ContentRouter(config or ContentRouterConfig())
+
+    def fake_compress(content, context: str = "", bias: float = 1.0):
+        return SimpleNamespace(
+            compressed=content[: len(content) // 2] + "[compressed]",
+            compression_ratio=0.5,
+            strategy_used=CompressionStrategy.SMART_CRUSHER,
+        )
+
+    monkeypatch.setattr(router, "compress", fake_compress)
+    return router
+
+
+def test_aged_tool_result_still_compresses_while_fresh_tail_is_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sibling case: an older message (messages_from_end > protect window)
+    is fully eligible for compression — the exemption only covers the tail,
+    it doesn't disable compression entirely."""
+    router = _make_router_with_mock_smart_crusher_compress(monkeypatch)
+    long_text = "Z" * 1000
+    msg = {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "aged", "content": long_text}],
+    }
+    counts: dict[str, int] = {}
+    result = router._process_content_blocks(
+        msg,
+        msg["content"],
+        "",
+        [],
+        set(),
+        route_counts=counts,
+        messages_from_end=2,
+    )
+    assert "[compressed]" in result["content"][0]["content"]
+    assert "recent_tool_result_protected" not in counts
+
+
+def test_unset_messages_from_end_does_not_trigger_freshness_protection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`messages_from_end` defaults to 0 (its "position unknown" sentinel).
+    Call sites that don't wire in a real position — direct unit tests, and
+    any future caller that doesn't track message order — must not have
+    every block silently protected as if it were the tail message."""
+    router = _make_router_with_mock_smart_crusher_compress(monkeypatch)
+    long_text = "Z" * 1000
+    msg = {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "unset", "content": long_text}],
+    }
+    counts: dict[str, int] = {}
+    result = router._process_content_blocks(
+        msg,
+        msg["content"],
+        "",
+        [],
+        set(),
+        route_counts=counts,
+        # messages_from_end intentionally omitted (defaults to 0)
+    )
+    assert "[compressed]" in result["content"][0]["content"]
+    assert "recent_tool_result_protected" not in counts
+
+
+def test_protect_recent_tool_results_zero_disables_freshness_protection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = _make_router_with_mock_smart_crusher_compress(
+        monkeypatch, ContentRouterConfig(protect_recent_tool_results=0)
+    )
+    long_text = "Z" * 1000
+    msg = {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "tail", "content": long_text}],
+    }
+    counts: dict[str, int] = {}
+    result = router._process_content_blocks(
+        msg,
+        msg["content"],
+        "",
+        [],
+        set(),
+        route_counts=counts,
+        messages_from_end=1,
+    )
+    assert "[compressed]" in result["content"][0]["content"]
+    assert "recent_tool_result_protected" not in counts
 
 
 def test_assistant_text_blocks_skipped_by_default(

--- a/tests/test_transforms_content_router.py
+++ b/tests/test_transforms_content_router.py
@@ -783,9 +783,12 @@ def test_unset_messages_from_end_does_not_trigger_freshness_protection(
 def test_protect_recent_tool_results_zero_disables_freshness_protection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    router = _make_router_with_mock_smart_crusher_compress(
-        monkeypatch, ContentRouterConfig(protect_recent_tool_results=0)
-    )
+    # `_process_content_blocks` reads the freshness window from its
+    # `protect_recent_tool_results` parameter (threaded down from `apply()`,
+    # which sources it from config / the runtime kwarg), not from `self.config`
+    # directly — so a direct call passes the knob explicitly. `0` disables the
+    # gate, letting the fresh tail compress normally.
+    router = _make_router_with_mock_smart_crusher_compress(monkeypatch)
     long_text = "Z" * 1000
     msg = {
         "role": "user",
@@ -800,9 +803,100 @@ def test_protect_recent_tool_results_zero_disables_freshness_protection(
         set(),
         route_counts=counts,
         messages_from_end=1,
+        protect_recent_tool_results=0,
     )
     assert "[compressed]" in result["content"][0]["content"]
     assert "recent_tool_result_protected" not in counts
+
+
+def test_apply_surfaces_protected_tool_result_contents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Full `apply()` path: the config field flows through to protect the fresh
+    tail AND surfaces its raw content on `TransformResult.protected_tool_result_
+    contents`, so the proxy's CompressionCache can avoid marking it stable
+    (see CompressionCache.update_from_result). An aged tool_result earlier in
+    the same request still compresses and is NOT surfaced as protected."""
+
+    class FakeTokenizer:
+        def count_text(self, text: str) -> int:
+            return len(text)
+
+        def count_message(self, message: object) -> int:
+            return 1
+
+        def count_messages(self, messages: object) -> int:
+            return 1
+
+    router = _make_router_with_mock_smart_crusher_compress(monkeypatch)
+    aged_text = "A" * 1000
+    fresh_text = "F" * 1000
+    messages = [
+        {"role": "user", "content": "do the thing"},
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "aged", "content": aged_text}],
+        },
+        {"role": "assistant", "content": "ok"},
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "fresh", "content": fresh_text}],
+        },
+    ]
+    result = router.apply(
+        messages,
+        FakeTokenizer(),
+        model_limit=200000,
+        compress_user_messages=True,
+        min_tokens_to_compress=1,
+    )
+
+    fresh_out = result.messages[3]["content"][0]["content"]
+    aged_out = result.messages[1]["content"][0]["content"]
+    assert fresh_out == fresh_text
+    assert "[compressed]" in aged_out
+    # The fresh tail's raw content is surfaced; the aged (compressed) one is not.
+    assert result.protected_tool_result_contents == [fresh_text]
+
+
+def test_apply_runtime_kwarg_overrides_protect_recent_tool_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The `protect_recent_tool_results` runtime kwarg overrides the config
+    default, mirroring how `read_protection_window` is overridable per call.
+    `0` opts out, so even the fresh tail compresses and nothing is surfaced
+    as protected."""
+
+    class FakeTokenizer:
+        def count_text(self, text: str) -> int:
+            return len(text)
+
+        def count_message(self, message: object) -> int:
+            return 1
+
+        def count_messages(self, messages: object) -> int:
+            return 1
+
+    router = _make_router_with_mock_smart_crusher_compress(monkeypatch)
+    fresh_text = "F" * 1000
+    messages = [
+        {"role": "user", "content": "do the thing"},
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "fresh", "content": fresh_text}],
+        },
+    ]
+    result = router.apply(
+        messages,
+        FakeTokenizer(),
+        model_limit=200000,
+        compress_user_messages=True,
+        min_tokens_to_compress=1,
+        protect_recent_tool_results=0,
+    )
+
+    assert "[compressed]" in result.messages[1]["content"][0]["content"]
+    assert result.protected_tool_result_contents == []
 
 
 def test_assistant_text_blocks_skipped_by_default(


### PR DESCRIPTION
## Description
<!-- Briefly explain the change and why it's needed. -->
Closes #3

Companion fix to #2083, but for the code path that's actually live in the deployed proxy: `headroom/transforms/content_router.py`'s `ContentRouter`, not the `crates/headroom-proxy` Rust crate. #2083 patches a crate the running proxy doesn't currently call; this PR patches the pure-Python entrypoint (`headroom.cli.proxy`) that real traffic goes through.

Existing `protect_recent_code` only gates `SOURCE_CODE`-classified content on the flattened/OpenAI-style message path; it doesn't cover general JSON/log/text `tool_result` content blocks (Anthropic-style), which is where SmartCrusher/CCR opaque-blob substitution actually happens for the typical MCP tool-output case. `read_protection_window` is similarly narrow (only covers an explicit tool allowlist). Neither protects a freshly-produced tool result from being swapped for a `<<ccr:...>>` marker before the model has had a chance to read it once.

## Type of Change
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made
- Added `protect_recent_tool_results` config field to `ContentRouterConfig` (default `1`).
- Added a freshness gate in `_process_content_blocks`'s general `tool_result` branch: the most-recent N messages (by real position from `apply()`'s loop) are skipped by both the lossless and lossy compression tiers, mirroring how the Rust live-zone dispatcher's `fresh_message_count` excludes the tail message.
- Guarded against the `messages_from_end` sentinel (`0`, meaning "position not tracked" — used by direct/test callers that don't wire in real position tracking) so the protection only fires for real message positions from `apply()`'s loop, not silently on every unpositioned call.

## Testing
<!-- Check what you actually ran, then paste the real command output below. -->
- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
tests/test_transforms_content_router.py ................................ [ 78%]
.........                                                                [100%]
41 passed in 0.49s

ruff check . / ruff format --check . / mypy headroom --ignore-missing-imports: all clean
```

## Real Behavior Proof
- Environment: local venv (`headroom-py314`, Python 3.14) with the worktree source loaded via `PYTHONPATH`, compiled `headroom._core` extension present.
- Exact command / steps: drove the real (unmocked) `ContentRouter.apply()` entry point — the same call the live proxy makes — with a 4-message Anthropic-style conversation: an aged `tool_result` (message 2 of 4, large JSON blob) and a fresh tail `tool_result` (message 4 of 4, same-sized blob).
- Observed result: `transforms_summary` showed `router:protected:recent_tool_result` firing once and `router:tool_result:smart_crusher` firing once. The fresh tail's content was byte-identical (25,586 → 25,586 bytes); the aged message compressed normally (24,385 → 16,412 bytes, ~33% reduction).
- Not tested: full live HTTP round-trip through a running `headroom proxy` process against a real Anthropic backend (would require spinning up a second isolated proxy instance and real API credentials; the direct-`apply()` test above exercises the identical code path without that overhead).

## Review Readiness
- [x] I performed a self-review
- [x] This PR is ready for human review

## Checklist
- [x] My code follows this project's style guidelines
- [x] I performed a self-review of my own code
- [x] I commented my code, particularly in hard-to-understand areas
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I updated CHANGELOG.md if applicable

## Additional Notes
<!-- Mention any N/A checklist items, tradeoffs, follow-ups, or maintainer context. -->
Supersedes #2087, which was accidentally opened from a branch based on my fork's `main` (30 commits ahead of `upstream/main` from unrelated prior fork PRs) instead of `upstream/main` directly, so its diff pulled in far more than intended. This PR is a single clean commit cherry-picked onto current `upstream/main`.