### PR TITLE
fix(ci): retry apt installs in wheel smoke gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,18 +608,30 @@ jobs:
                 fi
               elif command -v apt-get >/dev/null 2>&1; then
                 export DEBIAN_FRONTEND=noninteractive
-                apt-get update -qq
+                apt_retry() {
+                  apt_get_args="$*"
+                  for attempt in 1 2 3; do
+                    if apt-get "$@"; then
+                      return 0
+                    fi
+                    echo "apt-get ${apt_get_args} failed on attempt ${attempt}; refreshing package lists" >&2
+                    apt-get update -qq || true
+                    sleep $((attempt * 5))
+                  done
+                  apt-get "$@"
+                }
+                apt_retry update -qq
                 # ubuntu:20.04s default repo only ships 3.8; 3.10 lives
                 # in deadsnakes. Add it on demand. ubuntu:22.04 has
                 # 3.10/3.11 in main and 3.12 via deadsnakes.
-                apt-get install -y -qq --no-install-recommends ca-certificates software-properties-common >/dev/null
+                apt_retry install -y -qq --fix-missing --no-install-recommends ca-certificates software-properties-common >/dev/null
                 add-apt-repository -y ppa:deadsnakes/ppa >/dev/null 2>&1 || true
-                apt-get update -qq
-                apt-get install -y -qq --no-install-recommends \
+                apt_retry update -qq
+                apt_retry install -y -qq --fix-missing --no-install-recommends \
                   "python$PYTHON_VERSION" \
                   "python$PYTHON_VERSION-venv" \
                   "python$PYTHON_VERSION-distutils" >/dev/null 2>&1 \
-                || apt-get install -y -qq --no-install-recommends \
+                || apt_retry install -y -qq --fix-missing --no-install-recommends \
                   "python$PYTHON_VERSION" \
                   "python$PYTHON_VERSION-venv" >/dev/null
                 python_bin="python$PYTHON_VERSION"

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -835,6 +835,25 @@ def test_npm_publish_jobs_do_not_download_dist_artifact() -> None:
         )
 
 
+def test_smoke_import_ubuntu_apt_installs_are_retried() -> None:
+    """Ubuntu smoke-import containers must tolerate stale package mirrors.
+
+    The ARM Ubuntu ports mirror can briefly serve indexes that point at a
+    package version which has just been removed, causing apt install to fail
+    with a 404 even after an update. Keep the smoke gate strict, but retry the
+    package operations and use --fix-missing so transient mirror skew does not
+    make unrelated PRs red.
+    """
+    content = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    smoke_start = content.index("\n  smoke-import-wheels:")
+    smoke_end = content.index("\n  publish-pypi:", smoke_start)
+    smoke_body = content[smoke_start:smoke_end]
+
+    assert "apt_retry()" in smoke_body
+    assert "apt_retry update -qq" in smoke_body
+    assert "apt_retry install -y -qq --fix-missing --no-install-recommends" in smoke_body
+
+
 def test_release_workflow_runs_dry_run_on_pull_request() -> None:
     """X2: the release workflow MUST trigger on `pull_request` for paths
     that change wheel-layout / release pipeline so the wheel matrix +


### PR DESCRIPTION
## Summary
- add a small retry helper around Ubuntu-container `apt-get` operations in the Release wheel smoke-import gate
- use `--fix-missing` for the package installs that can fail when the ARM Ubuntu ports mirror serves stale package indexes
- add a workflow regression test so the smoke gate keeps the retry/fix-missing hardening

## Why
A Release smoke-import job on PR #2160 failed twice in the Ubuntu 22.04 ARM container while installing Python 3.12 dependencies:

`E: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/p/python-httplib2/python3-httplib2_0.20.2-2ubuntu0.1_all.deb 404 Not Found`

The smoke gate should still fail for broken wheels, but transient apt mirror skew should not make unrelated PRs red.

## Validation
- `python -m pytest tests/test_release_workflows.py -q` -> 32 passed
- `uvx ruff@0.15.17 check tests/test_release_workflows.py` -> All checks passed
- `git diff --check`