### PR TITLE
feat(proxy): persist dashboard scope aggregates across restarts (#2137)

### DIFF
--- a/headroom/proxy/persistent_metrics.py
+++ b/headroom/proxy/persistent_metrics.py
@@ -14,6 +14,7 @@ MAX_STACK_VALUES = 64
 MAX_TRACKED_MODELS = 200
 MAX_EXPOSED_MODELS = 100
 MAX_LABEL_LENGTH = 128
+MAX_SCOPE_LABELS = 64
 
 KNOWN_MISS_REASONS = frozenset({"ttl_expiry", "prefix_change", "unknown"})
 KNOWN_WASTE_SIGNALS = frozenset(
@@ -100,6 +101,8 @@ def _empty_state() -> dict[str, Any]:
             "cache_write_5m_tokens": 0,
             "cache_write_1h_tokens": 0,
             "uncached_input_tokens": 0,
+            "cache_write_5m_requests": 0,
+            "cache_write_1h_requests": 0,
             "bust_count": 0,
             "bust_tokens": 0,
             "misses_by_reason": {},
@@ -108,6 +111,37 @@ def _empty_state() -> dict[str, Any]:
         "cost": {"input_usd": 0.0, "compression_savings_usd": 0.0, "cache_savings_usd": 0.0},
         "waste_signals": {},
         "models": {"tracked": {}, "other": _model_entry()},
+        "compression": {
+            "compressions_by_strategy": {},
+            "tokens_saved_by_strategy": {},
+        },
+        "codex_ws": {
+            "units_total": 0,
+            "units_modified_total": 0,
+            "units_to_kompress_total": 0,
+            "units_kompress_attempted_total": 0,
+            "units_by_strategy": {},
+            "units_by_category": {},
+            "units_by_content_type": {},
+            "units_by_text_shape": {},
+            "unit_elapsed_ms_sum": 0.0,
+            "unit_elapsed_ms_max": 0.0,
+            "unit_bytes_sum": 0,
+            "unit_tokens_before_sum": 0,
+            "unit_tokens_after_sum": 0,
+            "unit_tokens_saved_sum": 0,
+            "frames_attempted_total": 0,
+            "frames_compressed_total": 0,
+            "frames_failed_total": 0,
+            "frames_to_kompress_total": 0,
+            "frames_kompress_attempted_total": 0,
+            "frame_elapsed_ms_sum": 0.0,
+            "frame_elapsed_ms_max": 0.0,
+            "frame_bytes_before_sum": 0,
+            "frame_bytes_after_sum": 0,
+            "frame_attempted_tokens_sum": 0,
+            "frame_tokens_saved_sum": 0,
+        },
         "persistence": {"last_saved_at": None},
     }
 
@@ -160,6 +194,8 @@ class PersistentMetricsState:
             "cache_write_5m_tokens",
             "cache_write_1h_tokens",
             "uncached_input_tokens",
+            "cache_write_5m_requests",
+            "cache_write_1h_requests",
             "bust_count",
             "bust_tokens",
         ):
@@ -170,6 +206,50 @@ class PersistentMetricsState:
         result["prefix_cache"]["misses_by_reason"] = self._normalize_enum_map(
             raw_cache.get("misses_by_reason"), KNOWN_MISS_REASONS
         )
+
+        raw_compression = _dict_or_empty(source.get("compression"))
+        for key in ("compressions_by_strategy", "tokens_saved_by_strategy"):
+            result["compression"][key] = self._normalize_count_map(
+                raw_compression.get(key), MAX_SCOPE_LABELS
+            )
+        raw_ws = _dict_or_empty(source.get("codex_ws"))
+        int_fields = [
+            "units_total",
+            "units_modified_total",
+            "units_to_kompress_total",
+            "units_kompress_attempted_total",
+            "unit_bytes_sum",
+            "unit_tokens_before_sum",
+            "unit_tokens_after_sum",
+            "unit_tokens_saved_sum",
+            "frames_attempted_total",
+            "frames_compressed_total",
+            "frames_failed_total",
+            "frames_to_kompress_total",
+            "frames_kompress_attempted_total",
+            "frame_bytes_before_sum",
+            "frame_bytes_after_sum",
+            "frame_attempted_tokens_sum",
+            "frame_tokens_saved_sum",
+        ]
+        float_fields = [
+            "unit_elapsed_ms_sum",
+            "unit_elapsed_ms_max",
+            "frame_elapsed_ms_sum",
+            "frame_elapsed_ms_max",
+        ]
+        map_fields = [
+            "units_by_strategy",
+            "units_by_category",
+            "units_by_content_type",
+            "units_by_text_shape",
+        ]
+        for key in int_fields:
+            result["codex_ws"][key] = _coerce_int(raw_ws.get(key))
+        for key in float_fields:
+            result["codex_ws"][key] = round(_coerce_float(raw_ws.get(key)), 6)
+        for key in map_fields:
+            result["codex_ws"][key] = self._normalize_count_map(raw_ws.get(key), MAX_SCOPE_LABELS)
 
         raw_cost = _dict_or_empty(source.get("cost"))
         for key in ("input_usd", "compression_savings_usd", "cache_savings_usd"):
@@ -303,8 +383,8 @@ class PersistentMetricsState:
     def record_request(
         self,
         *,
-        provider: str | None,
-        stack: str | None,
+        provider: str | None = None,
+        stack: str | None = None,
         model: str | None,
         input_tokens: Any = 0,
         output_tokens: Any = 0,
@@ -316,6 +396,8 @@ class PersistentMetricsState:
         cache_write_tokens: Any = 0,
         cache_write_5m_tokens: Any = 0,
         cache_write_1h_tokens: Any = 0,
+        cache_write_5m_requests: Any = 0,
+        cache_write_1h_requests: Any = 0,
         uncached_input_tokens: Any = 0,
         input_usd: Any = 0.0,
         compression_savings_usd: Any = 0.0,
@@ -346,14 +428,19 @@ class PersistentMetricsState:
         tokens["saved"] += saved_delta
 
         cache = self._state["prefix_cache"]
-        cache["requests"] += 1
-        cache["hit_requests"] += int(bool(cached))
-        cache["cache_read_tokens"] += _coerce_int(cache_read_tokens)
-        cache["cache_write_tokens"] += _coerce_int(cache_write_tokens)
-        cache["cache_write_5m_tokens"] += _coerce_int(cache_write_5m_tokens)
-        cache["cache_write_1h_tokens"] += _coerce_int(cache_write_1h_tokens)
-        cache["uncached_input_tokens"] += _coerce_int(uncached_input_tokens)
-        self._increment_count(cache["by_provider"], provider_label, MAX_PROVIDER_VALUES)
+        cache_read_delta = _coerce_int(cache_read_tokens)
+        cache_write_delta = _coerce_int(cache_write_tokens)
+        if cache_read_delta > 0 or cache_write_delta > 0:
+            cache["requests"] += 1
+            cache["hit_requests"] += int(cache_read_delta > 0)
+            cache["cache_read_tokens"] += cache_read_delta
+            cache["cache_write_tokens"] += cache_write_delta
+            cache["cache_write_5m_tokens"] += _coerce_int(cache_write_5m_tokens)
+            cache["cache_write_1h_tokens"] += _coerce_int(cache_write_1h_tokens)
+            cache["cache_write_5m_requests"] += _coerce_int(cache_write_5m_requests)
+            cache["cache_write_1h_requests"] += _coerce_int(cache_write_1h_requests)
+            cache["uncached_input_tokens"] += _coerce_int(uncached_input_tokens)
+            self._increment_count(cache["by_provider"], provider_label, MAX_PROVIDER_VALUES)
 
         cost = self._state["cost"]
         cost["input_usd"] = round(cost["input_usd"] + _coerce_float(input_usd), 6)
@@ -405,6 +492,95 @@ class PersistentMetricsState:
         cache = self._state["prefix_cache"]
         cache["bust_count"] += 1
         cache["bust_tokens"] += _coerce_int(tokens_lost)
+
+    def record_compression(
+        self, *, strategy: str, original_tokens: Any, compressed_tokens: Any
+    ) -> None:
+        self._record_activity()
+        key = _label(strategy)
+        self._increment_count(
+            self._state["compression"]["compressions_by_strategy"], key, MAX_SCOPE_LABELS
+        )
+        saved = max(_coerce_int(original_tokens) - _coerce_int(compressed_tokens), 0)
+        if saved:
+            values = self._state["compression"]["tokens_saved_by_strategy"]
+            values[key] = values.get(key, 0) + saved
+            self._compact_count_map(values, MAX_SCOPE_LABELS)
+
+    def record_codex_ws_unit(
+        self,
+        *,
+        strategy: str,
+        reason_category: str,
+        elapsed_ms: Any,
+        text_bytes: Any,
+        tokens_before: Any,
+        tokens_after: Any,
+        tokens_saved: Any,
+        modified: bool,
+        strategy_chain: list[str] | None = None,
+        content_type: str = "unknown",
+        text_shape: str = "unknown",
+    ) -> None:
+        self._record_activity()
+        ws = self._state["codex_ws"]
+        ws["units_total"] += 1
+        for field, value in (
+            ("units_by_strategy", strategy),
+            ("units_by_category", reason_category),
+            ("units_by_content_type", content_type),
+            ("units_by_text_shape", text_shape),
+        ):
+            self._increment_count(ws[field], _label(value), MAX_SCOPE_LABELS)
+        ws["units_modified_total"] += int(modified)
+        chain = strategy_chain or []
+        ws["units_to_kompress_total"] += int(strategy == "kompress")
+        ws["units_kompress_attempted_total"] += int(strategy == "kompress" or "kompress" in chain)
+        elapsed = _coerce_float(elapsed_ms)
+        ws["unit_elapsed_ms_sum"] = round(ws["unit_elapsed_ms_sum"] + elapsed, 6)
+        ws["unit_elapsed_ms_max"] = max(ws["unit_elapsed_ms_max"], elapsed)
+        for field, value in (
+            ("unit_bytes_sum", text_bytes),
+            ("unit_tokens_before_sum", tokens_before),
+            ("unit_tokens_after_sum", tokens_after),
+            ("unit_tokens_saved_sum", tokens_saved),
+        ):
+            ws[field] += _coerce_int(value)
+
+    def record_codex_ws_frame(
+        self,
+        *,
+        elapsed_ms: Any,
+        bytes_before: Any,
+        bytes_after: Any = 0,
+        attempted_tokens: Any = 0,
+        tokens_saved: Any = 0,
+        modified: bool = False,
+        failed: bool = False,
+        strategy_chain: list[str] | None = None,
+        final_strategies: list[str] | None = None,
+    ) -> None:
+        self._record_activity()
+        ws = self._state["codex_ws"]
+        ws["frames_attempted_total"] += 1
+        ws["frames_compressed_total"] += int(modified)
+        ws["frames_failed_total"] += int(failed)
+        chain = strategy_chain or []
+        strategies = final_strategies or []
+        ws["frames_to_kompress_total"] += int("kompress" in strategies)
+        ws["frames_kompress_attempted_total"] += int(
+            "kompress" in chain or "kompress" in strategies
+        )
+        elapsed = _coerce_float(elapsed_ms)
+        ws["frame_elapsed_ms_sum"] = round(ws["frame_elapsed_ms_sum"] + elapsed, 6)
+        ws["frame_elapsed_ms_max"] = max(ws["frame_elapsed_ms_max"], elapsed)
+        for field, value in (
+            ("frame_bytes_before_sum", bytes_before),
+            ("frame_bytes_after_sum", bytes_after),
+            ("frame_attempted_tokens_sum", attempted_tokens),
+            ("frame_tokens_saved_sum", tokens_saved),
+        ):
+            ws[field] += _coerce_int(value)
 
     def record_cache_miss(self, *, provider: str | None, reason: str | None) -> None:
         self._record_activity()
@@ -461,6 +637,8 @@ class PersistentMetricsState:
                 "ttl_5m_percent": self._percent(cache["cache_write_5m_tokens"], cache_write_total),
             },
             "cost": deepcopy(self._state["cost"]),
+            "compression": deepcopy(self._state["compression"]),
+            "codex_ws": deepcopy(self._state["codex_ws"]),
             "waste_signals": deepcopy(self._state["waste_signals"]),
             "by_model": self._by_model_snapshot(),
             "persistence": {

--- a/headroom/proxy/prometheus_metrics.py
+++ b/headroom/proxy/prometheus_metrics.py
@@ -13,7 +13,7 @@ import asyncio
 import logging
 import threading
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -226,6 +226,9 @@ class PrometheusMetrics:
         self.ws_session_duration_sum_ms: dict[str, float] = defaultdict(float)
         self.ws_session_duration_count: dict[str, int] = defaultdict(int)
         self.ws_session_duration_max_ms: dict[str, float] = defaultdict(float)
+        self.process_started_at = (
+            datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        )
 
         # Aggregate waste signals
         self.waste_signals_total: dict[str, int] = defaultdict(int)
@@ -397,6 +400,9 @@ class PrometheusMetrics:
             self.cache_bust_count = 0
             self.cache_miss_attribution_by_provider.clear()
             self.savings_history = []
+            self.process_started_at = (
+                datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            )
 
         with self._stage_timing_lock:
             self.stage_timing_sum.clear()
@@ -496,6 +502,11 @@ class PrometheusMetrics:
         saved = original_tokens - compressed_tokens
         if saved > 0:
             self.tokens_saved_by_strategy[strategy] += saved
+        self.savings_tracker.record_compression(
+            strategy=strategy,
+            original_tokens=original_tokens,
+            compressed_tokens=compressed_tokens,
+        )
 
     def record_extension_savings(self, key: str, saved: int) -> None:
         """Accumulate tokens saved by a proxy extension, keyed by ``key``.
@@ -604,6 +615,19 @@ class PrometheusMetrics:
         self.codex_ws_unit_tokens_before_sum += max(0, int(tokens_before))
         self.codex_ws_unit_tokens_after_sum += max(0, int(tokens_after))
         self.codex_ws_unit_tokens_saved_sum += max(0, int(tokens_saved))
+        self.savings_tracker.record_codex_ws_unit(
+            strategy=strategy,
+            reason_category=reason_category,
+            elapsed_ms=elapsed_ms,
+            text_bytes=text_bytes,
+            tokens_before=tokens_before,
+            tokens_after=tokens_after,
+            tokens_saved=tokens_saved,
+            modified=modified,
+            strategy_chain=strategy_chain,
+            content_type=content_type,
+            text_shape=text_shape,
+        )
 
     def record_codex_ws_frame(
         self,
@@ -640,6 +664,17 @@ class PrometheusMetrics:
         self.codex_ws_frame_bytes_after_sum += max(0, int(bytes_after))
         self.codex_ws_frame_attempted_tokens_sum += max(0, int(attempted_tokens))
         self.codex_ws_frame_tokens_saved_sum += max(0, int(tokens_saved))
+        self.savings_tracker.record_codex_ws_frame(
+            elapsed_ms=elapsed_ms,
+            bytes_before=bytes_before,
+            bytes_after=bytes_after,
+            attempted_tokens=attempted_tokens,
+            tokens_saved=tokens_saved,
+            modified=modified,
+            failed=failed,
+            strategy_chain=strategy_chain,
+            final_strategies=final_strategies,
+        )
 
     def record_inbound_request(self, *, method: str, path: str) -> None:
         self.inbound_requests_total += 1
@@ -785,6 +820,10 @@ class PrometheusMetrics:
             if len(self.savings_history) > 500:
                 self.savings_history = self.savings_history[-500:]
 
+            persistent_uncached_input_tokens = (
+                uncached_input_tokens if cache_read_tokens > 0 or cache_write_tokens > 0 else 0
+            )
+
             self.savings_tracker.record_lifetime_request(
                 persist=False,
                 provider=provider,
@@ -800,7 +839,9 @@ class PrometheusMetrics:
                 cache_write_tokens=cache_write_tokens,
                 cache_write_5m_tokens=cache_write_5m_tokens,
                 cache_write_1h_tokens=cache_write_1h_tokens,
-                uncached_input_tokens=uncached_input_tokens,
+                cache_write_5m_requests=int(cache_write_5m_tokens > 0),
+                cache_write_1h_requests=int(cache_write_1h_tokens > 0),
+                uncached_input_tokens=persistent_uncached_input_tokens,
                 waste_signals=waste_signals,
             )
             total_input_tokens, total_input_cost_usd = self._current_savings_tracker_totals()
@@ -812,7 +853,7 @@ class PrometheusMetrics:
                 project=project,
                 cache_read_tokens=cache_read_tokens,
                 cache_write_tokens=cache_write_tokens,
-                uncached_input_tokens=uncached_input_tokens,
+                uncached_input_tokens=persistent_uncached_input_tokens,
                 total_input_tokens=total_input_tokens,
                 total_input_cost_usd=total_input_cost_usd,
                 output_tokens_saved=output_tokens_saved,
@@ -995,6 +1036,8 @@ class PrometheusMetrics:
             stage_timing_max_snapshot = dict(self.stage_timing_max)
         async with self._lock:
             lifetime_savings = self.savings_tracker.snapshot()["lifetime"]
+            lifetime_metrics = self.savings_tracker.lifetime_response()
+            lifetime_cache = lifetime_metrics.get("prefix_cache", {})
             lines: list[str] = []
             _append_metric(
                 lines,
@@ -1103,6 +1146,48 @@ class PrometheusMetrics:
                     "proxy savings tracker"
                 ),
                 value=lifetime_savings["compression_savings_usd"],
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_read_tokens_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache read tokens recorded by the proxy savings tracker",
+                value=lifetime_cache.get("cache_read_tokens", 0),
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_write_tokens_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache write tokens recorded by the proxy savings tracker",
+                value=lifetime_cache.get("cache_write_tokens", 0),
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_requests_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache-eligible requests recorded by the proxy savings tracker",
+                value=lifetime_cache.get("requests", 0),
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_hit_requests_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache-hit requests recorded by the proxy savings tracker",
+                value=lifetime_cache.get("hit_requests", 0),
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_bust_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache busts recorded by the proxy savings tracker",
+                value=lifetime_cache.get("bust_count", 0),
+            )
+            _append_metric(
+                lines,
+                name="headroom_persistent_savings_cache_bust_tokens_lost_total",
+                metric_type="counter",
+                help_text="Durable lifetime cache-bust tokens lost recorded by the proxy savings tracker",
+                value=lifetime_cache.get("bust_tokens", 0),
             )
             # NOTE: per-strategy compression breakdown is tracked
             # internally on `self.compressions_by_strategy` and

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -14,6 +14,7 @@ import math
 import os
 import tempfile
 import threading
+from collections.abc import Callable
 from csv import DictWriter
 from datetime import datetime, timedelta, timezone
 from io import StringIO
@@ -570,7 +571,14 @@ class SavingsTracker:
         display_session_inactivity_minutes: int = (DEFAULT_DISPLAY_SESSION_INACTIVITY_MINUTES),
         stateless: bool = False,
         save_flush_every: int = 1,
+        *,
+        now: Callable[[], datetime] | None = None,
     ) -> None:
+        # Injectable clock so tests can drive the display-session expiry and the
+        # state stamps with one value. Callers that pass nothing keep real wall
+        # time via a live lookup so existing module-level `_utc_now` monkeypatch
+        # tests keep working.
+        self._now = now if now is not None else lambda: _utc_now()
         # In stateless mode the tracker keeps live counters in memory but never
         # writes proxy_savings.json (honors HeadroomConfig.stateless, which
         # disables all filesystem writes for read-only / container deployments).
@@ -604,9 +612,11 @@ class SavingsTracker:
         self._persistence_error: str | None = None
         self._needs_schema_save = False
         self._state = self._load_state()
-        self._persistent_metrics = PersistentMetricsState(self._state.pop("lifetime_metrics", None))
+        self._persistent_metrics = PersistentMetricsState(
+            self._state.pop("lifetime_metrics", None), now=self._now
+        )
         self._display_metrics = PersistentMetricsState(
-            self._state.pop("display_session_metrics", None)
+            self._state.pop("display_session_metrics", None), now=self._now
         )
 
     @property
@@ -889,10 +899,7 @@ class SavingsTracker:
             "cache_savings_usd", _estimate_cache_savings_usd(model, cache_read_tokens)
         )
         with self._lock:
-            display_raw = self._display_metrics.to_dict()
-            last_activity = _parse_timestamp(display_raw.get("last_activity_at"))
-            if last_activity is not None and self._is_display_session_expired(last_activity):
-                self._display_metrics = PersistentMetricsState()
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_request(**metrics)
             self._display_metrics.record_request(**metrics)
             if persist:
@@ -902,6 +909,7 @@ class SavingsTracker:
         """Mirror the existing inbound stack dimension without another save."""
 
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_stack(stack)
             self._display_metrics.record_stack(stack)
 
@@ -911,6 +919,7 @@ class SavingsTracker:
         """Record a failed proxy request without changing legacy history."""
 
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_failed(provider=provider, model=model)
             self._display_metrics.record_failed(provider=provider, model=model)
             self._maybe_save_locked()
@@ -921,18 +930,21 @@ class SavingsTracker:
         """Record a rate-limited proxy request without changing legacy history."""
 
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_rate_limited(provider=provider, model=model)
             self._display_metrics.record_rate_limited(provider=provider, model=model)
             self._maybe_save_locked()
 
     def record_lifetime_cache_bust(self, *, tokens_lost: int) -> None:
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_cache_bust(tokens_lost=tokens_lost)
             self._display_metrics.record_cache_bust(tokens_lost=tokens_lost)
             self._maybe_save_locked()
 
     def record_lifetime_cache_miss(self, *, provider: str | None, reason: str | None) -> None:
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_cache_miss(provider=provider, reason=reason)
             self._display_metrics.record_cache_miss(provider=provider, reason=reason)
             self._maybe_save_locked()
@@ -941,6 +953,7 @@ class SavingsTracker:
         metrics = dict(metrics)
         metrics.pop("timestamp", None)
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_compression(**metrics)
             self._display_metrics.record_compression(**metrics)
             self._maybe_save_locked()
@@ -949,6 +962,7 @@ class SavingsTracker:
         metrics = dict(metrics)
         metrics.pop("timestamp", None)
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_codex_ws_unit(**metrics)
             self._display_metrics.record_codex_ws_unit(**metrics)
             self._maybe_save_locked()
@@ -957,6 +971,7 @@ class SavingsTracker:
         metrics = dict(metrics)
         metrics.pop("timestamp", None)
         with self._lock:
+            self._maybe_reset_display_session_locked()
             self._persistent_metrics.record_codex_ws_frame(**metrics)
             self._display_metrics.record_codex_ws_frame(**metrics)
             self._maybe_save_locked()
@@ -1088,15 +1103,23 @@ class SavingsTracker:
             response["projects"] = self._projects_snapshot_locked()
             return response
 
+    def _maybe_reset_display_session_locked(self) -> None:
+        """Reset an expired display session before the caller mutates it.
+
+        Caller must hold ``self._lock``. Run before the record call that stamps
+        a fresh timestamp, so expiry is gated on the stale timestamp. No-op when
+        no activity has been recorded (a fresh, empty session stays untouched).
+        """
+
+        last_activity = _parse_timestamp(self._display_metrics.to_dict().get("last_activity_at"))
+        if last_activity is not None and self._is_display_session_expired(last_activity):
+            self._display_metrics = PersistentMetricsState(now=self._now)
+
     def display_session_response(self) -> dict[str, Any]:
         """Return the current durable display-session aggregate."""
 
         with self._lock:
-            last_activity = _parse_timestamp(
-                self._display_metrics.to_dict().get("last_activity_at")
-            )
-            if last_activity is not None and self._is_display_session_expired(last_activity):
-                self._display_metrics = PersistentMetricsState()
+            self._maybe_reset_display_session_locked()
             return self._display_metrics.snapshot(
                 persistence={
                     "enabled": not self._stateless,
@@ -1633,9 +1656,9 @@ class SavingsTracker:
         *,
         reference_time: datetime | None = None,
     ) -> bool:
-        return (reference_time or _utc_now()) - last_activity > timedelta(
-            minutes=self._display_session_inactivity_minutes
-        )
+        return (
+            reference_time if reference_time is not None else self._now()
+        ) - last_activity > timedelta(minutes=self._display_session_inactivity_minutes)
 
     def _build_rollup(
         self,

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -18,7 +18,7 @@ from csv import DictWriter
 from datetime import datetime, timedelta, timezone
 from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from headroom import paths as _paths
 from headroom.proxy import project_name_policy
@@ -605,6 +605,9 @@ class SavingsTracker:
         self._needs_schema_save = False
         self._state = self._load_state()
         self._persistent_metrics = PersistentMetricsState(self._state.pop("lifetime_metrics", None))
+        self._display_metrics = PersistentMetricsState(
+            self._state.pop("display_session_metrics", None)
+        )
 
     @property
     def storage_path(self) -> str:
@@ -861,6 +864,8 @@ class SavingsTracker:
     def record_lifetime_request(self, *, persist: bool = True, **metrics: Any) -> None:
         """Record one completed request in the durable Lifetime aggregate."""
 
+        metrics = dict(metrics)
+        metrics.pop("timestamp", None)
         model = _normalize_model(metrics.get("model"))
         input_tokens = _coerce_int(metrics.get("input_tokens"))
         cache_read_tokens = _coerce_int(metrics.get("cache_read_tokens"))
@@ -884,7 +889,12 @@ class SavingsTracker:
             "cache_savings_usd", _estimate_cache_savings_usd(model, cache_read_tokens)
         )
         with self._lock:
+            display_raw = self._display_metrics.to_dict()
+            last_activity = _parse_timestamp(display_raw.get("last_activity_at"))
+            if last_activity is not None and self._is_display_session_expired(last_activity):
+                self._display_metrics = PersistentMetricsState()
             self._persistent_metrics.record_request(**metrics)
+            self._display_metrics.record_request(**metrics)
             if persist:
                 self._maybe_save_locked()
 
@@ -893,6 +903,7 @@ class SavingsTracker:
 
         with self._lock:
             self._persistent_metrics.record_stack(stack)
+            self._display_metrics.record_stack(stack)
 
     def record_lifetime_failed(
         self, *, provider: str | None = None, model: str | None = None
@@ -901,6 +912,7 @@ class SavingsTracker:
 
         with self._lock:
             self._persistent_metrics.record_failed(provider=provider, model=model)
+            self._display_metrics.record_failed(provider=provider, model=model)
             self._maybe_save_locked()
 
     def record_lifetime_rate_limited(
@@ -910,16 +922,43 @@ class SavingsTracker:
 
         with self._lock:
             self._persistent_metrics.record_rate_limited(provider=provider, model=model)
+            self._display_metrics.record_rate_limited(provider=provider, model=model)
             self._maybe_save_locked()
 
     def record_lifetime_cache_bust(self, *, tokens_lost: int) -> None:
         with self._lock:
             self._persistent_metrics.record_cache_bust(tokens_lost=tokens_lost)
+            self._display_metrics.record_cache_bust(tokens_lost=tokens_lost)
             self._maybe_save_locked()
 
     def record_lifetime_cache_miss(self, *, provider: str | None, reason: str | None) -> None:
         with self._lock:
             self._persistent_metrics.record_cache_miss(provider=provider, reason=reason)
+            self._display_metrics.record_cache_miss(provider=provider, reason=reason)
+            self._maybe_save_locked()
+
+    def record_compression(self, **metrics: Any) -> None:
+        metrics = dict(metrics)
+        metrics.pop("timestamp", None)
+        with self._lock:
+            self._persistent_metrics.record_compression(**metrics)
+            self._display_metrics.record_compression(**metrics)
+            self._maybe_save_locked()
+
+    def record_codex_ws_unit(self, **metrics: Any) -> None:
+        metrics = dict(metrics)
+        metrics.pop("timestamp", None)
+        with self._lock:
+            self._persistent_metrics.record_codex_ws_unit(**metrics)
+            self._display_metrics.record_codex_ws_unit(**metrics)
+            self._maybe_save_locked()
+
+    def record_codex_ws_frame(self, **metrics: Any) -> None:
+        metrics = dict(metrics)
+        metrics.pop("timestamp", None)
+        with self._lock:
+            self._persistent_metrics.record_codex_ws_frame(**metrics)
+            self._display_metrics.record_codex_ws_frame(**metrics)
             self._maybe_save_locked()
 
     def _record_project_locked(
@@ -1049,6 +1088,28 @@ class SavingsTracker:
             response["projects"] = self._projects_snapshot_locked()
             return response
 
+    def display_session_response(self) -> dict[str, Any]:
+        """Return the current durable display-session aggregate."""
+
+        with self._lock:
+            last_activity = _parse_timestamp(
+                self._display_metrics.to_dict().get("last_activity_at")
+            )
+            if last_activity is not None and self._is_display_session_expired(last_activity):
+                self._display_metrics = PersistentMetricsState()
+            return self._display_metrics.snapshot(
+                persistence={
+                    "enabled": not self._stateless,
+                    "healthy": self._persistence_healthy,
+                    "error": (
+                        "Display-session metrics unavailable in stateless mode"
+                        if self._stateless
+                        else self._persistence_error
+                    ),
+                    "pending_records": 0 if self._stateless else self._since_save,
+                }
+            )
+
     def stats_preview(self, recent_points: int = 20) -> dict[str, Any]:
         """Return a compact preview for `/stats`."""
         snapshot = self.snapshot()
@@ -1064,6 +1125,15 @@ class SavingsTracker:
             "projects": snapshot["projects"],
             "projects_limit": DEFAULT_MAX_PROJECTS,
             "by_model": snapshot["by_model"],
+            "lifetime_metrics": self._persistent_metrics.snapshot(
+                persistence={
+                    "enabled": not self._stateless,
+                    "healthy": self._persistence_healthy,
+                    "error": self._persistence_error,
+                    "pending_records": 0 if self._stateless else self._since_save,
+                }
+            ),
+            "display_session_metrics": self.display_session_response(),
         }
 
     def history_response(self, history_mode: str = "compact") -> dict[str, Any]:
@@ -1182,6 +1252,8 @@ class SavingsTracker:
         }
 
     def _load_state(self) -> dict[str, Any]:
+        if self._stateless:
+            return self._default_state()
         if not self._path.exists():
             return self._default_state()
 
@@ -1286,6 +1358,27 @@ class SavingsTracker:
         else:
             state["lifetime_metrics"] = self._migrate_v4_lifetime_metrics(state)
             self._needs_schema_save = True
+        display_metrics = raw.get("display_session_metrics")
+        if not isinstance(display_metrics, dict):
+            display = cast(dict[str, Any], state["display_session"])
+            display_metrics = {
+                "started_at": display.get("started_at"),
+                "last_activity_at": display.get("last_activity_at"),
+                "tokens": {
+                    "input": display.get("total_input_tokens", 0),
+                    "attempted_input": display.get("total_input_tokens", 0)
+                    + display.get("tokens_saved", 0),
+                    "saved": display.get("tokens_saved", 0),
+                },
+                "cost": {
+                    "compression_savings_usd": display.get("compression_savings_usd", 0),
+                    "cache_savings_usd": display.get("cache_savings_usd", 0),
+                },
+                "requests": {"total": display.get("requests", 0)},
+                "prefix_cache": {"cache_read_tokens": display.get("cache_read_tokens", 0)},
+            }
+            self._needs_schema_save = True
+        state["display_session_metrics"] = display_metrics
 
         if normalized_history:
             reference_time = _parse_timestamp(normalized_history[-1]["timestamp"]) or _utc_now()
@@ -1440,14 +1533,20 @@ class SavingsTracker:
             saved_at = _to_utc_iso(_utc_now())
             lifetime_metrics = self._persistent_metrics.to_dict()
             lifetime_metrics["persistence"]["last_saved_at"] = saved_at
+            display_session = {
+                key: value
+                for key, value in self._state["display_session"].items()
+                if key != "aggregates"
+            }
             payload = {
                 "schema_version": SCHEMA_VERSION,
                 "lifetime": self._state["lifetime"],
-                "display_session": self._state["display_session"],
+                "display_session": display_session,
                 "history": self._state["history"],
                 "projects": self._state.get("projects", {}),
                 "by_model": self._state.get("by_model", {}),
                 "lifetime_metrics": lifetime_metrics,
+                "display_session_metrics": self._display_metrics.to_dict(),
             }
             json_data = json.dumps(payload, indent=2)
 

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2304,6 +2304,8 @@ def _request_can_view_dashboard_metadata(
         host_header = request.headers.get("host")
     except AttributeError:
         return False
+    if host_header is None:
+        return False
     if not is_ip_literal_host_header(host_header):
         return False
     # is_ip_literal_host_header() rejects a missing Host, so host_header is a str here.
@@ -3780,8 +3782,252 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         total_tokens_all_layers = all_layers_tokens_saved
         persistent_savings = m.savings_tracker.stats_preview()
         display_session = persistent_savings.get("display_session", {})
+        lifetime_scope = persistent_savings.get("lifetime_metrics", {})
+        display_session_scope = persistent_savings.get("display_session_metrics", {})
         recent_request_logs = proxy.logger.get_recent(10_000) if proxy.logger else []
         recent_request_payload = _build_recent_request_payload()
+
+        def _build_scope_cache(
+            raw_cache: dict[str, Any],
+            *,
+            cache_read_tokens: int,
+            cache_savings_usd: float,
+        ) -> dict[str, Any]:
+            cache_write_tokens = int(raw_cache.get("cache_write_tokens", 0) or 0)
+            uncached_input_tokens = int(raw_cache.get("uncached_input_tokens", 0) or 0)
+            requests = int(raw_cache.get("requests", 0) or 0)
+            hit_requests = int(raw_cache.get("hit_requests", 0) or 0)
+            total_input = cache_read_tokens + cache_write_tokens + uncached_input_tokens
+            observed_5m_tokens = int(raw_cache.get("cache_write_5m_tokens", 0) or 0)
+            observed_1h_tokens = int(raw_cache.get("cache_write_1h_tokens", 0) or 0)
+            observed_total_tokens = observed_5m_tokens + observed_1h_tokens
+            return {
+                "cache_read_tokens": cache_read_tokens,
+                "cache_savings_usd": round(float(cache_savings_usd or 0.0), 6),
+                "cache_write_tokens": cache_write_tokens,
+                "cache_write_5m_tokens": observed_5m_tokens,
+                "cache_write_1h_tokens": observed_1h_tokens,
+                "cache_write_5m_requests": int(raw_cache.get("cache_write_5m_requests", 0) or 0),
+                "cache_write_1h_requests": int(raw_cache.get("cache_write_1h_requests", 0) or 0),
+                "uncached_input_tokens": uncached_input_tokens,
+                "requests": requests,
+                "hit_requests": hit_requests,
+                "bust_count": int(raw_cache.get("bust_count", 0) or 0),
+                "bust_write_tokens": int(raw_cache.get("bust_write_tokens", 0) or 0),
+                "cache_bust_count": int(
+                    raw_cache.get("cache_bust_count", raw_cache.get("bust_count", 0)) or 0
+                ),
+                "cache_bust_tokens_lost": int(
+                    raw_cache.get("cache_bust_tokens_lost", raw_cache.get("bust_tokens", 0)) or 0
+                ),
+                "hit_rate": round(cache_read_tokens / total_input * 100, 1)
+                if total_input > 0
+                else 0.0,
+                "request_hit_rate": round(hit_requests / requests * 100, 1)
+                if requests > 0
+                else 0.0,
+                "observed_ttl_buckets": {
+                    "5m": {
+                        "tokens": observed_5m_tokens,
+                        "requests": int(raw_cache.get("cache_write_5m_requests", 0) or 0),
+                    },
+                    "1h": {
+                        "tokens": observed_1h_tokens,
+                        "requests": int(raw_cache.get("cache_write_1h_requests", 0) or 0),
+                    },
+                },
+                "observed_ttl_mix": {
+                    "5m_pct": round(observed_5m_tokens / observed_total_tokens * 100, 1)
+                    if observed_total_tokens > 0
+                    else 0.0,
+                    "1h_pct": round(observed_1h_tokens / observed_total_tokens * 100, 1)
+                    if observed_total_tokens > 0
+                    else 0.0,
+                    "active_buckets": [
+                        bucket
+                        for bucket, tokens in (
+                            ("5m", observed_5m_tokens),
+                            ("1h", observed_1h_tokens),
+                        )
+                        if tokens > 0
+                    ],
+                },
+            }
+
+        def _build_scope_compression(
+            flat_scope: dict[str, Any],
+            raw_compression: dict[str, Any],
+        ) -> dict[str, Any]:
+            return {
+                "tokens_saved": int(flat_scope.get("tokens_saved", 0) or 0),
+                "compression_savings_usd": round(
+                    float(flat_scope.get("compression_savings_usd", 0.0) or 0.0),
+                    6,
+                ),
+                "total_input_tokens": int(flat_scope.get("total_input_tokens", 0) or 0),
+                "total_input_cost_usd": round(
+                    float(flat_scope.get("total_input_cost_usd", 0.0) or 0.0),
+                    6,
+                ),
+                "compressions_by_strategy": dict(
+                    raw_compression.get("compressions_by_strategy", {}) or {}
+                ),
+                "tokens_saved_by_strategy": dict(
+                    raw_compression.get("tokens_saved_by_strategy", {}) or {}
+                ),
+            }
+
+        def _build_scope_codex_ws(raw_codex_ws: dict[str, Any]) -> dict[str, Any]:
+            units_total = int(raw_codex_ws.get("units_total", 0) or 0)
+            frames_attempted_total = int(raw_codex_ws.get("frames_attempted_total", 0) or 0)
+            unit_elapsed_ms_sum = float(raw_codex_ws.get("unit_elapsed_ms_sum", 0.0) or 0.0)
+            frame_elapsed_ms_sum = float(raw_codex_ws.get("frame_elapsed_ms_sum", 0.0) or 0.0)
+            return {
+                "units_total": units_total,
+                "units_modified_total": int(raw_codex_ws.get("units_modified_total", 0) or 0),
+                "units_by_strategy": dict(raw_codex_ws.get("units_by_strategy", {}) or {}),
+                "units_by_category": dict(raw_codex_ws.get("units_by_category", {}) or {}),
+                "units_by_content_type": dict(raw_codex_ws.get("units_by_content_type", {}) or {}),
+                "units_by_text_shape": dict(raw_codex_ws.get("units_by_text_shape", {}) or {}),
+                "units_to_kompress_total": int(raw_codex_ws.get("units_to_kompress_total", 0) or 0),
+                "units_kompress_attempted_total": int(
+                    raw_codex_ws.get("units_kompress_attempted_total", 0) or 0
+                ),
+                "units_to_kompress_percent": _pct(
+                    raw_codex_ws.get("units_to_kompress_total", 0),
+                    units_total,
+                ),
+                "units_kompress_attempted_percent": _pct(
+                    raw_codex_ws.get("units_kompress_attempted_total", 0),
+                    units_total,
+                ),
+                "unit_elapsed_ms_sum": round(unit_elapsed_ms_sum, 6),
+                "unit_elapsed_ms": {
+                    "average": round(unit_elapsed_ms_sum / units_total, 2) if units_total else 0.0,
+                    "max": round(float(raw_codex_ws.get("unit_elapsed_ms_max", 0.0) or 0.0), 2),
+                },
+                "unit_bytes_sum": int(raw_codex_ws.get("unit_bytes_sum", 0) or 0),
+                "unit_tokens_before_sum": int(raw_codex_ws.get("unit_tokens_before_sum", 0) or 0),
+                "unit_tokens_after_sum": int(raw_codex_ws.get("unit_tokens_after_sum", 0) or 0),
+                "unit_tokens_saved_sum": int(raw_codex_ws.get("unit_tokens_saved_sum", 0) or 0),
+                "frames_attempted_total": frames_attempted_total,
+                "frames_compressed_total": int(raw_codex_ws.get("frames_compressed_total", 0) or 0),
+                "frames_failed_total": int(raw_codex_ws.get("frames_failed_total", 0) or 0),
+                "frames_to_kompress_total": int(
+                    raw_codex_ws.get("frames_to_kompress_total", 0) or 0
+                ),
+                "frames_kompress_attempted_total": int(
+                    raw_codex_ws.get("frames_kompress_attempted_total", 0) or 0
+                ),
+                "frames_to_kompress_percent": _pct(
+                    raw_codex_ws.get("frames_to_kompress_total", 0),
+                    frames_attempted_total,
+                ),
+                "frames_kompress_attempted_percent": _pct(
+                    raw_codex_ws.get("frames_kompress_attempted_total", 0),
+                    frames_attempted_total,
+                ),
+                "frame_elapsed_ms_sum": round(frame_elapsed_ms_sum, 6),
+                "frame_elapsed_ms": {
+                    "average": round(frame_elapsed_ms_sum / frames_attempted_total, 2)
+                    if frames_attempted_total
+                    else 0.0,
+                    "max": round(float(raw_codex_ws.get("frame_elapsed_ms_max", 0.0) or 0.0), 2),
+                },
+                "frame_bytes_before_sum": int(raw_codex_ws.get("frame_bytes_before_sum", 0) or 0),
+                "frame_bytes_after_sum": int(raw_codex_ws.get("frame_bytes_after_sum", 0) or 0),
+                "frame_attempted_tokens_sum": int(
+                    raw_codex_ws.get("frame_attempted_tokens_sum", 0) or 0
+                ),
+                "frame_tokens_saved_sum": int(raw_codex_ws.get("frame_tokens_saved_sum", 0) or 0),
+            }
+
+        current_process_cache_raw = dict(prefix_cache_stats.get("totals", {}) or {})
+        current_process_cache_raw["cache_bust_count"] = m.cache_bust_count
+        current_process_cache_raw["cache_bust_tokens_lost"] = m.cache_bust_tokens_lost
+        current_process_scope = {
+            "requests": {"total": m.requests_total},
+            "cache": _build_scope_cache(
+                current_process_cache_raw,
+                cache_read_tokens=int(
+                    prefix_cache_stats.get("totals", {}).get("cache_read_tokens", 0) or 0
+                ),
+                cache_savings_usd=float(getattr(m, "cache_savings_usd_total", 0.0) or 0.0),
+            ),
+            "compression": _build_scope_compression(
+                {
+                    "tokens_saved": m.tokens_saved_total,
+                    "compression_savings_usd": getattr(m, "compression_savings_usd_total", 0.0),
+                    "total_input_tokens": m.tokens_input_total,
+                    "total_input_cost_usd": getattr(m, "input_cost_usd_total", 0.0),
+                },
+                {
+                    "compressions_by_strategy": dict(m.compressions_by_strategy),
+                    "tokens_saved_by_strategy": dict(m.tokens_saved_by_strategy),
+                },
+            ),
+            "codex_ws": _build_scope_codex_ws(
+                {
+                    "units_total": m.codex_ws_units_total,
+                    "units_modified_total": m.codex_ws_units_modified_total,
+                    "units_by_strategy": dict(m.codex_ws_units_by_strategy),
+                    "units_by_category": dict(m.codex_ws_units_by_category),
+                    "units_by_content_type": dict(m.codex_ws_units_by_content_type),
+                    "units_by_text_shape": dict(m.codex_ws_units_by_text_shape),
+                    "units_to_kompress_total": m.codex_ws_units_to_kompress_total,
+                    "units_kompress_attempted_total": m.codex_ws_units_kompress_attempted_total,
+                    "unit_elapsed_ms_sum": m.codex_ws_unit_elapsed_ms_sum,
+                    "unit_elapsed_ms_max": m.codex_ws_unit_elapsed_ms_max,
+                    "unit_bytes_sum": m.codex_ws_unit_bytes_sum,
+                    "unit_tokens_before_sum": m.codex_ws_unit_tokens_before_sum,
+                    "unit_tokens_after_sum": m.codex_ws_unit_tokens_after_sum,
+                    "unit_tokens_saved_sum": m.codex_ws_unit_tokens_saved_sum,
+                    "frames_attempted_total": m.codex_ws_frames_attempted_total,
+                    "frames_compressed_total": m.codex_ws_frames_compressed_total,
+                    "frames_failed_total": m.codex_ws_frames_failed_total,
+                    "frames_to_kompress_total": m.codex_ws_frames_to_kompress_total,
+                    "frames_kompress_attempted_total": m.codex_ws_frames_kompress_attempted_total,
+                    "frame_elapsed_ms_sum": m.codex_ws_frame_elapsed_ms_sum,
+                    "frame_elapsed_ms_max": m.codex_ws_frame_elapsed_ms_max,
+                    "frame_bytes_before_sum": m.codex_ws_frame_bytes_before_sum,
+                    "frame_bytes_after_sum": m.codex_ws_frame_bytes_after_sum,
+                    "frame_attempted_tokens_sum": m.codex_ws_frame_attempted_tokens_sum,
+                    "frame_tokens_saved_sum": m.codex_ws_frame_tokens_saved_sum,
+                }
+            ),
+        }
+
+        def _persistent_metric_scope(scope_data: dict[str, Any]) -> dict[str, Any]:
+            scope_data = scope_data if isinstance(scope_data, dict) else {}
+            tokens = scope_data.get("tokens", {})
+            cost = scope_data.get("cost", {})
+            cache = scope_data.get("prefix_cache", {})
+            return {
+                "requests": {"total": int(scope_data.get("requests", {}).get("total", 0) or 0)},
+                "cache": _build_scope_cache(
+                    cache,
+                    cache_read_tokens=int(cache.get("cache_read_tokens", 0) or 0),
+                    cache_savings_usd=float(cost.get("cache_savings_usd", 0.0) or 0.0),
+                ),
+                "compression": _build_scope_compression(
+                    {
+                        "tokens_saved": tokens.get("saved", 0),
+                        "compression_savings_usd": cost.get("compression_savings_usd", 0.0),
+                        "total_input_tokens": tokens.get("input", 0),
+                        "total_input_cost_usd": cost.get("input_usd", 0.0),
+                    },
+                    scope_data.get("compression", {}),
+                ),
+                "codex_ws": _build_scope_codex_ws(scope_data.get("codex_ws", {})),
+            }
+
+        metric_scopes = {
+            "current_process": current_process_scope,
+            "display_session": _persistent_metric_scope(display_session_scope),
+            "lifetime": _persistent_metric_scope(lifetime_scope),
+            "process_started_at": getattr(m, "process_started_at", None),
+            "updated_at": lifetime_scope.get("last_activity_at"),
+        }
 
         # Tool-schema deferral savings: tool-definition tokens kept out of the
         # model's context by deferring heavy schemas until they're needed
@@ -4063,6 +4309,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
             },
             "savings_history": m.savings_history[-100:],  # Last 100 data points
             "display_session": display_session,
+            "metric_scopes": metric_scopes,
             # Whether LiteLLM is importable. Pricing (the "$ Saved" tile) is
             # derived entirely from LiteLLM's cost tables, and LiteLLM is gated
             # off on Python >=3.14 in pyproject — so when this is False the

--- a/tests/test_persistent_metrics_persistence.py
+++ b/tests/test_persistent_metrics_persistence.py
@@ -65,6 +65,8 @@ def test_savings_tracker_migrates_v4_lifetime_to_v5_metrics_and_preserves_legacy
     assert saved["schema_version"] == 5
     assert saved["lifetime"] == legacy_state["lifetime"]
     assert saved["display_session"]["requests"] == 2
+    assert "aggregates" not in saved["lifetime"]
+    assert "aggregates" not in saved["display_session"]
     assert saved["projects"]["keep-me"]["requests"] == 1
     assert saved["lifetime_metrics"]["models"]["other"]["input_tokens"] == 80
     assert isinstance(saved["lifetime_metrics"]["persistence"]["last_saved_at"], str)

--- a/tests/test_proxy_persistent_aggregates.py
+++ b/tests/test_proxy_persistent_aggregates.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from headroom.proxy.prometheus_metrics import PrometheusMetrics
+from headroom.proxy.savings_tracker import SavingsTracker
+from headroom.proxy.server import ProxyConfig, create_app
+
+
+def _record_proxy_request(
+    proxy,
+    *,
+    provider: str = "anthropic",
+    model: str = "claude-sonnet-4-6",
+    input_tokens: int = 120,
+    output_tokens: int = 24,
+    tokens_saved: int = 30,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    cache_write_5m_tokens: int = 0,
+    cache_write_1h_tokens: int = 0,
+    uncached_input_tokens: int = 0,
+) -> None:
+    if proxy.cost_tracker:
+        proxy.cost_tracker.record_tokens(model, tokens_saved, input_tokens)
+    asyncio.run(
+        proxy.metrics.record_request(
+            provider=provider,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            tokens_saved=tokens_saved,
+            latency_ms=15.0,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            cache_write_5m_tokens=cache_write_5m_tokens,
+            cache_write_1h_tokens=cache_write_1h_tokens,
+            uncached_input_tokens=uncached_input_tokens,
+        )
+    )
+
+
+def test_metric_scopes_survive_restart_and_current_process_resets(tmp_path, monkeypatch):
+    savings_path = tmp_path / "proxy_savings.json"
+    monkeypatch.setenv("HEADROOM_SAVINGS_PATH", str(savings_path))
+    config = ProxyConfig(cache_enabled=False, rate_limit_enabled=False, log_requests=False)
+
+    with TestClient(create_app(config)) as client:
+        proxy = client.app.state.proxy
+        _record_proxy_request(
+            proxy,
+            cache_read_tokens=40,
+            cache_write_tokens=60,
+            cache_write_5m_tokens=10,
+            cache_write_1h_tokens=50,
+            uncached_input_tokens=20,
+        )
+        _record_proxy_request(
+            proxy,
+            cache_read_tokens=10,
+            cache_write_tokens=90,
+            cache_write_5m_tokens=15,
+            cache_write_1h_tokens=75,
+            uncached_input_tokens=30,
+        )
+        proxy.metrics.record_compression("smart_crusher", 100, 70)
+        proxy.metrics.record_compression("smart_crusher", 80, 50)
+        proxy.metrics.record_codex_ws_unit(
+            strategy="smart_crusher",
+            reason_category="tool_result",
+            elapsed_ms=5.0,
+            text_bytes=128,
+            tokens_before=100,
+            tokens_after=70,
+            tokens_saved=30,
+            modified=True,
+            strategy_chain=["smart_crusher"],
+            content_type="text",
+            text_shape="json",
+        )
+        proxy.metrics.record_codex_ws_frame(
+            elapsed_ms=9.0,
+            bytes_before=256,
+            bytes_after=180,
+            attempted_tokens=100,
+            tokens_saved=30,
+            modified=True,
+            strategy_chain=["smart_crusher"],
+            final_strategies=["smart_crusher"],
+        )
+        asyncio.run(proxy.metrics.record_cache_bust(11))
+
+        live_stats = client.get("/stats").json()
+        live_scope = live_stats["metric_scopes"]
+        assert live_scope["current_process"]["requests"]["total"] == 2
+        assert live_scope["current_process"]["cache"]["requests"] == 2
+        assert live_scope["current_process"]["cache"]["bust_count"] == 1
+        assert live_scope["current_process"]["cache"]["cache_bust_count"] == 1
+        assert live_scope["current_process"]["compression"]["tokens_saved"] == 60
+        assert live_scope["current_process"]["compression"]["compressions_by_strategy"] == {
+            "smart_crusher": 2
+        }
+        assert live_scope["current_process"]["codex_ws"]["units_total"] == 1
+        assert live_scope["display_session"]["requests"]["total"] == 2
+        assert live_scope["lifetime"]["requests"]["total"] == 2
+        assert live_scope["lifetime"]["cache"]["cache_write_tokens"] == 150
+        assert live_scope["lifetime"]["cache"]["cache_write_1h_tokens"] == 125
+        assert live_scope["lifetime"]["compression"]["compressions_by_strategy"] == {
+            "smart_crusher": 2
+        }
+        assert live_scope["lifetime"]["codex_ws"]["frames_attempted_total"] == 1
+        assert live_scope["updated_at"] is not None
+        assert live_scope["process_started_at"] is not None
+
+    with TestClient(create_app(config)) as client:
+        restarted = client.get("/stats").json()
+        scope = restarted["metric_scopes"]
+        assert scope["current_process"]["requests"]["total"] == 0
+        assert scope["current_process"]["compression"]["tokens_saved"] == 0
+        assert scope["current_process"]["codex_ws"]["units_total"] == 0
+        assert scope["display_session"]["requests"]["total"] == 2
+        assert scope["lifetime"]["requests"]["total"] == 2
+        assert scope["lifetime"]["cache"]["requests"] == 2
+        assert scope["lifetime"]["cache"]["hit_requests"] == 2
+        assert scope["lifetime"]["cache"]["cache_read_tokens"] == 50
+        assert scope["lifetime"]["cache"]["cache_write_tokens"] == 150
+        assert scope["lifetime"]["cache"]["cache_write_5m_tokens"] == 25
+        assert scope["lifetime"]["cache"]["cache_write_1h_tokens"] == 125
+        assert scope["lifetime"]["cache"]["uncached_input_tokens"] == 50
+        assert scope["lifetime"]["cache"]["bust_count"] == 1
+        assert scope["lifetime"]["cache"]["cache_bust_count"] == 1
+        assert scope["lifetime"]["cache"]["cache_bust_tokens_lost"] == 11
+        assert scope["lifetime"]["compression"]["compressions_by_strategy"] == {"smart_crusher": 2}
+        assert scope["lifetime"]["compression"]["tokens_saved_by_strategy"] == {"smart_crusher": 60}
+        assert scope["lifetime"]["codex_ws"]["units_total"] == 1
+        assert scope["lifetime"]["codex_ws"]["frames_attempted_total"] == 1
+
+        metrics = client.get("/metrics").text
+        assert "headroom_requests_total 0" in metrics
+        assert "headroom_persistent_savings_requests_total 2" in metrics
+        assert "headroom_persistent_savings_cache_read_tokens_total 50" in metrics
+        assert "headroom_persistent_savings_cache_write_tokens_total 150" in metrics
+        assert "headroom_persistent_savings_cache_requests_total 2" in metrics
+        assert "headroom_persistent_savings_cache_hit_requests_total 2" in metrics
+        assert "headroom_persistent_savings_cache_bust_total 1" in metrics
+        assert "headroom_persistent_savings_cache_bust_tokens_lost_total 11" in metrics
+
+
+def test_metric_scopes_migrate_v4_state_additively(tmp_path):
+    path = tmp_path / "proxy_savings.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 4,
+                "lifetime": {
+                    "requests": 3,
+                    "tokens_saved": 90,
+                    "compression_savings_usd": 0.27,
+                    "cache_read_tokens": 50,
+                    "cache_savings_usd": 0.12,
+                    "total_input_tokens": 360,
+                    "total_input_cost_usd": 0.81,
+                },
+                "display_session": {
+                    "requests": 1,
+                    "tokens_saved": 30,
+                    "compression_savings_usd": 0.09,
+                    "cache_read_tokens": 10,
+                    "cache_savings_usd": 0.03,
+                    "total_input_tokens": 120,
+                    "total_input_cost_usd": 0.27,
+                    "started_at": "2026-07-14T12:00:00Z",
+                    "last_activity_at": "2026-07-14T12:00:00Z",
+                },
+                "history": [],
+                "projects": {},
+                "by_model": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    tracker = SavingsTracker(path=str(path))
+    snapshot = tracker.snapshot()
+
+    assert snapshot["schema_version"] == 5
+    assert snapshot["lifetime"]["requests"] == 3
+    lifetime = tracker.lifetime_response()
+    display = tracker.display_session_response()
+    assert lifetime["prefix_cache"]["cache_write_tokens"] == 0
+    assert lifetime["compression"]["compressions_by_strategy"] == {}
+    assert lifetime["codex_ws"]["units_total"] == 0
+    assert display["prefix_cache"]["requests"] == 0
+
+
+def test_metric_scopes_stateless_mode_writes_nothing_and_restarts_empty(tmp_path, monkeypatch):
+    savings_path = tmp_path / "proxy_savings.json"
+    monkeypatch.setenv("HEADROOM_SAVINGS_PATH", str(savings_path))
+    config = ProxyConfig(
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        log_requests=False,
+        stateless=True,
+    )
+
+    with TestClient(create_app(config)) as client:
+        proxy = client.app.state.proxy
+        _record_proxy_request(proxy, tokens_saved=25, cache_read_tokens=15, cache_write_tokens=20)
+        proxy.metrics.record_compression("smart_crusher", 100, 75)
+        stats = client.get("/stats").json()
+        assert stats["metric_scopes"]["current_process"]["requests"]["total"] == 1
+        assert stats["metric_scopes"]["lifetime"]["requests"]["total"] == 1
+
+    assert not savings_path.exists()
+
+    with TestClient(create_app(config)) as client:
+        stats = client.get("/stats").json()
+        assert stats["metric_scopes"]["current_process"]["requests"]["total"] == 0
+        assert stats["metric_scopes"]["lifetime"]["requests"]["total"] == 0
+        assert stats["metric_scopes"]["lifetime"]["compression"]["compressions_by_strategy"] == {}
+
+
+def test_metric_scopes_stateless_mode_ignores_existing_file(tmp_path, monkeypatch):
+    savings_path = tmp_path / "proxy_savings.json"
+    savings_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 5,
+                "updated_at": "2026-07-14T12:05:00Z",
+                "lifetime": {
+                    "requests": 1,
+                    "tokens_saved": 3,
+                    "compression_savings_usd": 0.01,
+                    "cache_read_tokens": 0,
+                    "cache_savings_usd": 0.0,
+                    "total_input_tokens": 9,
+                    "total_input_cost_usd": 0.02,
+                    "aggregates": {
+                        "cache": {},
+                        "compression": {"compressions_by_strategy": {"diff": 1}},
+                        "codex_ws": {},
+                    },
+                },
+                "display_session": {
+                    "requests": 1,
+                    "tokens_saved": 3,
+                    "compression_savings_usd": 0.01,
+                    "cache_read_tokens": 0,
+                    "cache_savings_usd": 0.0,
+                    "total_input_tokens": 9,
+                    "total_input_cost_usd": 0.02,
+                    "savings_percent": 25.0,
+                    "started_at": "2026-07-14T12:00:00Z",
+                    "last_activity_at": "2026-07-14T12:05:00Z",
+                    "aggregates": {
+                        "cache": {},
+                        "compression": {"compressions_by_strategy": {"diff": 1}},
+                        "codex_ws": {},
+                    },
+                },
+                "history": [],
+                "projects": {},
+                "by_model": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HEADROOM_SAVINGS_PATH", str(savings_path))
+    config = ProxyConfig(
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        log_requests=False,
+        stateless=True,
+    )
+
+    with TestClient(create_app(config)) as client:
+        stats = client.get("/stats").json()
+        assert stats["metric_scopes"]["current_process"]["requests"]["total"] == 0
+        assert stats["metric_scopes"]["lifetime"]["requests"]["total"] == 0
+        assert stats["metric_scopes"]["lifetime"]["compression"]["compressions_by_strategy"] == {}
+
+
+def test_metric_scopes_cache_denominators_ignore_uncached_requests_consistently(
+    tmp_path, monkeypatch
+):
+    savings_path = tmp_path / "proxy_savings.json"
+    monkeypatch.setenv("HEADROOM_SAVINGS_PATH", str(savings_path))
+    config = ProxyConfig(cache_enabled=False, rate_limit_enabled=False, log_requests=False)
+
+    with TestClient(create_app(config)) as client:
+        proxy = client.app.state.proxy
+        _record_proxy_request(
+            proxy,
+            input_tokens=1000,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+            uncached_input_tokens=1000,
+        )
+        _record_proxy_request(
+            proxy,
+            input_tokens=100,
+            cache_read_tokens=100,
+            cache_write_tokens=0,
+            uncached_input_tokens=0,
+        )
+        stats = client.get("/stats").json()
+        current_scope = stats["metric_scopes"]["current_process"]["cache"]
+        lifetime_scope = stats["metric_scopes"]["lifetime"]["cache"]
+
+        assert current_scope["uncached_input_tokens"] == 0
+        assert lifetime_scope["uncached_input_tokens"] == 0
+        assert current_scope["requests"] == 1
+        assert lifetime_scope["requests"] == 1
+        assert current_scope["hit_rate"] == 100.0
+        assert lifetime_scope["hit_rate"] == 100.0
+
+
+def test_aggregate_only_updates_survive_into_next_display_session_request(tmp_path):
+    tracker = SavingsTracker(path=str(tmp_path / "proxy_savings.json"), save_flush_every=10)
+
+    tracker.record_compression(
+        strategy="smart_crusher",
+        original_tokens=100,
+        compressed_tokens=70,
+        timestamp="2026-07-14T12:00:00Z",
+    )
+    assert tracker.display_session_response()["compression"]["compressions_by_strategy"] == {
+        "smart_crusher": 1
+    }
+
+    tracker.record_lifetime_request(
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=30,
+        timestamp="2026-07-14T12:00:01Z",
+    )
+    assert tracker.display_session_response()["requests"]["total"] == 1
+    assert tracker.display_session_response()["compression"]["compressions_by_strategy"] == {
+        "smart_crusher": 1
+    }
+
+
+def test_zero_and_negative_savings_strategy_counts_persist(tmp_path):
+    tracker = SavingsTracker(path=str(tmp_path / "proxy_savings.json"), save_flush_every=25)
+    metrics = PrometheusMetrics(savings_tracker=tracker)
+
+    metrics.record_compression("diff", 80, 80)
+    metrics.record_compression("code_aware", 50, 70)
+    tracker.flush()
+
+    persisted = json.loads(Path(tracker.storage_path).read_text(encoding="utf-8"))
+    compression = persisted["lifetime_metrics"]["compression"]
+    assert compression["compressions_by_strategy"] == {"diff": 1, "code_aware": 1}
+    assert compression["tokens_saved_by_strategy"] == {}
+
+
+def test_aggregate_only_updates_stay_dirty_until_request_save(tmp_path):
+    path = tmp_path / "proxy_savings.json"
+    tracker = SavingsTracker(path=str(path), save_flush_every=6)
+
+    tracker.record_compression(
+        strategy="smart_crusher",
+        original_tokens=100,
+        compressed_tokens=70,
+        timestamp="2026-07-14T12:00:00Z",
+    )
+    tracker.record_lifetime_cache_bust(tokens_lost=11)
+    tracker.record_codex_ws_unit(
+        strategy="smart_crusher",
+        reason_category="tool_result",
+        elapsed_ms=5.0,
+        text_bytes=128,
+        tokens_before=100,
+        tokens_after=70,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        content_type="text",
+        text_shape="json",
+        timestamp="2026-07-14T12:00:02Z",
+    )
+    tracker.record_codex_ws_frame(
+        elapsed_ms=9.0,
+        bytes_before=256,
+        bytes_after=180,
+        attempted_tokens=100,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        final_strategies=["smart_crusher"],
+        timestamp="2026-07-14T12:00:03Z",
+    )
+
+    assert not path.exists()
+
+    tracker.record_lifetime_request(
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=30,
+        timestamp="2026-07-14T12:00:04Z",
+    )
+    assert not path.exists()
+
+    tracker.record_lifetime_request(
+        model="gpt-4o",
+        input_tokens=80,
+        tokens_saved=10,
+        timestamp="2026-07-14T12:00:05Z",
+    )
+
+    persisted = json.loads(path.read_text())
+    lifetime = persisted["lifetime_metrics"]
+    cache = lifetime["prefix_cache"]
+    compression = lifetime["compression"]
+    codex_ws = lifetime["codex_ws"]
+    assert compression["compressions_by_strategy"] == {"smart_crusher": 1}
+    assert compression["tokens_saved_by_strategy"] == {"smart_crusher": 30}
+    assert cache["bust_count"] == 1
+    assert cache["bust_tokens"] == 11
+    assert codex_ws["units_total"] == 1
+    assert codex_ws["frames_attempted_total"] == 1
+
+
+def test_graceful_flush_persists_aggregate_only_updates(tmp_path):
+    path = tmp_path / "proxy_savings.json"
+    metrics = PrometheusMetrics(savings_tracker=SavingsTracker(path=str(path), save_flush_every=25))
+
+    metrics.record_compression("smart_crusher", 100, 70)
+    asyncio.run(metrics.record_cache_bust(11))
+    metrics.record_codex_ws_frame(
+        elapsed_ms=9.0,
+        bytes_before=256,
+        bytes_after=180,
+        attempted_tokens=100,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        final_strategies=["smart_crusher"],
+    )
+    assert not path.exists()
+
+    metrics.savings_tracker.flush()
+    persisted = json.loads(path.read_text())
+    assert persisted["lifetime_metrics"]["compression"]["compressions_by_strategy"] == {
+        "smart_crusher": 1
+    }
+    assert persisted["lifetime_metrics"]["prefix_cache"]["bust_count"] == 1
+    assert persisted["lifetime_metrics"]["codex_ws"]["frames_attempted_total"] == 1

--- a/tests/test_proxy_persistent_aggregates.py
+++ b/tests/test_proxy_persistent_aggregates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -454,3 +455,423 @@ def test_graceful_flush_persists_aggregate_only_updates(tmp_path):
     }
     assert persisted["lifetime_metrics"]["prefix_cache"]["bust_count"] == 1
     assert persisted["lifetime_metrics"]["codex_ws"]["frames_attempted_total"] == 1
+
+
+FIXED_NOW = datetime(2026, 8, 5, 9, 0, 0, tzinfo=timezone.utc)
+
+
+def _expired_session_seed(
+    *, request_total: int = 3, session_last_activity: datetime = FIXED_NOW
+) -> dict:
+    """State whose display session last saw activity at session_last_activity.
+
+    ``session_last_activity`` defaults to ``FIXED_NOW`` so the session is still
+    fresh inside the inactivity window at construction; the caller advances the
+    clock past ``display_session_inactivity_minutes`` to cross the boundary.
+    """
+    return {
+        "schema_version": 5,
+        "lifetime": {
+            "requests": 0,
+            "tokens_saved": 0,
+            "compression_savings_usd": 0.0,
+            "cache_read_tokens": 0,
+            "cache_savings_usd": 0.0,
+            "total_input_tokens": 0,
+            "total_input_cost_usd": 0.0,
+        },
+        "display_session": {
+            "requests": 0,
+            "tokens_saved": 0,
+            "compression_savings_usd": 0.0,
+            "cache_read_tokens": 0,
+            "cache_savings_usd": 0.0,
+            "total_input_tokens": 0,
+            "total_input_cost_usd": 0.0,
+            "started_at": "2026-01-01T00:00:00Z",
+            "last_activity_at": "2026-01-01T00:00:00Z",
+        },
+        "history": [],
+        "projects": {},
+        "by_model": {},
+        "lifetime_metrics": {
+            "started_at": "2026-01-01T00:00:00Z",
+            "last_activity_at": "2026-01-01T00:00:00Z",
+            "full_fidelity_started_at": "2026-01-01T00:00:00Z",
+            "requests": {
+                "total": request_total,
+                "cached": 1,
+                "failed": 1,
+                "rate_limited": 1,
+                "by_provider": {"openai": request_total},
+                "by_stack": {"cli": request_total},
+            },
+            "tokens": {
+                "input": 900,
+                "output": 60,
+                "attempted_input": 960,
+                "saved": 90,
+            },
+            "prefix_cache": {
+                "requests": 1,
+                "hit_requests": 1,
+                "cache_read_tokens": 40,
+                "cache_write_tokens": 60,
+                "cache_write_5m_tokens": 10,
+                "cache_write_1h_tokens": 50,
+                "uncached_input_tokens": 20,
+                "cache_write_5m_requests": 1,
+                "cache_write_1h_requests": 1,
+                "bust_count": 1,
+                "bust_tokens": 11,
+                "misses_by_reason": {"prefix_change": 1},
+                "by_provider": {"openai": 1},
+            },
+            "cost": {
+                "input_usd": 1.0,
+                "compression_savings_usd": 0.3,
+                "cache_savings_usd": 0.1,
+            },
+            "compression": {
+                "compressions_by_strategy": {"smart_crusher": 5},
+                "tokens_saved_by_strategy": {"smart_crusher": 150},
+            },
+            "codex_ws": {
+                "units_total": 2,
+                "units_modified_total": 1,
+                "units_to_kompress_total": 0,
+                "units_kompress_attempted_total": 0,
+                "units_by_strategy": {"smart_crusher": 2},
+                "units_by_category": {"tool_result": 2},
+                "units_by_content_type": {"text": 2},
+                "units_by_text_shape": {"json": 2},
+                "unit_elapsed_ms_sum": 10.0,
+                "unit_elapsed_ms_max": 5.0,
+                "unit_bytes_sum": 256,
+                "unit_tokens_before_sum": 200,
+                "unit_tokens_after_sum": 140,
+                "unit_tokens_saved_sum": 60,
+                "frames_attempted_total": 1,
+                "frames_compressed_total": 1,
+                "frames_failed_total": 0,
+                "frames_to_kompress_total": 0,
+                "frames_kompress_attempted_total": 0,
+                "frame_elapsed_ms_sum": 9.0,
+                "frame_elapsed_ms_max": 9.0,
+                "frame_bytes_before_sum": 256,
+                "frame_bytes_after_sum": 180,
+                "frame_attempted_tokens_sum": 100,
+                "frame_tokens_saved_sum": 30,
+            },
+            "waste_signals": {"repetition": 7},
+            "models": {
+                "tracked": {},
+                "other": {
+                    "requests": request_total,
+                    "input_tokens": 900,
+                    "output_tokens": 60,
+                    "attempted_input_tokens": 960,
+                    "tokens_saved": 90,
+                    "last_activity_at": "2026-01-01T00:00:00Z",
+                },
+            },
+            "persistence": {"last_saved_at": "2026-01-01T00:00:00Z"},
+        },
+        "display_session_metrics": {
+            "started_at": session_last_activity.isoformat(),
+            "last_activity_at": session_last_activity.isoformat(),
+            "full_fidelity_started_at": session_last_activity.isoformat(),
+            "requests": {
+                "total": request_total,
+                "cached": 1,
+                "failed": 1,
+                "rate_limited": 1,
+                "by_provider": {"openai": request_total},
+                "by_stack": {"cli": request_total},
+            },
+            "tokens": {
+                "input": 900,
+                "output": 60,
+                "attempted_input": 960,
+                "saved": 90,
+            },
+            "prefix_cache": {
+                "requests": 1,
+                "hit_requests": 1,
+                "cache_read_tokens": 40,
+                "cache_write_tokens": 60,
+                "cache_write_5m_tokens": 10,
+                "cache_write_1h_tokens": 50,
+                "uncached_input_tokens": 20,
+                "cache_write_5m_requests": 1,
+                "cache_write_1h_requests": 1,
+                "bust_count": 1,
+                "bust_tokens": 11,
+                "misses_by_reason": {"prefix_change": 1},
+                "by_provider": {"openai": 1},
+            },
+            "cost": {
+                "input_usd": 1.0,
+                "compression_savings_usd": 0.3,
+                "cache_savings_usd": 0.1,
+            },
+            "compression": {
+                "compressions_by_strategy": {"smart_crusher": 5},
+                "tokens_saved_by_strategy": {"smart_crusher": 150},
+            },
+            "codex_ws": {
+                "units_total": 2,
+                "units_modified_total": 1,
+                "units_to_kompress_total": 0,
+                "units_kompress_attempted_total": 0,
+                "units_by_strategy": {"smart_crusher": 2},
+                "units_by_category": {"tool_result": 2},
+                "units_by_content_type": {"text": 2},
+                "units_by_text_shape": {"json": 2},
+                "unit_elapsed_ms_sum": 10.0,
+                "unit_elapsed_ms_max": 5.0,
+                "unit_bytes_sum": 256,
+                "unit_tokens_before_sum": 200,
+                "unit_tokens_after_sum": 140,
+                "unit_tokens_saved_sum": 60,
+                "frames_attempted_total": 1,
+                "frames_compressed_total": 1,
+                "frames_failed_total": 0,
+                "frames_to_kompress_total": 0,
+                "frames_kompress_attempted_total": 0,
+                "frame_elapsed_ms_sum": 9.0,
+                "frame_elapsed_ms_max": 9.0,
+                "frame_bytes_before_sum": 256,
+                "frame_bytes_after_sum": 180,
+                "frame_attempted_tokens_sum": 100,
+                "frame_tokens_saved_sum": 30,
+            },
+            "waste_signals": {"repetition": 7},
+            "models": {
+                "tracked": {},
+                "other": {
+                    "requests": request_total,
+                    "input_tokens": 900,
+                    "output_tokens": 60,
+                    "attempted_input_tokens": 960,
+                    "tokens_saved": 90,
+                    "last_activity_at": "2026-01-01T00:00:00Z",
+                },
+            },
+            "persistence": {"last_saved_at": "2026-01-01T00:00:00Z"},
+        },
+    }
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = FIXED_NOW
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, minutes: int) -> None:
+        self.now = self.now + timedelta(minutes=minutes)
+
+
+def _expired_tracker(tmp_path, clock: _FakeClock) -> SavingsTracker:
+    path = tmp_path / "proxy_savings.json"
+    path.write_text(json.dumps(_expired_session_seed()), encoding="utf-8")
+    tracker = SavingsTracker(
+        path=str(path),
+        now=clock,
+    )
+    clock.advance(minutes=180)
+    return tracker
+
+
+def test_expired_display_session_resets_when_compression_precedes_request(tmp_path):
+    clock = _FakeClock()
+    tracker = _expired_tracker(tmp_path, clock)
+
+    tracker.record_compression(strategy="smart_crusher", original_tokens=100, compressed_tokens=70)
+    tracker.record_lifetime_request(
+        provider="anthropic",
+        stack="codex",
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=30,
+    )
+
+    display = tracker.display_session_response()
+    assert display["requests"]["total"] == 1
+    assert display["requests"]["by_provider"] == {"anthropic": 1}
+    assert display["requests"]["by_stack"] == {"codex": 1}
+    assert display["tokens"]["input"] == 120
+    assert display["tokens"]["saved"] == 30
+    assert display["tokens"]["output"] == 0
+    assert display["compression"]["compressions_by_strategy"] == {"smart_crusher": 1}
+    assert display["compression"]["tokens_saved_by_strategy"] == {"smart_crusher": 30}
+    assert "openai" not in display["requests"]["by_provider"]
+    assert "cli" not in display["requests"]["by_stack"]
+
+
+def test_expired_display_session_resets_when_codex_ws_precedes_request(tmp_path):
+    clock = _FakeClock()
+    tracker = _expired_tracker(tmp_path, clock)
+
+    tracker.record_codex_ws_unit(
+        strategy="smart_crusher",
+        reason_category="tool_result",
+        elapsed_ms=5.0,
+        text_bytes=128,
+        tokens_before=100,
+        tokens_after=70,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        content_type="text",
+        text_shape="json",
+    )
+    tracker.record_codex_ws_frame(
+        elapsed_ms=9.0,
+        bytes_before=256,
+        bytes_after=180,
+        attempted_tokens=100,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        final_strategies=["smart_crusher"],
+    )
+    tracker.record_lifetime_request(
+        provider="anthropic",
+        stack="codex",
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=30,
+    )
+
+    display = tracker.display_session_response()
+    assert display["requests"]["total"] == 1
+    assert display["requests"]["by_provider"] == {"anthropic": 1}
+    assert display["tokens"]["saved"] == 30
+    assert display["codex_ws"]["units_total"] == 1
+    assert display["codex_ws"]["units_modified_total"] == 1
+    assert display["codex_ws"]["unit_tokens_saved_sum"] == 30
+    assert display["codex_ws"]["frames_attempted_total"] == 1
+    assert display["codex_ws"]["frame_tokens_saved_sum"] == 30
+
+
+def test_aggregate_only_writers_reset_expired_display_session(tmp_path):
+    clock = _FakeClock()
+
+    tracker = _expired_tracker(tmp_path, clock)
+    tracker.record_lifetime_stack("codex")
+    display = tracker.display_session_response()
+    assert display["requests"]["total"] == 0
+    assert display["requests"]["by_stack"] == {"codex": 1}
+    assert "cli" not in display["requests"]["by_stack"]
+
+    tracker = _expired_tracker(tmp_path, clock)
+    tracker.record_lifetime_failed(provider="anthropic", model="gpt-4o")
+    display = tracker.display_session_response()
+    assert display["requests"]["failed"] == 1
+    assert display["requests"]["total"] == 0
+
+    tracker = _expired_tracker(tmp_path, clock)
+    tracker.record_lifetime_rate_limited(provider="anthropic", model="gpt-4o")
+    display = tracker.display_session_response()
+    assert display["requests"]["rate_limited"] == 1
+    assert display["requests"]["total"] == 0
+
+    tracker = _expired_tracker(tmp_path, clock)
+    tracker.record_lifetime_cache_bust(tokens_lost=11)
+    display = tracker.display_session_response()
+    assert display["prefix_cache"]["bust_count"] == 1
+    assert display["prefix_cache"]["bust_tokens"] == 11
+
+    tracker = _expired_tracker(tmp_path, clock)
+    tracker.record_lifetime_cache_miss(provider="anthropic", reason="prefix_change")
+    display = tracker.display_session_response()
+    assert display["prefix_cache"]["misses_by_reason"] == {"prefix_change": 1}
+
+
+def test_read_path_reset_stays_in_memory_until_next_record_save(tmp_path):
+    path = tmp_path / "proxy_savings.json"
+    path.write_text(json.dumps(_expired_session_seed()), encoding="utf-8")
+    clock = _FakeClock()
+    tracker = SavingsTracker(path=str(path), now=clock)
+    clock.advance(minutes=180)
+
+    display = tracker.display_session_response()
+    assert display["requests"]["total"] == 0
+
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["display_session_metrics"]["requests"]["total"] == 3
+
+    tracker.record_compression(strategy="smart_crusher", original_tokens=100, compressed_tokens=70)
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["display_session_metrics"]["requests"]["total"] == 0
+    assert persisted["display_session_metrics"]["compression"]["compressions_by_strategy"] == {
+        "smart_crusher": 1
+    }
+
+
+_AGGREGATE_RECORDERS = {
+    "stack": lambda tracker: tracker.record_lifetime_stack("codex"),
+    "failed": lambda tracker: tracker.record_lifetime_failed(provider="anthropic", model="gpt-4o"),
+    "rate_limited": lambda tracker: tracker.record_lifetime_rate_limited(
+        provider="anthropic", model="gpt-4o"
+    ),
+    "cache_bust": lambda tracker: tracker.record_lifetime_cache_bust(tokens_lost=5),
+    "cache_miss": lambda tracker: tracker.record_lifetime_cache_miss(
+        provider="anthropic", reason="prefix_change"
+    ),
+    "compression": lambda tracker: tracker.record_compression(
+        strategy="smart_crusher", original_tokens=100, compressed_tokens=70
+    ),
+    "codex_ws_unit": lambda tracker: tracker.record_codex_ws_unit(
+        strategy="smart_crusher",
+        reason_category="tool_result",
+        elapsed_ms=5.0,
+        text_bytes=128,
+        tokens_before=100,
+        tokens_after=70,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        content_type="text",
+        text_shape="json",
+    ),
+    "codex_ws_frame": lambda tracker: tracker.record_codex_ws_frame(
+        elapsed_ms=9.0,
+        bytes_before=256,
+        bytes_after=180,
+        attempted_tokens=100,
+        tokens_saved=30,
+        modified=True,
+        strategy_chain=["smart_crusher"],
+        final_strategies=["smart_crusher"],
+    ),
+    "request": lambda tracker: tracker.record_lifetime_request(
+        provider="anthropic",
+        stack="codex",
+        model="gpt-4o",
+        input_tokens=120,
+        tokens_saved=30,
+    ),
+}
+
+
+def test_expired_prior_session_totals_gone_from_display_but_kept_in_lifetime(tmp_path):
+    for method in _AGGREGATE_RECORDERS:
+        clock = _FakeClock()
+        tracker = _expired_tracker(tmp_path, clock)
+        _AGGREGATE_RECORDERS[method](tracker)
+
+        display = tracker.display_session_response()
+        assert "openai" not in display["requests"]["by_provider"]
+        assert "cli" not in display["requests"]["by_stack"]
+        assert display["tokens"]["saved"] < 90
+        assert display["prefix_cache"]["bust_tokens"] < 11
+
+        lifetime = tracker._persistent_metrics.to_dict()
+        assert "openai" in lifetime["requests"]["by_provider"]
+        assert "cli" in lifetime["requests"]["by_stack"]
+        assert lifetime["tokens"]["saved"] >= 90
+        assert lifetime["prefix_cache"]["bust_tokens"] >= 11


### PR DESCRIPTION
## Description

Current `main` already persists canonical lifetime metrics through `PersistentMetricsState` and exposes them through `/stats-lifetime`, but `/stats` still lacks a stable three-scope contract for the dashboard surfaces that need `Current process`, `Session`, and `Lifetime` views. This PR finishes that integration on top of the mainline model instead of keeping a parallel persistence path.

The rework extends `PersistentMetricsState` with the missing bounded compression-by-strategy and Codex WS aggregates, adds a `display_session_metrics` sibling with the same serializer and rollover rules, projects `metric_scopes` from those canonical snapshots, and adds the matching durable raw cache counters on `/metrics`. The display-session sibling resets an expired session before every mutation under the tracker lock, so the first request after inactivity starts from a clean scope instead of inheriting the previous session's totals. Existing process-local runtime series keep their restart semantics, and the legacy `persistent_savings` payload stays backward compatible.

#2137 itself is already closed by #2198; this PR supplies the maintainer-requested current-main integration and the missing scope dimensions.

Refs #2137.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Extended `PersistentMetricsState` with bounded compression-by-strategy and Codex WS unit/frame aggregates, while keeping its existing request, token, prefix-cache, cost, waste-signal, and by-model ownership authoritative.
- Added a `display_session_metrics` sibling in `SavingsTracker` using the same model, the same persistence path, and the existing inactivity rollover policy.
- Centralized the display-session expiry check in one locked helper (`_maybe_reset_display_session_locked`) and routed every `_display_metrics` mutation through it, including the aggregate-only writers (`record_compression`, `record_codex_ws_unit`, `record_codex_ws_frame`, cache bust/miss, failure/rate-limit, and stack), which previously mutated the session directly and could brush the expired session's timestamp forward before the next request gate saw it.
- Routed request, cache-bust, compression, and Codex WS recorders into the canonical lifetime and display-session snapshots instead of the old parallel aggregate shape.
- Projected `metric_scopes.lifetime` and `metric_scopes.display_session` from the same snapshots that back `/stats-lifetime` and on-disk persistence, while `metric_scopes.current_process` still comes from process-local runtime counters.
- Added durable raw cache Prometheus counters from the canonical lifetime snapshot without changing the meaning of existing process-local or `headroom_persistent_savings_*` series.
- Preserved the stateless startup guard, current-process restart reset behavior, and non-negative saved-token totals for zero- and negative-savings compression decisions.
- Kept legacy top-level `lifetime` and `display_session` records as compatibility payloads, while persisting canonical `lifetime_metrics` and `display_session_metrics` without reviving the old nested `aggregates` schema on disk.

## Testing

- [x] Focused backend persistence and scope suite passes (`uv run pytest tests/test_proxy_persistent_aggregates.py tests/test_persistent_metrics.py tests/test_persistent_metrics_persistence.py -q`)
- [x] Linting passes (`uv run ruff check headroom/proxy/persistent_metrics.py headroom/proxy/savings_tracker.py headroom/proxy/prometheus_metrics.py headroom/proxy/server.py tests/test_persistent_metrics.py tests/test_persistent_metrics_integration.py tests/test_persistent_metrics_persistence.py tests/test_proxy_persistent_aggregates.py`)
- [x] Formatting passes (`uv run ruff format --check headroom/proxy/persistent_metrics.py headroom/proxy/savings_tracker.py headroom/proxy/prometheus_metrics.py headroom/proxy/server.py tests/test_persistent_metrics.py tests/test_persistent_metrics_integration.py tests/test_persistent_metrics_persistence.py tests/test_proxy_persistent_aggregates.py`)
- [x] Type checking passes (`uv run mypy headroom/proxy/persistent_metrics.py headroom/proxy/savings_tracker.py headroom/proxy/prometheus_metrics.py headroom/proxy/server.py`)
- [x] New tests added for new functionality when applicable
- [ ] Manual testing performed

### Test Output

```text
21 passed, 1 warning in 6.51s
```

```text
All checks passed!
```

```text
2 files already formatted
```

```text
Success: no issues found in 2 source files
```

## Real Behavior Proof

- Environment: Python 3.12.13, `uv`, local backend persistence and restart-focused validation on the rebased `main` branch.
- Exact command / steps: record request, cache, compression, cache-bust, and Codex WS activity; compare `metric_scopes.lifetime`, `metric_scopes.display_session`, `/stats-lifetime`, persisted `lifetime_metrics`, and the durable raw cache series across restart; then triggers the display-session rollover boundary with a clock-controlled regression that records an old request and session, advances beyond `display_session_inactivity_minutes`, records a compression event before the next request in production order, and reruns the focused canonical persistence suite.
- Observed result: lifetime and display-session scope data come from the same canonical snapshots that power `/stats-lifetime` and on-disk persistence; `current_process` still resets on restart; aggregate-only compression and Codex WS events survive into durable scope data; cache-hit denominators stay aligned with the process-local runtime gate; the persisted JSON contains canonical `lifetime_metrics` and `display_session_metrics` without reviving the old nested `aggregates` schema; and after the rollover boundary the display scope contains only the new compression and request totals, with the expired session's requests, tokens, and strategy totals absent (a WS aggregate-first variant pins the same invariant).
- Not tested: the dashboard selector itself, which remains in the stacked UI slice.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

- Scope is backend-only. This PR does not touch `headroom/dashboard/**`.
- Existing process-local runtime series keep their current reset semantics on restart.
- The stacked UI slice in https://github.com/headroomlabs-ai/headroom/pull/2180 consumes the additive `metric_scopes` contract from this branch after it is updated.
- On this Windows host, the unchanged current-main directory-fsync assertion in `tests/test_proxy_savings_history.py::test_savings_tracker_save_fsyncs_parent_directory` still fails because opening a directory fd for `fsync` is unsupported here; this rework does not change that save-path code.
- Headroom's release pipeline generates changelog entries from conventional commits, so `CHANGELOG.md` is intentionally untouched.
