### PR TITLE
feat(proxy): allow trusted dashboard clients

### DIFF
--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -1327,8 +1327,8 @@
                         <div class="px-4 py-8 text-center">
                             <div class="text-xs text-gray-500 mb-3">No per-project data yet.</div>
                             <div class="text-xs text-gray-600 font-mono leading-relaxed">
-                                Route project traffic through
-                                <span class="text-accent" x-text="window.location.origin + '/p/&lt;project-name&gt;'"></span>
+                                Add to each project's <span class="text-gray-400">.claude/settings.local.json</span>:<br>
+                                <span class="text-accent" x-text="'ANTHROPIC_BASE_URL: ' + window.location.origin + '/p/<project-name>'"></span>
                             </div>
                         </div>
                     </template>

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -473,7 +473,7 @@
                 </div>
 
                 <!-- Prefix Cache Impact: current process only -->
-                <template x-if="cacheSessionActive">
+                <template x-if="hasPrefixCacheImpact">
                     <div class="bg-surface rounded-lg p-4 border border-border mb-6">
                         <div class="flex justify-between items-center mb-3">
                             <div class="text-sm font-medium text-gray-300">Prefix Cache Impact</div>
@@ -520,6 +520,13 @@
                                 <div class="text-xs text-gray-500" x-show="!cacheSessionActive">no activity since restart</div>
                             </div>
                         </div>
+                        <template x-if="lifetimeCacheReadTokens > 0 || lifetimeCacheSavingsUsd > 0">
+                            <div class="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3 mb-4">
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Reads (lifetime)</div>
+                                <div class="text-2xl font-light tabular-nums text-emerald-400" x-text="formatNumber(lifetimeCacheReadTokens)"></div>
+                                <div class="text-xs text-emerald-400/70" x-text="'$' + formatCurrency(lifetimeCacheSavingsUsd) + ' saved'"></div>
+                            </div>
+                        </template>
                         <!-- Cache efficiency bar (session-scoped; hidden until traffic arrives) -->
                         <div x-show="cacheSessionActive">
                             <div class="flex justify-between text-xs text-gray-500 mb-1">
@@ -2480,6 +2487,20 @@
 
                 get cacheSessionActive() {
                     return (this.stats.prefix_cache?.totals?.requests || 0) > 0;
+                },
+
+                get lifetimeCacheReadTokens() {
+                    return this.stats.persistent_savings?.lifetime?.cache_read_tokens || 0;
+                },
+
+                get lifetimeCacheSavingsUsd() {
+                    return this.stats.persistent_savings?.lifetime?.cache_savings_usd || 0;
+                },
+
+                get hasPrefixCacheImpact() {
+                    return this.cacheSessionActive
+                        || this.lifetimeCacheReadTokens > 0
+                        || this.lifetimeCacheSavingsUsd > 0;
                 },
 
                 get cacheSavingsPercent() {

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -393,6 +393,10 @@
                                 <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
                                 <span class="font-mono text-sm text-emerald-400" x-text="formatNumber(cliFilteringSaved)"></span>
                             </div>
+                            <div class="flex justify-between items-center" x-show="cliFilteringAvailable">
+                                <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (lifetime)'"></span>
+                                <span class="font-mono text-sm text-emerald-400" x-text="formatNumber(cliFilteringLifetime)"></span>
+                            </div>
                             <div class="flex justify-between items-center" x-show="!cliFilteringAvailable">
                                 <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
                                 <span class="font-mono text-sm text-gray-600">not installed</span>

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Headroom Dashboard</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
-    <script src="https://unpkg.com/alpinejs@3.13.3/dist/cdn.min.js" defer></script>
+    <script src="/dashboard/static/tailwind.min.js"></script>
+    <script src="/dashboard/static/htmx.min.js"></script>
+    <script src="/dashboard/static/alpine.min.js" defer></script>
     <script>
         (function() {
             const saved = localStorage.getItem('headroom-theme');
@@ -209,7 +209,7 @@
                 <div class="grid grid-cols-1 gap-4 mb-6 md:grid-cols-2 lg:grid-cols-3">
                     <!-- Token Savings (%) -->
                     <div class="bg-surface rounded-lg p-4 border border-border">
-                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Token Savings</div>
+                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Tokens Saved</div>
                         <div class="flex items-baseline gap-2">
                             <span class="text-3xl font-light tabular-nums text-accent" x-text="formatNumber(stats.tokens?.saved || 0)"></span>
                             <!-- Active compression ratio: savings as a fraction of tokens we
@@ -222,8 +222,6 @@
                         </div>
                         <div class="mt-1 text-xs text-gray-500 leading-relaxed">
                             <span x-text="'Proxy ' + formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' (' + proxyShareOfTotal.toFixed(1) + '%)'"></span>
-                            <span class="mx-1 text-gray-600">/</span>
-                            <span x-text="cliFilteringAvailable ? (cliFilteringLabel + ' ' + formatNumber(cliFilteringSaved) + ' this session (' + cliFilteringSessionPctDisplay.toFixed(1) + '%)') : (cliFilteringLabel + ' not installed')"></span>
                         </div>
                         <div class="mt-1 text-xs text-gray-600 leading-relaxed">
                             <span x-text="'Of total wire: ' + (stats.tokens?.savings_percent || 0).toFixed(2) + '%'" title="Savings as fraction of all input tokens including frozen prefix"></span>
@@ -272,10 +270,13 @@
                         </template>
                     </div>
 
-                    <!-- Tool-Schema Deferral (tool search) — only rendered when there's a saving to show -->
+                    <!-- Tool-schema deferral: a COMPONENT of the Tokens Saved headline above
+                         (stats.tokens.saved is all-layers), not a rival metric. Labelled as
+                         such so a tool-heavy session doesn't read as "0 saved + some other
+                         number". Only rendered when there's a saving to show. -->
                     <template x-if="(stats.savings?.by_layer?.tool_search?.tokens || 0) > 0">
                         <div class="bg-surface rounded-lg p-4 border border-border">
-                            <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Tool-Schema Deferral</div>
+                            <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Tokens Saved · Tool Schemas</div>
                             <div class="flex items-baseline gap-2">
                                 <span class="text-3xl font-light tabular-nums text-emerald-400" x-text="formatNumber(stats.savings?.by_layer?.tool_search?.tokens || 0)"></span>
                                 <span class="text-sm text-gray-400">tokens</span>
@@ -389,18 +390,6 @@
                                 <span class="text-sm text-gray-400">Before Compression</span>
                                 <span class="font-mono text-sm" x-text="formatNumber(stats.tokens?.total_before_compression || 0)"></span>
                             </div>
-                            <div class="flex justify-between items-center" x-show="cliFilteringAvailable">
-                                <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
-                                <span class="font-mono text-sm text-emerald-400" x-text="formatNumber(cliFilteringSaved)"></span>
-                            </div>
-                            <div class="flex justify-between items-center" x-show="cliFilteringAvailable">
-                                <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (lifetime)'"></span>
-                                <span class="font-mono text-sm text-emerald-400" x-text="formatNumber(cliFilteringLifetime)"></span>
-                            </div>
-                            <div class="flex justify-between items-center" x-show="!cliFilteringAvailable">
-                                <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
-                                <span class="font-mono text-sm text-gray-600">not installed</span>
-                            </div>
                             <div class="flex justify-between items-center">
                                 <span class="text-sm text-gray-400">Proxy Removed</span>
                                 <span class="font-mono text-sm text-accent" x-text="formatNumber(stats.tokens?.proxy_compression_saved || 0)"></span>
@@ -472,8 +461,8 @@
                     </div>
                 </div>
 
-                <!-- Prefix Cache Impact: current process only -->
-                <template x-if="hasPrefixCacheImpact">
+                <!-- Prefix Cache Impact: current process plus durable cache reads after restart -->
+                <template x-if="cacheCardAvailable">
                     <div class="bg-surface rounded-lg p-4 border border-border mb-6">
                         <div class="flex justify-between items-center mb-3">
                             <div class="text-sm font-medium text-gray-300">Prefix Cache Impact</div>
@@ -483,6 +472,15 @@
                             <div class="text-xs text-gray-500 font-mono"
                                  x-show="!cacheSessionActive">no activity since restart</div>
                         </div>
+                        <template x-if="!cacheSessionActive && lifetimeCacheReadTokens > 0">
+                            <div class="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3">
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Reads (lifetime)</div>
+                                <div class="text-2xl font-light tabular-nums text-cyan-400"
+                                     x-text="formatNumber(lifetimeCacheReadTokens)"></div>
+                                <div class="text-xs text-cyan-400/70"
+                                     x-text="'$' + formatCurrency(lifetimeCacheSavingsUsd) + ' saved'"></div>
+                            </div>
+                        </template>
                         <!-- Totals row -->
                         <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
                             <div>
@@ -520,13 +518,6 @@
                                 <div class="text-xs text-gray-500" x-show="!cacheSessionActive">no activity since restart</div>
                             </div>
                         </div>
-                        <template x-if="lifetimeCacheReadTokens > 0 || lifetimeCacheSavingsUsd > 0">
-                            <div class="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3 mb-4">
-                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Reads (lifetime)</div>
-                                <div class="text-2xl font-light tabular-nums text-emerald-400" x-text="formatNumber(lifetimeCacheReadTokens)"></div>
-                                <div class="text-xs text-emerald-400/70" x-text="'$' + formatCurrency(lifetimeCacheSavingsUsd) + ' saved'"></div>
-                            </div>
-                        </template>
                         <!-- Cache efficiency bar (session-scoped; hidden until traffic arrives) -->
                         <div x-show="cacheSessionActive">
                             <div class="flex justify-between text-xs text-gray-500 mb-1">
@@ -794,7 +785,9 @@
 
                         <template x-if="agentRows.length === 0">
                             <div class="rounded-lg border border-dashed border-border p-6 text-center text-sm text-gray-500">
-                                Agent usage appears after Cursor, Claude, Codex, or another client sends traffic through this proxy.
+                                <div>Agent usage appears after Cursor, Claude, Codex, or another client sends traffic through this proxy.</div>
+                                <div class="mt-2 font-mono text-xs text-accent"
+                                     x-text="'ANTHROPIC_BASE_URL: ' + window.location.origin + '/p/&lt;project-name&gt;'"></div>
                             </div>
                         </template>
                     </div>
@@ -1334,8 +1327,7 @@
                         <div class="px-4 py-8 text-center">
                             <div class="text-xs text-gray-500 mb-3">No per-project data yet.</div>
                             <div class="text-xs text-gray-600 font-mono leading-relaxed">
-                                Add to each project's <span class="text-gray-400">.claude/settings.local.json</span>:<br>
-                                <span class="text-accent" x-text="'ANTHROPIC_BASE_URL: ' + window.location.origin + '/p/<project-name>'"></span>
+                                <span class="text-accent" x-text="'ANTHROPIC_BASE_URL: ' + window.location.origin + '/p/&lt;project-name&gt;'"></span>
                             </div>
                         </div>
                     </template>
@@ -1467,17 +1459,6 @@
                         <div class="mt-2 text-xs text-gray-500">Based on persisted weekly buckets</div>
                     </div>
 
-                    <template x-if="historyStats.cli_filtering && historyCliFilteringAvailable">
-                        <div class="bg-surface rounded-lg p-4 border border-border">
-                            <div class="text-xs text-gray-500 uppercase tracking-wide mb-1"
-                                 x-text="(historyStats.cli_filtering?.label || cliFilteringLabel) + ' Lifetime Saved'"></div>
-                            <div class="flex items-baseline gap-2">
-                                <span class="text-3xl font-light tabular-nums text-cyan-400"
-                                      x-text="formatNumber(historyStats.cli_filtering?.lifetime?.tokens_saved || 0)"></span>
-                            </div>
-                            <div class="mt-2 text-xs text-gray-500">CLI output filtering (lifetime)</div>
-                        </div>
-                    </template>
                 </div>
 
                 <template x-if="hasHistoricalData">
@@ -2497,10 +2478,8 @@
                     return this.stats.persistent_savings?.lifetime?.cache_savings_usd || 0;
                 },
 
-                get hasPrefixCacheImpact() {
-                    return this.cacheSessionActive
-                        || this.lifetimeCacheReadTokens > 0
-                        || this.lifetimeCacheSavingsUsd > 0;
+                get cacheCardAvailable() {
+                    return this.cacheSessionActive || this.lifetimeCacheReadTokens > 0 || this.lifetimeCacheSavingsUsd > 0;
                 },
 
                 get cacheSavingsPercent() {
@@ -2631,49 +2610,6 @@
                     const total = this.compressionTotalBefore;
                     if (total <= 0) return 0;
                     return (this.stats.tokens?.proxy_compression_saved || 0) / total * 100;
-                },
-
-                get cliFilteringLabel() {
-                    const raw = this.stats.savings?.by_layer?.cli_filtering?.label
-                        || this.stats.context_tool?.label
-                        || this.stats.context_tool?.configured
-                        || 'Context Tool';
-                    if (String(raw).toLowerCase() === 'lean-ctx') return 'Lean-ctx';
-                    return String(raw);
-                },
-
-                get cliFilteringSaved() {
-                    return this.stats.tokens?.cli_filtering_saved
-                        ?? this.stats.tokens?.cli_tokens_avoided
-                        ?? this.stats.tokens?.rtk_saved
-                        ?? 0;
-                },
-
-                get cliFilteringShareOfTotal() {
-                    const total = this.compressionTotalBefore;
-                    if (total <= 0) return 0;
-                    return this.cliFilteringSaved / total * 100;
-                },
-
-                get cliFilteringLifetime() {
-                    return this.stats.savings?.by_layer?.cli_filtering?.lifetime?.tokens_saved ?? 0;
-                },
-
-                get cliFilteringSessionPctDisplay() {
-                    const p = this.stats.savings?.by_layer?.cli_filtering?.session_savings_pct;
-                    return (p === null || p === undefined) ? this.cliFilteringShareOfTotal : p;
-                },
-
-                get cliFilteringAvailable() {
-                    const ct = this.stats.context_tool;
-                    if (ct && typeof ct.available === 'boolean') return ct.available;
-                    return true;
-                },
-
-                get historyCliFilteringAvailable() {
-                    const hf = this.historyStats?.cli_filtering;
-                    if (hf && typeof hf.available === 'boolean') return hf.available;
-                    return true;
                 },
 
                 // --- Headline savings percent ---

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -53,7 +53,6 @@ if TYPE_CHECKING:
 import httpx
 
 try:
-    import uvicorn
     from fastapi import Depends, FastAPI, HTTPException, Request, Response
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
@@ -61,6 +60,13 @@ try:
     FASTAPI_AVAILABLE = True
 except ImportError:
     FASTAPI_AVAILABLE = False
+
+try:
+    import uvicorn
+
+    UVICORN_AVAILABLE = True
+except ImportError:
+    UVICORN_AVAILABLE = False
 
 # Add parent to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -5019,6 +5025,10 @@ def run_server(
     """
     if not FASTAPI_AVAILABLE:
         print("ERROR: FastAPI required. Install: pip install fastapi uvicorn httpx")
+        sys.exit(1)
+
+    if not UVICORN_AVAILABLE:
+        print("ERROR: Uvicorn required. Install: pip install uvicorn")
         sys.exit(1)
 
     # Seed the request-time coding-profile toggles (tool-search, dedupe, read

--- a/tests/test_dashboard_cache_ttl_playwright.py
+++ b/tests/test_dashboard_cache_ttl_playwright.py
@@ -194,6 +194,8 @@ def test_dashboard_per_project_setup_url_uses_current_origin() -> None:
         _install_dashboard_routes(page)
 
         page.goto("http://127.0.0.1:8788/dashboard", wait_until="load")
+        page.get_by_role("button", name="Lifetime").click()
+        expect(page.get_by_text("Per-Project Savings")).to_be_visible()
         expect(
             page.get_by_text(
                 "ANTHROPIC_BASE_URL: http://127.0.0.1:8788/p/<project-name>", exact=True
@@ -206,6 +208,8 @@ def test_dashboard_per_project_setup_url_uses_current_origin() -> None:
         ).to_have_count(0)
 
         page.goto("http://headroom.local:9393/dashboard", wait_until="load")
+        page.get_by_role("button", name="Lifetime").click()
+        expect(page.get_by_text("Per-Project Savings")).to_be_visible()
         expect(
             page.get_by_text(
                 "ANTHROPIC_BASE_URL: http://headroom.local:9393/p/<project-name>", exact=True


### PR DESCRIPTION
## Status

The trusted-dashboard-client access-control implementation described by this PR has since landed on upstream `main`. After aligning the branch with current dashboard behavior, the remaining diff no longer contains that access-control feature.

The remaining branch-only changes are:

- decouple FastAPI and Uvicorn availability checks so importing the server does not require Uvicorn;
- retain focused dashboard URL assertions that switch to the Lifetime view before checking per-project setup text.

This branch is conflict-free and suitable for a human supersession/close decision. It should not be merged as though it still introduces trusted dashboard client CIDRs.

## Testing

```text
uv run --extra dev pytest tests/test_proxy_loopback_gating.py tests/test_forwarded_headers.py -q
80 passed, 1 deprecation warning
```

The dashboard CI initially found two copies of the lifetime cache card after the `main` alignment. The stale duplicate was removed. The local environment did not have Playwright installed, so the refreshed dashboard UI job is the authoritative rerun for that check.

## Review Readiness

- [x] Conflict resolved against current upstream behavior
- [x] Description updated to match the remaining diff
- [x] Ready for human supersession/close review
