### PR TITLE
fix(memory): annotate _EMBEDDER_CACHE key as 3-tuple (unbreak main lint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- **memory:** annotate `_EMBEDDER_CACHE` as `dict[tuple[str, str, str], Embedder]` to match the 3-element key (backend, model, ollama_base_url). The stale 2-tuple annotation made `mypy headroom` fail on `main`, which broke the `lint` CI job on every open PR.
 - **install:** include `orjson` in the `[proxy]` extra so `uv tool install "headroom-ai[all]"` satisfies LiteLLM OpenRouter/provider backends that import it at runtime ([#2056](https://github.com/headroomlabs-ai/headroom/issues/2056)).
 - The dashboard's per-request metadata (the `recent_requests` / `request_logs`
   tail and the `config` block with upstream URLs) is gated to loopback callers

--- a/headroom/memory/factory.py
+++ b/headroom/memory/factory.py
@@ -34,7 +34,7 @@ _MEMORY_TEXT_GROUP = "headroom.memory_text"
 # safely serve every per-project ``LocalBackend`` created by the
 # BackendRouter. Without this cache, opening N project DBs would load
 # the sentence-transformers / ONNX model N times.
-_EMBEDDER_CACHE: dict[tuple[str, str], Embedder] = {}
+_EMBEDDER_CACHE: dict[tuple[str, str, str], Embedder] = {}
 _EMBEDDER_CACHE_LOCK = threading.Lock()
 
 


### PR DESCRIPTION
## What
One-line type fix: `_EMBEDDER_CACHE` is keyed by a 3-tuple `(backend, model, ollama_base_url)` but was still annotated `dict[tuple[str, str], Embedder]`.

## Why
`mypy headroom --ignore-missing-imports` (the CI `lint` job) fails on `main` at `factory.py:187`/`:219` because of this mismatch. Since the lint job runs whole-package mypy, **every open PR is currently failing lint on this bug** — none of them introduced it. This unblocks the lint gate repo-wide.

## Proof
`mypy headroom --ignore-missing-imports` → `Success: no issues found in 469 source files`. `ruff check .` + `ruff format --check .` clean.

## Scope
Type annotation only; no runtime behavior change. The 3-tuple key itself is pre-existing (the Ollama base_url was already part of the key to avoid cross-server embedder cache collisions).