### PR TITLE
fix(copilot): refresh wrapped subscription tokens (#2156)

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -138,6 +138,17 @@ from headroom.proxy.project_context import with_project_prefix as _with_project_
 
 from .main import main
 
+_COPILOT_PROXY_SEED_ENV_VARS = (
+    "GITHUB_COPILOT_API_TOKEN",
+    "GITHUB_COPILOT_REFRESH_OAUTH_TOKEN",
+    "GITHUB_COPILOT_API_TOKEN_EXPIRES_AT",
+)
+
+
+def _scrub_copilot_proxy_seed_env(env: dict[str, str]) -> None:
+    for key in _COPILOT_PROXY_SEED_ENV_VARS:
+        env.pop(key, None)
+
 
 def _read_text(path: Path) -> str:
     """Read a text file as UTF-8, falling back to the system locale encoding."""
@@ -496,6 +507,7 @@ def _start_proxy(
 
     # Ensure proxy subprocess uses UTF-8 (Windows defaults to cp1252)
     proxy_env = os.environ.copy()
+    _scrub_copilot_proxy_seed_env(proxy_env)
     proxy_env["PYTHONIOENCODING"] = "utf-8"
     # Vertex AI RST_STREAMs HTTP/2 connections (error_code:2). Force HTTP/1.1
     # when wrapping a Vertex-mode client so upstream requests succeed.
@@ -3016,6 +3028,9 @@ def _ensure_proxy(
 ) -> tuple[subprocess.Popen | None, int]:
     """Start or verify proxy. Returns (process_handle, actual_port)."""
     helpers = _live_wrap_module()
+    copilot_subscription_seed_requested = bool(copilot_refresh_oauth_token) or (
+        copilot_api_token_expires_at is not None
+    )
     # --no-proxy reuses an already-running proxy, so backend/region/provider
     # flags (which only apply when we start one) would be silently dropped.
     if no_proxy and (backend or anyllm_provider or region):
@@ -3025,7 +3040,15 @@ def _ensure_proxy(
         )
     if not no_proxy:
         manifest = helpers._find_persistent_manifest(port)
-        if manifest is not None:
+        isolated_copilot_subscription_proxy = copilot_subscription_seed_requested and (
+            manifest is not None or helpers._check_proxy(port)
+        )
+        if isolated_copilot_subscription_proxy:
+            click.echo(
+                "  Copilot subscription refresh seeds are session-specific; "
+                "starting a dedicated local proxy instance for this wrap session."
+            )
+        if not isolated_copilot_subscription_proxy and manifest is not None:
             from headroom.install.health import probe_ready
 
             if probe_ready(manifest.health_url):
@@ -3070,6 +3093,8 @@ def _ensure_proxy(
                         missing.append("learn")
                     if code_graph and not running_config.get("code_graph"):
                         missing.append("code_graph")
+                    if copilot_subscription_seed_requested:
+                        missing.append("copilot-subscription-auth")
                     if openai_api_url:
                         running_openai_url = _normalize_proxy_api_url(
                             running_config.get("openai_api_url")
@@ -3090,7 +3115,15 @@ def _ensure_proxy(
                     # the shared running-proxy checks below so mismatch-driven
                     # restart logic can run. For plain recover-only calls,
                     # preserve the historical fast return.
-                    if not any((memory, learn, code_graph, openai_api_url)):
+                    if not any(
+                        (
+                            memory,
+                            learn,
+                            code_graph,
+                            openai_api_url,
+                            copilot_subscription_seed_requested,
+                        )
+                    ):
                         return None, port
                     if not helpers._check_proxy(port):
                         return None, port
@@ -3124,6 +3157,8 @@ def _ensure_proxy(
                         missing.append("learn")
                     if code_graph and not running_config.get("code_graph"):
                         missing.append("code-graph")
+                    if copilot_subscription_seed_requested:
+                        missing.append("copilot-subscription-auth")
                     if openai_api_url:
                         running_openai_url = _normalize_proxy_api_url(
                             running_config.get("openai_api_url")
@@ -3154,7 +3189,7 @@ def _ensure_proxy(
                 "is stale; starting a fresh proxy instead."
             )
 
-        if helpers._check_proxy(port):
+        if not isolated_copilot_subscription_proxy and helpers._check_proxy(port):
             # Proxy is running — check if it has the features we need
             needs_restart = False
             health_payload = helpers._query_proxy_health(port)
@@ -3211,6 +3246,8 @@ def _ensure_proxy(
                     missing.append("learn")
                 if code_graph and not running_config.get("code_graph"):
                     missing.append("code_graph")
+                if copilot_subscription_seed_requested:
+                    missing.append("copilot-subscription-auth")
                 expected_savings_profile = helpers._wrap_agent_savings_profile(agent_type)
                 if (
                     expected_savings_profile is not None
@@ -3282,17 +3319,26 @@ def _ensure_proxy(
                 click.echo(f"  Dashboard:    http://127.0.0.1:{port}/dashboard")
                 return None, port
 
-        # Start (or restart) the proxy with the requested flags
-        # Find an available port (port may be busy from a stale proxy).
+        # Start (or restart) the proxy with the requested flags.
+        # Subscription-seeded sessions must not claim the shared port even if
+        # it is momentarily free; the persistent install or shared proxy still
+        # owns that slot semantically.
+        port_search_start = port + 1 if isolated_copilot_subscription_proxy else port
         try:
-            actual_port = helpers._find_available_port(port)
+            actual_port = helpers._find_available_port(port_search_start)
         except OSError as e:
             raise click.ClickException(f"Port {port} is unavailable: {e}") from e
         except RuntimeError as e:
             raise click.ClickException(str(e)) from e
 
         if actual_port != port:
-            click.echo(f"  Port {port} is in use, using port {actual_port} instead.")
+            if isolated_copilot_subscription_proxy:
+                click.echo(
+                    f"  Port {port} is reserved for the shared proxy; "
+                    f"using port {actual_port} for this dedicated session instead."
+                )
+            else:
+                click.echo(f"  Port {port} is in use, using port {actual_port} instead.")
 
         click.echo(f"  Starting Headroom proxy on port {actual_port}...")
         try:
@@ -4472,6 +4518,7 @@ def copilot(
                 _inject_rtk_instructions(copilot_instructions, verbose=verbose)
 
     env = os.environ.copy()
+    _scrub_copilot_proxy_seed_env(env)
     openai_api_url: str | None = None
     copilot_proxy_token: str | None = None
     copilot_refresh_oauth_token: str | None = None

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -435,6 +435,8 @@ def _start_proxy(
     vertex_api_url: str | None = None,
     clear_vertex_api_url: bool = False,
     copilot_api_token: str | None = None,
+    copilot_refresh_oauth_token: str | None = None,
+    copilot_api_token_expires_at: float | None = None,
 ) -> subprocess.Popen:
     """Start Headroom proxy as a background subprocess.
 
@@ -522,6 +524,10 @@ def _start_proxy(
         proxy_env["GITHUB_COPILOT_API_TOKEN"] = copilot_api_token
         if openai_api_url:
             proxy_env["GITHUB_COPILOT_API_URL"] = openai_api_url
+    if copilot_refresh_oauth_token:
+        proxy_env["GITHUB_COPILOT_REFRESH_OAUTH_TOKEN"] = copilot_refresh_oauth_token
+    if copilot_api_token_expires_at is not None:
+        proxy_env["GITHUB_COPILOT_API_TOKEN_EXPIRES_AT"] = str(copilot_api_token_expires_at)
 
     # Detach the proxy from the launching console on Windows so an ungraceful
     # close of the owning agent (closing the terminal window, taskkill, or a
@@ -3005,6 +3011,8 @@ def _ensure_proxy(
     vertex_api_url: str | None = None,
     clear_vertex_api_url: bool = False,
     copilot_api_token: str | None = None,
+    copilot_refresh_oauth_token: str | None = None,
+    copilot_api_token_expires_at: float | None = None,
 ) -> tuple[subprocess.Popen | None, int]:
     """Start or verify proxy. Returns (process_handle, actual_port)."""
     helpers = _live_wrap_module()
@@ -3304,6 +3312,8 @@ def _ensure_proxy(
                     vertex_api_url=vertex_api_url,
                     clear_vertex_api_url=clear_vertex_api_url,
                     copilot_api_token=copilot_api_token,
+                    copilot_refresh_oauth_token=copilot_refresh_oauth_token,
+                    copilot_api_token_expires_at=copilot_api_token_expires_at,
                 ),
             )
             click.echo(f"  Proxy ready on http://127.0.0.1:{actual_port}")
@@ -3516,6 +3526,8 @@ def _launch_tool(
     region: str | None = None,
     openai_api_url: str | None = None,
     copilot_api_token: str | None = None,
+    copilot_refresh_oauth_token: str | None = None,
+    copilot_api_token_expires_at: float | None = None,
 ) -> None:
     """Common logic: start proxy, launch tool, clean up."""
     proxy_holder: list[subprocess.Popen | None] = [None]
@@ -3545,6 +3557,8 @@ def _launch_tool(
             region=region,
             openai_api_url=openai_api_url,
             copilot_api_token=copilot_api_token,
+            copilot_refresh_oauth_token=copilot_refresh_oauth_token,
+            copilot_api_token_expires_at=copilot_api_token_expires_at,
         )
         if actual_port != port:
             _unregister_proxy_client(port)
@@ -4460,6 +4474,8 @@ def copilot(
     env = os.environ.copy()
     openai_api_url: str | None = None
     copilot_proxy_token: str | None = None
+    copilot_refresh_oauth_token: str | None = None
+    copilot_api_token_expires_at: float | None = None
     subscription_resolution = None
     if _should_use_copilot_oauth(
         backend=effective_backend,
@@ -4521,6 +4537,9 @@ def copilot(
         # os.environ — keeps the token off shared state and out of unrelated
         # code paths.
         copilot_proxy_token = client_bearer
+        if subscription_resolution is not None:
+            copilot_refresh_oauth_token = subscription_resolution.refresh_oauth_token
+            copilot_api_token_expires_at = subscription_resolution.api_token_expires_at
         env_vars_display = [
             "COPILOT_PROVIDER_TYPE=openai",
             f"COPILOT_PROVIDER_BASE_URL={env['COPILOT_PROVIDER_BASE_URL']}",
@@ -4603,6 +4622,8 @@ def copilot(
         region=region,
         openai_api_url=openai_api_url,
         copilot_api_token=copilot_proxy_token,
+        copilot_refresh_oauth_token=copilot_refresh_oauth_token,
+        copilot_api_token_expires_at=copilot_api_token_expires_at,
     )
 
 

--- a/headroom/copilot_auth.py
+++ b/headroom/copilot_auth.py
@@ -7,6 +7,7 @@ import ctypes
 import hashlib
 import json
 import logging
+import math
 import os
 import time
 from ctypes import wintypes
@@ -373,6 +374,8 @@ def _parse_expiry(value: Any) -> float | None:
 
     if isinstance(value, int | float):
         number = float(value)
+        if not math.isfinite(number):
+            return None
         if number > 10_000_000_000:
             return number / 1000.0
         return number
@@ -383,6 +386,10 @@ def _parse_expiry(value: Any) -> float | None:
             return None
         if raw.isdigit():
             return _parse_expiry(int(raw))
+        try:
+            return _parse_expiry(float(raw))
+        except ValueError:
+            pass
         try:
             normalized = raw.replace("Z", "+00:00")
             return datetime.fromisoformat(normalized).timestamp()
@@ -1019,12 +1026,10 @@ class CopilotTokenProvider:
 
             if explicit_api_token and refresh_oauth_token:
                 if cached is None:
+                    seeded_expires_at = _parse_expiry(os.environ.get(_API_TOKEN_EXPIRES_AT_ENV_VAR))
                     seeded = CopilotAPIToken(
                         token=explicit_api_token,
-                        expires_at=(
-                            _parse_expiry(os.environ.get(_API_TOKEN_EXPIRES_AT_ENV_VAR))
-                            or (time.time() + 1800)
-                        ),
+                        expires_at=seeded_expires_at if seeded_expires_at is not None else 0.0,
                         api_url=_configured_api_url(),
                     )
                     self._cached = seeded
@@ -1170,6 +1175,20 @@ def _token_kind(token: str) -> str:
     return "unknown" if t else "empty"
 
 
+def _is_managed_copilot_seeded_bearer(token: str) -> bool:
+    """Return True when the incoming bearer is the proxy's seeded wrapper token."""
+
+    refresh_oauth_token = os.environ.get(_REFRESH_OAUTH_TOKEN_ENV_VAR, "").strip()
+    explicit_api_token = os.environ.get("GITHUB_COPILOT_API_TOKEN", "").strip()
+    normalized = token.strip()
+    return bool(
+        refresh_oauth_token
+        and explicit_api_token
+        and normalized
+        and normalized == explicit_api_token
+    )
+
+
 async def apply_copilot_api_auth(headers: dict[str, str], *, url: str) -> dict[str, str]:
     """Apply Copilot auth headers for GitHub Copilot API requests."""
     resolved = dict(headers)
@@ -1187,14 +1206,20 @@ async def apply_copilot_api_auth(headers: dict[str, str], *, url: str) -> dict[s
             and raw_token
             and _is_forwardable_copilot_bearer_token(raw_token)
         ):
-            logger.info(
-                "apply_copilot_api_auth: passing through client token kind=%s",
-                _token_kind(raw_token),
-            )
-            for key in list(resolved):
-                if key.lower() == "x-api-key":
-                    resolved.pop(key)
-            return resolved
+            if _is_managed_copilot_seeded_bearer(raw_token):
+                logger.info(
+                    "apply_copilot_api_auth: managed seed token kind=%s, will replace",
+                    _token_kind(raw_token),
+                )
+            else:
+                logger.info(
+                    "apply_copilot_api_auth: passing through client token kind=%s",
+                    _token_kind(raw_token),
+                )
+                for key in list(resolved):
+                    if key.lower() == "x-api-key":
+                        resolved.pop(key)
+                return resolved
         logger.info(
             "apply_copilot_api_auth: incoming token not suitable (kind=%s), will replace",
             _token_kind(raw_token) if raw_token else "none",

--- a/headroom/copilot_auth.py
+++ b/headroom/copilot_auth.py
@@ -41,6 +41,8 @@ _API_TOKEN_ENV_VARS = (
     "GITHUB_COPILOT_API_TOKEN",
     "COPILOT_PROVIDER_BEARER_TOKEN",
 )
+_REFRESH_OAUTH_TOKEN_ENV_VAR = "GITHUB_COPILOT_REFRESH_OAUTH_TOKEN"
+_API_TOKEN_EXPIRES_AT_ENV_VAR = "GITHUB_COPILOT_API_TOKEN_EXPIRES_AT"
 _COPILOT_OAUTH_TOKEN_ENV_VARS = (
     "GITHUB_COPILOT_GITHUB_TOKEN",
     "GITHUB_COPILOT_TOKEN",
@@ -94,6 +96,8 @@ class CopilotSubscriptionTokenResolution:
     confidence: str
     api_url: str
     token_fingerprint: str
+    refresh_oauth_token: str | None = None
+    api_token_expires_at: float | None = None
 
 
 def token_fingerprint(token: str) -> str:
@@ -795,6 +799,8 @@ def _subscription_resolution(
     source: str,
     confidence: str,
     api_url: str,
+    refresh_oauth_token: str | None = None,
+    api_token_expires_at: float | None = None,
 ) -> CopilotSubscriptionTokenResolution:
     return CopilotSubscriptionTokenResolution(
         token=token,
@@ -802,6 +808,8 @@ def _subscription_resolution(
         confidence=confidence,
         api_url=api_url,
         token_fingerprint=token_fingerprint(token),
+        refresh_oauth_token=refresh_oauth_token,
+        api_token_expires_at=api_token_expires_at,
     )
 
 
@@ -833,6 +841,8 @@ def _subscription_resolution_from_token_exchange(
         source=f"{candidate.source}:token-exchange",
         confidence="copilot-token-exchange",
         api_url=_api_url_from_exchange_payload(payload, oauth_token=candidate.token),
+        refresh_oauth_token=candidate.token,
+        api_token_expires_at=_parse_expiry(payload.get("expires_at")),
     )
 
 
@@ -990,7 +1000,8 @@ class CopilotTokenProvider:
 
     async def get_api_token(self) -> CopilotAPIToken:
         explicit_api_token = os.environ.get("GITHUB_COPILOT_API_TOKEN", "").strip()
-        if explicit_api_token:
+        refresh_oauth_token = os.environ.get(_REFRESH_OAUTH_TOKEN_ENV_VAR, "").strip()
+        if explicit_api_token and not refresh_oauth_token:
             return CopilotAPIToken(
                 token=explicit_api_token,
                 expires_at=time.time() + 3600,
@@ -1005,6 +1016,23 @@ class CopilotTokenProvider:
             cached = self._cached
             if cached is not None and cached.is_valid:
                 return cached
+
+            if explicit_api_token and refresh_oauth_token:
+                if cached is None:
+                    seeded = CopilotAPIToken(
+                        token=explicit_api_token,
+                        expires_at=(
+                            _parse_expiry(os.environ.get(_API_TOKEN_EXPIRES_AT_ENV_VAR))
+                            or (time.time() + 1800)
+                        ),
+                        api_url=_configured_api_url(),
+                    )
+                    self._cached = seeded
+                    if seeded.is_valid:
+                        return seeded
+                exchanged = await self._exchange_token(refresh_oauth_token)
+                self._cached = exchanged
+                return exchanged
 
             oauth_token = read_cached_oauth_token()
             if not oauth_token:

--- a/tests/test_cli/test_wrap_copilot.py
+++ b/tests/test_cli/test_wrap_copilot.py
@@ -33,6 +33,8 @@ def _subscription_resolution(
     api_url: str = DEFAULT_API_URL,
     source: str = "headroom-copilot-auth:/tmp/copilot_auth.json:token-exchange",
     confidence: str = "copilot-token-exchange",
+    refresh_oauth_token: str | None = None,
+    api_token_expires_at: float | None = None,
 ) -> CopilotSubscriptionTokenResolution:
     return CopilotSubscriptionTokenResolution(
         token=token,
@@ -40,6 +42,8 @@ def _subscription_resolution(
         confidence=confidence,
         api_url=api_url,
         token_fingerprint="sha256:0123456789ab",
+        refresh_oauth_token=refresh_oauth_token,
+        api_token_expires_at=api_token_expires_at,
     )
 
 
@@ -463,7 +467,12 @@ def test_wrap_copilot_subscription_pins_validated_token_for_proxy(
         patch("headroom.cli.wrap.shutil.which", return_value="copilot"),
         patch(
             "headroom.cli.wrap.resolve_subscription_bearer_token_details",
-            return_value=_subscription_resolution("gho-validated", api_url=business_api),
+            return_value=_subscription_resolution(
+                "gho-validated",
+                api_url=business_api,
+                refresh_oauth_token="gho-refresh",
+                api_token_expires_at=1234567890.0,
+            ),
         ),
         patch("headroom.cli.wrap.has_oauth_auth", return_value=False),
         patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool),
@@ -476,8 +485,14 @@ def test_wrap_copilot_subscription_pins_validated_token_for_proxy(
     # The validated token is handed to the proxy as an explicit launch
     # argument — not via the child env, not via the parent's os.environ.
     assert captured["copilot_api_token"] == "gho-validated"
+    assert captured["copilot_refresh_oauth_token"] == "gho-refresh"
+    assert captured["copilot_api_token_expires_at"] == 1234567890.0
     assert "GITHUB_COPILOT_API_TOKEN" not in env
+    assert "GITHUB_COPILOT_REFRESH_OAUTH_TOKEN" not in env
+    assert "GITHUB_COPILOT_API_TOKEN_EXPIRES_AT" not in env
     assert os.environ.get("GITHUB_COPILOT_API_TOKEN") is None
+    assert os.environ.get("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN") is None
+    assert os.environ.get("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT") is None
     assert env["COPILOT_PROVIDER_TYPE"] == "openai"
     assert env["COPILOT_PROVIDER_BEARER_TOKEN"] == "gho-validated"
     assert env["GITHUB_COPILOT_USE_TOKEN_EXCHANGE"] == "false"

--- a/tests/test_cli/test_wrap_copilot.py
+++ b/tests/test_cli/test_wrap_copilot.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib
-import os
 import sys
 import types
 from pathlib import Path
@@ -291,6 +290,9 @@ def test_wrap_copilot_subscription_uses_github_auth_without_provider_key(
     _wrap_cli, main = wrap_modules
     for var in ("COPILOT_PROVIDER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "stale-parent-token")
+    monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "stale-parent-refresh")
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", "1")
     captured: dict[str, object] = {}
 
     def fake_launch_tool(**kwargs):  # noqa: ANN003
@@ -477,7 +479,15 @@ def test_wrap_copilot_subscription_pins_validated_token_for_proxy(
         patch("headroom.cli.wrap.has_oauth_auth", return_value=False),
         patch("headroom.cli.wrap._launch_tool", side_effect=fake_launch_tool),
     ):
-        result = runner.invoke(main, ["wrap", "copilot", "--subscription", "--no-rtk"])
+        result = runner.invoke(
+            main,
+            ["wrap", "copilot", "--subscription", "--no-rtk"],
+            env={
+                "GITHUB_COPILOT_API_TOKEN": "stale-parent-token",
+                "GITHUB_COPILOT_REFRESH_OAUTH_TOKEN": "stale-parent-refresh",
+                "GITHUB_COPILOT_API_TOKEN_EXPIRES_AT": "1",
+            },
+        )
 
     assert result.exit_code == 0, result.output
     env = captured["env"]
@@ -490,9 +500,6 @@ def test_wrap_copilot_subscription_pins_validated_token_for_proxy(
     assert "GITHUB_COPILOT_API_TOKEN" not in env
     assert "GITHUB_COPILOT_REFRESH_OAUTH_TOKEN" not in env
     assert "GITHUB_COPILOT_API_TOKEN_EXPIRES_AT" not in env
-    assert os.environ.get("GITHUB_COPILOT_API_TOKEN") is None
-    assert os.environ.get("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN") is None
-    assert os.environ.get("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT") is None
     assert env["COPILOT_PROVIDER_TYPE"] == "openai"
     assert env["COPILOT_PROVIDER_BEARER_TOKEN"] == "gho-validated"
     assert env["GITHUB_COPILOT_USE_TOKEN_EXCHANGE"] == "false"
@@ -818,9 +825,12 @@ def _clear_copilot_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "COPILOT_PROVIDER_BEARER_TOKEN",
         "OPENAI_API_KEY",
         "ANTHROPIC_API_KEY",
+        "GITHUB_COPILOT_API_TOKEN",
         "GITHUB_COPILOT_API_URL",
+        "GITHUB_COPILOT_API_TOKEN_EXPIRES_AT",
         "GITHUB_COPILOT_ENTERPRISE_URL",
         "GITHUB_COPILOT_ENTERPRISE_DOMAIN",
+        "GITHUB_COPILOT_REFRESH_OAUTH_TOKEN",
         "GITHUB_COPILOT_TOKEN",
         "GITHUB_COPILOT_GITHUB_TOKEN",
         "COPILOT_MODEL",

--- a/tests/test_cli/test_wrap_persistent.py
+++ b/tests/test_cli/test_wrap_persistent.py
@@ -374,6 +374,97 @@ def test_ensure_proxy_restarts_ephemeral_proxy_for_openai_api_url_mismatch(monke
     assert calls[1][2]["openai_api_url"] == "https://api.individual.githubcopilot.com"
 
 
+def test_ensure_proxy_starts_isolated_ephemeral_proxy_for_copilot_subscription_seed(
+    monkeypatch,
+) -> None:
+    calls: list[object] = []
+
+    monkeypatch.setattr(wrap_cli, "_find_persistent_manifest", lambda port: None)
+    monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: port == 8787)
+    monkeypatch.setattr(
+        wrap_cli,
+        "_find_available_port",
+        lambda start_port, **kw: calls.append(("find_port", start_port)) or 8788,
+    )
+    monkeypatch.setattr(
+        wrap_cli,
+        "_kill_proxy_by_pid",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("subscription-seeded session should not restart the shared proxy")
+        ),
+    )
+    monkeypatch.setattr(
+        wrap_cli,
+        "_start_proxy",
+        lambda *args, **kwargs: calls.append(("start", args, kwargs)),
+    )
+
+    proc, actual_port = wrap_cli._ensure_proxy(
+        8787,
+        False,
+        copilot_api_token="tid-session-token",
+        copilot_refresh_oauth_token="gho-refresh",
+        copilot_api_token_expires_at=456.5,
+    )
+
+    assert proc is None
+    assert actual_port == 8788
+    assert calls[0] == ("find_port", 8788)
+    assert calls[1][0] == "start"
+    assert calls[1][1][0] == 8788
+    assert calls[1][2]["copilot_api_token"] == "tid-session-token"
+    assert calls[1][2]["copilot_refresh_oauth_token"] == "gho-refresh"
+    assert calls[1][2]["copilot_api_token_expires_at"] == 456.5
+
+
+def test_ensure_proxy_starts_isolated_ephemeral_proxy_when_subscription_seed_targets_persistent_port(
+    monkeypatch,
+) -> None:
+    calls: list[object] = []
+
+    monkeypatch.setattr(wrap_cli, "_find_persistent_manifest", lambda port: _Manifest())
+    monkeypatch.setattr(
+        "headroom.install.health.probe_ready",
+        lambda url: (_ for _ in ()).throw(
+            AssertionError("subscription-seeded session should skip persistent probing")
+        ),
+    )
+    monkeypatch.setattr(
+        wrap_cli,
+        "_restart_persistent_proxy",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("subscription-seeded session should not restart the persistent proxy")
+        ),
+    )
+    monkeypatch.setattr(
+        wrap_cli,
+        "_find_available_port",
+        lambda start_port, **kw: calls.append(("find_port", start_port)) or 8788,
+    )
+    monkeypatch.setattr(
+        wrap_cli,
+        "_start_proxy",
+        lambda *args, **kwargs: calls.append(("start", args, kwargs)),
+    )
+
+    proc, actual_port = wrap_cli._ensure_proxy(
+        8787,
+        False,
+        copilot_api_token="tid-session-token",
+        copilot_refresh_oauth_token="gho-refresh",
+        copilot_api_token_expires_at=456.5,
+    )
+
+    assert proc is None
+    assert actual_port == 8788
+    assert calls[0] == ("find_port", 8788)
+    assert calls[1][0] == "start"
+    assert calls[1][1][0] == 8788
+    assert calls[1][2]["copilot_api_token"] == "tid-session-token"
+    assert calls[1][2]["copilot_refresh_oauth_token"] == "gho-refresh"
+    assert calls[1][2]["copilot_api_token_expires_at"] == 456.5
+
+
 def test_ensure_proxy_reuses_agent_proxy_without_savings_profile(monkeypatch) -> None:
     health = {
         "version": wrap_cli._HEADROOM_VERSION,

--- a/tests/test_cli_proxy_env.py
+++ b/tests/test_cli_proxy_env.py
@@ -106,6 +106,39 @@ class TestCLIWrapProxyTimeout:
         assert env["GITHUB_COPILOT_API_URL"] == "https://copilot-api.acme.ghe.com"
         assert env["GITHUB_COPILOT_API_TOKEN"] == "copilot-api-token"
 
+    def test_start_proxy_scrubs_inherited_copilot_refresh_seed_env(self, monkeypatch, tmp_path):
+        fake_proc = _FakeProxyProcess()
+        captured: dict[str, object] = {}
+
+        monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "stale-parent-token")
+        monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "stale-parent-refresh")
+        monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", "123")
+        monkeypatch.delenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, raising=False)
+        monkeypatch.setattr(wrap_mod, "_ml_wrap_extras_detected", lambda: False)
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
+        monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
+
+        def fake_popen(*args, **kwargs):  # noqa: ANN002, ANN003
+            captured["kwargs"] = kwargs
+            return fake_proc
+
+        monkeypatch.setattr(wrap_mod.subprocess, "Popen", fake_popen)
+
+        proc = wrap_mod._start_proxy(
+            8787,
+            agent_type="copilot",
+            copilot_api_token="copilot-api-token",
+            copilot_refresh_oauth_token="gho-refresh",
+            copilot_api_token_expires_at=456.5,
+        )
+
+        assert proc is fake_proc
+        env = captured["kwargs"]["env"]
+        assert env["GITHUB_COPILOT_API_TOKEN"] == "copilot-api-token"
+        assert env["GITHUB_COPILOT_REFRESH_OAUTH_TOKEN"] == "gho-refresh"
+        assert env["GITHUB_COPILOT_API_TOKEN_EXPIRES_AT"] == "456.5"
+
     def test_start_proxy_redirects_subprocess_stdio_to_standalone_log(self, monkeypatch, tmp_path):
         fake_proc = _FakeProxyProcess()
         captured: dict[str, object] = {}

--- a/tests/test_copilot_auth.py
+++ b/tests/test_copilot_auth.py
@@ -681,6 +681,39 @@ def test_apply_copilot_api_auth_passes_through_existing_api_token(
     assert "x-api-key" not in headers
 
 
+def test_apply_copilot_api_auth_replaces_managed_seeded_api_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_api_token() -> copilot_auth.CopilotAPIToken:
+        return copilot_auth.CopilotAPIToken(
+            token="copilot-refreshed",
+            expires_at=time.time() + 3600,
+            api_url=copilot_auth.DEFAULT_API_URL,
+        )
+
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "tid_existing_copilot_token")
+    monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "gho-refresh")
+    monkeypatch.setattr(
+        copilot_auth.get_copilot_token_provider(),
+        "get_api_token",
+        fake_get_api_token,
+    )
+
+    headers = asyncio.run(
+        copilot_auth.apply_copilot_api_auth(
+            {
+                "authorization": "Bearer tid_existing_copilot_token",
+                "x-api-key": "sk-downstream",
+            },
+            url="https://api.githubcopilot.com/v1/chat/completions",
+        )
+    )
+
+    assert headers["Authorization"] == "Bearer copilot-refreshed"
+    assert "authorization" not in headers
+    assert "x-api-key" not in headers
+
+
 def test_apply_copilot_api_auth_passes_through_github_oauth_bearer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -985,7 +1018,7 @@ def test_token_provider_refreshes_expired_seeded_explicit_token(
 ) -> None:
     monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "copilot-expired")
     monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "gho-refresh")
-    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(int(time.time()) - 120))
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(time.time() - 120))
     monkeypatch.delenv("GITHUB_COPILOT_USE_TOKEN_EXCHANGE", raising=False)
 
     provider = copilot_auth.CopilotTokenProvider()
@@ -1015,7 +1048,7 @@ def test_token_provider_reuses_valid_seeded_explicit_token_without_exchange(
 ) -> None:
     monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "copilot-valid")
     monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "gho-refresh")
-    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(int(time.time()) + 3600))
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(time.time() + 3600))
 
     provider = copilot_auth.CopilotTokenProvider()
     calls = {"count": 0}
@@ -1038,12 +1071,38 @@ def test_token_provider_reuses_valid_seeded_explicit_token_without_exchange(
     assert calls["count"] == 0
 
 
+def test_token_provider_refreshes_seeded_token_when_expiry_is_nonfinite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "copilot-expired")
+    monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "gho-refresh")
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", "inf")
+
+    provider = copilot_auth.CopilotTokenProvider()
+    calls = {"count": 0}
+
+    def fake_exchange(_headers: dict[str, str]) -> dict[str, object]:
+        calls["count"] += 1
+        return {
+            "token": "copilot-refreshed",
+            "expires_at": int(time.time()) + 3600,
+            "endpoints": {"api": "https://api.githubcopilot.com"},
+        }
+
+    monkeypatch.setattr(provider, "_exchange_token_sync", staticmethod(fake_exchange))
+
+    token = asyncio.run(provider.get_api_token())
+
+    assert token.token == "copilot-refreshed"
+    assert calls["count"] == 1
+
+
 def test_token_provider_refreshes_seeded_token_even_when_exchange_flag_is_false(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "copilot-expired")
     monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "gho-refresh")
-    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(int(time.time()) - 120))
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(time.time() - 120))
     monkeypatch.setenv("GITHUB_COPILOT_USE_TOKEN_EXCHANGE", "false")
 
     provider = copilot_auth.CopilotTokenProvider()
@@ -1070,7 +1129,7 @@ def test_token_provider_preserves_configured_api_url_when_refreshing_seeded_toke
 ) -> None:
     monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "copilot-expired")
     monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "gho-refresh")
-    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(int(time.time()) - 120))
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(time.time() - 120))
     monkeypatch.setenv("GITHUB_COPILOT_API_URL", "https://proxy.internal.example.com")
 
     provider = copilot_auth.CopilotTokenProvider()

--- a/tests/test_copilot_auth.py
+++ b/tests/test_copilot_auth.py
@@ -162,6 +162,8 @@ def test_resolve_subscription_bearer_token_details_exchanges_oauth_candidate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("GITHUB_COPILOT_API_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", raising=False)
     monkeypatch.delenv("COPILOT_PROVIDER_BEARER_TOKEN", raising=False)
     monkeypatch.delenv("GITHUB_COPILOT_API_URL", raising=False)
     monkeypatch.delenv("GITHUB_COPILOT_ENTERPRISE_URL", raising=False)
@@ -202,6 +204,8 @@ def test_resolve_subscription_bearer_token_details_exchanges_oauth_candidate(
     assert resolution.confidence == "copilot-token-exchange"
     assert resolution.api_url == "https://api.business.githubcopilot.com"
     assert resolution.token_fingerprint == copilot_auth.token_fingerprint("copilot-api")
+    assert resolution.refresh_oauth_token == "gho-oauth"
+    assert isinstance(resolution.api_token_expires_at, float)
     assert captured == {
         "Accept": "application/json",
         "Authorization": "Bearer gho-oauth",
@@ -942,6 +946,8 @@ def test_token_provider_can_exchange_when_enabled(monkeypatch: pytest.MonkeyPatc
 
 def test_token_provider_prefers_explicit_api_token(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "copilot-api")
+    monkeypatch.delenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", raising=False)
     monkeypatch.setenv("GITHUB_COPILOT_API_URL", "https://api.githubcopilot.com")
 
     token = asyncio.run(copilot_auth.CopilotTokenProvider().get_api_token())
@@ -952,6 +958,8 @@ def test_token_provider_prefers_explicit_api_token(monkeypatch: pytest.MonkeyPat
 
 def test_token_provider_raises_without_oauth_token(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GITHUB_COPILOT_API_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", raising=False)
     monkeypatch.setattr(copilot_auth, "read_cached_oauth_token", lambda: None)
 
     with pytest.raises(RuntimeError, match="No GitHub Copilot OAuth token"):
@@ -970,6 +978,119 @@ def test_exchange_token_raises_when_exchange_returns_empty_token(
 
     with pytest.raises(RuntimeError, match="empty token"):
         asyncio.run(provider._exchange_token("gho-oauth"))
+
+
+def test_token_provider_refreshes_expired_seeded_explicit_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "copilot-expired")
+    monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "gho-refresh")
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(int(time.time()) - 120))
+    monkeypatch.delenv("GITHUB_COPILOT_USE_TOKEN_EXCHANGE", raising=False)
+
+    provider = copilot_auth.CopilotTokenProvider()
+    calls = {"count": 0}
+    captured: dict[str, str] = {}
+
+    def fake_exchange(headers: dict[str, str]) -> dict[str, object]:
+        calls["count"] += 1
+        captured.update(headers)
+        return {
+            "token": "copilot-refreshed",
+            "expires_at": int(time.time()) + 3600,
+            "endpoints": {"api": "https://api.business.githubcopilot.com"},
+        }
+
+    monkeypatch.setattr(provider, "_exchange_token_sync", staticmethod(fake_exchange))
+
+    token = asyncio.run(provider.get_api_token())
+
+    assert token.token == "copilot-refreshed"
+    assert captured["Authorization"] == "Bearer gho-refresh"
+    assert calls["count"] == 1
+
+
+def test_token_provider_reuses_valid_seeded_explicit_token_without_exchange(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "copilot-valid")
+    monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "gho-refresh")
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(int(time.time()) + 3600))
+
+    provider = copilot_auth.CopilotTokenProvider()
+    calls = {"count": 0}
+
+    def fake_exchange(_headers: dict[str, str]) -> dict[str, object]:
+        calls["count"] += 1
+        return {
+            "token": "copilot-refreshed",
+            "expires_at": int(time.time()) + 3600,
+            "endpoints": {"api": "https://api.githubcopilot.com"},
+        }
+
+    monkeypatch.setattr(provider, "_exchange_token_sync", staticmethod(fake_exchange))
+
+    first = asyncio.run(provider.get_api_token())
+    second = asyncio.run(provider.get_api_token())
+
+    assert first.token == "copilot-valid"
+    assert second.token == "copilot-valid"
+    assert calls["count"] == 0
+
+
+def test_token_provider_refreshes_seeded_token_even_when_exchange_flag_is_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "copilot-expired")
+    monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "gho-refresh")
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(int(time.time()) - 120))
+    monkeypatch.setenv("GITHUB_COPILOT_USE_TOKEN_EXCHANGE", "false")
+
+    provider = copilot_auth.CopilotTokenProvider()
+    calls = {"count": 0}
+
+    def fake_exchange(_headers: dict[str, str]) -> dict[str, object]:
+        calls["count"] += 1
+        return {
+            "token": "copilot-refreshed",
+            "expires_at": int(time.time()) + 3600,
+            "endpoints": {"api": "https://api.githubcopilot.com"},
+        }
+
+    monkeypatch.setattr(provider, "_exchange_token_sync", staticmethod(fake_exchange))
+
+    token = asyncio.run(provider.get_api_token())
+
+    assert token.token == "copilot-refreshed"
+    assert calls["count"] == 1
+
+
+def test_token_provider_preserves_configured_api_url_when_refreshing_seeded_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN", "copilot-expired")
+    monkeypatch.setenv("GITHUB_COPILOT_REFRESH_OAUTH_TOKEN", "gho-refresh")
+    monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", str(int(time.time()) - 120))
+    monkeypatch.setenv("GITHUB_COPILOT_API_URL", "https://proxy.internal.example.com")
+
+    provider = copilot_auth.CopilotTokenProvider()
+
+    monkeypatch.setattr(
+        provider,
+        "_exchange_token_sync",
+        staticmethod(
+            lambda _headers: {
+                "token": "copilot-refreshed",
+                "expires_at": int(time.time()) + 3600,
+                "endpoints": {"api": "https://api.other.githubcopilot.com"},
+            }
+        ),
+    )
+
+    token = asyncio.run(provider.get_api_token())
+
+    assert token.token == "copilot-refreshed"
+    assert token.api_url == "https://proxy.internal.example.com"
 
 
 def test_exchange_token_sync_raises_for_http_error(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description

`headroom wrap copilot --subscription` currently validates a Copilot subscription credential once at launch, exchanges it once, and then pins that short-lived API token into the proxy as an explicit override. When the token expires, long-lived wrapped sessions start returning `transient_auth_error` and then a final HTTP 401 until the entire wrapped session is restarted.

This PR keeps the validated launch token for first-request determinism, carries reusable OAuth refresh material into the proxy, and refreshes inside `CopilotTokenProvider` when the seeded token is expired. The explicit `GITHUB_COPILOT_API_TOKEN` override path stays unchanged when no reusable OAuth token exists. The configured `GITHUB_COPILOT_API_URL` also stays pinned across refresh, matching the current wrap contract.

Closes #2156.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Extended the Copilot subscription token resolution path to carry reusable OAuth refresh material and expiry metadata instead of discarding it after the wrap-time exchange.
- Reworked `CopilotTokenProvider.get_api_token()` so it seeds the wrapper-validated launch token once for the first request, then refreshes through the existing exchange path when that token is expired and reusable OAuth material exists.
- Rejected non-finite seeded expiry values such as `inf`, so malformed `GITHUB_COPILOT_API_TOKEN_EXPIRES_AT` inputs cannot pin a stale launch token forever.
- Preserved the explicit `GITHUB_COPILOT_API_TOKEN` override path when no reusable OAuth token exists, so non-refreshable overrides keep today's fixed behavior.
- Kept explicitly configured `GITHUB_COPILOT_API_URL` values pinned across refresh rather than adopting a refreshed payload's host.
- Replaced wrapper-managed seeded `tid_` bearer passthrough with the refresh-aware provider path, so the wrapped CLI no longer bypasses expiry refresh just because it keeps sending the launch token back to the proxy.
- Started a dedicated local proxy instance whenever a subscription-seeded session targets a shared or persistent proxy port, so per-session refresh material is not silently dropped on healthy-proxy reuse or cross-wired between concurrent sessions.
- Scrubbed inherited Copilot refresh-seed environment variables from both the Copilot child env and the proxy subprocess env before re-injecting the explicit launch-time values.
- Added focused auth, wrap, proxy-env, and proxy-reuse regression coverage for expiry refresh, non-finite expiry rejection, session-local proxy isolation, explicit-override preservation, exchange-flag independence, configured API URL pinning, and secret handling.

## Testing

- [x] Unit tests pass (`uv run pytest tests/test_copilot_auth.py tests/test_cli/test_wrap_copilot.py tests/test_cli_proxy_env.py tests/test_cli/test_wrap_persistent.py -q`)
- [x] Linting passes (`uv run ruff check headroom/copilot_auth.py headroom/cli/wrap.py tests/test_copilot_auth.py tests/test_cli/test_wrap_copilot.py tests/test_cli_proxy_env.py tests/test_cli/test_wrap_persistent.py`)
- [x] Formatting passes (`uv run ruff format --check headroom/copilot_auth.py headroom/cli/wrap.py tests/test_copilot_auth.py tests/test_cli/test_wrap_copilot.py tests/test_cli_proxy_env.py tests/test_cli/test_wrap_persistent.py`)
- [x] Type checking passes (`uv run mypy headroom/copilot_auth.py`)
- [x] New tests added for new functionality when applicable
- [ ] Manual testing performed

### Test Output

```text
195 passed, 1 skipped in 3.14s
```

```text
All checks passed!
```

```text
6 files already formatted
```

```text
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Python 3.12.13, `uv`, no live Copilot credentials.
- Exact command / steps: run the focused auth, wrap, proxy-env, and proxy-reuse regression suite after seeding an expired launch token plus reusable OAuth refresh material, then rerun lint and format checks on the touched files.
- Observed result: base reproduces the bug because the explicit-token branch never refreshes, accepts non-finite expiry inputs, and shared-proxy reuse can keep the wrong per-session refresh seed alive; head refreshes through the reusable OAuth token, rejects non-finite seeded expiry, replaces the wrapper-managed seeded bearer instead of blindly passing it through, preserves the valid-seed fast path and the fixed override path when no refresh material exists, keeps the configured API URL pinned across refresh, starts a dedicated local proxy when the requested port already belongs to a shared or persistent proxy, and keeps the reusable OAuth token confined to explicit proxy launch env only. The focused suite passed with `195 passed, 1 skipped in 3.14s`.
- Not tested: live business-subscription session past the provider's real token-expiry window.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

- Scope stays provider-local. The fix remains inside `headroom/copilot_auth.py` and the Copilot wrap handoff in `headroom/cli/wrap.py`; it does not add generic 401 retry logic to provider-neutral proxy layers.
- The line that disables token exchange for the Copilot CLI child env is unchanged because it never reached the proxy env and was not the root cause.
- Subscription-seeded sessions now get a dedicated local proxy whenever the requested port already belongs to a shared or persistent proxy; existing shared proxies are left alone to avoid disrupting attached wrappers.
- Live provider confirmation still needs maintainer or reporter validation because that truth is owned by GitHub's real subscription APIs, not by local stubs.
- Headroom's release pipeline generates changelog entries from conventional commits, so `CHANGELOG.md` is intentionally untouched.
