### PR TITLE
fix(codex): skip sockets in session home overlay

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -1505,7 +1505,14 @@ def _codex_session_home_overlay() -> Any:
     with tempfile.TemporaryDirectory(prefix="headroom-codex-home-") as tmp_dir:
         session_home = Path(tmp_dir)
         if source_home.exists():
-            shutil.copytree(source_home, session_home, dirs_exist_ok=True)
+            shutil.copytree(
+                source_home,
+                session_home,
+                dirs_exist_ok=True,
+                ignore=lambda directory, names: [
+                    name for name in names if (Path(directory) / name).is_socket()
+                ],
+            )
 
         os.environ["CODEX_HOME"] = str(session_home)
         try:

--- a/tests/test_cli/test_wrap_codex.py
+++ b/tests/test_cli/test_wrap_codex.py
@@ -10,7 +10,9 @@ way a user would from the shell.
 from __future__ import annotations
 
 import shutil
+import socket
 import sqlite3
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1079,6 +1081,38 @@ def test_codex_session_home_overlay_seeds_active_home_and_cleans_up(
     assert not session_home.exists()
     assert config_file.read_text(encoding="utf-8") == original_config
     assert auth_file.read_text(encoding="utf-8") == original_auth
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" or not hasattr(socket, "AF_UNIX"),
+    reason="requires POSIX Unix domain sockets",
+)
+def test_codex_session_home_overlay_skips_unix_sockets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_home(monkeypatch, tmp_path)
+    codex_home = tmp_path / "custom-codex-home"
+    socket_dir = codex_home / "vendor_imports" / "skills" / ".git"
+    socket_dir.mkdir(parents=True)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.chdir(codex_home)
+
+    head_file = socket_dir / "HEAD"
+    head_file.write_text("ref: refs/heads/main\n", encoding="utf-8")
+    socket_file = socket_dir / "fsmonitor--daemon.ipc"
+    relative_socket_file = socket_file.relative_to(codex_home)
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as fsmonitor_socket:
+        fsmonitor_socket.bind(str(relative_socket_file))
+
+        with wrap_mod._codex_session_home_overlay() as session_home:
+            session_socket_dir = session_home / socket_dir.relative_to(codex_home)
+            assert (session_socket_dir / "HEAD").read_text(encoding="utf-8") == (
+                "ref: refs/heads/main\n"
+            )
+            assert not (session_socket_dir / socket_file.name).exists()
+
+        assert socket_file.is_socket()
 
 
 def test_wrap_codex_launch_uses_session_scoped_codex_home(


### PR DESCRIPTION
## Description

Prevent `headroom wrap codex` from failing when the active `CODEX_HOME` contains a Unix socket. The session overlay copied every entry with `shutil.copytree()`, which raises `shutil.Error` when it reaches Git's `fsmonitor--daemon.ipc` socket.

The overlay now skips socket entries while continuing to copy regular Codex state and surface unrelated copy errors.

Closes #2103

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Ignore filesystem sockets while seeding the temporary Codex session home.
- Add a regression test with a real nested `fsmonitor--daemon.ipc` socket and a regular sibling file.

## Testing

- [x] Focused unit tests pass (`pytest tests/test_cli/test_wrap_codex.py -q`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New regression test added
- [ ] Manual interactive testing performed

### Test Output

```text
Docker, Linux arm64, Python 3.12.12

pytest tests/test_cli/test_wrap_codex.py -q
88 passed in 5.92s

ruff check .
All checks passed!

ruff format --check .
1191 files already formatted

mypy headroom --ignore-missing-imports
Success: no issues found in 469 source files
```

## Real Behavior Proof

- Environment: isolated Docker container on Linux arm64 with Python 3.12.12 and Rust 1.95.0
- Exact command / steps: bind a real Unix socket at `vendor_imports/skills/.git/fsmonitor--daemon.ipc`, then enter `_codex_session_home_overlay()` through the focused pytest regression
- Observed result: the regular sibling file is copied, the socket is omitted, the source socket remains active, and the overlay exits cleanly
- Not tested: an interactive Codex launch against the live host `~/.codex`

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing focused Codex wrapper tests pass with my changes

## Additional Notes

The filter is intentionally limited to socket entries. Permission errors and failures involving regular files still propagate from `shutil.copytree()`.
