### PR TITLE
chore: union-merge CHANGELOG.md to stop cross-PR merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 *.py text eol=lf
 *.sh text eol=lf
+
+# CHANGELOG appends conflict on nearly every concurrent PR; union-merge keeps
+# all entries instead of forcing a manual resolution, killing the merge cascade.
+CHANGELOG.md merge=union


### PR DESCRIPTION
## Description
Nearly every open PR appends an entry to the same `## [Unreleased]` section of `CHANGELOG.md`. With dozens of concurrent PRs, merging **any** one flips the others to `CONFLICTING`, so bulk-merging the backlog becomes quadratic (each merge re-conflicts the rest on the changelog alone — code is fine).

This adds git's built-in **`union`** merge driver for `CHANGELOG.md` via `.gitattributes`, so changelog conflicts auto-resolve by keeping every entry — removing the single largest merge-conflict blocker across the PR backlog. `union` is a built-in driver (no `.git/config` needed) and is honored by GitHub's server-side merge.

## Type of Change
- [x] Code refactoring / repo infrastructure (no functional change)

## Changes Made
- `.gitattributes`: `CHANGELOG.md merge=union`

## Testing
- [x] Linting passes (no code changed)
### Test Output
```text
N/A — .gitattributes-only change; verified the union driver resolves overlapping [Unreleased] appends locally.
```

## Real Behavior Proof
- Before: merging one PR that touches `CHANGELOG.md` conflicts every other PR that touches it.
- After: overlapping `CHANGELOG.md` appends merge automatically (both entries kept), no manual resolution.
