### PR TITLE
fix(proxy): satisfy rustfmt import ordering

### DIFF
--- a/crates/headroom-proxy/src/proxy.rs
+++ b/crates/headroom-proxy/src/proxy.rs
@@ -10,9 +10,9 @@ use axum::http::{HeaderMap, HeaderName, Request, Response, StatusCode, Uri};
 use axum::response::IntoResponse;
 use axum::routing::{any, get, post};
 use axum::Router;
-use futures_util::{StreamExt as _, TryStreamExt};
 #[cfg(test)]
 use bytes::Bytes;
+use futures_util::{StreamExt as _, TryStreamExt};
 #[cfg(test)]
 use http_body_util::BodyExt;
 


### PR DESCRIPTION
## Summary

Fixes the Rust workflow failure from https://github.com/headroomlabs-ai/headroom/actions/runs/29294598252/job/86965269576 by applying rustfmt's import ordering in `crates/headroom-proxy/src/proxy.rs`.

## Testing

```text
cargo fmt --all -- --check
# passed

git diff --check
# no output
```
