### PR TITLE
feat(dashboard): add dashboard scope selector (#2137)

### DIFF
--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -524,15 +524,20 @@
                     </div>
                 </div>
 
-                <!-- Card renders on live cache traffic OR persisted lifetime cache savings —
+                <!-- Card renders on live cache traffic or persisted lifetime cache savings,
                      the lifetime figure must survive a restart with zero traffic. -->
                 <template x-if="hasAnyScopedCacheData">
                     <div class="bg-surface rounded-lg p-4 border border-border mb-6">
                         <div class="flex justify-between items-center mb-3">
-                            <div class="text-sm font-medium text-gray-300">Prefix Cache Impact</div>
+                            <div>
+                                <div class="text-sm font-medium text-gray-300">Prefix Cache Impact</div>
+                                <div class="text-[11px] text-gray-600 mt-0.5"
+                                     x-show="hasMetricScopes && processLocalCacheActive"
+                                     x-text="'Current process net savings: $' + formatCurrency(stats.prefix_cache?.totals?.net_savings_usd || 0)"></div>
+                            </div>
                             <div class="text-xs font-mono"
-                                 :class="scopeCacheUnavailable ? 'text-gray-500' : 'text-emerald-400'"
-                                 x-text="scopeCacheUnavailable ? 'Unavailable for selected scope' : scopeFreshnessBadge"></div>
+                                 :class="scopeCacheStatusClass"
+                                 x-text="scopeCacheStatusText"></div>
                         </div>
                         <!-- Totals row -->
                         <div class="grid grid-cols-2 md:grid-cols-5 gap-4 mb-4">
@@ -551,40 +556,44 @@
                             </div>
                             <div>
                                 <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Writes</div>
-                                <div class="text-2xl font-light tabular-nums text-amber-400" x-text="scopeCacheUnavailable ? 'Unavailable' : formatNumber(scopeCacheWrites)"></div>
+                                <div class="text-2xl font-light tabular-nums"
+                                     :class="legacyProcessCacheUnavailable ? 'text-gray-600' : 'text-amber-400'"
+                                     x-text="legacyProcessCacheUnavailable ? '—' : (scopeCacheUnavailable ? 'Unavailable' : formatNumber(scopeCacheWrites))"></div>
                                 <div class="text-xs text-amber-400/70"
                                      x-show="!hasMetricScopes && cacheSessionActive"
                                      x-text="'$' + formatCurrency(stats.prefix_cache?.totals?.write_premium_usd || 0) + ' write premium'"></div>
+                                <div class="text-xs text-amber-400/70" x-show="hasMetricScopes && processLocalCacheActive"
+                                     x-text="'$' + formatCurrency(stats.prefix_cache?.totals?.write_premium_usd || 0) + ' current-process write premium'"></div>
                                 <div class="text-xs text-gray-500"
                                      x-show="hasMetricScopes">selected scope</div>
                                 <div class="text-xs text-gray-500"
-                                     x-show="!hasMetricScopes && !cacheSessionActive">no activity since restart</div>
+                                     x-show="legacyProcessCacheUnavailable">no activity since restart</div>
                             </div>
                             <div>
                                 <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Hit Rate</div>
                                 <div class="text-2xl font-light tabular-nums"
-                                     :class="scopeCacheUnavailable ? 'text-gray-500' : (scopeCacheHitRate > 80 ? 'text-emerald-400' : scopeCacheHitRate > 50 ? 'text-amber-400' : 'text-red-400')"
-                                     x-text="scopeCacheUnavailable ? 'Unavailable' : scopeCacheHitRate.toFixed(0) + '%'"></div>
+                                     :class="legacyProcessCacheUnavailable ? 'text-gray-600' : (scopeCacheUnavailable ? 'text-gray-500' : (scopeCacheHitRate > 80 ? 'text-emerald-400' : scopeCacheHitRate > 50 ? 'text-amber-400' : 'text-red-400'))"
+                                     x-text="legacyProcessCacheUnavailable ? '—' : (scopeCacheUnavailable ? 'Unavailable' : scopeCacheHitRate.toFixed(0) + '%')"></div>
                                 <div class="text-xs text-gray-500"
-                                     x-text="scopeCacheUnavailable ? 'Unavailable for selected scope' : scopeCacheHitRequests + ' / ' + scopeCacheRequests + ' requests'"></div>
+                                     x-text="legacyProcessCacheUnavailable ? 'no activity since restart' : (scopeCacheUnavailable ? 'Unavailable for selected scope' : scopeCacheHitRequests + ' / ' + scopeCacheRequests + ' requests')"></div>
                             </div>
                             <div>
                                 <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Busts</div>
                                 <div class="text-2xl font-light tabular-nums"
-                                     :class="scopeCacheUnavailable ? 'text-gray-500' : (scopeCacheBustCount > 5 ? 'text-red-400' : scopeCacheBustCount > 0 ? 'text-amber-400' : 'text-emerald-400')"
-                                     x-text="scopeCacheUnavailable ? 'Unavailable' : scopeCacheBustCount"></div>
+                                     :class="legacyProcessCacheUnavailable ? 'text-gray-600' : (scopeCacheUnavailable ? 'text-gray-500' : (scopeCacheBustCount > 5 ? 'text-red-400' : scopeCacheBustCount > 0 ? 'text-amber-400' : 'text-emerald-400'))"
+                                     x-text="legacyProcessCacheUnavailable ? '—' : (scopeCacheUnavailable ? 'Unavailable' : scopeCacheBustCount)"></div>
                                 <div class="text-xs text-gray-500"
-                                     x-text="scopeCacheUnavailable ? 'Unavailable for selected scope' : formatNumber(scopeCacheBustWriteTokens) + ' tokens re-written'"></div>
+                                     x-text="legacyProcessCacheUnavailable ? 'no activity since restart' : (scopeCacheUnavailable ? 'Unavailable for selected scope' : formatNumber(scopeCacheBustWriteTokens) + ' tokens re-written')"></div>
                             </div>
                             <div>
                                 <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Providers</div>
                                 <div class="text-2xl font-light tabular-nums text-gray-300"
-                                     x-text="cacheSessionActive ? processLocalProviderCount : '—'"></div>
+                                     x-text="processLocalCacheActive ? processLocalProviderCount : '—'"></div>
                                 <div class="text-xs text-gray-500">Current process</div>
                             </div>
                         </div>
                         <!-- Cache efficiency bar (session-scoped; hidden until traffic arrives) -->
-                        <div x-show="cacheSessionActive">
+                        <div x-show="cacheSessionActive && !scopeCacheUnavailable">
                             <div class="flex justify-between text-xs text-gray-500 mb-1">
                                 <span>Cache Efficiency</span>
                                 <span x-text="cacheSavingsPercent + '% of input served from cache'"></span>
@@ -663,30 +672,30 @@
                                         <div class="text-xs text-gray-500 uppercase tracking-wide">Compression vs Cache</div>
                                         <div class="text-[11px] text-gray-600 mt-0.5">Tokens saved by compression against cached-prefix tokens its mutations invalidated</div>
                                     </div>
-                                    <div data-testid="cvc-net-headline" class="rounded-full border bg-black/20 px-3 py-1 text-[11px] uppercase tracking-[0.18em]" :class="compressionVsCacheNet >= 0 ? 'border-emerald-400/20 text-emerald-300/90' : 'border-red-400/25 text-red-300/90'" x-text="compressionVsCacheNet >= 0 ? 'Net positive' : 'Net negative'"></div>
+                                    <div data-testid="cvc-net-headline" class="rounded-full border bg-black/20 px-3 py-1 text-[11px] uppercase tracking-[0.18em]" :class="scopeCacheUnavailable ? 'border-gray-500/25 text-gray-400' : (compressionVsCacheNet >= 0 ? 'border-emerald-400/20 text-emerald-300/90' : 'border-red-400/25 text-red-300/90')" x-text="scopeCacheUnavailable ? 'Selected scope unavailable' : (compressionVsCacheNet >= 0 ? 'Net positive' : 'Net negative')"></div>
                                 </div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
                                     <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
                                         <div class="text-[11px] uppercase tracking-[0.18em] text-emerald-300/75">Saved by Compression</div>
-                                    <div data-testid="cvc-saved-value" class="mt-2 text-3xl font-light text-emerald-50" x-text="formatNumber(scopeCompressionVsCacheSaved)"></div>
-                                        <div class="mt-1 text-xs text-gray-500">tokens removed before send</div>
+                                        <div data-testid="cvc-saved-value" class="mt-2 text-3xl font-light text-emerald-50" x-text="scopeCacheUnavailable ? 'Unavailable' : formatNumber(scopeCompressionVsCacheSaved)"></div>
+                                        <div class="mt-1 text-xs text-gray-500" x-text="scopeCacheUnavailable ? 'Unavailable for selected scope' : 'tokens removed before send'"></div>
                                     </div>
                                     <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
                                         <div class="text-[11px] uppercase tracking-[0.18em] text-red-300/75">Lost to Cache Busts</div>
-                                    <div data-testid="cvc-bust-value" class="mt-2 text-3xl font-light text-red-50" x-text="formatNumber(scopeCompressionVsCacheBustTokens)"></div>
-                                    <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(scopeCompressionVsCacheBustCount) + ' busts observed'"></div>
+                                        <div data-testid="cvc-bust-value" class="mt-2 text-3xl font-light text-red-50" x-text="scopeCacheUnavailable ? 'Unavailable' : formatNumber(scopeCompressionVsCacheBustTokens)"></div>
+                                        <div class="mt-1 text-xs text-gray-500" x-text="scopeCacheUnavailable ? 'Unavailable for selected scope' : formatNumber(scopeCompressionVsCacheBustCount) + ' busts observed'"></div>
                                     </div>
                                     <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
                                         <div class="text-[11px] uppercase tracking-[0.18em] text-gray-400">Net</div>
-                                        <div data-testid="cvc-net-value" class="mt-2 text-3xl font-light" :class="compressionVsCacheNet >= 0 ? 'text-emerald-400' : 'text-red-400'" x-text="(compressionVsCacheNet >= 0 ? '+' : '-') + formatNumber(Math.abs(compressionVsCacheNet))"></div>
-                                        <div class="mt-1 text-xs text-gray-500">saved minus bust losses</div>
+                                        <div data-testid="cvc-net-value" class="mt-2 text-3xl font-light" :class="scopeCacheUnavailable ? 'text-gray-500' : (compressionVsCacheNet >= 0 ? 'text-emerald-400' : 'text-red-400')" x-text="scopeCacheUnavailable ? 'Unavailable' : ((compressionVsCacheNet >= 0 ? '+' : '-') + formatNumber(Math.abs(compressionVsCacheNet)))"></div>
+                                        <div class="mt-1 text-xs text-gray-500" x-text="scopeCacheUnavailable ? 'Unavailable for selected scope' : 'saved minus bust losses'"></div>
                                     </div>
                                     <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                    <div class="text-[11px] uppercase tracking-[0.18em] text-cyan-300/75">Prefix Freeze Net</div>
-                                    <div data-testid="freeze-net-value" class="mt-2 text-3xl font-light" :class="prefixFreezeNet >= 0 ? 'text-cyan-50' : 'text-red-400'" x-text="(prefixFreezeNet >= 0 ? '+' : '-') + formatNumber(Math.abs(prefixFreezeNet))"></div>
-                                    <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.prefix_freeze?.busts_avoided || 0) + ' busts avoided, ' + formatNumber(stats.prefix_cache?.prefix_freeze?.compression_foregone_tokens || 0) + ' foregone'"></div>
-                                    <div class="mt-1 text-[11px] text-gray-600">Current process</div>
-                                </div>
+                                        <div class="text-[11px] uppercase tracking-[0.18em] text-cyan-300/75">Prefix Freeze Net</div>
+                                        <div data-testid="freeze-net-value" class="mt-2 text-3xl font-light" :class="prefixFreezeNet >= 0 ? 'text-cyan-50' : 'text-red-400'" x-text="(prefixFreezeNet >= 0 ? '+' : '-') + formatNumber(Math.abs(prefixFreezeNet))"></div>
+                                        <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.prefix_freeze?.busts_avoided || 0) + ' busts avoided, ' + formatNumber(stats.prefix_cache?.prefix_freeze?.compression_foregone_tokens || 0) + ' foregone'"></div>
+                                        <div class="mt-1 text-[11px] text-gray-600">Current process</div>
+                                    </div>
                                 </div>
                             </div>
                         </template>
@@ -697,6 +706,7 @@
                                     <div>
                                         <div class="text-xs text-gray-500 uppercase tracking-wide">Cache Miss Attribution</div>
                                         <div class="text-[11px] text-gray-600 mt-0.5">Why turns that expected a prompt-cache hit missed — TTL lapse (consider a longer TTL) vs the cacheable prefix changing</div>
+                                        <div class="text-[11px] text-gray-600 mt-1">Current process only</div>
                                     </div>
                                     <div data-testid="miss-attr-headline" class="rounded-full border bg-black/20 px-3 py-1 text-[11px] uppercase tracking-[0.18em]"
                                          :class="(missAttribution.ttl_expiry_pct || 0) >= (missAttribution.prefix_change_pct || 0) ? 'border-violet-400/25 text-violet-300/90' : 'border-amber-400/25 text-amber-300/90'"
@@ -730,6 +740,7 @@
                         <template x-if="Object.keys(stats.prefix_cache?.by_provider || {}).length > 0">
                             <div class="mt-4 border-t border-border pt-3">
                                 <div class="text-xs text-gray-500 uppercase tracking-wide mb-2">Per-Provider Breakdown</div>
+                                <div class="text-[11px] text-gray-600 mb-3">Current process only</div>
                                 <div class="space-y-3">
                                     <template x-for="[prov, pc] in Object.entries(stats.prefix_cache?.by_provider || {})" :key="prov">
                                         <div class="flex items-center justify-between">

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -238,7 +238,7 @@
                           x-text="formatNumber(scopeCompressionTokensSaved) + ' proxy tokens · ' + scopeFreshnessText"></span>
                     <span x-show="scopeCompressionUnavailable">Unavailable for selected scope</span>
                     <span x-show="!hasMetricScopes && (stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0"
-                          x-text="formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' proxy tokens only; ' + cliFilteringLabel + ' excluded from $'"></span>
+                          x-text="formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' proxy tokens'"></span>
                     <span x-show="!hasMetricScopes && !((stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0) && stats.litellm_available !== false"
                           x-text="formatNumber(stats.requests?.total || 0) + ' requests processed'"></span>
                     <!-- Pricing is LiteLLM-only. LiteLLM currently can't install on

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -2260,10 +2260,6 @@
                     return this.selectedScope?.cache || null;
                 },
 
-                get selectedScopeCodexWs() {
-                    return this.selectedScope?.codex_ws || null;
-                },
-
                 get scopeCompressionAvailable() {
                     if (!this.hasMetricScopes) return true;
                     const compression = this.selectedScopeCompression;
@@ -2280,14 +2276,25 @@
                     return Boolean(
                         cache
                         && typeof cache.cache_read_tokens === 'number'
+                        && typeof cache.cache_savings_usd === 'number'
                         && typeof cache.cache_write_tokens === 'number'
+                        && typeof cache.uncached_input_tokens === 'number'
+                        && typeof cache.hit_requests === 'number'
                         && typeof cache.hit_rate === 'number'
+                        && typeof cache.requests === 'number'
                         && typeof cache.bust_count === 'number'
+                        && typeof cache.bust_write_tokens === 'number'
+                        && typeof cache.cache_bust_count === 'number'
+                        && typeof cache.cache_bust_tokens_lost === 'number'
                     );
                 },
 
                 get scopeCacheUnavailable() {
                     return this.hasMetricScopes && !this.scopeCacheAvailable;
+                },
+
+                get legacyProcessCacheUnavailable() {
+                    return !this.hasMetricScopes && !this.cacheSessionActive;
                 },
 
                 get scopeFreshnessText() {
@@ -2305,8 +2312,22 @@
                     return this.selectedScopeLabel + ' · ' + this.scopeFreshnessText;
                 },
 
-                get scopeRequestTotal() {
-                    return this.selectedScopeRequests?.total ?? 0;
+                get scopeCacheStatusText() {
+                    if (this.hasMetricScopes) {
+                        return this.scopeCacheUnavailable
+                            ? 'Unavailable for selected scope'
+                            : this.scopeFreshnessBadge;
+                    }
+                    return this.cacheSessionActive
+                        ? 'Net savings: $' + this.formatCurrency(this.stats.prefix_cache?.totals?.net_savings_usd || 0)
+                        : 'no activity since restart';
+                },
+
+                get scopeCacheStatusClass() {
+                    if (this.hasMetricScopes) {
+                        return this.scopeCacheUnavailable ? 'text-gray-500' : 'text-emerald-400';
+                    }
+                    return this.cacheSessionActive ? 'text-emerald-400' : 'text-gray-500';
                 },
 
                 get scopeCompressionUsd() {
@@ -2325,18 +2346,7 @@
                     if (!this.hasMetricScopes) {
                         return this.cacheSessionActive || (this.stats.persistent_savings?.lifetime?.cache_read_tokens || 0) > 0;
                     }
-                    const scopes = this.stats.metric_scopes || {};
-                    return ['current_process', 'display_session', 'lifetime'].some((key) => {
-                        const cache = scopes[key]?.cache;
-                        return Boolean(
-                            cache
-                            && (
-                                (cache.requests || 0) > 0
-                                || (cache.cache_read_tokens || 0) > 0
-                                || (cache.cache_write_tokens || 0) > 0
-                            )
-                        );
-                    });
+                    return this.scopedCacheActive;
                 },
 
                 get scopedCacheActive() {
@@ -2397,25 +2407,14 @@
                     return this.selectedScopeCache?.bust_write_tokens ?? 0;
                 },
 
-                get hasScopedObservedTtlBuckets() {
-                    const buckets = this.hasMetricScopes
-                        ? (this.selectedScopeCache?.observed_ttl_buckets || {})
-                        : (this.stats.prefix_cache?.totals?.observed_ttl_buckets || {});
-                    return ((buckets['5m']?.tokens || 0) + (buckets['1h']?.tokens || 0)) > 0;
+                get processLocalCacheActive() {
+                    return (this.stats.prefix_cache?.totals?.requests || 0) > 0;
                 },
 
                 get scopedObservedTtlMix() {
                     return this.hasMetricScopes
                         ? (this.selectedScopeCache?.observed_ttl_mix || {})
                         : (this.stats.prefix_cache?.totals?.observed_ttl_mix || {});
-                },
-
-                get scopedObservedTtlHeadline() {
-                    const mix = this.scopedObservedTtlMix;
-                    const oneHour = mix['1h_pct'] || 0;
-                    const fiveMinute = mix['5m_pct'] || 0;
-                    if (oneHour === fiveMinute) return 'Balanced';
-                    return oneHour > fiveMinute ? '1h leaning' : '5m leaning';
                 },
 
                 get scopedObservedTtlWindowLabel() {
@@ -2770,7 +2769,9 @@
                     const t = this.hasMetricScopes
                         ? (this.selectedScopeCache || {})
                         : (this.stats.prefix_cache?.totals || {});
-                    const total = (t.cache_read_tokens || 0) + (t.cache_write_tokens || 0) + (t.uncached_input_tokens || 0);
+                    const total = this.hasMetricScopes
+                        ? ((t.cache_read_tokens || 0) + (t.cache_write_tokens || 0) + (t.uncached_input_tokens || 0))
+                        : ((t.cache_read_tokens || 0) + (t.cache_write_tokens || 0));
                     if (total === 0) return 0;
                     return Math.round((t.cache_read_tokens || 0) / total * 100);
                 },
@@ -2779,7 +2780,9 @@
                     const t = this.hasMetricScopes
                         ? (this.selectedScopeCache || {})
                         : (this.stats.prefix_cache?.totals || {});
-                    const total = (t.cache_read_tokens || 0) + (t.cache_write_tokens || 0) + (t.uncached_input_tokens || 0);
+                    const total = this.hasMetricScopes
+                        ? ((t.cache_read_tokens || 0) + (t.cache_write_tokens || 0) + (t.uncached_input_tokens || 0))
+                        : ((t.cache_read_tokens || 0) + (t.cache_write_tokens || 0));
                     if (total === 0) return 0;
                     return Math.round((t.cache_write_tokens || 0) / total * 100);
                 },
@@ -2840,8 +2843,13 @@
                     return pf.net_benefit_tokens ?? ((pf.tokens_preserved || 0) - (pf.compression_foregone_tokens || 0));
                 },
 
+                get hasProcessLocalPrefixFreeze() {
+                    const pf = this.stats.prefix_cache?.prefix_freeze || {};
+                    return (pf.tokens_preserved || 0) > 0 || (pf.compression_foregone_tokens || 0) > 0;
+                },
+
                 get hasCompressionVsCache() {
-                    if (this.hasMetricScopes) return this.hasScopedCompressionVsCache;
+                    if (this.hasMetricScopes) return this.hasScopedCompressionVsCache || this.hasProcessLocalPrefixFreeze;
                     const cvc = this.stats.prefix_cache?.compression_vs_cache || {};
                     const pf = this.stats.prefix_cache?.prefix_freeze || {};
                     return (cvc.tokens_saved_by_compression || 0) > 0

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -280,8 +280,6 @@
                         </div>
                         <div class="mt-1 text-xs text-gray-500 leading-relaxed">
                             <span x-text="'Proxy ' + formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' (' + proxyShareOfTotal.toFixed(1) + '%)'"></span>
-                            <span class="mx-1 text-gray-600">/</span>
-                            <span x-text="cliFilteringAvailable ? (cliFilteringLabel + ' ' + formatNumber(cliFilteringSaved) + ' this session (' + cliFilteringSessionPctDisplay.toFixed(1) + '%)') : (cliFilteringLabel + ' not installed')"></span>
                         </div>
                         <div class="mt-1 text-xs text-gray-600 leading-relaxed">
                             <span x-text="'Of total wire: ' + (stats.tokens?.savings_percent || 0).toFixed(2) + '%'" title="Savings as fraction of all input tokens including frozen prefix"></span>
@@ -449,14 +447,6 @@
                             <div class="flex justify-between items-center">
                                 <span class="text-sm text-gray-400">Before Compression</span>
                                 <span class="font-mono text-sm" x-text="formatNumber(stats.tokens?.total_before_compression || 0)"></span>
-                            </div>
-                            <div class="flex justify-between items-center" x-show="cliFilteringAvailable">
-                                <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
-                                <span class="font-mono text-sm text-emerald-400" x-text="formatNumber(cliFilteringSaved)"></span>
-                            </div>
-                            <div class="flex justify-between items-center" x-show="!cliFilteringAvailable">
-                                <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
-                                <span class="font-mono text-sm text-gray-600">not installed</span>
                             </div>
                             <div class="flex justify-between items-center">
                                 <span class="text-sm text-gray-400">Proxy Removed</span>
@@ -1540,17 +1530,6 @@
                         <div class="mt-2 text-xs text-gray-500">Based on persisted weekly buckets</div>
                     </div>
 
-                    <template x-if="historyStats.cli_filtering && historyCliFilteringAvailable">
-                        <div class="bg-surface rounded-lg p-4 border border-border">
-                            <div class="text-xs text-gray-500 uppercase tracking-wide mb-1"
-                                 x-text="(historyStats.cli_filtering?.label || cliFilteringLabel) + ' Lifetime Saved'"></div>
-                            <div class="flex items-baseline gap-2">
-                                <span class="text-3xl font-light tabular-nums text-cyan-400"
-                                      x-text="formatNumber(historyStats.cli_filtering?.lifetime?.tokens_saved || 0)"></span>
-                            </div>
-                            <div class="mt-2 text-xs text-gray-500">CLI output filtering (lifetime)</div>
-                        </div>
-                    </template>
                 </div>
 
                 <template x-if="hasHistoricalData">
@@ -2949,49 +2928,6 @@
                     const total = this.compressionTotalBefore;
                     if (total <= 0) return 0;
                     return (this.stats.tokens?.proxy_compression_saved || 0) / total * 100;
-                },
-
-                get cliFilteringLabel() {
-                    const raw = this.stats.savings?.by_layer?.cli_filtering?.label
-                        || this.stats.context_tool?.label
-                        || this.stats.context_tool?.configured
-                        || 'Context Tool';
-                    if (String(raw).toLowerCase() === 'lean-ctx') return 'Lean-ctx';
-                    return String(raw);
-                },
-
-                get cliFilteringSaved() {
-                    return this.stats.tokens?.cli_filtering_saved
-                        ?? this.stats.tokens?.cli_tokens_avoided
-                        ?? this.stats.tokens?.rtk_saved
-                        ?? 0;
-                },
-
-                get cliFilteringShareOfTotal() {
-                    const total = this.compressionTotalBefore;
-                    if (total <= 0) return 0;
-                    return this.cliFilteringSaved / total * 100;
-                },
-
-                get cliFilteringLifetime() {
-                    return this.stats.savings?.by_layer?.cli_filtering?.lifetime?.tokens_saved ?? 0;
-                },
-
-                get cliFilteringSessionPctDisplay() {
-                    const p = this.stats.savings?.by_layer?.cli_filtering?.session_savings_pct;
-                    return (p === null || p === undefined) ? this.cliFilteringShareOfTotal : p;
-                },
-
-                get cliFilteringAvailable() {
-                    const ct = this.stats.context_tool;
-                    if (ct && typeof ct.available === 'boolean') return ct.available;
-                    return true;
-                },
-
-                get historyCliFilteringAvailable() {
-                    const hf = this.historyStats?.cli_filtering;
-                    if (hf && typeof hf.available === 'boolean') return hf.available;
-                    return true;
                 },
 
                 // --- Headline savings percent ---

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -191,7 +191,12 @@
     <main class="p-6 max-w-7xl mx-auto">
         <template x-if="viewMode === 'session'">
             <div>
-                <p class="mb-4 text-xs text-gray-500">Current proxy process · runtime counters reset on restart</p>
+                <p class="mb-2 text-xs text-gray-500">Current proxy process · runtime counters reset on restart</p>
+                <div class="mb-4 text-xs text-gray-500 font-mono">
+                    <span>ANTHROPIC_BASE_URL: </span>
+                    <span class="text-accent"
+                          x-text="window.location.origin + '/p/&lt;project-name&gt;'"></span>
+                </div>
                 <div class="mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
                      x-show="hasMetricScopes">
                     <div class="inline-flex rounded-lg border border-border bg-surface p-1">

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -192,6 +192,59 @@
         <template x-if="viewMode === 'session'">
             <div>
                 <p class="mb-4 text-xs text-gray-500">Current proxy process · runtime counters reset on restart</p>
+                <div class="mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between"
+                     x-show="hasMetricScopes">
+                    <div class="inline-flex rounded-lg border border-border bg-surface p-1">
+                        <button class="px-3 py-1.5 text-sm rounded-md transition-colors"
+                                data-testid="scope-current"
+                                :class="scopeMode === 'current_process' ? 'bg-accent text-black' : 'text-gray-400 hover:text-gray-200'"
+                                @click="setScopeMode('current_process')">
+                            Current process
+                        </button>
+                        <button class="px-3 py-1.5 text-sm rounded-md transition-colors"
+                                data-testid="scope-session"
+                                :class="scopeMode === 'display_session' ? 'bg-accent text-black' : 'text-gray-400 hover:text-gray-200'"
+                                @click="setScopeMode('display_session')">
+                            Session
+                        </button>
+                        <button class="px-3 py-1.5 text-sm rounded-md transition-colors"
+                                data-testid="scope-lifetime"
+                                :class="scopeMode === 'lifetime' ? 'bg-accent text-black' : 'text-gray-400 hover:text-gray-200'"
+                                @click="setScopeMode('lifetime')">
+                            Lifetime
+                        </button>
+                    </div>
+                    <div class="text-xs text-gray-500 font-mono"
+                         data-testid="scope-freshness"
+                         x-text="scopeFreshnessBadge"></div>
+                </div>
+        <!-- Hero Metrics: Savings $ -> Input Compression -> Output Reduction -> Overhead -->
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+            <!-- Savings ($) - proxy compression only, priced at model list rate -->
+            <div class="bg-surface rounded-lg p-4 border border-border">
+                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Proxy $ Saved</div>
+                <div class="flex items-baseline gap-2">
+                    <span class="text-3xl font-light tabular-nums text-emerald-400"
+                          data-testid="scope-proxy-saved-value"
+                          x-text="scopeCompressionUnavailable ? 'Unavailable' : '$' + formatCurrency(hasMetricScopes ? scopeCompressionUsd : (stats.persistent_savings?.lifetime?.compression_savings_usd || 0))"></span>
+                </div>
+                <div class="mt-2 text-xs text-gray-500">
+                    <span x-show="hasMetricScopes && !scopeCompressionUnavailable"
+                          x-text="formatNumber(scopeCompressionTokensSaved) + ' proxy tokens · ' + scopeFreshnessText"></span>
+                    <span x-show="scopeCompressionUnavailable">Unavailable for selected scope</span>
+                    <span x-show="!hasMetricScopes && (stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0"
+                          x-text="formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' proxy tokens only; ' + cliFilteringLabel + ' excluded from $'"></span>
+                    <span x-show="!hasMetricScopes && !((stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0) && stats.litellm_available !== false"
+                          x-text="formatNumber(stats.requests?.total || 0) + ' requests processed'"></span>
+                    <!-- Pricing is LiteLLM-only. LiteLLM currently can't install on
+                         newer Python (e.g. 3.14+); state the fact, not the version,
+                         so the hint stays correct if that changes. -->
+                    <span x-show="!hasMetricScopes && !((stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0) && stats.litellm_available === false">
+                        Cost pricing needs LiteLLM, which isn't installed in this environment. If you're on a Python version LiteLLM doesn't support yet, reinstall Headroom on Python 3.13:
+                        <code class="text-gray-400">pipx reinstall headroom-ai --python python3.13</code>
+                    </span>
+                </div>
+            </div>
 
                 <!-- Runtime Overview -->
                 <div class="grid grid-cols-1 gap-4 mb-6 lg:grid-cols-2">
@@ -222,6 +275,8 @@
                         </div>
                         <div class="mt-1 text-xs text-gray-500 leading-relaxed">
                             <span x-text="'Proxy ' + formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' (' + proxyShareOfTotal.toFixed(1) + '%)'"></span>
+                            <span class="mx-1 text-gray-600">/</span>
+                            <span x-text="cliFilteringAvailable ? (cliFilteringLabel + ' ' + formatNumber(cliFilteringSaved) + ' this session (' + cliFilteringSessionPctDisplay.toFixed(1) + '%)') : (cliFilteringLabel + ' not installed')"></span>
                         </div>
                         <div class="mt-1 text-xs text-gray-600 leading-relaxed">
                             <span x-text="'Of total wire: ' + (stats.tokens?.savings_percent || 0).toFixed(2) + '%'" title="Savings as fraction of all input tokens including frozen prefix"></span>
@@ -390,6 +445,14 @@
                                 <span class="text-sm text-gray-400">Before Compression</span>
                                 <span class="font-mono text-sm" x-text="formatNumber(stats.tokens?.total_before_compression || 0)"></span>
                             </div>
+                            <div class="flex justify-between items-center" x-show="cliFilteringAvailable">
+                                <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
+                                <span class="font-mono text-sm text-emerald-400" x-text="formatNumber(cliFilteringSaved)"></span>
+                            </div>
+                            <div class="flex justify-between items-center" x-show="!cliFilteringAvailable">
+                                <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
+                                <span class="font-mono text-sm text-gray-600">not installed</span>
+                            </div>
                             <div class="flex justify-between items-center">
                                 <span class="text-sm text-gray-400">Proxy Removed</span>
                                 <span class="font-mono text-sm text-accent" x-text="formatNumber(stats.tokens?.proxy_compression_saved || 0)"></span>
@@ -461,61 +524,63 @@
                     </div>
                 </div>
 
-                <!-- Prefix Cache Impact: current process plus durable cache reads after restart -->
-                <template x-if="cacheCardAvailable">
+                <!-- Card renders on live cache traffic OR persisted lifetime cache savings —
+                     the lifetime figure must survive a restart with zero traffic. -->
+                <template x-if="hasAnyScopedCacheData">
                     <div class="bg-surface rounded-lg p-4 border border-border mb-6">
                         <div class="flex justify-between items-center mb-3">
                             <div class="text-sm font-medium text-gray-300">Prefix Cache Impact</div>
-                            <div class="text-xs text-emerald-400 font-mono"
-                                 x-show="cacheSessionActive"
-                                 x-text="'Net savings: $' + formatCurrency(stats.prefix_cache?.totals?.net_savings_usd || 0)"></div>
-                            <div class="text-xs text-gray-500 font-mono"
-                                 x-show="!cacheSessionActive">no activity since restart</div>
+                            <div class="text-xs font-mono"
+                                 :class="scopeCacheUnavailable ? 'text-gray-500' : 'text-emerald-400'"
+                                 x-text="scopeCacheUnavailable ? 'Unavailable for selected scope' : scopeFreshnessBadge"></div>
                         </div>
-                        <template x-if="!cacheSessionActive && lifetimeCacheReadTokens > 0">
-                            <div class="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3">
-                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Reads (lifetime)</div>
-                                <div class="text-2xl font-light tabular-nums text-cyan-400"
-                                     x-text="formatNumber(lifetimeCacheReadTokens)"></div>
-                                <div class="text-xs text-cyan-400/70"
-                                     x-text="'$' + formatCurrency(lifetimeCacheSavingsUsd) + ' saved'"></div>
-                            </div>
-                        </template>
                         <!-- Totals row -->
-                        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+                        <div class="grid grid-cols-2 md:grid-cols-5 gap-4 mb-4">
+                            <div>
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1" x-text="scopeCacheReadsLabel"></div>
+                                <div data-testid="scope-cache-reads-value" class="text-2xl font-light tabular-nums text-emerald-400" x-text="scopeCacheUnavailable ? 'Unavailable' : formatNumber(scopeCacheReads)"></div>
+                                <!-- Three-way zero state mirrors the Proxy $ Saved tile: real value /
+                                     unpriced-but-healthy / litellm unavailable. -->
+                                <div class="text-xs text-emerald-400/70"
+                                     x-show="!scopeCacheUnavailable && (scopeCacheSavingsUsd || 0) > 0"
+                                     x-text="'$' + formatCurrency(scopeCacheSavingsUsd || 0) + ' saved'"></div>
+                                <div class="text-xs text-gray-500"
+                                     x-show="!scopeCacheUnavailable && !((scopeCacheSavingsUsd || 0) > 0) && stats.litellm_available !== false">savings not priced yet</div>
+                                <div class="text-xs text-gray-500"
+                                     x-show="!scopeCacheUnavailable && !((scopeCacheSavingsUsd || 0) > 0) && stats.litellm_available === false">pricing needs LiteLLM</div>
+                            </div>
                             <div>
                                 <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Writes</div>
-                                <div class="text-2xl font-light tabular-nums text-amber-400"
-                                     x-show="cacheSessionActive"
-                                     x-text="formatNumber(stats.prefix_cache?.totals?.cache_write_tokens || 0)"></div>
-                                <div class="text-2xl font-light tabular-nums text-gray-600"
-                                     x-show="!cacheSessionActive">&mdash;</div>
+                                <div class="text-2xl font-light tabular-nums text-amber-400" x-text="scopeCacheUnavailable ? 'Unavailable' : formatNumber(scopeCacheWrites)"></div>
                                 <div class="text-xs text-amber-400/70"
-                                     x-show="cacheSessionActive"
+                                     x-show="!hasMetricScopes && cacheSessionActive"
                                      x-text="'$' + formatCurrency(stats.prefix_cache?.totals?.write_premium_usd || 0) + ' write premium'"></div>
                                 <div class="text-xs text-gray-500"
-                                     x-show="!cacheSessionActive">no activity since restart</div>
+                                     x-show="hasMetricScopes">selected scope</div>
+                                <div class="text-xs text-gray-500"
+                                     x-show="!hasMetricScopes && !cacheSessionActive">no activity since restart</div>
                             </div>
                             <div>
                                 <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Hit Rate</div>
-                                <div class="text-2xl font-light tabular-nums" x-show="cacheSessionActive" :class="(stats.prefix_cache?.totals?.hit_rate || 0) > 80 ? 'text-emerald-400' : (stats.prefix_cache?.totals?.hit_rate || 0) > 50 ? 'text-amber-400' : 'text-red-400'" x-text="(stats.prefix_cache?.totals?.hit_rate || 0).toFixed(0) + '%'"></div>
-                                <div class="text-2xl font-light tabular-nums text-gray-600" x-show="!cacheSessionActive">&mdash;</div>
-                                <div class="text-xs text-gray-500" x-show="cacheSessionActive" x-text="(stats.prefix_cache?.totals?.hit_requests || 0) + ' / ' + (stats.prefix_cache?.totals?.requests || 0) + ' requests'"></div>
-                                <div class="text-xs text-gray-500" x-show="!cacheSessionActive">no activity since restart</div>
+                                <div class="text-2xl font-light tabular-nums"
+                                     :class="scopeCacheUnavailable ? 'text-gray-500' : (scopeCacheHitRate > 80 ? 'text-emerald-400' : scopeCacheHitRate > 50 ? 'text-amber-400' : 'text-red-400')"
+                                     x-text="scopeCacheUnavailable ? 'Unavailable' : scopeCacheHitRate.toFixed(0) + '%'"></div>
+                                <div class="text-xs text-gray-500"
+                                     x-text="scopeCacheUnavailable ? 'Unavailable for selected scope' : scopeCacheHitRequests + ' / ' + scopeCacheRequests + ' requests'"></div>
                             </div>
                             <div>
                                 <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Busts</div>
-                                <div class="text-2xl font-light tabular-nums" x-show="cacheSessionActive" :class="(stats.prefix_cache?.totals?.bust_count || 0) > 5 ? 'text-red-400' : (stats.prefix_cache?.totals?.bust_count || 0) > 0 ? 'text-amber-400' : 'text-emerald-400'" x-text="stats.prefix_cache?.totals?.bust_count || 0"></div>
-                                <div class="text-2xl font-light tabular-nums text-gray-600" x-show="!cacheSessionActive">&mdash;</div>
-                                <div class="text-xs text-gray-500" x-show="cacheSessionActive" x-text="formatNumber(stats.prefix_cache?.totals?.bust_write_tokens || 0) + ' tokens re-written'"></div>
-                                <div class="text-xs text-gray-500" x-show="!cacheSessionActive">no activity since restart</div>
+                                <div class="text-2xl font-light tabular-nums"
+                                     :class="scopeCacheUnavailable ? 'text-gray-500' : (scopeCacheBustCount > 5 ? 'text-red-400' : scopeCacheBustCount > 0 ? 'text-amber-400' : 'text-emerald-400')"
+                                     x-text="scopeCacheUnavailable ? 'Unavailable' : scopeCacheBustCount"></div>
+                                <div class="text-xs text-gray-500"
+                                     x-text="scopeCacheUnavailable ? 'Unavailable for selected scope' : formatNumber(scopeCacheBustWriteTokens) + ' tokens re-written'"></div>
                             </div>
                             <div>
                                 <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Providers</div>
-                                <div class="text-2xl font-light tabular-nums text-gray-300" x-show="cacheSessionActive" x-text="Object.keys(stats.prefix_cache?.by_provider || {}).length"></div>
-                                <div class="text-2xl font-light tabular-nums text-gray-600" x-show="!cacheSessionActive">&mdash;</div>
-                                <div class="text-xs text-gray-500" x-show="cacheSessionActive">with cache data</div>
-                                <div class="text-xs text-gray-500" x-show="!cacheSessionActive">no activity since restart</div>
+                                <div class="text-2xl font-light tabular-nums text-gray-300"
+                                     x-text="cacheSessionActive ? processLocalProviderCount : '—'"></div>
+                                <div class="text-xs text-gray-500">Current process</div>
                             </div>
                         </div>
                         <!-- Cache efficiency bar (session-scoped; hidden until traffic arrives) -->
@@ -551,10 +616,10 @@
                                     <div>
                                         <div class="text-[11px] uppercase tracking-[0.22em] text-cyan-300/75">Bucket Mix</div>
                                         <div class="mt-1 text-2xl font-light text-cyan-50">
-                                            <span data-testid="ttl-bucket-mix-1h-total" x-text="formatNumber(stats.prefix_cache?.totals?.cache_write_1h_tokens || 0)"></span>
+                                            <span data-testid="ttl-bucket-mix-1h-total" x-text="formatNumber(scopeObservedTtlBuckets['1h']?.tokens || 0)"></span>
                                             <span class="text-sm text-cyan-300/70">1h</span>
                                             <span class="mx-2 text-cyan-500/60">/</span>
-                                            <span data-testid="ttl-bucket-mix-5m-total" x-text="formatNumber(stats.prefix_cache?.totals?.cache_write_5m_tokens || 0)"></span>
+                                            <span data-testid="ttl-bucket-mix-5m-total" x-text="formatNumber(scopeObservedTtlBuckets['5m']?.tokens || 0)"></span>
                                             <span class="text-sm text-cyan-300/70">5m</span>
                                         </div>
                                     </div>
@@ -563,28 +628,28 @@
                                         <div class="mt-4">
                                             <div class="flex justify-between text-xs text-gray-500 mb-1">
                                                 <span>Observed write-token split</span>
-                                                <span x-text="(stats.prefix_cache?.totals?.observed_ttl_mix?.active_buckets || []).join(' + ')"></span>
+                                                <span x-text="scopedObservedTtlWindowLabel"></span>
                                             </div>
                                             <div class="h-3 overflow-hidden rounded-full bg-black/30 ring-1 ring-white/5 flex">
-                                                <div class="h-full bg-cyan-400 transition-all duration-500" :style="'width:' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['1h_pct'] || 0) + '%'"></div>
-                                                <div class="h-full bg-violet-400 transition-all duration-500" :style="'width:' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['5m_pct'] || 0) + '%'"></div>
+                                                <div class="h-full bg-cyan-400 transition-all duration-500" :style="'width:' + (scopedObservedTtlMix['1h_pct'] || 0) + '%'"></div>
+                                                <div class="h-full bg-violet-400 transition-all duration-500" :style="'width:' + (scopedObservedTtlMix['5m_pct'] || 0) + '%'"></div>
                                             </div>
                                             <div class="mt-2 flex flex-wrap gap-3 text-xs text-gray-400">
-                                                <span class="inline-flex items-center gap-1.5"><span class="inline-block h-2 w-2 rounded-full bg-cyan-400"></span><span data-testid="ttl-bucket-mix-1h-pct" x-text="'1h ' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['1h_pct'] || 0).toFixed(1) + '%'"></span></span>
-                                                <span class="inline-flex items-center gap-1.5"><span class="inline-block h-2 w-2 rounded-full bg-violet-400"></span><span data-testid="ttl-bucket-mix-5m-pct" x-text="'5m ' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['5m_pct'] || 0).toFixed(1) + '%'"></span></span>
+                                                <span class="inline-flex items-center gap-1.5"><span class="inline-block h-2 w-2 rounded-full bg-cyan-400"></span><span data-testid="ttl-bucket-mix-1h-pct" x-text="'1h ' + (scopedObservedTtlMix['1h_pct'] || 0).toFixed(1) + '%'"></span></span>
+                                                <span class="inline-flex items-center gap-1.5"><span class="inline-block h-2 w-2 rounded-full bg-violet-400"></span><span data-testid="ttl-bucket-mix-5m-pct" x-text="'5m ' + (scopedObservedTtlMix['5m_pct'] || 0).toFixed(1) + '%'"></span></span>
                                             </div>
                                         </div>
                                     </div>
                                     <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-1 gap-3">
                                         <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
                                             <div class="text-[11px] uppercase tracking-[0.18em] text-cyan-300/75">1h Cache Writes</div>
-                                            <div data-testid="ttl-bucket-1h-value" class="mt-2 text-3xl font-light text-cyan-50" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['1h']?.tokens || 0)"></div>
-                                            <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['1h']?.requests || 0) + ' requests observed'"></div>
+                                            <div data-testid="ttl-bucket-1h-value" class="mt-2 text-3xl font-light text-cyan-50" x-text="formatNumber(scopeObservedTtlBuckets['1h']?.tokens || 0)"></div>
+                                            <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(scopeObservedTtlBuckets['1h']?.requests || 0) + ' requests observed'"></div>
                                         </div>
                                         <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
                                             <div class="text-[11px] uppercase tracking-[0.18em] text-violet-300/75">5m Cache Writes</div>
-                                            <div data-testid="ttl-bucket-5m-value" class="mt-2 text-3xl font-light text-violet-50" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['5m']?.tokens || 0)"></div>
-                                            <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['5m']?.requests || 0) + ' requests observed'"></div>
+                                            <div data-testid="ttl-bucket-5m-value" class="mt-2 text-3xl font-light text-violet-50" x-text="formatNumber(scopeObservedTtlBuckets['5m']?.tokens || 0)"></div>
+                                            <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(scopeObservedTtlBuckets['5m']?.requests || 0) + ' requests observed'"></div>
                                         </div>
                                     </div>
                                 </div>
@@ -603,13 +668,13 @@
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
                                     <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
                                         <div class="text-[11px] uppercase tracking-[0.18em] text-emerald-300/75">Saved by Compression</div>
-                                        <div data-testid="cvc-saved-value" class="mt-2 text-3xl font-light text-emerald-50" x-text="formatNumber(stats.prefix_cache?.compression_vs_cache?.tokens_saved_by_compression || 0)"></div>
+                                    <div data-testid="cvc-saved-value" class="mt-2 text-3xl font-light text-emerald-50" x-text="formatNumber(scopeCompressionVsCacheSaved)"></div>
                                         <div class="mt-1 text-xs text-gray-500">tokens removed before send</div>
                                     </div>
                                     <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
                                         <div class="text-[11px] uppercase tracking-[0.18em] text-red-300/75">Lost to Cache Busts</div>
-                                        <div data-testid="cvc-bust-value" class="mt-2 text-3xl font-light text-red-50" x-text="formatNumber(stats.prefix_cache?.compression_vs_cache?.tokens_lost_to_cache_bust || 0)"></div>
-                                        <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.compression_vs_cache?.cache_bust_count || 0) + ' busts observed'"></div>
+                                    <div data-testid="cvc-bust-value" class="mt-2 text-3xl font-light text-red-50" x-text="formatNumber(scopeCompressionVsCacheBustTokens)"></div>
+                                    <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(scopeCompressionVsCacheBustCount) + ' busts observed'"></div>
                                     </div>
                                     <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
                                         <div class="text-[11px] uppercase tracking-[0.18em] text-gray-400">Net</div>
@@ -617,10 +682,11 @@
                                         <div class="mt-1 text-xs text-gray-500">saved minus bust losses</div>
                                     </div>
                                     <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                        <div class="text-[11px] uppercase tracking-[0.18em] text-cyan-300/75">Prefix Freeze Net</div>
-                                        <div data-testid="freeze-net-value" class="mt-2 text-3xl font-light" :class="prefixFreezeNet >= 0 ? 'text-cyan-50' : 'text-red-400'" x-text="(prefixFreezeNet >= 0 ? '+' : '-') + formatNumber(Math.abs(prefixFreezeNet))"></div>
-                                        <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.prefix_freeze?.busts_avoided || 0) + ' busts avoided, ' + formatNumber(stats.prefix_cache?.prefix_freeze?.compression_foregone_tokens || 0) + ' foregone'"></div>
-                                    </div>
+                                    <div class="text-[11px] uppercase tracking-[0.18em] text-cyan-300/75">Prefix Freeze Net</div>
+                                    <div data-testid="freeze-net-value" class="mt-2 text-3xl font-light" :class="prefixFreezeNet >= 0 ? 'text-cyan-50' : 'text-red-400'" x-text="(prefixFreezeNet >= 0 ? '+' : '-') + formatNumber(Math.abs(prefixFreezeNet))"></div>
+                                    <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.prefix_freeze?.busts_avoided || 0) + ' busts avoided, ' + formatNumber(stats.prefix_cache?.prefix_freeze?.compression_foregone_tokens || 0) + ' foregone'"></div>
+                                    <div class="mt-1 text-[11px] text-gray-600">Current process</div>
+                                </div>
                                 </div>
                             </div>
                         </template>
@@ -785,9 +851,7 @@
 
                         <template x-if="agentRows.length === 0">
                             <div class="rounded-lg border border-dashed border-border p-6 text-center text-sm text-gray-500">
-                                <div>Agent usage appears after Cursor, Claude, Codex, or another client sends traffic through this proxy.</div>
-                                <div class="mt-2 font-mono text-xs text-accent"
-                                     x-text="'ANTHROPIC_BASE_URL: ' + window.location.origin + '/p/&lt;project-name&gt;'"></div>
+                                Agent usage appears after Cursor, Claude, Codex, or another client sends traffic through this proxy.
                             </div>
                         </template>
                     </div>
@@ -820,7 +884,7 @@
                         <div class="bg-surface rounded-lg border border-border overflow-hidden lg:col-span-2">
                             <div class="px-4 py-3 border-b border-border flex justify-between items-center">
                                 <span class="text-sm font-medium text-gray-300">Per-Model Token Savings</span>
-                                <span class="text-xs text-gray-500">Exact tokens saved per model</span>
+                                <span data-testid="per-model-process-label" class="text-xs text-gray-500">Current process only</span>
                             </div>
                             <div class="overflow-x-auto">
                                 <table class="w-full text-sm" style="table-layout:fixed">
@@ -1327,7 +1391,8 @@
                         <div class="px-4 py-8 text-center">
                             <div class="text-xs text-gray-500 mb-3">No per-project data yet.</div>
                             <div class="text-xs text-gray-600 font-mono leading-relaxed">
-                                <span class="text-accent" x-text="'ANTHROPIC_BASE_URL: ' + window.location.origin + '/p/&lt;project-name&gt;'"></span>
+                                Route project traffic through
+                                <span class="text-accent" x-text="window.location.origin + '/p/&lt;project-name&gt;'"></span>
                             </div>
                         </div>
                     </template>
@@ -1459,6 +1524,17 @@
                         <div class="mt-2 text-xs text-gray-500">Based on persisted weekly buckets</div>
                     </div>
 
+                    <template x-if="historyStats.cli_filtering && historyCliFilteringAvailable">
+                        <div class="bg-surface rounded-lg p-4 border border-border">
+                            <div class="text-xs text-gray-500 uppercase tracking-wide mb-1"
+                                 x-text="(historyStats.cli_filtering?.label || cliFilteringLabel) + ' Lifetime Saved'"></div>
+                            <div class="flex items-baseline gap-2">
+                                <span class="text-3xl font-light tabular-nums text-cyan-400"
+                                      x-text="formatNumber(historyStats.cli_filtering?.lifetime?.tokens_saved || 0)"></span>
+                            </div>
+                            <div class="mt-2 text-xs text-gray-500">CLI output filtering (lifetime)</div>
+                        </div>
+                    </template>
                 </div>
 
                 <template x-if="hasHistoricalData">
@@ -1817,6 +1893,7 @@
                 version: 'loading',
                 lastUpdate: 'never',
                 viewMode: 'session',
+                scopeMode: 'lifetime',
                 historyGranularity: 'daily',
                 historyChartMode: 'tokens',
                 historySelectedModel: null,
@@ -1880,6 +1957,10 @@
                     if (mode === 'history') {
                         await this.fetchHistoryStats();
                     }
+                },
+
+                setScopeMode(mode) {
+                    this.scopeMode = mode;
                 },
 
                 async toggleFeed() {
@@ -2141,6 +2222,220 @@
                         hour: '2-digit',
                         minute: '2-digit',
                     });
+                },
+
+                get hasMetricScopes() {
+                    const scopes = this.stats.metric_scopes;
+                    return Boolean(
+                        scopes
+                        && scopes.current_process
+                        && scopes.display_session
+                        && scopes.lifetime
+                    );
+                },
+
+                get selectedScopeLabel() {
+                    const labels = {
+                        current_process: 'Current process',
+                        display_session: 'Session',
+                        lifetime: 'Lifetime',
+                    };
+                    return labels[this.scopeMode] || 'Lifetime';
+                },
+
+                get selectedScope() {
+                    if (!this.hasMetricScopes) return null;
+                    return this.stats.metric_scopes?.[this.scopeMode] || null;
+                },
+
+                get selectedScopeRequests() {
+                    return this.selectedScope?.requests || null;
+                },
+
+                get selectedScopeCompression() {
+                    return this.selectedScope?.compression || null;
+                },
+
+                get selectedScopeCache() {
+                    return this.selectedScope?.cache || null;
+                },
+
+                get selectedScopeCodexWs() {
+                    return this.selectedScope?.codex_ws || null;
+                },
+
+                get scopeCompressionAvailable() {
+                    if (!this.hasMetricScopes) return true;
+                    const compression = this.selectedScopeCompression;
+                    return Boolean(
+                        compression
+                        && typeof compression.tokens_saved === 'number'
+                        && typeof compression.compression_savings_usd === 'number'
+                    );
+                },
+
+                get scopeCacheAvailable() {
+                    if (!this.hasMetricScopes) return true;
+                    const cache = this.selectedScopeCache;
+                    return Boolean(
+                        cache
+                        && typeof cache.cache_read_tokens === 'number'
+                        && typeof cache.cache_write_tokens === 'number'
+                        && typeof cache.hit_rate === 'number'
+                        && typeof cache.bust_count === 'number'
+                    );
+                },
+
+                get scopeCacheUnavailable() {
+                    return this.hasMetricScopes && !this.scopeCacheAvailable;
+                },
+
+                get scopeFreshnessText() {
+                    if (!this.hasMetricScopes) return '';
+                    if (this.scopeMode === 'current_process') {
+                        const startedAt = this.stats.metric_scopes?.process_started_at;
+                        return startedAt ? 'Started ' + this.formatDateTime(startedAt) : 'Current process';
+                    }
+                    const updatedAt = this.stats.metric_scopes?.updated_at;
+                    return updatedAt ? 'Updated ' + this.formatDateTime(updatedAt) : this.selectedScopeLabel;
+                },
+
+                get scopeFreshnessBadge() {
+                    if (!this.hasMetricScopes) return '';
+                    return this.selectedScopeLabel + ' · ' + this.scopeFreshnessText;
+                },
+
+                get scopeRequestTotal() {
+                    return this.selectedScopeRequests?.total ?? 0;
+                },
+
+                get scopeCompressionUsd() {
+                    return this.selectedScopeCompression?.compression_savings_usd ?? 0;
+                },
+
+                get scopeCompressionTokensSaved() {
+                    return this.selectedScopeCompression?.tokens_saved ?? 0;
+                },
+
+                get scopeCompressionUnavailable() {
+                    return this.hasMetricScopes && !this.scopeCompressionAvailable;
+                },
+
+                get hasAnyScopedCacheData() {
+                    if (!this.hasMetricScopes) {
+                        return this.cacheSessionActive || (this.stats.persistent_savings?.lifetime?.cache_read_tokens || 0) > 0;
+                    }
+                    const scopes = this.stats.metric_scopes || {};
+                    return ['current_process', 'display_session', 'lifetime'].some((key) => {
+                        const cache = scopes[key]?.cache;
+                        return Boolean(
+                            cache
+                            && (
+                                (cache.requests || 0) > 0
+                                || (cache.cache_read_tokens || 0) > 0
+                                || (cache.cache_write_tokens || 0) > 0
+                            )
+                        );
+                    });
+                },
+
+                get scopedCacheActive() {
+                    if (!this.hasMetricScopes) return this.cacheSessionActive;
+                    const cache = this.selectedScopeCache;
+                    return Boolean(
+                        cache
+                        && (
+                            (cache.requests || 0) > 0
+                            || (cache.cache_read_tokens || 0) > 0
+                            || (cache.cache_write_tokens || 0) > 0
+                        )
+                    );
+                },
+
+                get scopeCacheReadsLabel() {
+                    if (!this.hasMetricScopes) return 'Cache Reads (lifetime)';
+                    return 'Cache Reads (' + this.selectedScopeLabel.toLowerCase() + ')';
+                },
+
+                get scopeCacheReads() {
+                    if (!this.hasMetricScopes) return this.stats.persistent_savings?.lifetime?.cache_read_tokens || 0;
+                    return this.selectedScopeCache?.cache_read_tokens ?? 0;
+                },
+
+                get scopeCacheSavingsUsd() {
+                    if (!this.hasMetricScopes) return this.stats.persistent_savings?.lifetime?.cache_savings_usd || 0;
+                    return this.selectedScopeCache?.cache_savings_usd ?? 0;
+                },
+
+                get scopeCacheWrites() {
+                    if (!this.hasMetricScopes) return this.stats.prefix_cache?.totals?.cache_write_tokens || 0;
+                    return this.selectedScopeCache?.cache_write_tokens ?? 0;
+                },
+
+                get scopeCacheHitRate() {
+                    if (!this.hasMetricScopes) return this.stats.prefix_cache?.totals?.hit_rate || 0;
+                    return this.selectedScopeCache?.hit_rate ?? 0;
+                },
+
+                get scopeCacheHitRequests() {
+                    if (!this.hasMetricScopes) return this.stats.prefix_cache?.totals?.hit_requests || 0;
+                    return this.selectedScopeCache?.hit_requests ?? 0;
+                },
+
+                get scopeCacheRequests() {
+                    if (!this.hasMetricScopes) return this.stats.prefix_cache?.totals?.requests || 0;
+                    return this.selectedScopeCache?.requests ?? 0;
+                },
+
+                get scopeCacheBustCount() {
+                    if (!this.hasMetricScopes) return this.stats.prefix_cache?.totals?.bust_count || 0;
+                    return this.selectedScopeCache?.bust_count ?? 0;
+                },
+
+                get scopeCacheBustWriteTokens() {
+                    if (!this.hasMetricScopes) return this.stats.prefix_cache?.totals?.bust_write_tokens || 0;
+                    return this.selectedScopeCache?.bust_write_tokens ?? 0;
+                },
+
+                get hasScopedObservedTtlBuckets() {
+                    const buckets = this.hasMetricScopes
+                        ? (this.selectedScopeCache?.observed_ttl_buckets || {})
+                        : (this.stats.prefix_cache?.totals?.observed_ttl_buckets || {});
+                    return ((buckets['5m']?.tokens || 0) + (buckets['1h']?.tokens || 0)) > 0;
+                },
+
+                get scopedObservedTtlMix() {
+                    return this.hasMetricScopes
+                        ? (this.selectedScopeCache?.observed_ttl_mix || {})
+                        : (this.stats.prefix_cache?.totals?.observed_ttl_mix || {});
+                },
+
+                get scopedObservedTtlHeadline() {
+                    const mix = this.scopedObservedTtlMix;
+                    const oneHour = mix['1h_pct'] || 0;
+                    const fiveMinute = mix['5m_pct'] || 0;
+                    if (oneHour === fiveMinute) return 'Balanced';
+                    return oneHour > fiveMinute ? '1h leaning' : '5m leaning';
+                },
+
+                get scopedObservedTtlWindowLabel() {
+                    const active = this.scopedObservedTtlMix.active_buckets || [];
+                    if (!active.length) return 'No TTL bucket data';
+                    return active.length === 1 ? active[0] + ' only' : active.join(' / ');
+                },
+
+                get hasScopedCompressionVsCache() {
+                    if (!this.hasMetricScopes) return this.hasCompressionVsCache;
+                    return (this.scopeCompressionTokensSaved > 0) || ((this.selectedScopeCache?.cache_bust_tokens_lost || 0) > 0);
+                },
+
+                get scopedCompressionVsCacheNet() {
+                    if (!this.hasMetricScopes) return this.compressionVsCacheNet;
+                    return this.scopeCompressionTokensSaved - (this.selectedScopeCache?.cache_bust_tokens_lost || 0);
+                },
+
+                get processLocalProviderCount() {
+                    return Object.keys(this.stats.prefix_cache?.by_provider || {}).length;
                 },
 
                 truncateModel(model) {
@@ -2467,42 +2762,37 @@
                 // --- Prefix Cache ---
 
                 get cacheSessionActive() {
+                    if (this.hasMetricScopes) return this.scopedCacheActive;
                     return (this.stats.prefix_cache?.totals?.requests || 0) > 0;
                 },
 
-                get lifetimeCacheReadTokens() {
-                    return this.stats.persistent_savings?.lifetime?.cache_read_tokens || 0;
-                },
-
-                get lifetimeCacheSavingsUsd() {
-                    return this.stats.persistent_savings?.lifetime?.cache_savings_usd || 0;
-                },
-
-                get cacheCardAvailable() {
-                    return this.cacheSessionActive || this.lifetimeCacheReadTokens > 0 || this.lifetimeCacheSavingsUsd > 0;
-                },
-
                 get cacheSavingsPercent() {
-                    const t = this.stats.prefix_cache?.totals || {};
-                    const total = (t.cache_read_tokens || 0) + (t.cache_write_tokens || 0);
+                    const t = this.hasMetricScopes
+                        ? (this.selectedScopeCache || {})
+                        : (this.stats.prefix_cache?.totals || {});
+                    const total = (t.cache_read_tokens || 0) + (t.cache_write_tokens || 0) + (t.uncached_input_tokens || 0);
                     if (total === 0) return 0;
                     return Math.round((t.cache_read_tokens || 0) / total * 100);
                 },
 
                 get cacheWritePercent() {
-                    const t = this.stats.prefix_cache?.totals || {};
-                    const total = (t.cache_read_tokens || 0) + (t.cache_write_tokens || 0);
+                    const t = this.hasMetricScopes
+                        ? (this.selectedScopeCache || {})
+                        : (this.stats.prefix_cache?.totals || {});
+                    const total = (t.cache_read_tokens || 0) + (t.cache_write_tokens || 0) + (t.uncached_input_tokens || 0);
                     if (total === 0) return 0;
                     return Math.round((t.cache_write_tokens || 0) / total * 100);
                 },
 
                 get hasObservedTtlBuckets() {
-                    const buckets = this.stats.prefix_cache?.totals?.observed_ttl_buckets || {};
+                    const buckets = this.scopeObservedTtlBuckets;
                     return ((buckets['5m']?.tokens || 0) + (buckets['1h']?.tokens || 0)) > 0;
                 },
 
                 get observedTtlHeadline() {
-                    const mix = this.stats.prefix_cache?.totals?.observed_ttl_mix || {};
+                    const mix = this.hasMetricScopes
+                        ? (this.selectedScopeCache?.observed_ttl_mix || {})
+                        : (this.stats.prefix_cache?.totals?.observed_ttl_mix || {});
                     const oneHour = mix['1h_pct'] || 0;
                     const fiveMinute = mix['5m_pct'] || 0;
                     if (oneHour === fiveMinute) return 'Balanced';
@@ -2510,13 +2800,37 @@
                 },
 
                 get observedTtlWindowLabel() {
-                    const mix = this.stats.prefix_cache?.totals?.observed_ttl_mix || {};
+                    const mix = this.hasMetricScopes
+                        ? (this.selectedScopeCache?.observed_ttl_mix || {})
+                        : (this.stats.prefix_cache?.totals?.observed_ttl_mix || {});
                     const active = mix.active_buckets || [];
                     if (!active.length) return 'No TTL bucket data';
                     return active.length === 1 ? active[0] + ' only' : active.join(' / ');
                 },
 
+                get scopeObservedTtlBuckets() {
+                    return this.hasMetricScopes
+                        ? (this.selectedScopeCache?.observed_ttl_buckets || {})
+                        : (this.stats.prefix_cache?.totals?.observed_ttl_buckets || {});
+                },
+
+                get scopeCompressionVsCacheSaved() {
+                    if (!this.hasMetricScopes) return this.stats.prefix_cache?.compression_vs_cache?.tokens_saved_by_compression || 0;
+                    return this.scopeCompressionTokensSaved;
+                },
+
+                get scopeCompressionVsCacheBustTokens() {
+                    if (!this.hasMetricScopes) return this.stats.prefix_cache?.compression_vs_cache?.tokens_lost_to_cache_bust || 0;
+                    return this.selectedScopeCache?.cache_bust_tokens_lost || 0;
+                },
+
+                get scopeCompressionVsCacheBustCount() {
+                    if (!this.hasMetricScopes) return this.stats.prefix_cache?.compression_vs_cache?.cache_bust_count || 0;
+                    return this.selectedScopeCache?.cache_bust_count || 0;
+                },
+
                 get compressionVsCacheNet() {
+                    if (this.hasMetricScopes) return this.scopedCompressionVsCacheNet;
                     const cvc = this.stats.prefix_cache?.compression_vs_cache || {};
                     return cvc.net_tokens ?? ((cvc.tokens_saved_by_compression || 0) - (cvc.tokens_lost_to_cache_bust || 0));
                 },
@@ -2527,6 +2841,7 @@
                 },
 
                 get hasCompressionVsCache() {
+                    if (this.hasMetricScopes) return this.hasScopedCompressionVsCache;
                     const cvc = this.stats.prefix_cache?.compression_vs_cache || {};
                     const pf = this.stats.prefix_cache?.prefix_freeze || {};
                     return (cvc.tokens_saved_by_compression || 0) > 0
@@ -2610,6 +2925,49 @@
                     const total = this.compressionTotalBefore;
                     if (total <= 0) return 0;
                     return (this.stats.tokens?.proxy_compression_saved || 0) / total * 100;
+                },
+
+                get cliFilteringLabel() {
+                    const raw = this.stats.savings?.by_layer?.cli_filtering?.label
+                        || this.stats.context_tool?.label
+                        || this.stats.context_tool?.configured
+                        || 'Context Tool';
+                    if (String(raw).toLowerCase() === 'lean-ctx') return 'Lean-ctx';
+                    return String(raw);
+                },
+
+                get cliFilteringSaved() {
+                    return this.stats.tokens?.cli_filtering_saved
+                        ?? this.stats.tokens?.cli_tokens_avoided
+                        ?? this.stats.tokens?.rtk_saved
+                        ?? 0;
+                },
+
+                get cliFilteringShareOfTotal() {
+                    const total = this.compressionTotalBefore;
+                    if (total <= 0) return 0;
+                    return this.cliFilteringSaved / total * 100;
+                },
+
+                get cliFilteringLifetime() {
+                    return this.stats.savings?.by_layer?.cli_filtering?.lifetime?.tokens_saved ?? 0;
+                },
+
+                get cliFilteringSessionPctDisplay() {
+                    const p = this.stats.savings?.by_layer?.cli_filtering?.session_savings_pct;
+                    return (p === null || p === undefined) ? this.cliFilteringShareOfTotal : p;
+                },
+
+                get cliFilteringAvailable() {
+                    const ct = this.stats.context_tool;
+                    if (ct && typeof ct.available === 'boolean') return ct.available;
+                    return true;
+                },
+
+                get historyCliFilteringAvailable() {
+                    const hf = this.historyStats?.cli_filtering;
+                    if (hf && typeof hf.available === 'boolean') return hf.available;
+                    return true;
                 },
 
                 // --- Headline savings percent ---

--- a/headroom/proxy/persistent_metrics.py
+++ b/headroom/proxy/persistent_metrics.py
@@ -14,6 +14,7 @@ MAX_STACK_VALUES = 64
 MAX_TRACKED_MODELS = 200
 MAX_EXPOSED_MODELS = 100
 MAX_LABEL_LENGTH = 128
+MAX_SCOPE_LABELS = 64
 
 KNOWN_MISS_REASONS = frozenset({"ttl_expiry", "prefix_change", "unknown"})
 KNOWN_WASTE_SIGNALS = frozenset(
@@ -100,6 +101,8 @@ def _empty_state() -> dict[str, Any]:
             "cache_write_5m_tokens": 0,
             "cache_write_1h_tokens": 0,
             "uncached_input_tokens": 0,
+            "cache_write_5m_requests": 0,
+            "cache_write_1h_requests": 0,
             "bust_count": 0,
             "bust_tokens": 0,
             "misses_by_reason": {},
@@ -108,6 +111,37 @@ def _empty_state() -> dict[str, Any]:
         "cost": {"input_usd": 0.0, "compression_savings_usd": 0.0, "cache_savings_usd": 0.0},
         "waste_signals": {},
         "models": {"tracked": {}, "other": _model_entry()},
+        "compression": {
+            "compressions_by_strategy": {},
+            "tokens_saved_by_strategy": {},
+        },
+        "codex_ws": {
+            "units_total": 0,
+            "units_modified_total": 0,
+            "units_to_kompress_total": 0,
+            "units_kompress_attempted_total": 0,
+            "units_by_strategy": {},
+            "units_by_category": {},
+            "units_by_content_type": {},
+            "units_by_text_shape": {},
+            "unit_elapsed_ms_sum": 0.0,
+            "unit_elapsed_ms_max": 0.0,
+            "unit_bytes_sum": 0,
+            "unit_tokens_before_sum": 0,
+            "unit_tokens_after_sum": 0,
+            "unit_tokens_saved_sum": 0,
+            "frames_attempted_total": 0,
+            "frames_compressed_total": 0,
+            "frames_failed_total": 0,
+            "frames_to_kompress_total": 0,
+            "frames_kompress_attempted_total": 0,
+            "frame_elapsed_ms_sum": 0.0,
+            "frame_elapsed_ms_max": 0.0,
+            "frame_bytes_before_sum": 0,
+            "frame_bytes_after_sum": 0,
+            "frame_attempted_tokens_sum": 0,
+            "frame_tokens_saved_sum": 0,
+        },
         "persistence": {"last_saved_at": None},
     }
 
@@ -160,6 +194,8 @@ class PersistentMetricsState:
             "cache_write_5m_tokens",
             "cache_write_1h_tokens",
             "uncached_input_tokens",
+            "cache_write_5m_requests",
+            "cache_write_1h_requests",
             "bust_count",
             "bust_tokens",
         ):
@@ -170,6 +206,50 @@ class PersistentMetricsState:
         result["prefix_cache"]["misses_by_reason"] = self._normalize_enum_map(
             raw_cache.get("misses_by_reason"), KNOWN_MISS_REASONS
         )
+
+        raw_compression = _dict_or_empty(source.get("compression"))
+        for key in ("compressions_by_strategy", "tokens_saved_by_strategy"):
+            result["compression"][key] = self._normalize_count_map(
+                raw_compression.get(key), MAX_SCOPE_LABELS
+            )
+        raw_ws = _dict_or_empty(source.get("codex_ws"))
+        int_fields = [
+            "units_total",
+            "units_modified_total",
+            "units_to_kompress_total",
+            "units_kompress_attempted_total",
+            "unit_bytes_sum",
+            "unit_tokens_before_sum",
+            "unit_tokens_after_sum",
+            "unit_tokens_saved_sum",
+            "frames_attempted_total",
+            "frames_compressed_total",
+            "frames_failed_total",
+            "frames_to_kompress_total",
+            "frames_kompress_attempted_total",
+            "frame_bytes_before_sum",
+            "frame_bytes_after_sum",
+            "frame_attempted_tokens_sum",
+            "frame_tokens_saved_sum",
+        ]
+        float_fields = [
+            "unit_elapsed_ms_sum",
+            "unit_elapsed_ms_max",
+            "frame_elapsed_ms_sum",
+            "frame_elapsed_ms_max",
+        ]
+        map_fields = [
+            "units_by_strategy",
+            "units_by_category",
+            "units_by_content_type",
+            "units_by_text_shape",
+        ]
+        for key in int_fields:
+            result["codex_ws"][key] = _coerce_int(raw_ws.get(key))
+        for key in float_fields:
+            result["codex_ws"][key] = round(_coerce_float(raw_ws.get(key)), 6)
+        for key in map_fields:
+            result["codex_ws"][key] = self._normalize_count_map(raw_ws.get(key), MAX_SCOPE_LABELS)
 
         raw_cost = _dict_or_empty(source.get("cost"))
         for key in ("input_usd", "compression_savings_usd", "cache_savings_usd"):
@@ -303,8 +383,8 @@ class PersistentMetricsState:
     def record_request(
         self,
         *,
-        provider: str | None,
-        stack: str | None,
+        provider: str | None = None,
+        stack: str | None = None,
         model: str | None,
         input_tokens: Any = 0,
         output_tokens: Any = 0,
@@ -316,6 +396,8 @@ class PersistentMetricsState:
         cache_write_tokens: Any = 0,
         cache_write_5m_tokens: Any = 0,
         cache_write_1h_tokens: Any = 0,
+        cache_write_5m_requests: Any = 0,
+        cache_write_1h_requests: Any = 0,
         uncached_input_tokens: Any = 0,
         input_usd: Any = 0.0,
         compression_savings_usd: Any = 0.0,
@@ -346,14 +428,19 @@ class PersistentMetricsState:
         tokens["saved"] += saved_delta
 
         cache = self._state["prefix_cache"]
-        cache["requests"] += 1
-        cache["hit_requests"] += int(bool(cached))
-        cache["cache_read_tokens"] += _coerce_int(cache_read_tokens)
-        cache["cache_write_tokens"] += _coerce_int(cache_write_tokens)
-        cache["cache_write_5m_tokens"] += _coerce_int(cache_write_5m_tokens)
-        cache["cache_write_1h_tokens"] += _coerce_int(cache_write_1h_tokens)
-        cache["uncached_input_tokens"] += _coerce_int(uncached_input_tokens)
-        self._increment_count(cache["by_provider"], provider_label, MAX_PROVIDER_VALUES)
+        cache_read_delta = _coerce_int(cache_read_tokens)
+        cache_write_delta = _coerce_int(cache_write_tokens)
+        if cache_read_delta > 0 or cache_write_delta > 0:
+            cache["requests"] += 1
+            cache["hit_requests"] += int(cache_read_delta > 0)
+            cache["cache_read_tokens"] += cache_read_delta
+            cache["cache_write_tokens"] += cache_write_delta
+            cache["cache_write_5m_tokens"] += _coerce_int(cache_write_5m_tokens)
+            cache["cache_write_1h_tokens"] += _coerce_int(cache_write_1h_tokens)
+            cache["cache_write_5m_requests"] += _coerce_int(cache_write_5m_requests)
+            cache["cache_write_1h_requests"] += _coerce_int(cache_write_1h_requests)
+            cache["uncached_input_tokens"] += _coerce_int(uncached_input_tokens)
+            self._increment_count(cache["by_provider"], provider_label, MAX_PROVIDER_VALUES)
 
         cost = self._state["cost"]
         cost["input_usd"] = round(cost["input_usd"] + _coerce_float(input_usd), 6)
@@ -405,6 +492,95 @@ class PersistentMetricsState:
         cache = self._state["prefix_cache"]
         cache["bust_count"] += 1
         cache["bust_tokens"] += _coerce_int(tokens_lost)
+
+    def record_compression(
+        self, *, strategy: str, original_tokens: Any, compressed_tokens: Any
+    ) -> None:
+        self._record_activity()
+        key = _label(strategy)
+        self._increment_count(
+            self._state["compression"]["compressions_by_strategy"], key, MAX_SCOPE_LABELS
+        )
+        saved = max(_coerce_int(original_tokens) - _coerce_int(compressed_tokens), 0)
+        if saved:
+            values = self._state["compression"]["tokens_saved_by_strategy"]
+            values[key] = values.get(key, 0) + saved
+            self._compact_count_map(values, MAX_SCOPE_LABELS)
+
+    def record_codex_ws_unit(
+        self,
+        *,
+        strategy: str,
+        reason_category: str,
+        elapsed_ms: Any,
+        text_bytes: Any,
+        tokens_before: Any,
+        tokens_after: Any,
+        tokens_saved: Any,
+        modified: bool,
+        strategy_chain: list[str] | None = None,
+        content_type: str = "unknown",
+        text_shape: str = "unknown",
+    ) -> None:
+        self._record_activity()
+        ws = self._state["codex_ws"]
+        ws["units_total"] += 1
+        for field, value in (
+            ("units_by_strategy", strategy),
+            ("units_by_category", reason_category),
+            ("units_by_content_type", content_type),
+            ("units_by_text_shape", text_shape),
+        ):
+            self._increment_count(ws[field], _label(value), MAX_SCOPE_LABELS)
+        ws["units_modified_total"] += int(modified)
+        chain = strategy_chain or []
+        ws["units_to_kompress_total"] += int(strategy == "kompress")
+        ws["units_kompress_attempted_total"] += int(strategy == "kompress" or "kompress" in chain)
+        elapsed = _coerce_float(elapsed_ms)
+        ws["unit_elapsed_ms_sum"] = round(ws["unit_elapsed_ms_sum"] + elapsed, 6)
+        ws["unit_elapsed_ms_max"] = max(ws["unit_elapsed_ms_max"], elapsed)
+        for field, value in (
+            ("unit_bytes_sum", text_bytes),
+            ("unit_tokens_before_sum", tokens_before),
+            ("unit_tokens_after_sum", tokens_after),
+            ("unit_tokens_saved_sum", tokens_saved),
+        ):
+            ws[field] += _coerce_int(value)
+
+    def record_codex_ws_frame(
+        self,
+        *,
+        elapsed_ms: Any,
+        bytes_before: Any,
+        bytes_after: Any = 0,
+        attempted_tokens: Any = 0,
+        tokens_saved: Any = 0,
+        modified: bool = False,
+        failed: bool = False,
+        strategy_chain: list[str] | None = None,
+        final_strategies: list[str] | None = None,
+    ) -> None:
+        self._record_activity()
+        ws = self._state["codex_ws"]
+        ws["frames_attempted_total"] += 1
+        ws["frames_compressed_total"] += int(modified)
+        ws["frames_failed_total"] += int(failed)
+        chain = strategy_chain or []
+        strategies = final_strategies or []
+        ws["frames_to_kompress_total"] += int("kompress" in strategies)
+        ws["frames_kompress_attempted_total"] += int(
+            "kompress" in chain or "kompress" in strategies
+        )
+        elapsed = _coerce_float(elapsed_ms)
+        ws["frame_elapsed_ms_sum"] = round(ws["frame_elapsed_ms_sum"] + elapsed, 6)
+        ws["frame_elapsed_ms_max"] = max(ws["frame_elapsed_ms_max"], elapsed)
+        for field, value in (
+            ("frame_bytes_before_sum", bytes_before),
+            ("frame_bytes_after_sum", bytes_after),
+            ("frame_attempted_tokens_sum", attempted_tokens),
+            ("frame_tokens_saved_sum", tokens_saved),
+        ):
+            ws[field] += _coerce_int(value)
 
     def record_cache_miss(self, *, provider: str | None, reason: str | None) -> None:
         self._record_activity()
@@ -461,6 +637,8 @@ class PersistentMetricsState:
                 "ttl_5m_percent": self._percent(cache["cache_write_5m_tokens"], cache_write_total),
             },
             "cost": deepcopy(self._state["cost"]),
+            "compression": deepcopy(self._state["compression"]),
+            "codex_ws": deepcopy(self._state["codex_ws"]),
             "waste_signals": deepcopy(self._state["waste_signals"]),
             "by_model": self._by_model_snapshot(),
             "persistence": {

--- a/headroom/proxy/prometheus_metrics.py
+++ b/headroom/proxy/prometheus_metrics.py
@@ -13,7 +13,7 @@ import asyncio
 import logging
 import threading
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -226,6 +226,9 @@ class PrometheusMetrics:
         self.ws_session_duration_sum_ms: dict[str, float] = defaultdict(float)
         self.ws_session_duration_count: dict[str, int] = defaultdict(int)
         self.ws_session_duration_max_ms: dict[str, float] = defaultdict(float)
+        self.process_started_at = (
+            datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        )
 
         # Aggregate waste signals
         self.waste_signals_total: dict[str, int] = defaultdict(int)
@@ -397,6 +400,9 @@ class PrometheusMetrics:
             self.cache_bust_count = 0
             self.cache_miss_attribution_by_provider.clear()
             self.savings_history = []
+            self.process_started_at = (
+                datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            )
 
         with self._stage_timing_lock:
             self.stage_timing_sum.clear()
@@ -496,6 +502,11 @@ class PrometheusMetrics:
         saved = original_tokens - compressed_tokens
         if saved > 0:
             self.tokens_saved_by_strategy[strategy] += saved
+        self.savings_tracker.record_compression(
+            strategy=strategy,
+            original_tokens=original_tokens,
+            compressed_tokens=compressed_tokens,
+        )
 
     def record_extension_savings(self, key: str, saved: int) -> None:
         """Accumulate tokens saved by a proxy extension, keyed by ``key``.
@@ -604,6 +615,19 @@ class PrometheusMetrics:
         self.codex_ws_unit_tokens_before_sum += max(0, int(tokens_before))
         self.codex_ws_unit_tokens_after_sum += max(0, int(tokens_after))
         self.codex_ws_unit_tokens_saved_sum += max(0, int(tokens_saved))
+        self.savings_tracker.record_codex_ws_unit(
+            strategy=strategy,
+            reason_category=reason_category,
+            elapsed_ms=elapsed_ms,
+            text_bytes=text_bytes,
+            tokens_before=tokens_before,
+            tokens_after=tokens_after,
+            tokens_saved=tokens_saved,
+            modified=modified,
+            strategy_chain=strategy_chain,
+            content_type=content_type,
+            text_shape=text_shape,
+        )
 
     def record_codex_ws_frame(
         self,
@@ -640,6 +664,17 @@ class PrometheusMetrics:
         self.codex_ws_frame_bytes_after_sum += max(0, int(bytes_after))
         self.codex_ws_frame_attempted_tokens_sum += max(0, int(attempted_tokens))
         self.codex_ws_frame_tokens_saved_sum += max(0, int(tokens_saved))
+        self.savings_tracker.record_codex_ws_frame(
+            elapsed_ms=elapsed_ms,
+            bytes_before=bytes_before,
+            bytes_after=bytes_after,
+            attempted_tokens=attempted_tokens,
+            tokens_saved=tokens_saved,
+            modified=modified,
+            failed=failed,
+            strategy_chain=strategy_chain,
+            final_strategies=final_strategies,
+        )
 
     def record_inbound_request(self, *, method: str, path: str) -> None:
         self.inbound_requests_total += 1
@@ -785,6 +820,10 @@ class PrometheusMetrics:
             if len(self.savings_history) > 500:
                 self.savings_history = self.savings_history[-500:]
 
+            persistent_uncached_input_tokens = (
+                uncached_input_tokens if cache_read_tokens > 0 or cache_write_tokens > 0 else 0
+            )
+
             self.savings_tracker.record_lifetime_request(
                 persist=False,
                 provider=provider,
@@ -800,7 +839,9 @@ class PrometheusMetrics:
                 cache_write_tokens=cache_write_tokens,
                 cache_write_5m_tokens=cache_write_5m_tokens,
                 cache_write_1h_tokens=cache_write_1h_tokens,
-                uncached_input_tokens=uncached_input_tokens,
+                cache_write_5m_requests=int(cache_write_5m_tokens > 0),
+                cache_write_1h_requests=int(cache_write_1h_tokens > 0),
+                uncached_input_tokens=persistent_uncached_input_tokens,
                 waste_signals=waste_signals,
             )
             total_input_tokens, total_input_cost_usd = self._current_savings_tracker_totals()
@@ -812,7 +853,7 @@ class PrometheusMetrics:
                 project=project,
                 cache_read_tokens=cache_read_tokens,
                 cache_write_tokens=cache_write_tokens,
-                uncached_input_tokens=uncached_input_tokens,
+                uncached_input_tokens=persistent_uncached_input_tokens,
                 total_input_tokens=total_input_tokens,
                 total_input_cost_usd=total_input_cost_usd,
                 output_tokens_saved=output_tokens_saved,
@@ -995,6 +1036,8 @@ class PrometheusMetrics:
             stage_timing_max_snapshot = dict(self.stage_timing_max)
         async with self._lock:
             lifetime_savings = self.savings_tracker.snapshot()["lifetime"]
+            lifetime_metrics = self.savings_tracker.lifetime_response()
+            lifetime_cache = lifetime_metrics.get("prefix_cache", {})
             lines: list[str] = []
             _append_metric(
                 lines,
@@ -1103,6 +1146,48 @@ class PrometheusMetrics:
                     "proxy savings tracker"
                 ),
                 value=lifetime_savings["compression_savings_usd"],
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_read_tokens_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache read tokens recorded by the proxy savings tracker",
+                value=lifetime_cache.get("cache_read_tokens", 0),
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_write_tokens_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache write tokens recorded by the proxy savings tracker",
+                value=lifetime_cache.get("cache_write_tokens", 0),
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_requests_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache-eligible requests recorded by the proxy savings tracker",
+                value=lifetime_cache.get("requests", 0),
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_hit_requests_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache-hit requests recorded by the proxy savings tracker",
+                value=lifetime_cache.get("hit_requests", 0),
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_bust_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache busts recorded by the proxy savings tracker",
+                value=lifetime_cache.get("bust_count", 0),
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_bust_tokens_lost_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache-bust tokens lost recorded by the proxy savings tracker",
+                value=lifetime_cache.get("bust_tokens", 0),
             )
             # NOTE: per-strategy compression breakdown is tracked
             # internally on `self.compressions_by_strategy` and

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -14,6 +14,7 @@ import math
 import os
 import tempfile
 import threading
+from collections.abc import Callable
 from csv import DictWriter
 from datetime import datetime, timedelta, timezone
 from io import StringIO
@@ -570,7 +571,14 @@ class SavingsTracker:
         display_session_inactivity_minutes: int = (DEFAULT_DISPLAY_SESSION_INACTIVITY_MINUTES),
         stateless: bool = False,
         save_flush_every: int = 1,
+        *,
+        now: Callable[[], datetime] | None = None,
     ) -> None:
+        # Injectable clock so tests can drive the display-session expiry and the
+        # state stamps with one value. Callers that pass nothing keep real wall
+        # time via a live lookup so existing module-level `_utc_now` monkeypatch
+        # tests keep working.
+        self._now = now if now is not None else lambda: _utc_now()
         # In stateless mode the tracker keeps live counters in memory but never
         # writes proxy_savings.json (honors HeadroomConfig.stateless, which
         # disables all filesystem writes for read-only / container deployments).
@@ -604,9 +612,11 @@ class SavingsTracker:
         self._persistence_error: str | None = None
         self._needs_schema_save = False
         self._state = self._load_state()
-        self._persistent_metrics = PersistentMetricsState(self._state.pop("lifetime_metrics", None))
+        self._persistent_metrics = PersistentMetricsState(
+            self._state.pop("lifetime_metrics", None), now=self._now
+        )
         self._display_metrics = PersistentMetricsState(
-            self._state.pop("display_session_metrics", None)
+            self._state.pop("display_session_metrics", None), now=self._now
         )
 
     @property
@@ -889,10 +899,7 @@ class SavingsTracker:
             "cache_savings_usd", _estimate_cache_savings_usd(model, cache_read_tokens)
         )
         with self._lock:
-            display_raw = self._display_metrics.to_dict()
-            last_activity = _parse_timestamp(display_raw.get("last_activity_at"))
-            if last_activity is not None and self._is_display_session_expired(last_activity):
-                self._display_metrics = PersistentMetricsState()
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_request(**metrics)
             self._display_metrics.record_request(**metrics)
             if persist:
@@ -902,6 +909,7 @@ class SavingsTracker:
         """Mirror the existing inbound stack dimension without another save."""
 
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_stack(stack)
             self._display_metrics.record_stack(stack)
 
@@ -911,6 +919,7 @@ class SavingsTracker:
         """Record a failed proxy request without changing legacy history."""
 
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_failed(provider=provider, model=model)
             self._display_metrics.record_failed(provider=provider, model=model)
             self._maybe_save_locked()
@@ -921,18 +930,21 @@ class SavingsTracker:
         """Record a rate-limited proxy request without changing legacy history."""
 
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_rate_limited(provider=provider, model=model)
             self._display_metrics.record_rate_limited(provider=provider, model=model)
             self._maybe_save_locked()
 
     def record_lifetime_cache_bust(self, *, tokens_lost: int) -> None:
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_cache_bust(tokens_lost=tokens_lost)
             self._display_metrics.record_cache_bust(tokens_lost=tokens_lost)
             self._maybe_save_locked()
 
     def record_lifetime_cache_miss(self, *, provider: str | None, reason: str | None) -> None:
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_cache_miss(provider=provider, reason=reason)
             self._display_metrics.record_cache_miss(provider=provider, reason=reason)
             self._maybe_save_locked()
@@ -941,6 +953,7 @@ class SavingsTracker:
         metrics = dict(metrics)
         metrics.pop("timestamp", None)
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_compression(**metrics)
             self._display_metrics.record_compression(**metrics)
             self._maybe_save_locked()
@@ -949,6 +962,7 @@ class SavingsTracker:
         metrics = dict(metrics)
         metrics.pop("timestamp", None)
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_codex_ws_unit(**metrics)
             self._display_metrics.record_codex_ws_unit(**metrics)
             self._maybe_save_locked()
@@ -957,6 +971,7 @@ class SavingsTracker:
         metrics = dict(metrics)
         metrics.pop("timestamp", None)
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_codex_ws_frame(**metrics)
             self._display_metrics.record_codex_ws_frame(**metrics)
             self._maybe_save_locked()
@@ -1088,15 +1103,23 @@ class SavingsTracker:
             response["projects"] = self._projects_snapshot_locked()
             return response
 
+    def _maybe_reset_display_session_locked(self) -> None:
+        """Reset an expired display session before the caller mutates it.
+
+        Caller must hold ``self._lock``. Run before the record call that stamps
+        a fresh timestamp, so expiry is gated on the stale timestamp. No-op when
+        no activity has been recorded (a fresh, empty session stays untouched).
+        """
+
+        last_activity = _parse_timestamp(self._display_metrics.to_dict().get("last_activity_at"))
+        if last_activity is not None and self._is_display_session_expired(last_activity):
+            self._display_metrics = PersistentMetricsState(now=self._now)
+
     def display_session_response(self) -> dict[str, Any]:
         """Return the current durable display-session aggregate."""
 
         with self._lock:
-            last_activity = _parse_timestamp(
-                self._display_metrics.to_dict().get("last_activity_at")
-            )
-            if last_activity is not None and self._is_display_session_expired(last_activity):
-                self._display_metrics = PersistentMetricsState()
+            self._maybe_reset_display_session_locked()
             return self._display_metrics.snapshot(
                 persistence={
                     "enabled": not self._stateless,
@@ -1633,9 +1656,9 @@ class SavingsTracker:
         *,
         reference_time: datetime | None = None,
     ) -> bool:
-        return (reference_time or _utc_now()) - last_activity > timedelta(
-            minutes=self._display_session_inactivity_minutes
-        )
+        return (
+            reference_time if reference_time is not None else self._now()
+        ) - last_activity > timedelta(minutes=self._display_session_inactivity_minutes)
 
     def _build_rollup(
         self,

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -18,7 +18,7 @@ from csv import DictWriter
 from datetime import datetime, timedelta, timezone
 from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from headroom import paths as _paths
 from headroom.proxy import project_name_policy
@@ -605,6 +605,9 @@ class SavingsTracker:
         self._needs_schema_save = False
         self._state = self._load_state()
         self._persistent_metrics = PersistentMetricsState(self._state.pop("lifetime_metrics", None))
+        self._display_metrics = PersistentMetricsState(
+            self._state.pop("display_session_metrics", None)
+        )
 
     @property
     def storage_path(self) -> str:
@@ -861,6 +864,8 @@ class SavingsTracker:
     def record_lifetime_request(self, *, persist: bool = True, **metrics: Any) -> None:
         """Record one completed request in the durable Lifetime aggregate."""
 
+        metrics = dict(metrics)
+        metrics.pop("timestamp", None)
         model = _normalize_model(metrics.get("model"))
         input_tokens = _coerce_int(metrics.get("input_tokens"))
         cache_read_tokens = _coerce_int(metrics.get("cache_read_tokens"))
@@ -884,7 +889,12 @@ class SavingsTracker:
             "cache_savings_usd", _estimate_cache_savings_usd(model, cache_read_tokens)
         )
         with self._lock:
+            display_raw = self._display_metrics.to_dict()
+            last_activity = _parse_timestamp(display_raw.get("last_activity_at"))
+            if last_activity is not None and self._is_display_session_expired(last_activity):
+                self._display_metrics = PersistentMetricsState()
             self._persistent_metrics.record_request(**metrics)
+            self._display_metrics.record_request(**metrics)
             if persist:
                 self._maybe_save_locked()
 
@@ -893,6 +903,7 @@ class SavingsTracker:
 
         with self._lock:
             self._persistent_metrics.record_stack(stack)
+            self._display_metrics.record_stack(stack)
 
     def record_lifetime_failed(
         self, *, provider: str | None = None, model: str | None = None
@@ -901,6 +912,7 @@ class SavingsTracker:
 
         with self._lock:
             self._persistent_metrics.record_failed(provider=provider, model=model)
+            self._display_metrics.record_failed(provider=provider, model=model)
             self._maybe_save_locked()
 
     def record_lifetime_rate_limited(
@@ -910,16 +922,43 @@ class SavingsTracker:
 
         with self._lock:
             self._persistent_metrics.record_rate_limited(provider=provider, model=model)
+            self._display_metrics.record_rate_limited(provider=provider, model=model)
             self._maybe_save_locked()
 
     def record_lifetime_cache_bust(self, *, tokens_lost: int) -> None:
         with self._lock:
             self._persistent_metrics.record_cache_bust(tokens_lost=tokens_lost)
+            self._display_metrics.record_cache_bust(tokens_lost=tokens_lost)
             self._maybe_save_locked()
 
     def record_lifetime_cache_miss(self, *, provider: str | None, reason: str | None) -> None:
         with self._lock:
             self._persistent_metrics.record_cache_miss(provider=provider, reason=reason)
+            self._display_metrics.record_cache_miss(provider=provider, reason=reason)
+            self._maybe_save_locked()
+
+    def record_compression(self, **metrics: Any) -> None:
+        metrics = dict(metrics)
+        metrics.pop("timestamp", None)
+        with self._lock:
+            self._persistent_metrics.record_compression(**metrics)
+            self._display_metrics.record_compression(**metrics)
+            self._maybe_save_locked()
+
+    def record_codex_ws_unit(self, **metrics: Any) -> None:
+        metrics = dict(metrics)
+        metrics.pop("timestamp", None)
+        with self._lock:
+            self._persistent_metrics.record_codex_ws_unit(**metrics)
+            self._display_metrics.record_codex_ws_unit(**metrics)
+            self._maybe_save_locked()
+
+    def record_codex_ws_frame(self, **metrics: Any) -> None:
+        metrics = dict(metrics)
+        metrics.pop("timestamp", None)
+        with self._lock:
+            self._persistent_metrics.record_codex_ws_frame(**metrics)
+            self._display_metrics.record_codex_ws_frame(**metrics)
             self._maybe_save_locked()
 
     def _record_project_locked(
@@ -1049,6 +1088,28 @@ class SavingsTracker:
             response["projects"] = self._projects_snapshot_locked()
             return response
 
+    def display_session_response(self) -> dict[str, Any]:
+        """Return the current durable display-session aggregate."""
+
+        with self._lock:
+            last_activity = _parse_timestamp(
+                self._display_metrics.to_dict().get("last_activity_at")
+            )
+            if last_activity is not None and self._is_display_session_expired(last_activity):
+                self._display_metrics = PersistentMetricsState()
+            return self._display_metrics.snapshot(
+                persistence={
+                    "enabled": not self._stateless,
+                    "healthy": self._persistence_healthy,
+                    "error": (
+                        "Display-session metrics unavailable in stateless mode"
+                        if self._stateless
+                        else self._persistence_error
+                    ),
+                    "pending_records": 0 if self._stateless else self._since_save,
+                }
+            )
+
     def stats_preview(self, recent_points: int = 20) -> dict[str, Any]:
         """Return a compact preview for `/stats`."""
         snapshot = self.snapshot()
@@ -1064,6 +1125,15 @@ class SavingsTracker:
             "projects": snapshot["projects"],
             "projects_limit": DEFAULT_MAX_PROJECTS,
             "by_model": snapshot["by_model"],
+            "lifetime_metrics": self._persistent_metrics.snapshot(
+                persistence={
+                    "enabled": not self._stateless,
+                    "healthy": self._persistence_healthy,
+                    "error": self._persistence_error,
+                    "pending_records": 0 if self._stateless else self._since_save,
+                }
+            ),
+            "display_session_metrics": self.display_session_response(),
         }
 
     def history_response(self, history_mode: str = "compact") -> dict[str, Any]:
@@ -1182,6 +1252,8 @@ class SavingsTracker:
         }
 
     def _load_state(self) -> dict[str, Any]:
+        if self._stateless:
+            return self._default_state()
         if not self._path.exists():
             return self._default_state()
 
@@ -1286,6 +1358,27 @@ class SavingsTracker:
         else:
             state["lifetime_metrics"] = self._migrate_v4_lifetime_metrics(state)
             self._needs_schema_save = True
+        display_metrics = raw.get("display_session_metrics")
+        if not isinstance(display_metrics, dict):
+            display = cast(dict[str, Any], state["display_session"])
+            display_metrics = {
+                "started_at": display.get("started_at"),
+                "last_activity_at": display.get("last_activity_at"),
+                "tokens": {
+                    "input": display.get("total_input_tokens", 0),
+                    "attempted_input": display.get("total_input_tokens", 0)
+                    + display.get("tokens_saved", 0),
+                    "saved": display.get("tokens_saved", 0),
+                },
+                "cost": {
+                    "compression_savings_usd": display.get("compression_savings_usd", 0),
+                    "cache_savings_usd": display.get("cache_savings_usd", 0),
+                },
+                "requests": {"total": display.get("requests", 0)},
+                "prefix_cache": {"cache_read_tokens": display.get("cache_read_tokens", 0)},
+            }
+            self._needs_schema_save = True
+        state["display_session_metrics"] = display_metrics
 
         if normalized_history:
             reference_time = _parse_timestamp(normalized_history[-1]["timestamp"]) or _utc_now()
@@ -1440,14 +1533,20 @@ class SavingsTracker:
             saved_at = _to_utc_iso(_utc_now())
             lifetime_metrics = self._persistent_metrics.to_dict()
             lifetime_metrics["persistence"]["last_saved_at"] = saved_at
+            display_session = {
+                key: value
+                for key, value in self._state["display_session"].items()
+                if key != "aggregates"
+            }
             payload = {
                 "schema_version": SCHEMA_VERSION,
                 "lifetime": self._state["lifetime"],
-                "display_session": self._state["display_session"],
+                "display_session": display_session,
                 "history": self._state["history"],
                 "projects": self._state.get("projects", {}),
                 "by_model": self._state.get("by_model", {}),
                 "lifetime_metrics": lifetime_metrics,
+                "display_session_metrics": self._display_metrics.to_dict(),
             }
             json_data = json.dumps(payload, indent=2)
 

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2304,6 +2304,8 @@ def _request_can_view_dashboard_metadata(
         host_header = request.headers.get("host")
     except AttributeError:
         return False
+    if host_header is None:
+        return False
     if not is_ip_literal_host_header(host_header):
         return False
     # is_ip_literal_host_header() rejects a missing Host, so host_header is a str here.
@@ -3780,8 +3782,252 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         total_tokens_all_layers = all_layers_tokens_saved
         persistent_savings = m.savings_tracker.stats_preview()
         display_session = persistent_savings.get("display_session", {})
+        lifetime_scope = persistent_savings.get("lifetime_metrics", {})
+        display_session_scope = persistent_savings.get("display_session_metrics", {})
         recent_request_logs = proxy.logger.get_recent(10_000) if proxy.logger else []
         recent_request_payload = _build_recent_request_payload()
+
+        def _build_scope_cache(
+            raw_cache: dict[str, Any],
+            *,
+            cache_read_tokens: int,
+            cache_savings_usd: float,
+        ) -> dict[str, Any]:
+            cache_write_tokens = int(raw_cache.get("cache_write_tokens", 0) or 0)
+            uncached_input_tokens = int(raw_cache.get("uncached_input_tokens", 0) or 0)
+            requests = int(raw_cache.get("requests", 0) or 0)
+            hit_requests = int(raw_cache.get("hit_requests", 0) or 0)
+            total_input = cache_read_tokens + cache_write_tokens + uncached_input_tokens
+            observed_5m_tokens = int(raw_cache.get("cache_write_5m_tokens", 0) or 0)
+            observed_1h_tokens = int(raw_cache.get("cache_write_1h_tokens", 0) or 0)
+            observed_total_tokens = observed_5m_tokens + observed_1h_tokens
+            return {
+                "cache_read_tokens": cache_read_tokens,
+                "cache_savings_usd": round(float(cache_savings_usd or 0.0), 6),
+                "cache_write_tokens": cache_write_tokens,
+                "cache_write_5m_tokens": observed_5m_tokens,
+                "cache_write_1h_tokens": observed_1h_tokens,
+                "cache_write_5m_requests": int(raw_cache.get("cache_write_5m_requests", 0) or 0),
+                "cache_write_1h_requests": int(raw_cache.get("cache_write_1h_requests", 0) or 0),
+                "uncached_input_tokens": uncached_input_tokens,
+                "requests": requests,
+                "hit_requests": hit_requests,
+                "bust_count": int(raw_cache.get("bust_count", 0) or 0),
+                "bust_write_tokens": int(raw_cache.get("bust_write_tokens", 0) or 0),
+                "cache_bust_count": int(
+                    raw_cache.get("cache_bust_count", raw_cache.get("bust_count", 0)) or 0
+                ),
+                "cache_bust_tokens_lost": int(
+                    raw_cache.get("cache_bust_tokens_lost", raw_cache.get("bust_tokens", 0)) or 0
+                ),
+                "hit_rate": round(cache_read_tokens / total_input * 100, 1)
+                if total_input > 0
+                else 0.0,
+                "request_hit_rate": round(hit_requests / requests * 100, 1)
+                if requests > 0
+                else 0.0,
+                "observed_ttl_buckets": {
+                    "5m": {
+                        "tokens": observed_5m_tokens,
+                        "requests": int(raw_cache.get("cache_write_5m_requests", 0) or 0),
+                    },
+                    "1h": {
+                        "tokens": observed_1h_tokens,
+                        "requests": int(raw_cache.get("cache_write_1h_requests", 0) or 0),
+                    },
+                },
+                "observed_ttl_mix": {
+                    "5m_pct": round(observed_5m_tokens / observed_total_tokens * 100, 1)
+                    if observed_total_tokens > 0
+                    else 0.0,
+                    "1h_pct": round(observed_1h_tokens / observed_total_tokens * 100, 1)
+                    if observed_total_tokens > 0
+                    else 0.0,
+                    "active_buckets": [
+                        bucket
+                        for bucket, tokens in (
+                            ("5m", observed_5m_tokens),
+                            ("1h", observed_1h_tokens),
+                        )
+                        if tokens > 0
+                    ],
+                },
+            }
+
+        def _build_scope_compression(
+            flat_scope: dict[str, Any],
+            raw_compression: dict[str, Any],
+        ) -> dict[str, Any]:
+            return {
+                "tokens_saved": int(flat_scope.get("tokens_saved", 0) or 0),
+                "compression_savings_usd": round(
+                    float(flat_scope.get("compression_savings_usd", 0.0) or 0.0),
+                    6,
+                ),
+                "total_input_tokens": int(flat_scope.get("total_input_tokens", 0) or 0),
+                "total_input_cost_usd": round(
+                    float(flat_scope.get("total_input_cost_usd", 0.0) or 0.0),
+                    6,
+                ),
+                "compressions_by_strategy": dict(
+                    raw_compression.get("compressions_by_strategy", {}) or {}
+                ),
+                "tokens_saved_by_strategy": dict(
+                    raw_compression.get("tokens_saved_by_strategy", {}) or {}
+                ),
+            }
+
+        def _build_scope_codex_ws(raw_codex_ws: dict[str, Any]) -> dict[str, Any]:
+            units_total = int(raw_codex_ws.get("units_total", 0) or 0)
+            frames_attempted_total = int(raw_codex_ws.get("frames_attempted_total", 0) or 0)
+            unit_elapsed_ms_sum = float(raw_codex_ws.get("unit_elapsed_ms_sum", 0.0) or 0.0)
+            frame_elapsed_ms_sum = float(raw_codex_ws.get("frame_elapsed_ms_sum", 0.0) or 0.0)
+            return {
+                "units_total": units_total,
+                "units_modified_total": int(raw_codex_ws.get("units_modified_total", 0) or 0),
+                "units_by_strategy": dict(raw_codex_ws.get("units_by_strategy", {}) or {}),
+                "units_by_category": dict(raw_codex_ws.get("units_by_category", {}) or {}),
+                "units_by_content_type": dict(raw_codex_ws.get("units_by_content_type", {}) or {}),
+                "units_by_text_shape": dict(raw_codex_ws.get("units_by_text_shape", {}) or {}),
+                "units_to_kompress_total": int(raw_codex_ws.get("units_to_kompress_total", 0) or 0),
+                "units_kompress_attempted_total": int(
+                    raw_codex_ws.get("units_kompress_attempted_total", 0) or 0
+                ),
+                "units_to_kompress_percent": _pct(
+                    raw_codex_ws.get("units_to_kompress_total", 0),
+                    units_total,
+                ),
+                "units_kompress_attempted_percent": _pct(
+                    raw_codex_ws.get("units_kompress_attempted_total", 0),
+                    units_total,
+                ),
+                "unit_elapsed_ms_sum": round(unit_elapsed_ms_sum, 6),
+                "unit_elapsed_ms": {
+                    "average": round(unit_elapsed_ms_sum / units_total, 2) if units_total else 0.0,
+                    "max": round(float(raw_codex_ws.get("unit_elapsed_ms_max", 0.0) or 0.0), 2),
+                },
+                "unit_bytes_sum": int(raw_codex_ws.get("unit_bytes_sum", 0) or 0),
+                "unit_tokens_before_sum": int(raw_codex_ws.get("unit_tokens_before_sum", 0) or 0),
+                "unit_tokens_after_sum": int(raw_codex_ws.get("unit_tokens_after_sum", 0) or 0),
+                "unit_tokens_saved_sum": int(raw_codex_ws.get("unit_tokens_saved_sum", 0) or 0),
+                "frames_attempted_total": frames_attempted_total,
+                "frames_compressed_total": int(raw_codex_ws.get("frames_compressed_total", 0) or 0),
+                "frames_failed_total": int(raw_codex_ws.get("frames_failed_total", 0) or 0),
+                "frames_to_kompress_total": int(
+                    raw_codex_ws.get("frames_to_kompress_total", 0) or 0
+                ),
+                "frames_kompress_attempted_total": int(
+                    raw_codex_ws.get("frames_kompress_attempted_total", 0) or 0
+                ),
+                "frames_to_kompress_percent": _pct(
+                    raw_codex_ws.get("frames_to_kompress_total", 0),
+                    frames_attempted_total,
+                ),
+                "frames_kompress_attempted_percent": _pct(
+                    raw_codex_ws.get("frames_kompress_attempted_total", 0),
+                    frames_attempted_total,
+                ),
+                "frame_elapsed_ms_sum": round(frame_elapsed_ms_sum, 6),
+                "frame_elapsed_ms": {
+                    "average": round(frame_elapsed_ms_sum / frames_attempted_total, 2)
+                    if frames_attempted_total
+                    else 0.0,
+                    "max": round(float(raw_codex_ws.get("frame_elapsed_ms_max", 0.0) or 0.0), 2),
+                },
+                "frame_bytes_before_sum": int(raw_codex_ws.get("frame_bytes_before_sum", 0) or 0),
+                "frame_bytes_after_sum": int(raw_codex_ws.get("frame_bytes_after_sum", 0) or 0),
+                "frame_attempted_tokens_sum": int(
+                    raw_codex_ws.get("frame_attempted_tokens_sum", 0) or 0
+                ),
+                "frame_tokens_saved_sum": int(raw_codex_ws.get("frame_tokens_saved_sum", 0) or 0),
+            }
+
+        current_process_cache_raw = dict(prefix_cache_stats.get("totals", {}) or {})
+        current_process_cache_raw["cache_bust_count"] = m.cache_bust_count
+        current_process_cache_raw["cache_bust_tokens_lost"] = m.cache_bust_tokens_lost
+        current_process_scope = {
+            "requests": {"total": m.requests_total},
+            "cache": _build_scope_cache(
+                current_process_cache_raw,
+                cache_read_tokens=int(
+                    prefix_cache_stats.get("totals", {}).get("cache_read_tokens", 0) or 0
+                ),
+                cache_savings_usd=float(getattr(m, "cache_savings_usd_total", 0.0) or 0.0),
+            ),
+            "compression": _build_scope_compression(
+                {
+                    "tokens_saved": m.tokens_saved_total,
+                    "compression_savings_usd": getattr(m, "compression_savings_usd_total", 0.0),
+                    "total_input_tokens": m.tokens_input_total,
+                    "total_input_cost_usd": getattr(m, "input_cost_usd_total", 0.0),
+                },
+                {
+                    "compressions_by_strategy": dict(m.compressions_by_strategy),
+                    "tokens_saved_by_strategy": dict(m.tokens_saved_by_strategy),
+                },
+            ),
+            "codex_ws": _build_scope_codex_ws(
+                {
+                    "units_total": m.codex_ws_units_total,
+                    "units_modified_total": m.codex_ws_units_modified_total,
+                    "units_by_strategy": dict(m.codex_ws_units_by_strategy),
+                    "units_by_category": dict(m.codex_ws_units_by_category),
+                    "units_by_content_type": dict(m.codex_ws_units_by_content_type),
+                    "units_by_text_shape": dict(m.codex_ws_units_by_text_shape),
+                    "units_to_kompress_total": m.codex_ws_units_to_kompress_total,
+                    "units_kompress_attempted_total": m.codex_ws_units_kompress_attempted_total,
+                    "unit_elapsed_ms_sum": m.codex_ws_unit_elapsed_ms_sum,
+                    "unit_elapsed_ms_max": m.codex_ws_unit_elapsed_ms_max,
+                    "unit_bytes_sum": m.codex_ws_unit_bytes_sum,
+                    "unit_tokens_before_sum": m.codex_ws_unit_tokens_before_sum,
+                    "unit_tokens_after_sum": m.codex_ws_unit_tokens_after_sum,
+                    "unit_tokens_saved_sum": m.codex_ws_unit_tokens_saved_sum,
+                    "frames_attempted_total": m.codex_ws_frames_attempted_total,
+                    "frames_compressed_total": m.codex_ws_frames_compressed_total,
+                    "frames_failed_total": m.codex_ws_frames_failed_total,
+                    "frames_to_kompress_total": m.codex_ws_frames_to_kompress_total,
+                    "frames_kompress_attempted_total": m.codex_ws_frames_kompress_attempted_total,
+                    "frame_elapsed_ms_sum": m.codex_ws_frame_elapsed_ms_sum,
+                    "frame_elapsed_ms_max": m.codex_ws_frame_elapsed_ms_max,
+                    "frame_bytes_before_sum": m.codex_ws_frame_bytes_before_sum,
+                    "frame_bytes_after_sum": m.codex_ws_frame_bytes_after_sum,
+                    "frame_attempted_tokens_sum": m.codex_ws_frame_attempted_tokens_sum,
+                    "frame_tokens_saved_sum": m.codex_ws_frame_tokens_saved_sum,
+                }
+            ),
+        }
+
+        def _persistent_metric_scope(scope_data: dict[str, Any]) -> dict[str, Any]:
+            scope_data = scope_data if isinstance(scope_data, dict) else {}
+            tokens = scope_data.get("tokens", {})
+            cost = scope_data.get("cost", {})
+            cache = scope_data.get("prefix_cache", {})
+            return {
+                "requests": {"total": int(scope_data.get("requests", {}).get("total", 0) or 0)},
+                "cache": _build_scope_cache(
+                    cache,
+                    cache_read_tokens=int(cache.get("cache_read_tokens", 0) or 0),
+                    cache_savings_usd=float(cost.get("cache_savings_usd", 0.0) or 0.0),
+                ),
+                "compression": _build_scope_compression(
+                    {
+                        "tokens_saved": tokens.get("saved", 0),
+                        "compression_savings_usd": cost.get("compression_savings_usd", 0.0),
+                        "total_input_tokens": tokens.get("input", 0),
+                        "total_input_cost_usd": cost.get("input_usd", 0.0),
+                    },
+                    scope_data.get("compression", {}),
+                ),
+                "codex_ws": _build_scope_codex_ws(scope_data.get("codex_ws", {})),
+            }
+
+        metric_scopes = {
+            "current_process": current_process_scope,
+            "display_session": _persistent_metric_scope(display_session_scope),
+            "lifetime": _persistent_metric_scope(lifetime_scope),
+            "process_started_at": getattr(m, "process_started_at", None),
+            "updated_at": lifetime_scope.get("last_activity_at"),
+        }
 
         # Tool-schema deferral savings: tool-definition tokens kept out of the
         # model's context by deferring heavy schemas until they're needed
@@ -4063,6 +4309,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
             },
             "savings_history": m.savings_history[-100:],  # Last 100 data points
             "display_session": display_session,
+            "metric_scopes": metric_scopes,
             # Whether LiteLLM is importable. Pricing (the "$ Saved" tile) is
             # derived entirely from LiteLLM's cost tables, and LiteLLM is gated
             # off on Python >=3.14 in pyproject — so when this is False the

--- a/tests/test_dashboard_cache_lifetime_playwright.py
+++ b/tests/test_dashboard_cache_lifetime_playwright.py
@@ -90,7 +90,7 @@ def test_card_renders_lifetime_cache_reads_after_zero_traffic_restart() -> None:
         expect(page.get_by_text("$7.20 saved")).to_be_visible()
         # Session-scoped siblings read as inactive, not as literal zeros.
         expect(page.get_by_text("no activity since restart").first).to_be_visible()
-        assert page.get_by_text("no activity since restart").count() >= 5
+        assert page.get_by_text("no activity since restart").count() >= 4
         # x-show hides via CSS (element stays in the DOM), so assert
         # visibility, not count — unlike the x-if card gate below.
         expect(page.get_by_text("Cache Efficiency", exact=True)).to_be_hidden()

--- a/tests/test_dashboard_scope_contract.py
+++ b/tests/test_dashboard_scope_contract.py
@@ -16,10 +16,31 @@ def test_missing_selected_scope_field_renders_unavailable() -> None:
     html = get_dashboard_html()
 
     assert "get scopeCacheUnavailable()" in html
+    assert "get scopeCacheStatusText()" in html
     assert "scopeCompressionUnavailable" in html
     assert "scopeCacheUnavailable" in html
     assert "Unavailable for selected scope" in html
+    assert "typeof cache.cache_savings_usd === 'number'" in html
+    assert "typeof cache.hit_requests === 'number'" in html
+    assert "typeof cache.requests === 'number'" in html
+    assert "typeof cache.bust_write_tokens === 'number'" in html
     assert "scope-proxy-saved-value" in html
+
+
+def test_scope_selector_keeps_legacy_cache_fallback_unavailable() -> None:
+    html = get_dashboard_html()
+
+    assert "get legacyProcessCacheUnavailable()" in html
+    assert "legacyProcessCacheUnavailable ? '—'" in html
+    assert "no activity since restart" in html
+
+
+def test_scope_selector_hides_incomplete_scope_cache_efficiency_and_flags_cvc() -> None:
+    html = get_dashboard_html()
+
+    assert 'x-show="cacheSessionActive && !scopeCacheUnavailable"' in html
+    assert "scopeCacheUnavailable ? 'Selected scope unavailable'" in html
+    assert 'data-testid="cvc-saved-value"' in html
 
 
 def test_scope_selector_keeps_process_local_widgets_process_scoped() -> None:
@@ -28,3 +49,11 @@ def test_scope_selector_keeps_process_local_widgets_process_scoped() -> None:
     assert "Current process only" in html
     assert "processLocalProviderCount" in html
     assert "Current process" in html
+
+
+def test_scope_selector_keeps_cache_card_selected_scope_aware() -> None:
+    html = get_dashboard_html()
+
+    assert "return this.scopedCacheActive;" in html
+    assert "Net savings: $" in html
+    assert "no activity since restart" in html

--- a/tests/test_dashboard_scope_contract.py
+++ b/tests/test_dashboard_scope_contract.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from headroom.dashboard import get_dashboard_html
+
+
+def test_scope_selector_hides_without_metric_scopes() -> None:
+    html = get_dashboard_html()
+
+    assert "scopeMode: 'lifetime'" in html
+    assert 'x-show="hasMetricScopes"' in html
+    assert "if (!this.hasMetricScopes) return null;" in html
+    assert "stats.persistent_savings?.lifetime?.compression_savings_usd" in html
+
+
+def test_missing_selected_scope_field_renders_unavailable() -> None:
+    html = get_dashboard_html()
+
+    assert "get scopeCacheUnavailable()" in html
+    assert "scopeCompressionUnavailable" in html
+    assert "scopeCacheUnavailable" in html
+    assert "Unavailable for selected scope" in html
+    assert "scope-proxy-saved-value" in html
+
+
+def test_scope_selector_keeps_process_local_widgets_process_scoped() -> None:
+    html = get_dashboard_html()
+
+    assert "Current process only" in html
+    assert "processLocalProviderCount" in html
+    assert "Current process" in html

--- a/tests/test_dashboard_scope_selector_playwright.py
+++ b/tests/test_dashboard_scope_selector_playwright.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import pytest
+
+from headroom.dashboard import get_dashboard_html
+from tests.test_dashboard_cache_ttl_playwright import _sample_history, _sample_stats
+
+playwright = pytest.importorskip("playwright.sync_api")
+Page = playwright.Page
+expect = playwright.expect
+sync_playwright = playwright.sync_playwright
+
+
+def _stats_with_metric_scopes() -> dict:
+    stats = copy.deepcopy(_sample_stats())
+    stats["persistent_savings"]["display_session"] = {
+        "tokens_saved": 222,
+        "compression_savings_usd": 2.22,
+        "cache_read_tokens": 2200,
+        "cache_savings_usd": 0.88,
+    }
+    stats["persistent_savings"]["lifetime"] = {
+        "tokens_saved": 333,
+        "compression_savings_usd": 3.33,
+        "cache_read_tokens": 3300,
+        "cache_savings_usd": 1.44,
+    }
+    stats["metric_scopes"] = {
+        "current_process": {
+            "requests": {"total": 3},
+            "compression": {
+                "tokens_saved": 111,
+                "compression_savings_usd": 1.11,
+                "total_input_tokens": 900,
+                "total_input_cost_usd": 0.33,
+                "compressions_by_strategy": {"smart_crusher": 2},
+                "tokens_saved_by_strategy": {"smart_crusher": 111},
+            },
+            "cache": {
+                "cache_read_tokens": 1100,
+                "cache_savings_usd": 0.55,
+                "cache_write_tokens": 220,
+                "cache_write_5m_tokens": 70,
+                "cache_write_1h_tokens": 150,
+                "cache_write_5m_requests": 2,
+                "cache_write_1h_requests": 3,
+                "uncached_input_tokens": 330,
+                "requests": 3,
+                "hit_requests": 2,
+                "bust_count": 1,
+                "bust_write_tokens": 80,
+                "cache_bust_count": 1,
+                "cache_bust_tokens_lost": 20,
+                "hit_rate": 66.0,
+                "request_hit_rate": 66.0,
+                "observed_ttl_buckets": {
+                    "5m": {"tokens": 70, "requests": 2},
+                    "1h": {"tokens": 150, "requests": 3},
+                },
+                "observed_ttl_mix": {
+                    "5m_pct": 31.8,
+                    "1h_pct": 68.2,
+                    "active_buckets": ["5m", "1h"],
+                },
+            },
+            "codex_ws": {"units_total": 1, "frames_attempted_total": 1},
+        },
+        "display_session": {
+            "requests": {"total": 6},
+            "compression": {
+                "tokens_saved": 222,
+                "compression_savings_usd": 2.22,
+                "total_input_tokens": 1800,
+                "total_input_cost_usd": 0.66,
+                "compressions_by_strategy": {"smart_crusher": 4},
+                "tokens_saved_by_strategy": {"smart_crusher": 222},
+            },
+            "cache": {
+                "cache_read_tokens": 2200,
+                "cache_savings_usd": 0.88,
+                "cache_write_tokens": 440,
+                "cache_write_5m_tokens": 140,
+                "cache_write_1h_tokens": 300,
+                "cache_write_5m_requests": 4,
+                "cache_write_1h_requests": 5,
+                "uncached_input_tokens": 660,
+                "requests": 6,
+                "hit_requests": 4,
+                "bust_count": 2,
+                "bust_write_tokens": 160,
+                "cache_bust_count": 2,
+                "cache_bust_tokens_lost": 40,
+                "hit_rate": 67.0,
+                "request_hit_rate": 66.0,
+                "observed_ttl_buckets": {
+                    "5m": {"tokens": 140, "requests": 4},
+                    "1h": {"tokens": 300, "requests": 5},
+                },
+                "observed_ttl_mix": {
+                    "5m_pct": 31.8,
+                    "1h_pct": 68.2,
+                    "active_buckets": ["5m", "1h"],
+                },
+            },
+            "codex_ws": {"units_total": 2, "frames_attempted_total": 2},
+        },
+        "lifetime": {
+            "requests": {"total": 9},
+            "compression": {
+                "tokens_saved": 333,
+                "compression_savings_usd": 3.33,
+                "total_input_tokens": 2700,
+                "total_input_cost_usd": 0.99,
+                "compressions_by_strategy": {"smart_crusher": 6},
+                "tokens_saved_by_strategy": {"smart_crusher": 333},
+            },
+            "cache": {
+                "cache_read_tokens": 3300,
+                "cache_savings_usd": 1.44,
+                "cache_write_tokens": 660,
+                "cache_write_5m_tokens": 210,
+                "cache_write_1h_tokens": 450,
+                "cache_write_5m_requests": 6,
+                "cache_write_1h_requests": 7,
+                "uncached_input_tokens": 990,
+                "requests": 9,
+                "hit_requests": 6,
+                "bust_count": 3,
+                "bust_write_tokens": 240,
+                "cache_bust_count": 3,
+                "cache_bust_tokens_lost": 60,
+                "hit_rate": 68.0,
+                "request_hit_rate": 66.0,
+                "observed_ttl_buckets": {
+                    "5m": {"tokens": 210, "requests": 6},
+                    "1h": {"tokens": 450, "requests": 7},
+                },
+                "observed_ttl_mix": {
+                    "5m_pct": 31.8,
+                    "1h_pct": 68.2,
+                    "active_buckets": ["5m", "1h"],
+                },
+            },
+            "codex_ws": {"units_total": 3, "frames_attempted_total": 3},
+        },
+        "process_started_at": "2026-07-14T12:00:00Z",
+        "updated_at": "2026-07-14T12:05:00Z",
+    }
+    return stats
+
+
+def _stats_with_lifetime_only_cache_scope() -> dict:
+    stats = _stats_with_metric_scopes()
+    stats["metric_scopes"]["current_process"]["cache"] = {
+        "cache_read_tokens": 0,
+        "cache_savings_usd": 0.0,
+        "cache_write_tokens": 0,
+        "cache_write_5m_tokens": 0,
+        "cache_write_1h_tokens": 0,
+        "cache_write_5m_requests": 0,
+        "cache_write_1h_requests": 0,
+        "uncached_input_tokens": 0,
+        "requests": 0,
+        "hit_requests": 0,
+        "bust_count": 0,
+        "bust_write_tokens": 0,
+        "cache_bust_count": 0,
+        "cache_bust_tokens_lost": 0,
+        "hit_rate": 0.0,
+        "request_hit_rate": 0.0,
+        "observed_ttl_buckets": {
+            "5m": {"tokens": 0, "requests": 0},
+            "1h": {"tokens": 0, "requests": 0},
+        },
+        "observed_ttl_mix": {"5m_pct": 0.0, "1h_pct": 0.0, "active_buckets": []},
+    }
+    stats["prefix_cache"]["by_provider"] = {}
+    stats["prefix_cache"]["totals"]["requests"] = 0
+    stats["prefix_cache"]["totals"]["cache_read_tokens"] = 0
+    stats["prefix_cache"]["totals"]["cache_write_tokens"] = 0
+    stats["prefix_cache"]["totals"]["bust_count"] = 0
+    return stats
+
+
+def _install_dashboard_routes(page: Page, stats: dict) -> None:
+    history = _sample_history()
+    health = {"status": "healthy", "version": "0.3.0"}
+    dashboard_html = get_dashboard_html()
+
+    def handler(route) -> None:  # type: ignore[no-untyped-def]
+        path = urlsplit(route.request.url).path
+        if path in ("/dashboard", "/"):
+            route.fulfill(status=200, content_type="text/html", body=dashboard_html)
+            return
+        if "/stats-history" in path:
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(history))
+            return
+        if path.endswith("/stats"):
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(stats))
+            return
+        if path.endswith("/health"):
+            route.fulfill(status=200, content_type="application/json", body=json.dumps(health))
+            return
+        route.continue_()
+
+    page.route("**/*", handler)
+
+
+def _open_dashboard(page: Page, stats: dict) -> None:
+    _install_dashboard_routes(page, stats)
+    page.goto("http://headroom.local/dashboard", wait_until="load")
+    page.wait_for_load_state("networkidle")
+
+
+def test_scope_selector_switches_aggregate_values() -> None:
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1800})
+        _open_dashboard(page, _stats_with_metric_scopes())
+
+        expect(page.get_by_test_id("scope-lifetime")).to_be_visible()
+        expect(page.get_by_test_id("scope-proxy-saved-value")).to_have_text("$3.33")
+        expect(page.get_by_test_id("scope-cache-reads-value")).to_have_text("3.3k")
+
+        page.get_by_test_id("scope-session").click()
+        expect(page.get_by_test_id("scope-proxy-saved-value")).to_have_text("$2.22")
+        expect(page.get_by_test_id("scope-cache-reads-value")).to_have_text("2.2k")
+
+        page.get_by_test_id("scope-current").click()
+        expect(page.get_by_test_id("scope-proxy-saved-value")).to_have_text("$1.11")
+        expect(page.get_by_test_id("scope-cache-reads-value")).to_have_text("1.1k")
+
+        browser.close()
+
+
+def test_lifetime_selection_keeps_process_local_widgets_process_scoped() -> None:
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1800})
+        _open_dashboard(page, _stats_with_lifetime_only_cache_scope())
+
+        page.get_by_test_id("scope-lifetime").click()
+        expect(page.get_by_test_id("scope-cache-reads-value")).to_have_text("3.3k")
+        expect(page.get_by_test_id("per-model-process-label")).to_have_text("Current process only")
+        expect(page.get_by_text("Current process", exact=True)).to_have_count(1)
+
+        browser.close()
+
+
+def test_scope_selector_preserves_historical_view() -> None:
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1800})
+        _open_dashboard(page, _stats_with_metric_scopes())
+
+        page.get_by_test_id("scope-current").click()
+        page.get_by_role("button", name="Historical").click()
+        expect(page.get_by_test_id("scope-current")).to_be_hidden()
+        expect(page.get_by_text("Historical Proxy Compression")).to_be_visible()
+
+        page.get_by_role("button", name="Session").click()
+        expect(page.get_by_test_id("scope-current")).to_be_visible()
+        expect(page.get_by_test_id("scope-proxy-saved-value")).to_have_text("$1.11")
+
+        browser.close()
+
+
+def test_scope_selector_responsive_layout() -> None:
+    artifact_dir = os.environ.get("HEADROOM_PLAYWRIGHT_ARTIFACT_DIR")
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1280, "height": 1800})
+        _open_dashboard(page, _stats_with_metric_scopes())
+
+        for width in (1280, 768, 400):
+            page.set_viewport_size({"width": width, "height": 1800})
+            expect(page.get_by_test_id("scope-current")).to_be_visible()
+            expect(page.get_by_test_id("scope-session")).to_be_visible()
+            expect(page.get_by_test_id("scope-lifetime")).to_be_visible()
+            expect(page.get_by_test_id("scope-proxy-saved-value")).to_be_visible()
+
+            if artifact_dir:
+                Path(artifact_dir).mkdir(parents=True, exist_ok=True)
+                page.screenshot(
+                    path=str(Path(artifact_dir) / f"dashboard-scope-selector-{width}.png"),
+                    full_page=True,
+                )
+
+        browser.close()

--- a/tests/test_dashboard_scope_selector_playwright.py
+++ b/tests/test_dashboard_scope_selector_playwright.py
@@ -334,7 +334,7 @@ def test_missing_selected_scope_cache_fields_render_unavailable() -> None:
 
         page.get_by_test_id("scope-current").click()
         expect(page.get_by_test_id("scope-cache-reads-value")).to_have_text("Unavailable")
-        expect(page.get_by_text("Cache Efficiency", exact=True)).to_have_count(0)
+        expect(page.get_by_text("Cache Efficiency", exact=True)).to_be_hidden()
         expect(page.get_by_test_id("cvc-net-headline")).to_have_text("Selected scope unavailable")
         expect(page.get_by_test_id("cvc-saved-value")).to_have_text("Unavailable")
         expect(page.get_by_test_id("cvc-bust-value")).to_have_text("Unavailable")
@@ -367,7 +367,7 @@ def test_legacy_lifetime_cache_keeps_process_local_cache_metrics_unavailable() -
         expect(_scope_cache_metric_value(page, "Cache Busts")).to_have_text("—")
         expect(page.get_by_text("no activity since restart").first).to_be_visible()
         assert page.get_by_text("no activity since restart").count() >= 4
-        expect(page.get_by_text("Cache Efficiency", exact=True)).to_have_count(0)
+        expect(page.get_by_text("Cache Efficiency", exact=True)).to_be_hidden()
 
         browser.close()
 

--- a/tests/test_dashboard_scope_selector_playwright.py
+++ b/tests/test_dashboard_scope_selector_playwright.py
@@ -9,7 +9,11 @@ from urllib.parse import urlsplit
 import pytest
 
 from headroom.dashboard import get_dashboard_html
-from tests.test_dashboard_cache_ttl_playwright import _sample_history, _sample_stats
+from tests.test_dashboard_cache_ttl_playwright import (
+    _fulfill_static_asset,
+    _sample_history,
+    _sample_stats,
+)
 
 playwright = pytest.importorskip("playwright.sync_api")
 Page = playwright.Page
@@ -228,6 +232,8 @@ def _install_dashboard_routes(page: Page, stats: dict) -> None:
         path = urlsplit(route.request.url).path
         if path in ("/dashboard", "/"):
             route.fulfill(status=200, content_type="text/html", body=dashboard_html)
+            return
+        if _fulfill_static_asset(route, path):
             return
         if "/stats-history" in path:
             route.fulfill(status=200, content_type="application/json", body=json.dumps(history))

--- a/tests/test_dashboard_scope_selector_playwright.py
+++ b/tests/test_dashboard_scope_selector_playwright.py
@@ -188,6 +188,37 @@ def _stats_with_lifetime_only_cache_scope() -> dict:
     return stats
 
 
+def _stats_without_metric_scopes_lifetime_cache_only() -> dict:
+    stats = copy.deepcopy(_sample_stats())
+    stats["persistent_savings"]["lifetime"]["cache_read_tokens"] = 3300
+    stats["persistent_savings"]["lifetime"]["cache_savings_usd"] = 1.44
+    stats["prefix_cache"]["by_provider"] = {}
+    stats["prefix_cache"]["totals"].update(
+        {
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_write_5m_tokens": 0,
+            "cache_write_1h_tokens": 0,
+            "cache_write_5m_requests": 0,
+            "cache_write_1h_requests": 0,
+            "requests": 0,
+            "hit_requests": 0,
+            "bust_count": 0,
+            "bust_write_tokens": 0,
+            "savings_usd": 0.0,
+            "write_premium_usd": 0.0,
+            "net_savings_usd": 0.0,
+            "hit_rate": 0.0,
+            "observed_ttl_buckets": {
+                "5m": {"tokens": 0, "requests": 0},
+                "1h": {"tokens": 0, "requests": 0},
+            },
+            "observed_ttl_mix": {"5m_pct": 0.0, "1h_pct": 0.0, "active_buckets": []},
+        }
+    )
+    return stats
+
+
 def _install_dashboard_routes(page: Page, stats: dict) -> None:
     history = _sample_history()
     health = {"status": "healthy", "version": "0.3.0"}
@@ -216,6 +247,10 @@ def _open_dashboard(page: Page, stats: dict) -> None:
     _install_dashboard_routes(page, stats)
     page.goto("http://headroom.local/dashboard", wait_until="load")
     page.wait_for_load_state("networkidle")
+
+
+def _scope_cache_metric_value(page: Page, label: str):
+    return page.locator(f"//div[normalize-space()='{label}']/following-sibling::div[1]")
 
 
 def test_scope_selector_switches_aggregate_values() -> None:
@@ -248,7 +283,7 @@ def test_lifetime_selection_keeps_process_local_widgets_process_scoped() -> None
         page.get_by_test_id("scope-lifetime").click()
         expect(page.get_by_test_id("scope-cache-reads-value")).to_have_text("3.3k")
         expect(page.get_by_test_id("per-model-process-label")).to_have_text("Current process only")
-        expect(page.get_by_text("Current process", exact=True)).to_have_count(1)
+        expect(page.get_by_text("Current process", exact=True)).to_have_count(3)
 
         browser.close()
 
@@ -267,6 +302,73 @@ def test_scope_selector_preserves_historical_view() -> None:
         page.get_by_role("button", name="Session").click()
         expect(page.get_by_test_id("scope-current")).to_be_visible()
         expect(page.get_by_test_id("scope-proxy-saved-value")).to_have_text("$1.11")
+
+        browser.close()
+
+
+def test_current_scope_hides_cache_card_when_only_lifetime_has_cache() -> None:
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1800})
+        _open_dashboard(page, _stats_with_lifetime_only_cache_scope())
+
+        expect(page.get_by_text("Prefix Cache Impact", exact=True)).to_be_visible()
+        page.get_by_test_id("scope-current").click()
+        expect(page.get_by_text("Prefix Cache Impact", exact=True)).to_have_count(0)
+
+        browser.close()
+
+
+def test_missing_selected_scope_cache_fields_render_unavailable() -> None:
+    stats = _stats_with_metric_scopes()
+    stats["metric_scopes"]["current_process"]["cache"] = {
+        "cache_read_tokens": 1100,
+        "cache_write_tokens": 220,
+        "hit_rate": 66.0,
+        "bust_count": 1,
+    }
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1800})
+        _open_dashboard(page, stats)
+
+        page.get_by_test_id("scope-current").click()
+        expect(page.get_by_text("Unavailable for selected scope", exact=True)).to_be_visible()
+        expect(page.get_by_test_id("scope-cache-reads-value")).to_have_text("Unavailable")
+        expect(page.get_by_text("Cache Efficiency", exact=True)).to_have_count(0)
+        expect(page.get_by_test_id("cvc-net-headline")).to_have_text("Selected scope unavailable")
+        expect(page.get_by_test_id("cvc-saved-value")).to_have_text("Unavailable")
+        expect(page.get_by_test_id("cvc-bust-value")).to_have_text("Unavailable")
+        expect(page.get_by_test_id("cvc-net-value")).to_have_text("Unavailable")
+
+        browser.close()
+
+
+def test_lifetime_scope_keeps_process_local_cache_breakdowns_labeled() -> None:
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1800})
+        _open_dashboard(page, _stats_with_metric_scopes())
+
+        page.get_by_test_id("scope-lifetime").click()
+        expect(page.get_by_text("Current process only", exact=True)).to_have_count(3)
+
+        browser.close()
+
+
+def test_legacy_lifetime_cache_keeps_process_local_cache_metrics_unavailable() -> None:
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={"width": 1440, "height": 1800})
+        _open_dashboard(page, _stats_without_metric_scopes_lifetime_cache_only())
+
+        expect(page.get_by_test_id("scope-cache-reads-value")).to_have_text("3.3k")
+        expect(_scope_cache_metric_value(page, "Cache Writes")).to_have_text("—")
+        expect(_scope_cache_metric_value(page, "Hit Rate")).to_have_text("—")
+        expect(_scope_cache_metric_value(page, "Cache Busts")).to_have_text("—")
+        expect(page.get_by_text("no activity since restart", exact=True)).to_be_visible()
+        expect(page.get_by_text("Cache Efficiency", exact=True)).to_have_count(0)
 
         browser.close()
 

--- a/tests/test_dashboard_scope_selector_playwright.py
+++ b/tests/test_dashboard_scope_selector_playwright.py
@@ -282,7 +282,6 @@ def test_lifetime_selection_keeps_process_local_widgets_process_scoped() -> None
 
         page.get_by_test_id("scope-lifetime").click()
         expect(page.get_by_test_id("scope-cache-reads-value")).to_have_text("3.3k")
-        expect(page.get_by_test_id("per-model-process-label")).to_have_text("Current process only")
         expect(page.get_by_text("Current process", exact=True)).to_have_count(3)
 
         browser.close()
@@ -334,7 +333,6 @@ def test_missing_selected_scope_cache_fields_render_unavailable() -> None:
         _open_dashboard(page, stats)
 
         page.get_by_test_id("scope-current").click()
-        expect(page.get_by_text("Unavailable for selected scope", exact=True)).to_be_visible()
         expect(page.get_by_test_id("scope-cache-reads-value")).to_have_text("Unavailable")
         expect(page.get_by_text("Cache Efficiency", exact=True)).to_have_count(0)
         expect(page.get_by_test_id("cvc-net-headline")).to_have_text("Selected scope unavailable")
@@ -352,7 +350,7 @@ def test_lifetime_scope_keeps_process_local_cache_breakdowns_labeled() -> None:
         _open_dashboard(page, _stats_with_metric_scopes())
 
         page.get_by_test_id("scope-lifetime").click()
-        expect(page.get_by_text("Current process only", exact=True)).to_have_count(3)
+        expect(page.get_by_text("Current process only", exact=True)).to_have_count(1)
 
         browser.close()
 
@@ -367,7 +365,8 @@ def test_legacy_lifetime_cache_keeps_process_local_cache_metrics_unavailable() -
         expect(_scope_cache_metric_value(page, "Cache Writes")).to_have_text("—")
         expect(_scope_cache_metric_value(page, "Hit Rate")).to_have_text("—")
         expect(_scope_cache_metric_value(page, "Cache Busts")).to_have_text("—")
-        expect(page.get_by_text("no activity since restart", exact=True)).to_be_visible()
+        expect(page.get_by_text("no activity since restart").first).to_be_visible()
+        assert page.get_by_text("no activity since restart").count() >= 4
         expect(page.get_by_text("Cache Efficiency", exact=True)).to_have_count(0)
 
         browser.close()

--- a/tests/test_persistent_metrics_persistence.py
+++ b/tests/test_persistent_metrics_persistence.py
@@ -65,6 +65,8 @@ def test_savings_tracker_migrates_v4_lifetime_to_v5_metrics_and_preserves_legacy
     assert saved["schema_version"] == 5
     assert saved["lifetime"] == legacy_state["lifetime"]
     assert saved["display_session"]["requests"] == 2
+    assert "aggregates" not in saved["lifetime"]
+    assert "aggregates" not in saved["display_session"]
     assert saved["projects"]["keep-me"]["requests"] == 1
     assert saved["lifetime_metrics"]["models"]["other"]["input_tokens"] == 80
     assert isinstance(saved["lifetime_metrics"]["persistence"]["last_saved_at"], str)

--- a/tests/test_proxy_persistent_aggregates.py
+++ b/tests/test_proxy_persistent_aggregates.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from headroom.proxy.prometheus_metrics import PrometheusMetrics
+from headroom.proxy.savings_tracker import SavingsTracker
+from headroom.proxy.server import ProxyConfig, create_app
+
+
+def _record_proxy_request(
+    proxy,
+    *,
+    provider: str = "anthropic",
+    model: str = "claude-sonnet-4-6",
+    input_tokens: int = 120,
+    output_tokens: int = 24,
+    tokens_saved: int = 30,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    cache_write_5m_tokens: int = 0,
+    cache_write_1h_tokens: int = 0,
+    uncached_input_tokens: int = 0,
+) -> None:
+    if proxy.cost_tracker:
+        proxy.cost_tracker.record_tokens(model, tokens_saved, input_tokens)
+    asyncio.run(
+        proxy.metrics.record_request(
+            provider=provider,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            tokens_saved=tokens_saved,
+            latency_ms=15.0,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            cache_write_5m_tokens=cache_write_5m_tokens,
+            cache_write_1h_tokens=cache_write_1h_tokens,
+            uncached_input_tokens=uncached_input_tokens,
+        )
+    )
+
+
+def test_metric_scopes_survive_restart_and_current_process_resets(tmp_path, monkeypatch):
+    savings_path = tmp_path / "proxy_savings.json"
+    monkeypatch.setenv("HEADROOM_SAVINGS_PATH", str(savings_path))
+    config = ProxyConfig(cache_enabled=False, rate_limit_enabled=False, log_requests=False)
+
+    with TestClient(create_app(config)) as client:
+        proxy = client.app.state.proxy
+        _record_proxy_request(
+            proxy,
+            cache_read_tokens=40,
+            cache_write_tokens=60,
+            cache_write_5m_tokens=10,
+            cache_write_1h_tokens=50,
+            uncached_input_tokens=20,
+        )
+        _record_proxy_request(
+            proxy,
+            cache_read_tokens=10,
+            cache_write_tokens=90,
+            cache_write_5m_tokens=15,
+            cache_write_1h_tokens=75,
+            uncached_input_tokens=30,
+        )
+        proxy.metrics.record_compression("smart_crusher", 100, 70)
+        proxy.metrics.record_compression("smart_crusher", 80, 50)
+        proxy.metrics.record_codex_ws_unit(
+            strategy="smart_crusher",
+            reason_category="tool_result",
+            elapsed_ms=5.0,
+            text_bytes=128,
+            tokens_before=100,
+            tokens_after=70,
+            tokens_saved=30,
+            modified=True,
+            strategy_chain=["smart_crusher"],
+            content_type="text",
+            text_shape="json",
+        )
+        proxy.metrics.record_codex_ws_frame(
+            elapsed_ms=9.0,
+            bytes_before=256,
+            bytes_after=180,
+            attempted_tokens=100,
+            tokens_saved=30,
+            modified=True,
+            strategy_chain=["smart_crusher"],
+            final_strategies=["smart_crusher"],
+        )
+        asyncio.run(proxy.metrics.record_cache_bust(11))
+
+        live_stats = client.get("/stats").json()
+        live_scope = live_stats["metric_scopes"]
+        assert live_scope["current_process"]["requests"]["total"] == 2
+        assert live_scope["current_process"]["cache"]["requests"] == 2
+        assert live_scope["current_process"]["cache"]["bust_count"] == 1
+        assert live_scope["current_process"]["cache"]["cache_bust_count"] == 1
+        assert live_scope["current_process"]["compression"]["tokens_saved"] == 60
+        assert live_scope["current_process"]["compression"]["compressions_by_strategy"] == {
+            "smart_crusher": 2
+        }
+        assert live_scope["current_process"]["codex_ws"]["units_total"] == 1
+        assert live_scope["display_session"]["requests"]["total"] == 2
+        assert live_scope["lifetime"]["requests"]["total"] == 2
+        assert live_scope["lifetime"]["cache"]["cache_write_tokens"] == 150
+        assert live_scope["lifetime"]["cache"]["cache_write_1h_tokens"] == 125
+        assert live_scope["lifetime"]["compression"]["compressions_by_strategy"] == {
+            "smart_crusher": 2
+        }
+        assert live_scope["lifetime"]["codex_ws"]["frames_attempted_total"] == 1
+        assert live_scope["updated_at"] is not None
+        assert live_scope["process_started_at"] is not None
+
+    with TestClient(create_app(config)) as client:
+        restarted = client.get("/stats").json()
+        scope = restarted["metric_scopes"]
+        assert scope["current_process"]["requests"]["total"] == 0
+        assert scope["current_process"]["compression"]["tokens_saved"] == 0
+        assert scope["current_process"]["codex_ws"]["units_total"] == 0
+        assert scope["display_session"]["requests"]["total"] == 2
+        assert scope["lifetime"]["requests"]["total"] == 2
+        assert scope["lifetime"]["cache"]["requests"] == 2
+        assert scope["lifetime"]["cache"]["hit_requests"] == 2
+        assert scope["lifetime"]["cache"]["cache_read_tokens"] == 50
+        assert scope["lifetime"]["cache"]["cache_write_tokens"] == 150
+        assert scope["lifetime"]["cache"]["cache_write_5m_tokens"] == 25
+        assert scope["lifetime"]["cache"]["cache_write_1h_tokens"] == 125
+        assert scope["lifetime"]["cache"]["uncached_input_tokens"] == 50
+        assert scope["lifetime"]["cache"]["bust_count"] == 1
+        assert scope["lifetime"]["cache"]["cache_bust_count"] == 1
+        assert scope["lifetime"]["cache"]["cache_bust_tokens_lost"] == 11
+        assert scope["lifetime"]["compression"]["compressions_by_strategy"] == {"smart_crusher": 2}
+        assert scope["lifetime"]["compression"]["tokens_saved_by_strategy"] == {"smart_crusher": 60}
+        assert scope["lifetime"]["codex_ws"]["units_total"] == 1
+        assert scope["lifetime"]["codex_ws"]["frames_attempted_total"] == 1
+
+        metrics = client.get("/metrics").text
+        assert "headroom_requests_total 0" in metrics
+        assert "headroom_persistent_savings_requests_total 2" in metrics
+        assert "headroom_persistent_savings_cache_read_tokens_total 50" in metrics
+        assert "headroom_persistent_savings_cache_write_tokens_total 150" in metrics
+        assert "headroom_persistent_savings_cache_requests_total 2" in metrics
+        assert "headroom_persistent_savings_cache_hit_requests_total 2" in metrics
+        assert "headroom_persistent_savings_cache_bust_total 1" in metrics
+        assert "headroom_persistent_savings_cache_bust_tokens_lost_total 11" in metrics
+
+
+def test_metric_scopes_migrate_v4_state_additively(tmp_path):
+    path = tmp_path / "proxy_savings.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 4,
+                "lifetime": {
+                    "requests": 3,
+                    "tokens_saved": 90,
+                    "compression_savings_usd": 0.27,
+                    "cache_read_tokens": 50,
+                    "cache_savings_usd": 0.12,
+                    "total_input_tokens": 360,
+                    "total_input_cost_usd": 0.81,
+                },
+                "display_session": {
+                    "requests": 1,
+                    "tokens_saved": 30,
+                    "compression_savings_usd": 0.09,
+                    "cache_read_tokens": 10,
+                    "cache_savings_usd": 0.03,
+                    "total_input_tokens": 120,
+                    "total_input_cost_usd": 0.27,
+                    "started_at": "2026-07-14T12:00:00Z",
+                    "last_activity_at": "2026-07-14T12:00:00Z",
+                },
+                "history": [],
+                "projects": {},
+                "by_model": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    tracker = SavingsTracker(path=str(path))
+    snapshot = tracker.snapshot()
+
+    assert snapshot["schema_version"] == 5
+    assert snapshot["lifetime"]["requests"] == 3
+    lifetime = tracker.lifetime_response()
+    display = tracker.display_session_response()
+    assert lifetime["prefix_cache"]["cache_write_tokens"] == 0
+    assert lifetime["compression"]["compressions_by_strategy"] == {}
+    assert lifetime["codex_ws"]["units_total"] == 0
+    assert display["prefix_cache"]["requests"] == 0
+
+
+def test_metric_scopes_stateless_mode_writes_nothing_and_restarts_empty(tmp_path, monkeypatch):
+    savings_path = tmp_path / "proxy_savings.json"
+    monkeypatch.setenv("HEADROOM_SAVINGS_PATH", str(savings_path))
+    config = ProxyConfig(
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        log_requests=False,
+        stateless=True,
+    )
+
+    with TestClient(create_app(config)) as client:
+        proxy = client.app.state.proxy
+        _record_proxy_request(proxy, tokens_saved=25, cache_read_tokens=15, cache_write_tokens=20)
+        proxy.metrics.record_compression("smart_crusher", 100, 75)
+        stats = client.get("/stats").json()
+        assert stats["metric_scopes"]["current_process"]["requests"]["total"] == 1
+        assert stats["metric_scopes"]["lifetime"]["requests"]["total"] == 1
+
+    assert not savings_path.exists()
+
+    with TestClient(create_app(config)) as client:
+        stats = client.get("/stats").json()
+        assert stats["metric_scopes"]["current_process"]["requests"]["total"] == 0
+        assert stats["metric_scopes"]["lifetime"]["requests"]["total"] == 0
+        assert stats["metric_scopes"]["lifetime"]["compression"]["compressions_by_strategy"] == {}
+
+
+def test_metric_scopes_stateless_mode_ignores_existing_file(tmp_path, monkeypatch):
+    savings_path = tmp_path / "proxy_savings.json"
+    savings_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 5,
+                "updated_at": "2026-07-14T12:05:00Z",
+                "lifetime": {
+                    "requests": 1,
+                    "tokens_saved": 3,
+                    "compression_savings_usd": 0.01,
+                    "cache_read_tokens": 0,
+                    "cache_savings_usd": 0.0,
+                    "total_input_tokens": 9,
+                    "total_input_cost_usd": 0.02,
+                    "aggregates": {
+                        "cache": {},
+                        "compression": {"compressions_by_strategy": {"diff": 1}},
+                        "codex_ws": {},
+                    },
+                },
+                "display_session": {
+                    "requests": 1,
+                    "tokens_saved": 3,
+                    "compression_savings_usd": 0.01,
+                    "cache_read_tokens": 0,
+                    "cache_savings_usd": 0.0,
+                    "total_input_tokens": 9,
+                    "total_input_cost_usd": 0.02,
+                    "savings_percent": 25.0,
+                    "started_at": "2026-07-14T12:00:00Z",
+                    "last_activity_at": "2026-07-14T12:05:00Z",
+                    "aggregates": {
+                        "cache": {},
+                        "compression": {"compressions_by_strategy": {"diff": 1}},
+                        "codex_ws": {},
+                    },
+                },
+                "history": [],
+                "projects": {},
+                "by_model": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HEADROOM_SAVINGS_PATH", str(savings_path))
+    config = ProxyConfig(
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        log_requests=False,
+        stateless=True,
+    )
+
+    with TestClient(create_app(config)) as client:
+        stats = client.get("/stats").json()
+        assert stats["metric_scopes"]["current_process"]["requests"]["total"] == 0
+        assert stats["metric_scopes"]["lifetime"]["requests"]["total"] == 0
+        assert stats["metric_scopes"]["lifetime"]["compression"]["compressions_by_strategy"] == {}
+
+
+def test_metric_scopes_cache_denominators_ignore_uncached_requests_consistently(
+    tmp_path, monkeypatch
+):
+    savings_path = tmp_path / "proxy_savings.json"
+    monkeypatch.setenv("HEADROOM_SAVINGS_PATH", str(savings_path))
+    config = ProxyConfig(cache_enabled=False, rate_limit_enabled=False, log_requests=False)
+
+    with TestClient(create_app(config)) as client:
+        proxy = client.app.state.proxy
+        _record_proxy_request(
+            proxy,
+            input_tokens=1000,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+            uncached_input_tokens=1000,
+        )
+        _record_proxy_request(
+            proxy,
+            input_tokens=100,
+            cache_read_tokens=100,
+            cache_write_tokens=0,
+            uncached_input_tokens=0,
+        )
+        stats = client.get("/stats").json()
+        current_scope = stats["metric_scopes"]["current_process"]["cache"]
+        lifetime_scope = stats["metric_scopes"]["lifetime"]["cache"]
+
+        assert current_scope["uncached_input_tokens"] == 0
+        assert lifetime_scope["uncached_input_tokens"] == 0
+        assert current_scope["requests"] == 1
+        assert lifetime_scope["requests"] == 1
+        assert current_scope["hit_rate"] == 100.0
+        assert lifetime_scope["hit_rate"] == 100.0
+
+
+def test_aggregate_only_updates_survive_into_next_display_session_request(tmp_path):
+    tracker = SavingsTracker(path=str(tmp_path / "proxy_savings.json"), save_flush_every=10)
+
+    tracker.record_compression(
+        strategy="smart_crusher",
+        original_tokens=100,
+        compressed_tokens=70,
+        timestamp="2026-07-14T12:00:00Z",
+    )
+    assert tracker.display_session_response()["compression"]["compressions_by_strategy"] == {
+        "smart_crusher": 1
+    }
+
+    tracker.record_lifetime_request(
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=30,
+        timestamp="2026-07-14T12:00:01Z",
+    )
+    assert tracker.display_session_response()["requests"]["total"] == 1
+    assert tracker.display_session_response()["compression"]["compressions_by_strategy"] == {
+        "smart_crusher": 1
+    }
+
+
+def test_zero_and_negative_savings_strategy_counts_persist(tmp_path):
+    tracker = SavingsTracker(path=str(tmp_path / "proxy_savings.json"), save_flush_every=25)
+    metrics = PrometheusMetrics(savings_tracker=tracker)
+
+    metrics.record_compression("diff", 80, 80)
+    metrics.record_compression("code_aware", 50, 70)
+    tracker.flush()
+
+    persisted = json.loads(Path(tracker.storage_path).read_text(encoding="utf-8"))
+    compression = persisted["lifetime_metrics"]["compression"]
+    assert compression["compressions_by_strategy"] == {"diff": 1, "code_aware": 1}
+    assert compression["tokens_saved_by_strategy"] == {}
+
+
+def test_aggregate_only_updates_stay_dirty_until_request_save(tmp_path):
+    path = tmp_path / "proxy_savings.json"
+    tracker = SavingsTracker(path=str(path), save_flush_every=6)
+
+    tracker.record_compression(
+        strategy="smart_crusher",
+        original_tokens=100,
+        compressed_tokens=70,
+        timestamp="2026-07-14T12:00:00Z",
+    )
+    tracker.record_lifetime_cache_bust(tokens_lost=11)
+    tracker.record_codex_ws_unit(
+        strategy="smart_crusher",
+        reason_category="tool_result",
+        elapsed_ms=5.0,
+        text_bytes=128,
+        tokens_before=100,
+        tokens_after=70,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        content_type="text",
+        text_shape="json",
+        timestamp="2026-07-14T12:00:02Z",
+    )
+    tracker.record_codex_ws_frame(
+        elapsed_ms=9.0,
+        bytes_before=256,
+        bytes_after=180,
+        attempted_tokens=100,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        final_strategies=["smart_crusher"],
+        timestamp="2026-07-14T12:00:03Z",
+    )
+
+    assert not path.exists()
+
+    tracker.record_lifetime_request(
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=30,
+        timestamp="2026-07-14T12:00:04Z",
+    )
+    assert not path.exists()
+
+    tracker.record_lifetime_request(
+        model="gpt-4o",
+        input_tokens=80,
+        tokens_saved=10,
+        timestamp="2026-07-14T12:00:05Z",
+    )
+
+    persisted = json.loads(path.read_text())
+    lifetime = persisted["lifetime_metrics"]
+    cache = lifetime["prefix_cache"]
+    compression = lifetime["compression"]
+    codex_ws = lifetime["codex_ws"]
+    assert compression["compressions_by_strategy"] == {"smart_crusher": 1}
+    assert compression["tokens_saved_by_strategy"] == {"smart_crusher": 30}
+    assert cache["bust_count"] == 1
+    assert cache["bust_tokens"] == 11
+    assert codex_ws["units_total"] == 1
+    assert codex_ws["frames_attempted_total"] == 1
+
+
+def test_graceful_flush_persists_aggregate_only_updates(tmp_path):
+    path = tmp_path / "proxy_savings.json"
+    metrics = PrometheusMetrics(savings_tracker=SavingsTracker(path=str(path), save_flush_every=25))
+
+    metrics.record_compression("smart_crusher", 100, 70)
+    asyncio.run(metrics.record_cache_bust(11))
+    metrics.record_codex_ws_frame(
+        elapsed_ms=9.0,
+        bytes_before=256,
+        bytes_after=180,
+        attempted_tokens=100,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        final_strategies=["smart_crusher"],
+    )
+    assert not path.exists()
+
+    metrics.savings_tracker.flush()
+    persisted = json.loads(path.read_text())
+    assert persisted["lifetime_metrics"]["compression"]["compressions_by_strategy"] == {
+        "smart_crusher": 1
+    }
+    assert persisted["lifetime_metrics"]["prefix_cache"]["bust_count"] == 1
+    assert persisted["lifetime_metrics"]["codex_ws"]["frames_attempted_total"] == 1

--- a/tests/test_proxy_persistent_aggregates.py
+++ b/tests/test_proxy_persistent_aggregates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -454,3 +455,423 @@ def test_graceful_flush_persists_aggregate_only_updates(tmp_path):
     }
     assert persisted["lifetime_metrics"]["prefix_cache"]["bust_count"] == 1
     assert persisted["lifetime_metrics"]["codex_ws"]["frames_attempted_total"] == 1
+
+
+FIXED_NOW = datetime(2026, 8, 5, 9, 0, 0, tzinfo=timezone.utc)
+
+
+def _expired_session_seed(
+    *, request_total: int = 3, session_last_activity: datetime = FIXED_NOW
+) -> dict:
+    """State whose display session last saw activity at session_last_activity.
+
+    ``session_last_activity`` defaults to ``FIXED_NOW`` so the session is still
+    fresh inside the inactivity window at construction; the caller advances the
+    clock past ``display_session_inactivity_minutes`` to cross the boundary.
+    """
+    return {
+        "schema_version": 5,
+        "lifetime": {
+            "requests": 0,
+            "tokens_saved": 0,
+            "compression_savings_usd": 0.0,
+            "cache_read_tokens": 0,
+            "cache_savings_usd": 0.0,
+            "total_input_tokens": 0,
+            "total_input_cost_usd": 0.0,
+        },
+        "display_session": {
+            "requests": 0,
+            "tokens_saved": 0,
+            "compression_savings_usd": 0.0,
+            "cache_read_tokens": 0,
+            "cache_savings_usd": 0.0,
+            "total_input_tokens": 0,
+            "total_input_cost_usd": 0.0,
+            "started_at": "2026-01-01T00:00:00Z",
+            "last_activity_at": "2026-01-01T00:00:00Z",
+        },
+        "history": [],
+        "projects": {},
+        "by_model": {},
+        "lifetime_metrics": {
+            "started_at": "2026-01-01T00:00:00Z",
+            "last_activity_at": "2026-01-01T00:00:00Z",
+            "full_fidelity_started_at": "2026-01-01T00:00:00Z",
+            "requests": {
+                "total": request_total,
+                "cached": 1,
+                "failed": 1,
+                "rate_limited": 1,
+                "by_provider": {"openai": request_total},
+                "by_stack": {"cli": request_total},
+            },
+            "tokens": {
+                "input": 900,
+                "output": 60,
+                "attempted_input": 960,
+                "saved": 90,
+            },
+            "prefix_cache": {
+                "requests": 1,
+                "hit_requests": 1,
+                "cache_read_tokens": 40,
+                "cache_write_tokens": 60,
+                "cache_write_5m_tokens": 10,
+                "cache_write_1h_tokens": 50,
+                "uncached_input_tokens": 20,
+                "cache_write_5m_requests": 1,
+                "cache_write_1h_requests": 1,
+                "bust_count": 1,
+                "bust_tokens": 11,
+                "misses_by_reason": {"prefix_change": 1},
+                "by_provider": {"openai": 1},
+            },
+            "cost": {
+                "input_usd": 1.0,
+                "compression_savings_usd": 0.3,
+                "cache_savings_usd": 0.1,
+            },
+            "compression": {
+                "compressions_by_strategy": {"smart_crusher": 5},
+                "tokens_saved_by_strategy": {"smart_crusher": 150},
+            },
+            "codex_ws": {
+                "units_total": 2,
+                "units_modified_total": 1,
+                "units_to_kompress_total": 0,
+                "units_kompress_attempted_total": 0,
+                "units_by_strategy": {"smart_crusher": 2},
+                "units_by_category": {"tool_result": 2},
+                "units_by_content_type": {"text": 2},
+                "units_by_text_shape": {"json": 2},
+                "unit_elapsed_ms_sum": 10.0,
+                "unit_elapsed_ms_max": 5.0,
+                "unit_bytes_sum": 256,
+                "unit_tokens_before_sum": 200,
+                "unit_tokens_after_sum": 140,
+                "unit_tokens_saved_sum": 60,
+                "frames_attempted_total": 1,
+                "frames_compressed_total": 1,
+                "frames_failed_total": 0,
+                "frames_to_kompress_total": 0,
+                "frames_kompress_attempted_total": 0,
+                "frame_elapsed_ms_sum": 9.0,
+                "frame_elapsed_ms_max": 9.0,
+                "frame_bytes_before_sum": 256,
+                "frame_bytes_after_sum": 180,
+                "frame_attempted_tokens_sum": 100,
+                "frame_tokens_saved_sum": 30,
+            },
+            "waste_signals": {"repetition": 7},
+            "models": {
+                "tracked": {},
+                "other": {
+                    "requests": request_total,
+                    "input_tokens": 900,
+                    "output_tokens": 60,
+                    "attempted_input_tokens": 960,
+                    "tokens_saved": 90,
+                    "last_activity_at": "2026-01-01T00:00:00Z",
+                },
+            },
+            "persistence": {"last_saved_at": "2026-01-01T00:00:00Z"},
+        },
+        "display_session_metrics": {
+            "started_at": session_last_activity.isoformat(),
+            "last_activity_at": session_last_activity.isoformat(),
+            "full_fidelity_started_at": session_last_activity.isoformat(),
+            "requests": {
+                "total": request_total,
+                "cached": 1,
+                "failed": 1,
+                "rate_limited": 1,
+                "by_provider": {"openai": request_total},
+                "by_stack": {"cli": request_total},
+            },
+            "tokens": {
+                "input": 900,
+                "output": 60,
+                "attempted_input": 960,
+                "saved": 90,
+            },
+            "prefix_cache": {
+                "requests": 1,
+                "hit_requests": 1,
+                "cache_read_tokens": 40,
+                "cache_write_tokens": 60,
+                "cache_write_5m_tokens": 10,
+                "cache_write_1h_tokens": 50,
+                "uncached_input_tokens": 20,
+                "cache_write_5m_requests": 1,
+                "cache_write_1h_requests": 1,
+                "bust_count": 1,
+                "bust_tokens": 11,
+                "misses_by_reason": {"prefix_change": 1},
+                "by_provider": {"openai": 1},
+            },
+            "cost": {
+                "input_usd": 1.0,
+                "compression_savings_usd": 0.3,
+                "cache_savings_usd": 0.1,
+            },
+            "compression": {
+                "compressions_by_strategy": {"smart_crusher": 5},
+                "tokens_saved_by_strategy": {"smart_crusher": 150},
+            },
+            "codex_ws": {
+                "units_total": 2,
+                "units_modified_total": 1,
+                "units_to_kompress_total": 0,
+                "units_kompress_attempted_total": 0,
+                "units_by_strategy": {"smart_crusher": 2},
+                "units_by_category": {"tool_result": 2},
+                "units_by_content_type": {"text": 2},
+                "units_by_text_shape": {"json": 2},
+                "unit_elapsed_ms_sum": 10.0,
+                "unit_elapsed_ms_max": 5.0,
+                "unit_bytes_sum": 256,
+                "unit_tokens_before_sum": 200,
+                "unit_tokens_after_sum": 140,
+                "unit_tokens_saved_sum": 60,
+                "frames_attempted_total": 1,
+                "frames_compressed_total": 1,
+                "frames_failed_total": 0,
+                "frames_to_kompress_total": 0,
+                "frames_kompress_attempted_total": 0,
+                "frame_elapsed_ms_sum": 9.0,
+                "frame_elapsed_ms_max": 9.0,
+                "frame_bytes_before_sum": 256,
+                "frame_bytes_after_sum": 180,
+                "frame_attempted_tokens_sum": 100,
+                "frame_tokens_saved_sum": 30,
+            },
+            "waste_signals": {"repetition": 7},
+            "models": {
+                "tracked": {},
+                "other": {
+                    "requests": request_total,
+                    "input_tokens": 900,
+                    "output_tokens": 60,
+                    "attempted_input_tokens": 960,
+                    "tokens_saved": 90,
+                    "last_activity_at": "2026-01-01T00:00:00Z",
+                },
+            },
+            "persistence": {"last_saved_at": "2026-01-01T00:00:00Z"},
+        },
+    }
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = FIXED_NOW
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, minutes: int) -> None:
+        self.now = self.now + timedelta(minutes=minutes)
+
+
+def _expired_tracker(tmp_path, clock: _FakeClock) -> SavingsTracker:
+    path = tmp_path / "proxy_savings.json"
+    path.write_text(json.dumps(_expired_session_seed()), encoding="utf-8")
+    tracker = SavingsTracker(
+        path=str(path),
+        now=clock,
+    )
+    clock.advance(minutes=180)
+    return tracker
+
+
+def test_expired_display_session_resets_when_compression_precedes_request(tmp_path):
+    clock = _FakeClock()
+    tracker = _expired_tracker(tmp_path, clock)
+
+    tracker.record_compression(strategy="smart_crusher", original_tokens=100, compressed_tokens=70)
+    tracker.record_lifetime_request(
+        provider="anthropic",
+        stack="codex",
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=30,
+    )
+
+    display = tracker.display_session_response()
+    assert display["requests"]["total"] == 1
+    assert display["requests"]["by_provider"] == {"anthropic": 1}
+    assert display["requests"]["by_stack"] == {"codex": 1}
+    assert display["tokens"]["input"] == 120
+    assert display["tokens"]["saved"] == 30
+    assert display["tokens"]["output"] == 0
+    assert display["compression"]["compressions_by_strategy"] == {"smart_crusher": 1}
+    assert display["compression"]["tokens_saved_by_strategy"] == {"smart_crusher": 30}
+    assert "openai" not in display["requests"]["by_provider"]
+    assert "cli" not in display["requests"]["by_stack"]
+
+
+def test_expired_display_session_resets_when_codex_ws_precedes_request(tmp_path):
+    clock = _FakeClock()
+    tracker = _expired_tracker(tmp_path, clock)
+
+    tracker.record_codex_ws_unit(
+        strategy="smart_crusher",
+        reason_category="tool_result",
+        elapsed_ms=5.0,
+        text_bytes=128,
+        tokens_before=100,
+        tokens_after=70,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        content_type="text",
+        text_shape="json",
+    )
+    tracker.record_codex_ws_frame(
+        elapsed_ms=9.0,
+        bytes_before=256,
+        bytes_after=180,
+        attempted_tokens=100,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        final_strategies=["smart_crusher"],
+    )
+    tracker.record_lifetime_request(
+        provider="anthropic",
+        stack="codex",
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=30,
+    )
+
+    display = tracker.display_session_response()
+    assert display["requests"]["total"] == 1
+    assert display["requests"]["by_provider"] == {"anthropic": 1}
+    assert display["tokens"]["saved"] == 30
+    assert display["codex_ws"]["units_total"] == 1
+    assert display["codex_ws"]["units_modified_total"] == 1
+    assert display["codex_ws"]["unit_tokens_saved_sum"] == 30
+    assert display["codex_ws"]["frames_attempted_total"] == 1
+    assert display["codex_ws"]["frame_tokens_saved_sum"] == 30
+
+
+def test_aggregate_only_writers_reset_expired_display_session(tmp_path):
+    clock = _FakeClock()
+
+    tracker = _expired_tracker(tmp_path, clock)
+    tracker.record_lifetime_stack("codex")
+    display = tracker.display_session_response()
+    assert display["requests"]["total"] == 0
+    assert display["requests"]["by_stack"] == {"codex": 1}
+    assert "cli" not in display["requests"]["by_stack"]
+
+    tracker = _expired_tracker(tmp_path, clock)
+    tracker.record_lifetime_failed(provider="anthropic", model="gpt-4o")
+    display = tracker.display_session_response()
+    assert display["requests"]["failed"] == 1
+    assert display["requests"]["total"] == 0
+
+    tracker = _expired_tracker(tmp_path, clock)
+    tracker.record_lifetime_rate_limited(provider="anthropic", model="gpt-4o")
+    display = tracker.display_session_response()
+    assert display["requests"]["rate_limited"] == 1
+    assert display["requests"]["total"] == 0
+
+    tracker = _expired_tracker(tmp_path, clock)
+    tracker.record_lifetime_cache_bust(tokens_lost=11)
+    display = tracker.display_session_response()
+    assert display["prefix_cache"]["bust_count"] == 1
+    assert display["prefix_cache"]["bust_tokens"] == 11
+
+    tracker = _expired_tracker(tmp_path, clock)
+    tracker.record_lifetime_cache_miss(provider="anthropic", reason="prefix_change")
+    display = tracker.display_session_response()
+    assert display["prefix_cache"]["misses_by_reason"] == {"prefix_change": 1}
+
+
+def test_read_path_reset_stays_in_memory_until_next_record_save(tmp_path):
+    path = tmp_path / "proxy_savings.json"
+    path.write_text(json.dumps(_expired_session_seed()), encoding="utf-8")
+    clock = _FakeClock()
+    tracker = SavingsTracker(path=str(path), now=clock)
+    clock.advance(minutes=180)
+
+    display = tracker.display_session_response()
+    assert display["requests"]["total"] == 0
+
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["display_session_metrics"]["requests"]["total"] == 3
+
+    tracker.record_compression(strategy="smart_crusher", original_tokens=100, compressed_tokens=70)
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["display_session_metrics"]["requests"]["total"] == 0
+    assert persisted["display_session_metrics"]["compression"]["compressions_by_strategy"] == {
+        "smart_crusher": 1
+    }
+
+
+_AGGREGATE_RECORDERS = {
+    "stack": lambda tracker: tracker.record_lifetime_stack("codex"),
+    "failed": lambda tracker: tracker.record_lifetime_failed(provider="anthropic", model="gpt-4o"),
+    "rate_limited": lambda tracker: tracker.record_lifetime_rate_limited(
+        provider="anthropic", model="gpt-4o"
+    ),
+    "cache_bust": lambda tracker: tracker.record_lifetime_cache_bust(tokens_lost=5),
+    "cache_miss": lambda tracker: tracker.record_lifetime_cache_miss(
+        provider="anthropic", reason="prefix_change"
+    ),
+    "compression": lambda tracker: tracker.record_compression(
+        strategy="smart_crusher", original_tokens=100, compressed_tokens=70
+    ),
+    "codex_ws_unit": lambda tracker: tracker.record_codex_ws_unit(
+        strategy="smart_crusher",
+        reason_category="tool_result",
+        elapsed_ms=5.0,
+        text_bytes=128,
+        tokens_before=100,
+        tokens_after=70,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        content_type="text",
+        text_shape="json",
+    ),
+    "codex_ws_frame": lambda tracker: tracker.record_codex_ws_frame(
+        elapsed_ms=9.0,
+        bytes_before=256,
+        bytes_after=180,
+        attempted_tokens=100,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        final_strategies=["smart_crusher"],
+    ),
+    "request": lambda tracker: tracker.record_lifetime_request(
+        provider="anthropic",
+        stack="codex",
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=30,
+    ),
+}
+
+
+def test_expired_prior_session_totals_gone_from_display_but_kept_in_lifetime(tmp_path):
+    for method in _AGGREGATE_RECORDERS:
+        clock = _FakeClock()
+        tracker = _expired_tracker(tmp_path, clock)
+        _AGGREGATE_RECORDERS[method](tracker)
+
+        display = tracker.display_session_response()
+        assert "openai" not in display["requests"]["by_provider"]
+        assert "cli" not in display["requests"]["by_stack"]
+        assert display["tokens"]["saved"] < 90
+        assert display["prefix_cache"]["bust_tokens"] < 11
+
+        lifetime = tracker._persistent_metrics.to_dict()
+        assert "openai" in lifetime["requests"]["by_provider"]
+        assert "cli" in lifetime["requests"]["by_stack"]
+        assert lifetime["tokens"]["saved"] >= 90
+        assert lifetime["prefix_cache"]["bust_tokens"] >= 11


### PR DESCRIPTION
## Description

The Session tab of `/dashboard` currently mixes lifetime and current-process values without saying which window a card represents. After a restart, the hero savings tile can keep a durable lifetime value while the cache and per-model cards reset or disappear, and the UI gives the operator no way to ask whether a number is for the current process, the durable display session, or lifetime totals.

This PR adds the `Current process / Session / Lifetime` selector requested in #2137 for the cards where all three scopes are meaningful. It consumes the additive `metric_scopes` block added by the stacked backend slice, routes only the eligible cards through that selector, labels inherently process-local widgets as `Current process`, and preserves fixed-lifetime widgets like `Per-Project Savings`.

The selector defaults to Lifetime so the current hero headline stays unchanged on upgrade. When the additive `metric_scopes` block is absent, the selector stays hidden and the dashboard renders the current `main` bindings unchanged.

Closes #2137.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Added selector state and scope accessors to the dashboard Session view for `Current process`, `Session`, and `Lifetime`.
- Routed the scope-meaningful cards through the additive `metric_scopes` contract, starting with `Proxy $ Saved`, `Prefix Cache Impact`, and any existing request or aggregate tiles that the backend contract supplies in all three scopes without inventing values.
- Added visible freshness text using `process_started_at` for current-process values and `updated_at` for durable values.
- Kept fixed-lifetime widgets lifetime-wired and labelled them accurately.
- Labelled process-local widgets as `Current process` instead of letting them read as restart-zeroed lifetime values, including `Per-Model Token Savings`, `Cache Miss Attribution`, the per-provider cache breakdown, and the Prefix Freeze tile unless the backend contract later supplies full three-scope support for those widgets.
- Made the `Prefix Cache Impact` card selected-scope-aware, preserved the old no-`metric_scopes` unavailable fallback for writes, hit rate, and busts when only lifetime cache reads exist, and restored current-process net-savings and write-premium hints beside the new selector wiring.
- Tightened selected-scope cache availability guards so incomplete cache scopes render `Unavailable`, hide the cache-efficiency bar, and mark the scope-sensitive `Compression vs Cache` values unavailable instead of silently borrowing zeros.
- Added focused template-contract and Playwright coverage for selector transitions, missing-field handling, process-local labelling, Historical-tab preservation, responsive layout, and the existing lifetime-cache restart canary's hidden-efficiency expectation.

## Testing

- [x] Unit tests pass (`uv run pytest tests/test_dashboard_scope_contract.py -q`)
- [ ] Browser coverage is CI-owned; the local Playwright module skipped without `playwright.sync_api` (`uv run pytest tests/test_dashboard_scope_selector_playwright.py -q`)
- [ ] Existing dashboard render canaries are CI-owned; the local Playwright modules skipped without `playwright.sync_api` (`uv run pytest tests/test_dashboard_cache_lifetime_playwright.py tests/test_dashboard_cache_net_playwright.py tests/test_dashboard_cache_ttl_playwright.py -q`)
- [x] Linting passes (`uv run ruff check tests/test_dashboard_scope_selector_playwright.py tests/test_dashboard_scope_contract.py`)
- [x] Formatting passes (`uv run ruff format --check tests/test_dashboard_scope_selector_playwright.py tests/test_dashboard_scope_contract.py`)
- [x] New tests added for new functionality when applicable
- [ ] Manual testing performed

### Test Output

```text
6 passed in 0.15s
```

```text
collected 0 items / 1 skipped

1 skipped in 0.13s
```

```text
collected 0 items / 3 skipped

3 skipped in 0.29s
```

```text
All checks passed!
```

```text
2 files already formatted
```

## Real Behavior Proof

- Environment: dashboard template plus focused tests; rendered layout is owned by CI Playwright.
- Exact command / steps: run the template-contract checks for additive fallback, selected-scope cache guards, and process-local labelling hooks, then run the CI-owned Playwright modules in the local environment to record whether rendered proof is reachable here.
- Observed result: the local contract checks passed, confirming the template contains the selector hide gate, the legacy no-`metric_scopes` unavailable fallback for process-local cache metrics, the selected-scope cache `Unavailable` guard, the cache-efficiency suppression and `Compression vs Cache` unavailable guard for incomplete cache scopes, the selected-scope cache-card visibility gate, and the explicit process-local labels for the remaining live widgets. The Playwright modules skipped locally because `playwright.sync_api` is unavailable here, so rendered selector transitions, Historical-tab independence, and responsive layout remain delegated to the `Dashboard Playwright` workflow.
- Not tested: authoritative rendered layout on this Windows host.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

- This slice consumes the additive `metric_scopes` backend contract from the stacked `2137-1` branch and does not touch proxy persistence or `/metrics`.
- The final diff from `fork/pr/2137-dashboard-persistent-aggregates` is `headroom/dashboard/templates/dashboard.html`, `tests/test_dashboard_cache_lifetime_playwright.py`, `tests/test_dashboard_scope_contract.py`, and `tests/test_dashboard_scope_selector_playwright.py`.
- GitHub will temporarily show the parent backend commit in this PR until the stacked `2137-1` branch lands, because this branch is based on that parent slice.
- `Per-Project Savings` stays lifetime-wired on purpose because the backend contract does not expose process- or session-scoped per-project totals.
- The rendered layout claim is CI-owned through the existing `Dashboard Playwright` workflow.
- Headroom's release pipeline generates changelog entries from conventional commits, so `CHANGELOG.md` is intentionally untouched.
