### PR TITLE
fix: apply proxy Rust formatting

### DIFF
--- a/crates/headroom-proxy/src/proxy.rs
+++ b/crates/headroom-proxy/src/proxy.rs
@@ -10,9 +10,9 @@ use axum::http::{HeaderMap, HeaderName, Request, Response, StatusCode, Uri};
 use axum::response::IntoResponse;
 use axum::routing::{any, get, post};
 use axum::Router;
-use futures_util::{StreamExt as _, TryStreamExt};
 #[cfg(test)]
 use bytes::Bytes;
+use futures_util::{StreamExt as _, TryStreamExt};
 #[cfg(test)]
 use http_body_util::BodyExt;
 


### PR DESCRIPTION
## Description

Fixes the `cargo fmt --check` failure on `main` after #2027 by applying rustfmt's import ordering in `crates/headroom-proxy/src/proxy.rs`.

Failing job: https://github.com/headroomlabs-ai/headroom/actions/runs/29294598252/job/86965269576

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Reordered one import in `crates/headroom-proxy/src/proxy.rs` according to `cargo fmt`.

## Testing

- [x] Linting passes (`cargo fmt --all -- --check`)

### Test Output

```text
$ cargo fmt --all -- --check
# no output

$ git diff --check
# no output
```

## Real Behavior Proof

- Environment: Windows 11, Rust toolchain from this repo.
- Exact command / steps: ran `cargo fmt --all`, then reran `cargo fmt --all -- --check`.
- Observed result: rustfmt check now passes locally.
- Not tested: full CI, pending on this PR.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings