### PR TITLE
feat(dashboard): persist lifetime proxy metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,5 @@ uv.lock
 /headroom/_core.*.so
 /headroom/_core.so
 .tokensave
+
+.codebase-memory/

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -1303,6 +1303,79 @@
                     <section class="bg-surface rounded-lg p-4 border border-border"><h3 class="mb-3 text-sm text-gray-300">Stacks</h3><template x-for="[name, count] in Object.entries(lifetimeStats.requests?.by_stack || {})" :key="name"><div class="flex justify-between text-sm"><span x-text="name"></span><span x-text="formatNumber(count)"></span></div></template></section>
                     <section class="bg-surface rounded-lg p-4 border border-border"><h3 class="mb-3 text-sm text-gray-300">Top Models + Other</h3><template x-for="[name, metric] in Object.entries(lifetimeStats.by_model || {})" :key="name"><div class="flex justify-between text-sm"><span class="truncate pr-3" x-text="name"></span><span x-text="formatNumber(metric.input_tokens + metric.output_tokens)"></span></div></template></section>
                 </div>
+                <!-- Per-Project Savings Breakdown -->
+                <section class="bg-surface rounded-lg border border-border overflow-hidden mt-6">
+                    <div class="px-4 py-3 border-b border-border flex justify-between items-center">
+                        <div>
+                            <span class="text-sm font-medium text-gray-300">Per-Project Savings</span>
+                            <div class="text-xs text-gray-500 mt-0.5">Lifetime totals — attributed requests only</div>
+                        </div>
+                        <span class="text-xs text-gray-500 font-mono"
+                              x-text="Object.keys(lifetimeStats.projects || {}).length + ' project(s)'"></span>
+                    </div>
+
+                    <template x-if="Object.keys(lifetimeStats.projects || {}).length === 0">
+                        <div class="px-4 py-8 text-center">
+                            <div class="text-xs text-gray-500 mb-3">No per-project data yet.</div>
+                            <div class="text-xs text-gray-600 font-mono leading-relaxed">
+                                Route project traffic through
+                                <span class="text-accent" x-text="window.location.origin + '/p/&lt;project-name&gt;'"></span>
+                            </div>
+                        </div>
+                    </template>
+
+                    <template x-if="Object.keys(lifetimeStats.projects || {}).length > 0">
+                        <div class="overflow-x-auto">
+                            <table class="w-full text-sm" style="table-layout:fixed">
+                                <colgroup>
+                                    <col style="width:25%">
+                                    <col style="width:10%">
+                                    <col style="width:15%">
+                                    <col style="width:12%">
+                                    <col style="width:18%">
+                                    <col style="width:20%">
+                                </colgroup>
+                                <thead class="text-xs text-gray-500 tracking-wide">
+                                    <tr>
+                                        <th class="px-4 py-3 font-medium text-left">Project</th>
+                                        <th class="px-4 py-3 font-medium text-right">Requests</th>
+                                        <th class="px-4 py-3 font-medium text-right">Tokens Saved</th>
+                                        <th class="px-4 py-3 font-medium text-right">Saved $</th>
+                                        <th class="px-4 py-3 font-medium text-right">Savings %</th>
+                                        <th class="px-4 py-3 font-medium text-right md:table-cell">Last Active</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-border">
+                                    <template x-for="[project, info] in Object.entries(lifetimeStats.projects || {})" :key="project">
+                                        <tr class="hover:bg-border/30 transition-colors">
+                                            <td class="px-4 py-3 text-left">
+                                                <span class="px-2 py-0.5 bg-border text-xs font-mono" x-text="project"></span>
+                                            </td>
+                                            <td class="px-4 py-3 text-right font-mono tabular-nums"
+                                                x-text="formatNumber(info.requests || 0)"></td>
+                                            <td class="px-4 py-3 text-right font-mono tabular-nums text-accent"
+                                                x-text="formatNumber(info.tokens_saved || 0)"></td>
+                                            <td class="px-4 py-3 text-right font-mono tabular-nums text-emerald-400"
+                                                x-text="'$' + formatCurrency(info.compression_savings_usd || 0)"></td>
+                                            <td class="px-4 py-3 text-right">
+                                                <div class="flex items-center justify-end gap-2">
+                                                    <div class="w-16 h-1.5 bg-border rounded-full overflow-hidden">
+                                                        <div class="h-full bg-accent rounded-full"
+                                                             :style="'width:' + Math.min(info.savings_percent || 0, 100) + '%'"></div>
+                                                    </div>
+                                                    <span class="text-accent font-mono tabular-nums text-xs w-10 text-right"
+                                                          x-text="(info.savings_percent || 0).toFixed(1) + '%'"></span>
+                                                </div>
+                                            </td>
+                                            <td class="px-4 py-3 text-right text-xs text-gray-500 font-mono md:table-cell"
+                                                x-text="info.last_activity_at ? new Date(info.last_activity_at).toLocaleString() : '—'"></td>
+                                        </tr>
+                                    </template>
+                                </tbody>
+                            </table>
+                        </div>
+                    </template>
+                </section>
             </div>
         </template>
 

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -113,12 +113,17 @@
         </div>
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-6">
             <div class="inline-flex rounded-lg border border-border bg-surface p-1">
-                <button class="px-3 py-1.5 text-sm rounded-md transition-colors"
-                        :class="viewMode === 'session' ? 'bg-accent text-black' : 'text-gray-400 hover:text-gray-200'"
-                        @click="setViewMode('session')">
-                    Session
-                </button>
-                <button class="px-3 py-1.5 text-sm rounded-md transition-colors"
+                    <button class="px-3 py-1.5 text-sm rounded-md transition-colors"
+                            :class="viewMode === 'session' ? 'bg-accent text-black' : 'text-gray-400 hover:text-gray-200'"
+                            @click="setViewMode('session')">
+                        Session
+                    </button>
+                    <button class="px-3 py-1.5 text-sm rounded-md transition-colors"
+                            :class="viewMode === 'lifetime' ? 'bg-accent text-black' : 'text-gray-400 hover:text-gray-200'"
+                            @click="setViewMode('lifetime')">
+                        Lifetime
+                    </button>
+                    <button class="px-3 py-1.5 text-sm rounded-md transition-colors"
                         :class="viewMode === 'history' ? 'bg-accent text-black' : 'text-gray-400 hover:text-gray-200'"
                         @click="setViewMode('history')">
                     Historical
@@ -181,1198 +186,1123 @@
     <main class="p-6 max-w-7xl mx-auto">
         <template x-if="viewMode === 'session'">
             <div>
-        <!-- Hero Metrics: Savings $ -> Input Compression -> Output Reduction -> Overhead -->
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-            <!-- Savings ($) - proxy compression only, priced at model list rate -->
-            <div class="bg-surface rounded-lg p-4 border border-border">
-                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Proxy $ Saved</div>
-                <div class="flex items-baseline gap-2">
-                    <span class="text-3xl font-light tabular-nums text-emerald-400" x-text="'$' + formatCurrency(stats.persistent_savings?.lifetime?.compression_savings_usd || 0)"></span>
-                </div>
-                <div class="mt-2 text-xs text-gray-500">
-                    <span x-show="(stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0"
-                          x-text="formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' proxy tokens only; ' + cliFilteringLabel + ' excluded from $'"></span>
-                    <span x-show="!((stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0) && stats.litellm_available !== false"
-                          x-text="formatNumber(stats.requests?.total || 0) + ' requests processed'"></span>
-                    <!-- Pricing is LiteLLM-only. LiteLLM currently can't install on
-                         newer Python (e.g. 3.14+); state the fact, not the version,
-                         so the hint stays correct if that changes. -->
-                    <span x-show="!((stats.persistent_savings?.lifetime?.compression_savings_usd || 0) > 0) && stats.litellm_available === false">
-                        Cost pricing needs LiteLLM, which isn't installed in this environment. If you're on a Python version LiteLLM doesn't support yet, reinstall Headroom on Python 3.13:
-                        <code class="text-gray-400">pipx reinstall headroom-ai --python python3.13</code>
-                    </span>
-                </div>
-            </div>
+                <p class="mb-4 text-xs text-gray-500">Current proxy process · runtime counters reset on restart</p>
 
-            <!-- Token Savings (%) -->
-            <div class="bg-surface rounded-lg p-4 border border-border">
-                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Token Savings</div>
-                <div class="flex items-baseline gap-2">
-                    <span class="text-3xl font-light tabular-nums text-accent" x-text="formatNumber(stats.tokens?.saved || 0)"></span>
-                    <!-- Active compression ratio: savings as a fraction of tokens we
-                         *attempted* to compress (extracted units + tool schema). When
-                         the attempted denominator is missing (backend-routed paths
-                         that don't yet wire per-message live-zone tracking), fall back
-                         to the whole-request ratio so the headline doesn't collapse to
-                         0% while compression is happening (issue #455). -->
-                    <span class="text-sm text-accent" x-text="headlineSavingsPercent.toFixed(1) + '%'" :title="headlineSavingsTitle"></span>
+                <!-- Runtime Overview -->
+                <div class="grid grid-cols-1 gap-4 mb-6 lg:grid-cols-2">
+                    <section class="bg-surface rounded-lg p-4 border border-border">
+                        <h3 class="mb-3 text-sm font-medium text-gray-300">Request Health</h3>
+                        <div class="grid grid-cols-2 gap-3 text-sm"><div>Completed <span class="float-right tabular-nums" x-text="formatNumber(stats.requests?.total || 0)"></span></div><div>Failed <span class="float-right tabular-nums text-red-400" x-text="formatNumber(stats.requests?.failed || 0)"></span></div><div>Rate Limited <span class="float-right tabular-nums text-amber-400" x-text="formatNumber(stats.requests?.rate_limited || 0)"></span></div><div>Cached <span class="float-right tabular-nums text-cyan-400" x-text="formatNumber(stats.requests?.cached || 0)"></span></div></div>
+                    </section>
+                    <section class="bg-surface rounded-lg p-4 border border-border">
+                        <h3 class="mb-3 text-sm font-medium text-gray-300">Live Activity</h3>
+                        <div class="grid grid-cols-2 gap-3 text-sm"><div>Active Requests <span class="float-right tabular-nums" x-text="formatNumber(stats.proxy_inbound?.active || 0)"></span></div><div>Active WebSockets <span class="float-right tabular-nums" x-text="formatNumber(stats.runtime?.websocket_sessions?.active_sessions || 0)"></span></div><div>Relay Tasks <span class="float-right tabular-nums" x-text="formatNumber(stats.runtime?.websocket_sessions?.active_relay_tasks || 0)"></span></div><div>Compression Queued <span class="float-right tabular-nums" x-text="formatNumber(stats.runtime?.compression_executor?.queued || 0)"></span></div></div>
+                    </section>
                 </div>
-                <div class="mt-1 text-xs text-gray-500 leading-relaxed">
-                    <span x-text="'Proxy ' + formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' (' + proxyShareOfTotal.toFixed(1) + '%)'"></span>
-                    <span class="mx-1 text-gray-600">/</span>
-                    <span x-text="cliFilteringAvailable ? (cliFilteringLabel + ' ' + formatNumber(cliFilteringSaved) + ' this session (' + cliFilteringSessionPctDisplay.toFixed(1) + '%)') : (cliFilteringLabel + ' not installed')"></span>
-                </div>
-                <div class="mt-1 text-xs text-gray-600 leading-relaxed">
-                    <span x-text="'Of total wire: ' + (stats.tokens?.savings_percent || 0).toFixed(2) + '%'" title="Savings as fraction of all input tokens including frozen prefix"></span>
-                </div>
-                <div class="mt-2 h-8">
-                    <svg class="w-full h-full" viewBox="0 0 100 32" preserveAspectRatio="none">
-                        <defs>
-                            <linearGradient id="sparkline-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                                <stop offset="0%" style="stop-color:#22d3ee;stop-opacity:0.3"/>
-                                <stop offset="100%" style="stop-color:#22d3ee;stop-opacity:0"/>
-                            </linearGradient>
-                        </defs>
-                        <path class="sparkline-area" :d="getSparklineArea(savingsHistory)"></path>
-                        <path class="sparkline" :d="getSparkline(savingsHistory)"></path>
-                    </svg>
-                </div>
-            </div>
 
-            <!-- Output Tokens Saved (counterfactual) -->
-            <div class="bg-surface rounded-lg p-4 border border-border">
-                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Output Tokens Saved</div>
-                <template x-if="stats.tokens?.output_reduction?.available">
-                    <div>
+                <!-- Session Optimization -->
+                <div class="grid grid-cols-1 gap-4 mb-6 md:grid-cols-2 lg:grid-cols-3">
+                    <!-- Token Savings (%) -->
+                    <div class="bg-surface rounded-lg p-4 border border-border">
+                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Token Savings</div>
                         <div class="flex items-baseline gap-2">
-                            <span class="text-3xl font-light tabular-nums text-accent" x-text="formatNumber(stats.tokens?.output_saved || 0)"></span>
-                            <span class="text-sm text-accent" x-text="(stats.tokens?.output_reduction_percent || 0).toFixed(1) + '%'"></span>
+                            <span class="text-3xl font-light tabular-nums text-accent" x-text="formatNumber(stats.tokens?.saved || 0)"></span>
+                            <!-- Active compression ratio: savings as a fraction of tokens we
+                                 *attempted* to compress (extracted units + tool schema). When
+                                 the attempted denominator is missing (backend-routed paths
+                                 that don't yet wire per-message live-zone tracking), fall back
+                                 to the whole-request ratio so the headline doesn't collapse to
+                                 0% while compression is happening (issue #455). -->
+                            <span class="text-sm text-accent" x-text="headlineSavingsPercent.toFixed(1) + '%'" :title="headlineSavingsTitle"></span>
                         </div>
                         <div class="mt-1 text-xs text-gray-500 leading-relaxed">
-                            <!-- "measured" = A/B holdout (unbiased); "estimated" = vs learned baseline -->
-                            <span class="uppercase tracking-wide"
-                                  :class="stats.tokens?.output_reduction?.method === 'measured' ? 'text-emerald-400' : 'text-gray-400'"
-                                  x-text="stats.tokens?.output_reduction?.method || ''"></span>
-                            <span x-text="'· 95% CI ' + (stats.tokens?.output_reduction?.ci_low_percent || 0).toFixed(1) + '–' + (stats.tokens?.output_reduction?.ci_high_percent || 0).toFixed(1) + '%'"></span>
+                            <span x-text="'Proxy ' + formatNumber(stats.tokens?.proxy_compression_saved || 0) + ' (' + proxyShareOfTotal.toFixed(1) + '%)'"></span>
+                            <span class="mx-1 text-gray-600">/</span>
+                            <span x-text="cliFilteringAvailable ? (cliFilteringLabel + ' ' + formatNumber(cliFilteringSaved) + ' this session (' + cliFilteringSessionPctDisplay.toFixed(1) + '%)') : (cliFilteringLabel + ' not installed')"></span>
                         </div>
-                        <div class="mt-1 text-xs text-gray-600 leading-relaxed"
-                             x-text="formatNumber(stats.tokens?.output_reduction?.requests || 0) + ' shaped responses · counterfactual'">
+                        <div class="mt-1 text-xs text-gray-600 leading-relaxed">
+                            <span x-text="'Of total wire: ' + (stats.tokens?.savings_percent || 0).toFixed(2) + '%'" title="Savings as fraction of all input tokens including frozen prefix"></span>
                         </div>
-                    </div>
-                </template>
-                <template x-if="!stats.tokens?.output_reduction?.available">
-                    <div class="mt-1 text-xs text-gray-500 leading-relaxed">
-                        <span class="text-2xl font-light tabular-nums text-gray-600">—</span>
-                        <div class="mt-1">Enable the output shaper (HEADROOM_OUTPUT_SHAPER=1) and run
-                            <code class="text-gray-400">headroom learn --verbosity --apply</code> to start measuring.</div>
-                    </div>
-                </template>
-            </div>
-
-            <!-- Tool-Schema Deferral (tool search) — only rendered when there's a saving to show -->
-            <template x-if="(stats.savings?.by_layer?.tool_search?.tokens || 0) > 0">
-                <div class="bg-surface rounded-lg p-4 border border-border">
-                    <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Tool-Schema Deferral</div>
-                    <div class="flex items-baseline gap-2">
-                        <span class="text-3xl font-light tabular-nums text-emerald-400" x-text="formatNumber(stats.savings?.by_layer?.tool_search?.tokens || 0)"></span>
-                        <span class="text-sm text-gray-400">tokens</span>
-                    </div>
-                    <div class="mt-1 text-xs text-gray-600 leading-relaxed"
-                         x-text="formatNumber(stats.savings?.by_layer?.tool_search?.requests || 0) + ' calls · tool schemas deferred (recent window)'">
-                    </div>
-                </div>
-            </template>
-
-            <!-- Headroom Overhead -->
-            <div class="bg-surface rounded-lg p-4 border border-border">
-                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Overhead</div>
-                <div class="flex items-baseline gap-2">
-                    <span class="text-3xl font-light tabular-nums" x-text="(stats.overhead?.average_ms || 0).toFixed(0) + 'ms'"></span>
-                </div>
-                <div class="mt-2 text-xs text-gray-500">
-                    TTFB <span x-text="((stats.ttfb?.average_ms || 0) / 1000).toFixed(2)"></span>s avg
-                </div>
-            </div>
-
-            <!-- Token Throughput -->
-            <div class="bg-surface rounded-lg p-4 border border-border flex flex-col justify-between">
-                <div>
-                    <div class="text-xs text-gray-500 uppercase tracking-wide mb-1.5">Throughput</div>
-                    <div class="flex flex-col gap-1 text-[11px] text-gray-300">
-                        <div class="flex justify-between items-baseline border-b border-border/40 pb-0.5">
-                            <span class="text-gray-500">Input (wall / active p50)</span>
-                            <span class="font-mono text-accent">
-                                <span x-text="(stats.throughput?.rolling?.input_wall_clock || 0).toFixed(1)"></span> /
-                                <span x-text="(stats.throughput?.rolling?.input_active_p50 || 0).toFixed(1)"></span> tok/s
-                            </span>
-                        </div>
-                        <div class="flex justify-between items-baseline border-b border-border/40 pb-0.5" x-show="(stats.throughput?.rolling?.compression_p50 || 0) > 0">
-                            <span class="text-gray-500">Compression (p50 / p95)</span>
-                            <span class="font-mono text-emerald-400">
-                                <span x-text="(stats.throughput?.rolling?.compression_p50 || 0).toFixed(1)"></span> /
-                                <span x-text="(stats.throughput?.rolling?.compression_p95 || 0).toFixed(1)"></span> tok/s
-                            </span>
-                        </div>
-                        <div class="flex justify-between items-baseline border-b border-border/40 pb-0.5">
-                            <span class="text-gray-500">Forward (p50 / p95)</span>
-                            <span class="font-mono text-cyan-400">
-                                <span x-text="(stats.throughput?.rolling?.forward_p50 || 0).toFixed(1)"></span> /
-                                <span x-text="(stats.throughput?.rolling?.forward_p95 || 0).toFixed(1)"></span> tok/s
-                            </span>
-                        </div>
-                        <div class="flex justify-between items-baseline" x-show="(stats.throughput?.rolling?.generation_p50 || 0) > 0">
-                            <span class="text-gray-500">Generation (p50 / p95)</span>
-                            <span class="font-mono text-yellow-400">
-                                <span x-text="(stats.throughput?.rolling?.generation_p50 || 0).toFixed(1)"></span> /
-                                <span x-text="(stats.throughput?.rolling?.generation_p95 || 0).toFixed(1)"></span> tok/s
-                            </span>
+                        <div class="mt-2 h-8">
+                            <svg class="w-full h-full" viewBox="0 0 100 32" preserveAspectRatio="none">
+                                <defs>
+                                    <linearGradient id="sparkline-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                                        <stop offset="0%" style="stop-color:#22d3ee;stop-opacity:0.3"/>
+                                        <stop offset="100%" style="stop-color:#22d3ee;stop-opacity:0"/>
+                                    </linearGradient>
+                                </defs>
+                                <path class="sparkline-area" :d="getSparklineArea(savingsHistory)"></path>
+                                <path class="sparkline" :d="getSparkline(savingsHistory)"></path>
+                            </svg>
                         </div>
                     </div>
-                </div>
-                <div class="mt-2 pt-1.5 border-t border-border/40 text-[10px] text-gray-500 flex justify-between items-center">
-                    <span>Current 5m (active p50):</span>
-                    <span class="font-mono text-gray-400">
-                        In: <span x-text="(stats.throughput?.current?.input_active_p50 || 0).toFixed(0)"></span> ·
-                        Fwd: <span x-text="(stats.throughput?.current?.forward_p50 || 0).toFixed(0)"></span> tok/s
-                    </span>
-                </div>
-            </div>
-        </div>
 
-        <!-- Agent Usage -->
-        <div class="bg-surface rounded-lg border border-border overflow-hidden mb-6">
-            <div class="px-4 py-3 border-b border-border flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
-                <div>
-                    <div class="text-sm font-medium text-gray-300">Agent Usage</div>
-                    <div class="text-xs text-gray-500">Before and after token usage by detected client</div>
-                </div>
-                <div class="flex flex-wrap items-center gap-3 text-xs">
-                    <span class="text-gray-500" x-text="'Coverage: ' + agentCoverageLabel"></span>
-                    <span class="px-2 py-0.5 rounded border border-border bg-card-alt font-mono text-gray-400"
-                          x-text="formatNumber(stats.agent_usage?.totals?.requests || 0) + ' requests'"></span>
-                </div>
-            </div>
-
-            <div class="p-4">
-                <div class="grid grid-cols-1 md:grid-cols-4 gap-3 mb-5">
-                    <div class="rounded-lg border border-border bg-card-alt p-3">
-                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Before</div>
-                        <div class="text-2xl font-light tabular-nums" x-text="formatNumber(stats.agent_usage?.totals?.before_tokens || 0)"></div>
-                    </div>
-                    <div class="rounded-lg border border-border bg-card-alt p-3">
-                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">After</div>
-                        <div class="text-2xl font-light tabular-nums text-gray-200" x-text="formatNumber(stats.agent_usage?.totals?.after_tokens || 0)"></div>
-                    </div>
-                    <div class="rounded-lg border border-border bg-card-alt p-3">
-                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Saved</div>
-                        <div class="text-2xl font-light tabular-nums text-accent" x-text="formatNumber(stats.agent_usage?.totals?.tokens_saved || 0)"></div>
-                    </div>
-                    <div class="rounded-lg border border-border bg-card-alt p-3">
-                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Savings</div>
-                        <div class="text-2xl font-light tabular-nums text-emerald-400" x-text="(stats.agent_usage?.totals?.savings_percent || 0).toFixed(1) + '%'"></div>
-                    </div>
-                </div>
-
-                <template x-if="agentRows.length > 0">
-                    <div class="space-y-3">
-                        <template x-for="agent in agentRows" :key="agent.agent">
-                            <div class="rounded-lg border border-border bg-card-alt p-3">
-                                <div class="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(160px,0.9fr)_minmax(260px,1.5fr)_minmax(260px,1.2fr)] lg:items-center">
-                                    <div class="min-w-0">
-                                        <div class="flex items-center gap-2">
-                                            <span class="h-2.5 w-2.5 rounded-full" :class="agentDotClass(agent.agent)"></span>
-                                            <span class="text-sm font-medium text-gray-200 truncate" x-text="agent.label"></span>
-                                        </div>
-                                        <div class="mt-1 text-xs text-gray-500">
-                                            <span x-text="formatNumber(agent.requests || 0) + ' requests'"></span>
-                                            <span class="mx-1 text-gray-700">/</span>
-                                            <span x-text="agent.source"></span>
-                                        </div>
-                                    </div>
-
-                                    <div>
-                                        <div class="flex items-center justify-between text-xs mb-1">
-                                            <span class="text-gray-500">Token flow</span>
-                                            <span class="font-mono text-emerald-400" x-text="(agent.savings_percent || 0).toFixed(1) + '% saved'"></span>
-                                        </div>
-                                        <div class="h-3 w-full rounded-full bg-border overflow-hidden flex">
-                                            <div class="h-full bg-emerald-500 transition-all duration-500"
-                                                 :style="'width:' + agentSavedWidth(agent) + '%'"></div>
-                                            <div class="h-full bg-accent/60 transition-all duration-500"
-                                                 :style="'width:' + agentAfterWidth(agent) + '%'"></div>
-                                        </div>
-                                        <div class="mt-1 flex flex-wrap gap-3 text-xs text-gray-500">
-                                            <span class="inline-flex items-center gap-1"><span class="h-2 w-2 rounded-full bg-emerald-500"></span>Saved</span>
-                                            <span class="inline-flex items-center gap-1"><span class="h-2 w-2 rounded-full bg-accent/60"></span>Sent</span>
-                                        </div>
-                                    </div>
-
-                                    <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 text-right">
-                                        <div>
-                                            <div class="text-[11px] uppercase tracking-wide text-gray-500">Before</div>
-                                            <div class="font-mono text-sm" x-text="formatNumber(agent.before_tokens || 0)"></div>
-                                        </div>
-                                        <div>
-                                            <div class="text-[11px] uppercase tracking-wide text-gray-500">After</div>
-                                            <div class="font-mono text-sm" x-text="formatNumber(agent.after_tokens || 0)"></div>
-                                        </div>
-                                        <div>
-                                            <div class="text-[11px] uppercase tracking-wide text-gray-500">Saved</div>
-                                            <div class="font-mono text-sm text-accent" x-text="formatNumber(agent.tokens_saved || 0)"></div>
-                                        </div>
-                                        <div>
-                                            <div class="text-[11px] uppercase tracking-wide text-gray-500">Share</div>
-                                            <div class="font-mono text-sm text-gray-300" x-text="(agent.share_of_saved_percent || 0).toFixed(1) + '%'"></div>
-                                        </div>
-                                    </div>
+                    <!-- Output Tokens Saved (counterfactual) -->
+                    <div class="bg-surface rounded-lg p-4 border border-border">
+                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Output Tokens Saved</div>
+                        <template x-if="stats.tokens?.output_reduction?.available">
+                            <div>
+                                <div class="flex items-baseline gap-2">
+                                    <span class="text-3xl font-light tabular-nums text-accent" x-text="formatNumber(stats.tokens?.output_saved || 0)"></span>
+                                    <span class="text-sm text-accent" x-text="(stats.tokens?.output_reduction_percent || 0).toFixed(1) + '%'"></span>
+                                </div>
+                                <div class="mt-1 text-xs text-gray-500 leading-relaxed">
+                                    <!-- "measured" = A/B holdout (unbiased); "estimated" = vs learned baseline -->
+                                    <span class="uppercase tracking-wide"
+                                          :class="stats.tokens?.output_reduction?.method === 'measured' ? 'text-emerald-400' : 'text-gray-400'"
+                                          x-text="stats.tokens?.output_reduction?.method || ''"></span>
+                                    <span x-text="'· 95% CI ' + (stats.tokens?.output_reduction?.ci_low_percent || 0).toFixed(1) + '–' + (stats.tokens?.output_reduction?.ci_high_percent || 0).toFixed(1) + '%'"></span>
+                                </div>
+                                <div class="mt-1 text-xs text-gray-600 leading-relaxed"
+                                     x-text="formatNumber(stats.tokens?.output_reduction?.requests || 0) + ' shaped responses · counterfactual'">
                                 </div>
                             </div>
                         </template>
-                    </div>
-                </template>
-
-                <template x-if="agentRows.length === 0">
-                    <div class="rounded-lg border border-dashed border-border p-6 text-center text-sm text-gray-500">
-                        Agent usage appears after Cursor, Claude, Codex, or another client sends traffic through this proxy.
-                    </div>
-                </template>
-            </div>
-        </div>
-
-        <!-- Savings Breakdown -->
-        <template x-if="(stats.cost?.savings_usd || 0) > 0 || (stats.cost?.cache_savings_usd || 0) > 0">
-            <div class="bg-surface rounded-lg p-4 border border-border mb-6">
-                <div class="text-sm font-medium text-gray-300 mb-3">Savings Breakdown</div>
-                <div class="flex items-center gap-8">
-                    <div>
-                        <div class="text-xs text-gray-500 mb-1">Compression</div>
-                        <div class="text-2xl font-light tabular-nums text-emerald-400" x-text="'$' + formatCurrency(stats.cost?.compression_savings_usd || 0)"></div>
-                    </div>
-                    <template x-if="(stats.cost?.cache_savings_usd || 0) > 0">
-                        <div>
-                            <div class="text-xs text-gray-500 mb-1">Prefix Cache Discount</div>
-                            <div class="text-2xl font-light tabular-nums text-cyan-400" x-text="'$' + formatCurrency(stats.cost?.cache_savings_usd || 0)"></div>
-                            <div class="text-xs text-gray-500">Provider-native caching</div>
-                        </div>
-                    </template>
-                </div>
-            </div>
-        </template>
-
-        <!-- Anthropic Subscription Window -->
-        <template x-if="stats.subscription_window && stats.subscription_window.latest">
-            <div class="bg-surface rounded-lg p-4 border border-border mb-6">
-                <div class="flex justify-between items-center mb-4">
-                    <div class="text-sm font-medium text-gray-300">Anthropic Subscription Window</div>
-                    <div class="flex items-center gap-2">
-                        <span class="w-2 h-2 rounded-full pulse-live"
-                              :class="stats.subscription_window.last_active_at ? 'bg-emerald-400' : 'bg-gray-600'"></span>
-                        <span class="text-xs text-gray-500" x-text="stats.subscription_window.last_active_at ? 'Active' : 'Idle'"></span>
-                    </div>
-                </div>
-
-                <!-- 5h / 7d progress bars -->
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                    <!-- 5-hour window -->
-                    <template x-if="stats.subscription_window.latest.five_hour">
-                        <div>
-                            <div class="flex justify-between text-xs mb-1">
-                                <span class="text-gray-400 uppercase tracking-wide">5-Hour Window</span>
-                                <span class="tabular-nums font-mono"
-                                      :class="stats.subscription_window.latest.five_hour.utilization_pct > 80 ? 'text-red-400' : stats.subscription_window.latest.five_hour.utilization_pct > 60 ? 'text-amber-400' : 'text-emerald-400'"
-                                      x-text="(stats.subscription_window.latest.five_hour.utilization_pct || 0).toFixed(1) + '%'"></span>
+                        <template x-if="!stats.tokens?.output_reduction?.available">
+                            <div class="mt-1 text-xs text-gray-500 leading-relaxed">
+                                <span class="text-2xl font-light tabular-nums text-gray-600">—</span>
+                                <div class="mt-1">Enable the output shaper (HEADROOM_OUTPUT_SHAPER=1) and run
+                                    <code class="text-gray-400">headroom learn --verbosity --apply</code> to start measuring.</div>
                             </div>
-                            <div class="w-full h-3 bg-border rounded-full overflow-hidden">
-                                <div class="h-full rounded-full transition-all duration-500"
-                                     :class="stats.subscription_window.latest.five_hour.utilization_pct > 80 ? 'bg-red-500' : stats.subscription_window.latest.five_hour.utilization_pct > 60 ? 'bg-amber-500' : 'bg-emerald-500'"
-                                     :style="'width: ' + Math.min(stats.subscription_window.latest.five_hour.utilization_pct || 0, 100) + '%'"></div>
-                            </div>
-                            <div class="text-xs text-gray-500 mt-1"
-                                 x-text="'Resets in ' + formatResetTime(stats.subscription_window.latest.five_hour.seconds_to_reset)"></div>
-                        </div>
-                    </template>
+                        </template>
+                    </div>
 
-                    <!-- 7-day window -->
-                    <template x-if="stats.subscription_window.latest.seven_day">
-                        <div>
-                            <div class="flex justify-between text-xs mb-1">
-                                <span class="text-gray-400 uppercase tracking-wide">7-Day Window</span>
-                                <span class="tabular-nums font-mono"
-                                      :class="stats.subscription_window.latest.seven_day.utilization_pct > 80 ? 'text-red-400' : stats.subscription_window.latest.seven_day.utilization_pct > 60 ? 'text-amber-400' : 'text-emerald-400'"
-                                      x-text="(stats.subscription_window.latest.seven_day.utilization_pct || 0).toFixed(1) + '%'"></span>
+                    <!-- Tool-Schema Deferral (tool search) — only rendered when there's a saving to show -->
+                    <template x-if="(stats.savings?.by_layer?.tool_search?.tokens || 0) > 0">
+                        <div class="bg-surface rounded-lg p-4 border border-border">
+                            <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Tool-Schema Deferral</div>
+                            <div class="flex items-baseline gap-2">
+                                <span class="text-3xl font-light tabular-nums text-emerald-400" x-text="formatNumber(stats.savings?.by_layer?.tool_search?.tokens || 0)"></span>
+                                <span class="text-sm text-gray-400">tokens</span>
                             </div>
-                            <div class="w-full h-3 bg-border rounded-full overflow-hidden">
-                                <div class="h-full rounded-full transition-all duration-500"
-                                     :class="stats.subscription_window.latest.seven_day.utilization_pct > 80 ? 'bg-red-500' : stats.subscription_window.latest.seven_day.utilization_pct > 60 ? 'bg-amber-500' : 'bg-emerald-500'"
-                                     :style="'width: ' + Math.min(stats.subscription_window.latest.seven_day.utilization_pct || 0, 100) + '%'"></div>
+                            <div class="mt-1 text-xs text-gray-600 leading-relaxed"
+                                 x-text="formatNumber(stats.savings?.by_layer?.tool_search?.requests || 0) + ' calls · tool schemas deferred (recent window)'">
                             </div>
-                            <div class="text-xs text-gray-500 mt-1"
-                                 x-text="'Resets in ' + formatResetTime(stats.subscription_window.latest.seven_day.seconds_to_reset)"></div>
                         </div>
                     </template>
                 </div>
 
-                <!-- Overage / extra usage -->
-                <template x-if="stats.subscription_window.latest.extra_usage && stats.subscription_window.latest.extra_usage.is_enabled">
-                    <div class="border-t border-border pt-3 mb-3">
-                        <div class="flex justify-between text-xs mb-1">
-                            <span class="text-gray-400 uppercase tracking-wide">Extra Usage (Overage)</span>
-                            <span class="text-amber-400 tabular-nums font-mono"
-                                  x-text="'$' + formatCurrency(stats.subscription_window.latest.extra_usage.used_credits_usd || 0) + (stats.subscription_window.latest.extra_usage.monthly_limit_usd ? ' / $' + formatCurrency(stats.subscription_window.latest.extra_usage.monthly_limit_usd) : '')"></span>
+                <!-- Performance -->
+                <div class="grid grid-cols-1 gap-4 mb-6 lg:grid-cols-3">
+                    <!-- Headroom Overhead -->
+                    <div class="bg-surface rounded-lg p-4 border border-border">
+                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Overhead</div>
+                        <div class="flex items-baseline gap-2">
+                            <span class="text-3xl font-light tabular-nums" x-text="(stats.overhead?.average_ms || 0).toFixed(0) + 'ms'"></span>
                         </div>
-                        <template x-if="stats.subscription_window.latest.extra_usage.utilization_pct != null">
-                            <div class="w-full h-2 bg-border rounded-full overflow-hidden">
-                                <div class="h-full bg-amber-500 rounded-full transition-all duration-500"
-                                     :style="'width: ' + Math.min(stats.subscription_window.latest.extra_usage.utilization_pct || 0, 100) + '%'"></div>
-                            </div>
-                        </template>
-                    </div>
-                </template>
-
-                <!-- Headroom contribution row -->
-                <template x-if="stats.subscription_window.contribution && stats.subscription_window.contribution.tokens_submitted > 0">
-                    <div class="border-t border-border pt-3">
-                        <div class="text-xs text-gray-400 uppercase tracking-wide mb-2">Headroom Contribution This Window</div>
-                        <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-                            <div>
-                                <div class="text-xs text-gray-500 mb-0.5">Efficiency</div>
-                                <div class="text-lg font-light tabular-nums text-accent"
-                                     x-text="(stats.subscription_window.contribution.efficiency_pct || 0).toFixed(1) + '%'"></div>
-                            </div>
-                            <div>
-                                <div class="text-xs text-gray-500 mb-0.5">Tokens Saved</div>
-                                <div class="text-lg font-light tabular-nums text-emerald-400"
-                                     x-text="formatNumber(stats.subscription_window.contribution.tokens_saved?.total || 0)"></div>
-                            </div>
-                            <div>
-                                <div class="text-xs text-gray-500 mb-0.5">Compression</div>
-                                <div class="text-sm tabular-nums text-gray-300"
-                                     x-text="formatNumber(stats.subscription_window.contribution.tokens_saved?.compression || 0) + ' tok'"></div>
-                            </div>
-                            <div>
-                                <div class="text-xs text-gray-500 mb-0.5">Cache Reads</div>
-                                <div class="text-sm tabular-nums text-cyan-400"
-                                     x-text="formatNumber(stats.subscription_window.contribution.tokens_saved?.cache_reads || 0) + ' tok'"></div>
-                            </div>
+                        <div class="mt-2 text-xs text-gray-500">
+                            TTFB <span x-text="((stats.ttfb?.average_ms || 0) / 1000).toFixed(2)"></span>s avg
                         </div>
-
-                        <!-- Efficiency bar: tokens submitted vs what would have been sent without headroom -->
-                        <template x-if="stats.subscription_window.contribution.raw_without_headroom > 0">
-                            <div class="mt-3">
-                                <div class="flex justify-between text-xs text-gray-500 mb-1">
-                                    <span>Raw vs Submitted</span>
-                                    <span x-text="formatNumber(stats.subscription_window.contribution.tokens_submitted) + ' / ' + formatNumber(stats.subscription_window.contribution.raw_without_headroom) + ' tokens forwarded'"></span>
-                                </div>
-                                <div class="w-full h-2 bg-border rounded-full overflow-hidden flex">
-                                    <div class="h-full bg-accent rounded-l-full"
-                                         :style="'width: ' + ((stats.subscription_window.contribution.tokens_submitted / stats.subscription_window.contribution.raw_without_headroom) * 100).toFixed(1) + '%'"></div>
-                                </div>
-                                <div class="flex gap-4 mt-1 text-xs text-gray-500">
-                                    <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-accent inline-block"></span>Forwarded to Anthropic</span>
-                                    <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-border inline-block"></span>Saved by Headroom</span>
-                                </div>
-                            </div>
-                        </template>
                     </div>
-                </template>
 
-                <!-- Discrepancies -->
-                <template x-if="stats.subscription_window.discrepancies && stats.subscription_window.discrepancies.length > 0">
-                    <div class="border-t border-border pt-3 mt-3">
-                        <div class="text-xs text-amber-400 uppercase tracking-wide mb-2">⚠ Anomalies Detected</div>
-                        <template x-for="d in stats.subscription_window.discrepancies" :key="d.kind + d.description">
-                            <div class="text-xs mb-1"
-                                 :class="d.severity === 'alert' ? 'text-red-400' : 'text-amber-400'"
-                                 x-text="d.description"></div>
-                        </template>
-                    </div>
-                </template>
-            </div>
-        </template>
-        <!-- Codex Rate-Limit Window -->
-        <template x-if="stats.codex_rate_limits && stats.codex_rate_limits.primary">
-            <div class="bg-surface rounded-lg p-4 border border-border mb-6">
-                <div class="flex justify-between items-center mb-4">
-                    <div class="text-sm font-medium text-gray-300">OpenAI Codex Rate-Limit Window</div>
-                    <template x-if="stats.codex_rate_limits.limit_name">
-                        <span class="text-xs text-gray-500 font-mono" x-text="stats.codex_rate_limits.limit_name"></span>
-                    </template>
-                </div>
-
-                <!-- Primary / Secondary window grid (mirrors Anthropic 5h/7d layout) -->
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                    <!-- Primary window -->
-                    <div>
-                        <div class="flex justify-between text-xs mb-1">
-                            <span class="text-gray-400 uppercase tracking-wide">Primary
-                                <template x-if="stats.codex_rate_limits.primary.window_label">
-                                    <span class="text-gray-600 normal-case font-mono ml-1"
-                                          x-text="'(' + stats.codex_rate_limits.primary.window_label + ')'"></span>
-                                </template>
-                            </span>
-                            <span class="tabular-nums font-mono"
-                                  :class="(stats.codex_rate_limits.primary.used_percent||0) > 80 ? 'text-red-400' : (stats.codex_rate_limits.primary.used_percent||0) > 60 ? 'text-amber-400' : 'text-emerald-400'"
-                                  x-text="(stats.codex_rate_limits.primary.used_percent||0).toFixed(1) + '%'"></span>
-                        </div>
-                        <div class="w-full h-3 bg-border rounded-full overflow-hidden">
-                            <div class="h-full rounded-full transition-all duration-500"
-                                 :class="(stats.codex_rate_limits.primary.used_percent||0) > 80 ? 'bg-red-500' : (stats.codex_rate_limits.primary.used_percent||0) > 60 ? 'bg-amber-500' : 'bg-emerald-500'"
-                                 :style="'width: ' + Math.min(stats.codex_rate_limits.primary.used_percent||0, 100) + '%'"></div>
-                        </div>
-                        <template x-if="stats.codex_rate_limits.primary.seconds_until_reset !== null">
-                            <div class="text-xs text-gray-500 mt-1"
-                                 x-text="'Resets in ' + formatResetTime(stats.codex_rate_limits.primary.seconds_until_reset)"></div>
-                        </template>
-                    </div>
-                    <!-- Secondary window -->
-                    <template x-if="stats.codex_rate_limits.secondary">
+                    <!-- Token Throughput -->
+                    <div class="bg-surface rounded-lg p-4 border border-border flex flex-col justify-between">
                         <div>
-                            <div class="flex justify-between text-xs mb-1">
-                                <span class="text-gray-400 uppercase tracking-wide">Secondary
-                                    <template x-if="stats.codex_rate_limits.secondary.window_label">
-                                        <span class="text-gray-600 normal-case font-mono ml-1"
-                                              x-text="'(' + stats.codex_rate_limits.secondary.window_label + ')'"></span>
+                            <div class="text-xs text-gray-500 uppercase tracking-wide mb-1.5">Throughput</div>
+                            <div class="flex flex-col gap-1 text-[11px] text-gray-300">
+                                <div class="flex justify-between items-baseline border-b border-border/40 pb-0.5">
+                                    <span class="text-gray-500">Input (wall / active p50)</span>
+                                    <span class="font-mono text-accent">
+                                        <span x-text="(stats.throughput?.rolling?.input_wall_clock || 0).toFixed(1)"></span> /
+                                        <span x-text="(stats.throughput?.rolling?.input_active_p50 || 0).toFixed(1)"></span> tok/s
+                                    </span>
+                                </div>
+                                <div class="flex justify-between items-baseline border-b border-border/40 pb-0.5" x-show="(stats.throughput?.rolling?.compression_p50 || 0) > 0">
+                                    <span class="text-gray-500">Compression (p50 / p95)</span>
+                                    <span class="font-mono text-emerald-400">
+                                        <span x-text="(stats.throughput?.rolling?.compression_p50 || 0).toFixed(1)"></span> /
+                                        <span x-text="(stats.throughput?.rolling?.compression_p95 || 0).toFixed(1)"></span> tok/s
+                                    </span>
+                                </div>
+                                <div class="flex justify-between items-baseline border-b border-border/40 pb-0.5">
+                                    <span class="text-gray-500">Forward (p50 / p95)</span>
+                                    <span class="font-mono text-cyan-400">
+                                        <span x-text="(stats.throughput?.rolling?.forward_p50 || 0).toFixed(1)"></span> /
+                                        <span x-text="(stats.throughput?.rolling?.forward_p95 || 0).toFixed(1)"></span> tok/s
+                                    </span>
+                                </div>
+                                <div class="flex justify-between items-baseline" x-show="(stats.throughput?.rolling?.generation_p50 || 0) > 0">
+                                    <span class="text-gray-500">Generation (p50 / p95)</span>
+                                    <span class="font-mono text-yellow-400">
+                                        <span x-text="(stats.throughput?.rolling?.generation_p50 || 0).toFixed(1)"></span> /
+                                        <span x-text="(stats.throughput?.rolling?.generation_p95 || 0).toFixed(1)"></span> tok/s
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="mt-2 pt-1.5 border-t border-border/40 text-[10px] text-gray-500 flex justify-between items-center">
+                            <span>Current 5m (active p50):</span>
+                            <span class="font-mono text-gray-400">
+                                In: <span x-text="(stats.throughput?.current?.input_active_p50 || 0).toFixed(0)"></span> ·
+                                Fwd: <span x-text="(stats.throughput?.current?.forward_p50 || 0).toFixed(0)"></span> tok/s
+                            </span>
+                        </div>
+                    </div>
+
+                    <!-- Performance -->
+                    <div class="bg-surface rounded-lg p-4 border border-border">
+                        <div class="text-sm font-medium mb-4 text-gray-300">Performance</div>
+                        <div class="space-y-3">
+                            <div class="flex justify-between items-center">
+                                <span class="text-sm text-gray-400">Overhead Range</span>
+                                <span class="font-mono text-sm" x-text="(stats.overhead?.min_ms || 0).toFixed(0) + ' - ' + (stats.overhead?.max_ms || 0).toFixed(0) + 'ms'"></span>
+                            </div>
+                            <div class="flex justify-between items-center">
+                                <span class="text-sm text-gray-400">TTFB Range</span>
+                                <span class="font-mono text-sm" x-text="((stats.ttfb?.min_ms || 0) / 1000).toFixed(2) + ' - ' + ((stats.ttfb?.max_ms || 0) / 1000).toFixed(2) + 's'"></span>
+                            </div>
+                            <div class="flex justify-between items-center">
+                                <span class="text-sm text-gray-400">Failed Requests</span>
+                                <span class="font-mono text-sm" x-text="stats.requests?.failed || 0"></span>
+                            </div>
+                            <!-- Per-transform timing breakdown -->
+                            <template x-if="Object.keys(stats.pipeline_timing || {}).length > 0">
+                                <div>
+                                    <div class="border-t border-border my-2"></div>
+                                    <div class="text-xs text-gray-500 uppercase tracking-wide mb-2">Pipeline Breakdown</div>
+                                    <template x-for="[name, t] in Object.entries(stats.pipeline_timing || {})" :key="name">
+                                        <div class="flex justify-between items-center mb-1">
+                                            <span class="text-xs text-gray-400 font-mono truncate mr-2" x-text="name"></span>
+                                            <span class="text-xs font-mono whitespace-nowrap"
+                                                  :class="t.average_ms > 100 ? 'text-amber-400' : t.average_ms > 50 ? 'text-yellow-400' : 'text-gray-400'"
+                                                  x-text="t.average_ms.toFixed(0) + 'ms avg / ' + t.max_ms.toFixed(0) + 'ms max'"></span>
+                                        </div>
                                     </template>
-                                </span>
-                                <span class="tabular-nums font-mono"
-                                      :class="(stats.codex_rate_limits.secondary.used_percent||0) > 80 ? 'text-red-400' : (stats.codex_rate_limits.secondary.used_percent||0) > 60 ? 'text-amber-400' : 'text-emerald-400'"
-                                      x-text="(stats.codex_rate_limits.secondary.used_percent||0).toFixed(1) + '%'"></span>
-                            </div>
-                            <div class="w-full h-3 bg-border rounded-full overflow-hidden">
-                                <div class="h-full rounded-full transition-all duration-500"
-                                     :class="(stats.codex_rate_limits.secondary.used_percent||0) > 80 ? 'bg-red-500' : (stats.codex_rate_limits.secondary.used_percent||0) > 60 ? 'bg-amber-500' : 'bg-emerald-500'"
-                                     :style="'width: ' + Math.min(stats.codex_rate_limits.secondary.used_percent||0, 100) + '%'"></div>
-                            </div>
-                            <template x-if="stats.codex_rate_limits.secondary.seconds_until_reset !== null">
-                                <div class="text-xs text-gray-500 mt-1"
-                                     x-text="'Resets in ' + formatResetTime(stats.codex_rate_limits.secondary.seconds_until_reset)"></div>
+                                </div>
                             </template>
                         </div>
+                    </div>
+                </div>
+
+                <!-- Optimization Breakdown -->
+                <div class="grid grid-cols-1 gap-4 mb-6 lg:grid-cols-3">
+                    <!-- Token Usage -->
+                    <div class="bg-surface rounded-lg p-4 border border-border">
+                        <div class="text-sm font-medium mb-4 text-gray-300">Token Usage</div>
+                        <div class="space-y-3">
+                            <div class="flex justify-between items-center">
+                                <span class="text-sm text-gray-400">Before Compression</span>
+                                <span class="font-mono text-sm" x-text="formatNumber(stats.tokens?.total_before_compression || 0)"></span>
+                            </div>
+                            <div class="flex justify-between items-center" x-show="cliFilteringAvailable">
+                                <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
+                                <span class="font-mono text-sm text-emerald-400" x-text="formatNumber(cliFilteringSaved)"></span>
+                            </div>
+                            <div class="flex justify-between items-center" x-show="!cliFilteringAvailable">
+                                <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
+                                <span class="font-mono text-sm text-gray-600">not installed</span>
+                            </div>
+                            <div class="flex justify-between items-center">
+                                <span class="text-sm text-gray-400">Proxy Removed</span>
+                                <span class="font-mono text-sm text-accent" x-text="formatNumber(stats.tokens?.proxy_compression_saved || 0)"></span>
+                            </div>
+                            <div class="flex justify-between items-center">
+                                <span class="text-sm text-gray-400">After Compression (sent)</span>
+                                <span class="font-mono text-sm" x-text="formatNumber(stats.tokens?.input || 0)"></span>
+                            </div>
+                            <div class="border-t border-border my-2"></div>
+                            <div class="flex justify-between items-center">
+                                <span class="text-sm text-gray-400">Output Tokens</span>
+                                <span class="font-mono text-sm" x-text="formatNumber(stats.tokens?.output || 0)"></span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- What Headroom Removed -->
+                    <div class="bg-surface rounded-lg p-4 border border-border">
+                        <div class="text-sm font-medium mb-4 text-gray-300">What Headroom Removed</div>
+                        <template x-if="Object.keys(stats.waste_signals || {}).length > 0">
+                            <div class="space-y-3">
+                                <template x-for="[signal, tokens] in sortedWasteSignals" :key="signal">
+                                    <div>
+                                        <div class="flex justify-between items-center mb-1">
+                                            <span class="text-sm text-gray-400" x-text="wasteSignalLabel(signal)"></span>
+                                            <span class="font-mono text-sm text-accent" x-text="formatNumber(tokens) + ' tokens'"></span>
+                                        </div>
+                                        <div class="w-full h-2 bg-border rounded-full overflow-hidden">
+                                            <div class="h-full rounded-full transition-all duration-500"
+                                                 :class="wasteSignalColor(signal)"
+                                                 :style="'width: ' + getWastePercent(tokens) + '%'"></div>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                        </template>
+                        <template x-if="Object.keys(stats.waste_signals || {}).length === 0">
+                            <div class="text-sm text-gray-500 italic py-8 text-center">
+                                No waste signals detected yet. Data appears after requests are processed.
+                            </div>
+                        </template>
+                    </div>
+
+                    <!-- Cumulative Savings Trend -->
+                    <div class="bg-surface rounded-lg p-4 border border-border">
+                        <div class="flex justify-between items-center mb-4">
+                            <span class="text-sm font-medium text-gray-300">Savings Over Time</span>
+                            <span class="text-xs text-gray-500 font-mono" x-text="formatNumber(stats.tokens?.saved || 0) + ' tokens total'"></span>
+                        </div>
+                        <template x-if="(stats.savings_history || []).length >= 2">
+                            <div class="h-32">
+                                <svg class="w-full h-full" viewBox="0 0 200 64" preserveAspectRatio="none">
+                                    <defs>
+                                        <linearGradient id="trend-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                                            <stop offset="0%" style="stop-color:#22d3ee;stop-opacity:0.2"/>
+                                            <stop offset="100%" style="stop-color:#22d3ee;stop-opacity:0"/>
+                                        </linearGradient>
+                                    </defs>
+                                    <path class="trend-area" :d="getTrendArea(stats.savings_history)"></path>
+                                    <path class="trend-line" :d="getTrendLine(stats.savings_history)"></path>
+                                </svg>
+                            </div>
+                        </template>
+                        <template x-if="(stats.savings_history || []).length < 2">
+                            <div class="h-32 flex items-center justify-center text-sm text-gray-500 italic">
+                                Trend data will appear after multiple requests.
+                            </div>
+                        </template>
+                    </div>
+                </div>
+
+                <!-- Prefix Cache Impact: current process only -->
+                <template x-if="cacheSessionActive">
+                    <div class="bg-surface rounded-lg p-4 border border-border mb-6">
+                        <div class="flex justify-between items-center mb-3">
+                            <div class="text-sm font-medium text-gray-300">Prefix Cache Impact</div>
+                            <div class="text-xs text-emerald-400 font-mono"
+                                 x-show="cacheSessionActive"
+                                 x-text="'Net savings: $' + formatCurrency(stats.prefix_cache?.totals?.net_savings_usd || 0)"></div>
+                            <div class="text-xs text-gray-500 font-mono"
+                                 x-show="!cacheSessionActive">no activity since restart</div>
+                        </div>
+                        <!-- Totals row -->
+                        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+                            <div>
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Writes</div>
+                                <div class="text-2xl font-light tabular-nums text-amber-400"
+                                     x-show="cacheSessionActive"
+                                     x-text="formatNumber(stats.prefix_cache?.totals?.cache_write_tokens || 0)"></div>
+                                <div class="text-2xl font-light tabular-nums text-gray-600"
+                                     x-show="!cacheSessionActive">&mdash;</div>
+                                <div class="text-xs text-amber-400/70"
+                                     x-show="cacheSessionActive"
+                                     x-text="'$' + formatCurrency(stats.prefix_cache?.totals?.write_premium_usd || 0) + ' write premium'"></div>
+                                <div class="text-xs text-gray-500"
+                                     x-show="!cacheSessionActive">no activity since restart</div>
+                            </div>
+                            <div>
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Hit Rate</div>
+                                <div class="text-2xl font-light tabular-nums" x-show="cacheSessionActive" :class="(stats.prefix_cache?.totals?.hit_rate || 0) > 80 ? 'text-emerald-400' : (stats.prefix_cache?.totals?.hit_rate || 0) > 50 ? 'text-amber-400' : 'text-red-400'" x-text="(stats.prefix_cache?.totals?.hit_rate || 0).toFixed(0) + '%'"></div>
+                                <div class="text-2xl font-light tabular-nums text-gray-600" x-show="!cacheSessionActive">&mdash;</div>
+                                <div class="text-xs text-gray-500" x-show="cacheSessionActive" x-text="(stats.prefix_cache?.totals?.hit_requests || 0) + ' / ' + (stats.prefix_cache?.totals?.requests || 0) + ' requests'"></div>
+                                <div class="text-xs text-gray-500" x-show="!cacheSessionActive">no activity since restart</div>
+                            </div>
+                            <div>
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Busts</div>
+                                <div class="text-2xl font-light tabular-nums" x-show="cacheSessionActive" :class="(stats.prefix_cache?.totals?.bust_count || 0) > 5 ? 'text-red-400' : (stats.prefix_cache?.totals?.bust_count || 0) > 0 ? 'text-amber-400' : 'text-emerald-400'" x-text="stats.prefix_cache?.totals?.bust_count || 0"></div>
+                                <div class="text-2xl font-light tabular-nums text-gray-600" x-show="!cacheSessionActive">&mdash;</div>
+                                <div class="text-xs text-gray-500" x-show="cacheSessionActive" x-text="formatNumber(stats.prefix_cache?.totals?.bust_write_tokens || 0) + ' tokens re-written'"></div>
+                                <div class="text-xs text-gray-500" x-show="!cacheSessionActive">no activity since restart</div>
+                            </div>
+                            <div>
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Providers</div>
+                                <div class="text-2xl font-light tabular-nums text-gray-300" x-show="cacheSessionActive" x-text="Object.keys(stats.prefix_cache?.by_provider || {}).length"></div>
+                                <div class="text-2xl font-light tabular-nums text-gray-600" x-show="!cacheSessionActive">&mdash;</div>
+                                <div class="text-xs text-gray-500" x-show="cacheSessionActive">with cache data</div>
+                                <div class="text-xs text-gray-500" x-show="!cacheSessionActive">no activity since restart</div>
+                            </div>
+                        </div>
+                        <!-- Cache efficiency bar (session-scoped; hidden until traffic arrives) -->
+                        <div x-show="cacheSessionActive">
+                            <div class="flex justify-between text-xs text-gray-500 mb-1">
+                                <span>Cache Efficiency</span>
+                                <span x-text="cacheSavingsPercent + '% of input served from cache'"></span>
+                            </div>
+                            <div class="w-full h-3 bg-border rounded-full overflow-hidden flex">
+                                <div class="h-full bg-emerald-500 transition-all duration-500"
+                                     :style="'width: ' + cacheSavingsPercent + '%'"></div>
+                                <div class="h-full bg-amber-500 transition-all duration-500"
+                                     :style="'width: ' + cacheWritePercent + '%'"></div>
+                            </div>
+                            <div class="flex gap-4 mt-1 text-xs text-gray-500">
+                                <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-emerald-500 inline-block"></span> Reads (discounted)</span>
+                                <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-amber-500 inline-block"></span> Writes</span>
+                                <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-border inline-block"></span> Uncached</span>
+                            </div>
+                        </div>
+                        <template x-if="hasObservedTtlBuckets">
+                            <div class="mt-5 border-t border-border pt-4">
+                                <div class="flex items-center justify-between mb-3">
+                                    <div>
+                                        <div class="text-xs text-gray-500 uppercase tracking-[0.22em]">Observed TTL Buckets</div>
+                                        <div class="text-sm text-gray-300 mt-1">Provider-reported cache write mix</div>
+                                    </div>
+                                    <div class="text-xs text-gray-500 font-mono" x-text="observedTtlWindowLabel"></div>
+                                </div>
+                                <div class="grid grid-cols-1 xl:grid-cols-[1.3fr_0.9fr] gap-4">
+                                    <div class="ttl-bucket-gradient-card rounded-2xl border border-cyan-500/20 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div>
+                                        <div class="text-[11px] uppercase tracking-[0.22em] text-cyan-300/75">Bucket Mix</div>
+                                        <div class="mt-1 text-2xl font-light text-cyan-50">
+                                            <span data-testid="ttl-bucket-mix-1h-total" x-text="formatNumber(stats.prefix_cache?.totals?.cache_write_1h_tokens || 0)"></span>
+                                            <span class="text-sm text-cyan-300/70">1h</span>
+                                            <span class="mx-2 text-cyan-500/60">/</span>
+                                            <span data-testid="ttl-bucket-mix-5m-total" x-text="formatNumber(stats.prefix_cache?.totals?.cache_write_5m_tokens || 0)"></span>
+                                            <span class="text-sm text-cyan-300/70">5m</span>
+                                        </div>
+                                    </div>
+                                    <div data-testid="ttl-bucket-headline" class="rounded-full border border-cyan-400/20 bg-black/20 px-3 py-1 text-[11px] uppercase tracking-[0.18em] text-cyan-200/80" x-text="observedTtlHeadline"></div>
+                                        </div>
+                                        <div class="mt-4">
+                                            <div class="flex justify-between text-xs text-gray-500 mb-1">
+                                                <span>Observed write-token split</span>
+                                                <span x-text="(stats.prefix_cache?.totals?.observed_ttl_mix?.active_buckets || []).join(' + ')"></span>
+                                            </div>
+                                            <div class="h-3 overflow-hidden rounded-full bg-black/30 ring-1 ring-white/5 flex">
+                                                <div class="h-full bg-cyan-400 transition-all duration-500" :style="'width:' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['1h_pct'] || 0) + '%'"></div>
+                                                <div class="h-full bg-violet-400 transition-all duration-500" :style="'width:' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['5m_pct'] || 0) + '%'"></div>
+                                            </div>
+                                            <div class="mt-2 flex flex-wrap gap-3 text-xs text-gray-400">
+                                                <span class="inline-flex items-center gap-1.5"><span class="inline-block h-2 w-2 rounded-full bg-cyan-400"></span><span data-testid="ttl-bucket-mix-1h-pct" x-text="'1h ' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['1h_pct'] || 0).toFixed(1) + '%'"></span></span>
+                                                <span class="inline-flex items-center gap-1.5"><span class="inline-block h-2 w-2 rounded-full bg-violet-400"></span><span data-testid="ttl-bucket-mix-5m-pct" x-text="'5m ' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['5m_pct'] || 0).toFixed(1) + '%'"></span></span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-1 gap-3">
+                                        <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                                            <div class="text-[11px] uppercase tracking-[0.18em] text-cyan-300/75">1h Cache Writes</div>
+                                            <div data-testid="ttl-bucket-1h-value" class="mt-2 text-3xl font-light text-cyan-50" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['1h']?.tokens || 0)"></div>
+                                            <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['1h']?.requests || 0) + ' requests observed'"></div>
+                                        </div>
+                                        <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                                            <div class="text-[11px] uppercase tracking-[0.18em] text-violet-300/75">5m Cache Writes</div>
+                                            <div data-testid="ttl-bucket-5m-value" class="mt-2 text-3xl font-light text-violet-50" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['5m']?.tokens || 0)"></div>
+                                            <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['5m']?.requests || 0) + ' requests observed'"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </template>
+                        <!-- Compression vs cache: net impact of prefix-mutating layers -->
+                        <template x-if="hasCompressionVsCache">
+                            <div class="mt-5 border-t border-border pt-4">
+                                <div class="flex items-center justify-between mb-3">
+                                    <div>
+                                        <div class="text-xs text-gray-500 uppercase tracking-wide">Compression vs Cache</div>
+                                        <div class="text-[11px] text-gray-600 mt-0.5">Tokens saved by compression against cached-prefix tokens its mutations invalidated</div>
+                                    </div>
+                                    <div data-testid="cvc-net-headline" class="rounded-full border bg-black/20 px-3 py-1 text-[11px] uppercase tracking-[0.18em]" :class="compressionVsCacheNet >= 0 ? 'border-emerald-400/20 text-emerald-300/90' : 'border-red-400/25 text-red-300/90'" x-text="compressionVsCacheNet >= 0 ? 'Net positive' : 'Net negative'"></div>
+                                </div>
+                                <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+                                    <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                                        <div class="text-[11px] uppercase tracking-[0.18em] text-emerald-300/75">Saved by Compression</div>
+                                        <div data-testid="cvc-saved-value" class="mt-2 text-3xl font-light text-emerald-50" x-text="formatNumber(stats.prefix_cache?.compression_vs_cache?.tokens_saved_by_compression || 0)"></div>
+                                        <div class="mt-1 text-xs text-gray-500">tokens removed before send</div>
+                                    </div>
+                                    <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                                        <div class="text-[11px] uppercase tracking-[0.18em] text-red-300/75">Lost to Cache Busts</div>
+                                        <div data-testid="cvc-bust-value" class="mt-2 text-3xl font-light text-red-50" x-text="formatNumber(stats.prefix_cache?.compression_vs_cache?.tokens_lost_to_cache_bust || 0)"></div>
+                                        <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.compression_vs_cache?.cache_bust_count || 0) + ' busts observed'"></div>
+                                    </div>
+                                    <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                                        <div class="text-[11px] uppercase tracking-[0.18em] text-gray-400">Net</div>
+                                        <div data-testid="cvc-net-value" class="mt-2 text-3xl font-light" :class="compressionVsCacheNet >= 0 ? 'text-emerald-400' : 'text-red-400'" x-text="(compressionVsCacheNet >= 0 ? '+' : '-') + formatNumber(Math.abs(compressionVsCacheNet))"></div>
+                                        <div class="mt-1 text-xs text-gray-500">saved minus bust losses</div>
+                                    </div>
+                                    <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                                        <div class="text-[11px] uppercase tracking-[0.18em] text-cyan-300/75">Prefix Freeze Net</div>
+                                        <div data-testid="freeze-net-value" class="mt-2 text-3xl font-light" :class="prefixFreezeNet >= 0 ? 'text-cyan-50' : 'text-red-400'" x-text="(prefixFreezeNet >= 0 ? '+' : '-') + formatNumber(Math.abs(prefixFreezeNet))"></div>
+                                        <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.prefix_freeze?.busts_avoided || 0) + ' busts avoided, ' + formatNumber(stats.prefix_cache?.prefix_freeze?.compression_foregone_tokens || 0) + ' foregone'"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </template>
+                        <!-- Cache miss attribution: why expected-cache turns missed (#1313) -->
+                        <template x-if="hasMissAttribution">
+                            <div class="mt-5 border-t border-border pt-4">
+                                <div class="flex items-center justify-between mb-3">
+                                    <div>
+                                        <div class="text-xs text-gray-500 uppercase tracking-wide">Cache Miss Attribution</div>
+                                        <div class="text-[11px] text-gray-600 mt-0.5">Why turns that expected a prompt-cache hit missed — TTL lapse (consider a longer TTL) vs the cacheable prefix changing</div>
+                                    </div>
+                                    <div data-testid="miss-attr-headline" class="rounded-full border bg-black/20 px-3 py-1 text-[11px] uppercase tracking-[0.18em]"
+                                         :class="(missAttribution.ttl_expiry_pct || 0) >= (missAttribution.prefix_change_pct || 0) ? 'border-violet-400/25 text-violet-300/90' : 'border-amber-400/25 text-amber-300/90'"
+                                         x-text="(missAttribution.ttl_expiry_pct || 0) >= (missAttribution.prefix_change_pct || 0) ? 'Mostly TTL lapse' : 'Mostly prefix change'"></div>
+                                </div>
+                                <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+                                    <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                                        <div class="text-[11px] uppercase tracking-[0.18em] text-violet-300/75">TTL Expiry</div>
+                                        <div data-testid="miss-attr-ttl-value" class="mt-2 text-3xl font-light text-violet-50" x-text="formatNumber(missAttribution.ttl_expiry || 0)"></div>
+                                        <div class="mt-1 text-xs text-gray-500" x-text="(missAttribution.ttl_expiry_pct || 0).toFixed(1) + '% of attributed — idle past cache TTL'"></div>
+                                    </div>
+                                    <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                                        <div class="text-[11px] uppercase tracking-[0.18em] text-amber-300/75">Prefix Change</div>
+                                        <div data-testid="miss-attr-prefix-value" class="mt-2 text-3xl font-light text-amber-50" x-text="formatNumber(missAttribution.prefix_change || 0)"></div>
+                                        <div class="mt-1 text-xs text-gray-500" x-text="(missAttribution.prefix_change_pct || 0).toFixed(1) + '% of attributed — cached prefix shifted'"></div>
+                                    </div>
+                                    <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                                        <div class="text-[11px] uppercase tracking-[0.18em] text-gray-400">Unknown</div>
+                                        <div data-testid="miss-attr-unknown-value" class="mt-2 text-3xl font-light text-gray-300" x-text="formatNumber(missAttribution.unknown || 0)"></div>
+                                        <div class="mt-1 text-xs text-gray-500">stable prefix, within TTL</div>
+                                    </div>
+                                    <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
+                                        <div class="text-[11px] uppercase tracking-[0.18em] text-gray-400">Total Misses</div>
+                                        <div data-testid="miss-attr-total-value" class="mt-2 text-3xl font-light text-gray-100" x-text="formatNumber(missAttribution.total || 0)"></div>
+                                        <div class="mt-1 text-xs text-gray-500">expected a cache hit, got none</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </template>
+                        <!-- Per-provider breakdown -->
+                        <template x-if="Object.keys(stats.prefix_cache?.by_provider || {}).length > 0">
+                            <div class="mt-4 border-t border-border pt-3">
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-2">Per-Provider Breakdown</div>
+                                <div class="space-y-3">
+                                    <template x-for="[prov, pc] in Object.entries(stats.prefix_cache?.by_provider || {})" :key="prov">
+                                        <div class="flex items-center justify-between">
+                                            <div class="flex items-center gap-3">
+                                                <span class="px-2 py-0.5 bg-border rounded text-xs font-mono" x-text="prov"></span>
+                                                <span class="text-xs text-gray-500" x-text="pc.label"></span>
+                                            </div>
+                                            <div class="flex flex-wrap items-center justify-end gap-4 text-xs font-mono">
+                                                <span class="text-emerald-400" x-text="formatNumber(pc.cache_read_tokens) + ' reads (' + pc.read_discount + ' off)'"></span>
+                                                <template x-if="pc.write_premium !== 'none'">
+                                                    <span class="text-amber-400" x-text="formatNumber(pc.cache_write_tokens) + ' writes (+' + pc.write_premium + ')'"></span>
+                                                </template>
+                                                <template x-if="pc.observed_ttl_mix">
+                                                    <span class="text-cyan-300" x-text="'TTL 1h ' + (pc.observed_ttl_mix['1h_pct'] || 0).toFixed(1) + '% / 5m ' + (pc.observed_ttl_mix['5m_pct'] || 0).toFixed(1) + '%'"></span>
+                                                </template>
+                                                <span :class="pc.bust_count > 0 ? 'text-red-400' : 'text-gray-500'" x-text="pc.bust_count + ' busts'"></span>
+                                                <span class="text-emerald-400" x-text="'$' + formatCurrency(pc.net_savings_usd)"></span>
+                                            </div>
+                                        </div>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                </template>
+
+                <!-- Traffic & Workload -->
+                <!-- Agent Usage -->
+                <div class="bg-surface rounded-lg border border-border overflow-hidden mb-6">
+                    <div class="px-4 py-3 border-b border-border flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+                        <div>
+                            <div class="text-sm font-medium text-gray-300">Agent Usage</div>
+                            <div class="text-xs text-gray-500">Before and after token usage by detected client</div>
+                        </div>
+                        <div class="flex flex-wrap items-center gap-3 text-xs">
+                            <span class="text-gray-500" x-text="'Coverage: ' + agentCoverageLabel"></span>
+                            <span class="px-2 py-0.5 rounded border border-border bg-card-alt font-mono text-gray-400"
+                                  x-text="formatNumber(stats.agent_usage?.totals?.requests || 0) + ' requests'"></span>
+                        </div>
+                    </div>
+
+                    <div class="p-4">
+                        <div class="grid grid-cols-1 md:grid-cols-4 gap-3 mb-5">
+                            <div class="rounded-lg border border-border bg-card-alt p-3">
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Before</div>
+                                <div class="text-2xl font-light tabular-nums" x-text="formatNumber(stats.agent_usage?.totals?.before_tokens || 0)"></div>
+                            </div>
+                            <div class="rounded-lg border border-border bg-card-alt p-3">
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">After</div>
+                                <div class="text-2xl font-light tabular-nums text-gray-200" x-text="formatNumber(stats.agent_usage?.totals?.after_tokens || 0)"></div>
+                            </div>
+                            <div class="rounded-lg border border-border bg-card-alt p-3">
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Saved</div>
+                                <div class="text-2xl font-light tabular-nums text-accent" x-text="formatNumber(stats.agent_usage?.totals?.tokens_saved || 0)"></div>
+                            </div>
+                            <div class="rounded-lg border border-border bg-card-alt p-3">
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Savings</div>
+                                <div class="text-2xl font-light tabular-nums text-emerald-400" x-text="(stats.agent_usage?.totals?.savings_percent || 0).toFixed(1) + '%'"></div>
+                            </div>
+                        </div>
+
+                        <template x-if="agentRows.length > 0">
+                            <div class="space-y-3">
+                                <template x-for="agent in agentRows" :key="agent.agent">
+                                    <div class="rounded-lg border border-border bg-card-alt p-3">
+                                        <div class="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(160px,0.9fr)_minmax(260px,1.5fr)_minmax(260px,1.2fr)] lg:items-center">
+                                            <div class="min-w-0">
+                                                <div class="flex items-center gap-2">
+                                                    <span class="h-2.5 w-2.5 rounded-full" :class="agentDotClass(agent.agent)"></span>
+                                                    <span class="text-sm font-medium text-gray-200 truncate" x-text="agent.label"></span>
+                                                </div>
+                                                <div class="mt-1 text-xs text-gray-500">
+                                                    <span x-text="formatNumber(agent.requests || 0) + ' requests'"></span>
+                                                    <span class="mx-1 text-gray-700">/</span>
+                                                    <span x-text="agent.source"></span>
+                                                </div>
+                                            </div>
+
+                                            <div>
+                                                <div class="flex items-center justify-between text-xs mb-1">
+                                                    <span class="text-gray-500">Token flow</span>
+                                                    <span class="font-mono text-emerald-400" x-text="(agent.savings_percent || 0).toFixed(1) + '% saved'"></span>
+                                                </div>
+                                                <div class="h-3 w-full rounded-full bg-border overflow-hidden flex">
+                                                    <div class="h-full bg-emerald-500 transition-all duration-500"
+                                                         :style="'width:' + agentSavedWidth(agent) + '%'"></div>
+                                                    <div class="h-full bg-accent/60 transition-all duration-500"
+                                                         :style="'width:' + agentAfterWidth(agent) + '%'"></div>
+                                                </div>
+                                                <div class="mt-1 flex flex-wrap gap-3 text-xs text-gray-500">
+                                                    <span class="inline-flex items-center gap-1"><span class="h-2 w-2 rounded-full bg-emerald-500"></span>Saved</span>
+                                                    <span class="inline-flex items-center gap-1"><span class="h-2 w-2 rounded-full bg-accent/60"></span>Sent</span>
+                                                </div>
+                                            </div>
+
+                                            <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 text-right">
+                                                <div>
+                                                    <div class="text-[11px] uppercase tracking-wide text-gray-500">Before</div>
+                                                    <div class="font-mono text-sm" x-text="formatNumber(agent.before_tokens || 0)"></div>
+                                                </div>
+                                                <div>
+                                                    <div class="text-[11px] uppercase tracking-wide text-gray-500">After</div>
+                                                    <div class="font-mono text-sm" x-text="formatNumber(agent.after_tokens || 0)"></div>
+                                                </div>
+                                                <div>
+                                                    <div class="text-[11px] uppercase tracking-wide text-gray-500">Saved</div>
+                                                    <div class="font-mono text-sm text-accent" x-text="formatNumber(agent.tokens_saved || 0)"></div>
+                                                </div>
+                                                <div>
+                                                    <div class="text-[11px] uppercase tracking-wide text-gray-500">Share</div>
+                                                    <div class="font-mono text-sm text-gray-300" x-text="(agent.share_of_saved_percent || 0).toFixed(1) + '%'"></div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                        </template>
+
+                        <template x-if="agentRows.length === 0">
+                            <div class="rounded-lg border border-dashed border-border p-6 text-center text-sm text-gray-500">
+                                Agent usage appears after Cursor, Claude, Codex, or another client sends traffic through this proxy.
+                            </div>
+                        </template>
+                    </div>
+                </div>
+                <div class="grid grid-cols-1 gap-4 mb-6 lg:grid-cols-3">
+                    <!-- Providers -->
+                    <div class="bg-surface rounded-lg p-4 border border-border">
+                        <div class="text-sm font-medium mb-4 text-gray-300">Providers</div>
+                        <div class="space-y-2">
+                            <template x-for="(count, provider) in (stats.requests?.by_provider || {})" :key="provider">
+                                <div class="flex justify-between items-center">
+                                    <span class="text-sm text-gray-400" x-text="provider"></span>
+                                    <div class="flex items-center gap-2">
+                                        <div class="w-24 h-1.5 bg-border rounded-full overflow-hidden">
+                                            <div class="h-full bg-accent rounded-full"
+                                                 :style="'width: ' + getProviderPercent(count) + '%'"></div>
+                                        </div>
+                                        <span class="font-mono text-sm w-12 text-right" x-text="formatNumber(count)"></span>
+                                    </div>
+                                </div>
+                            </template>
+                            <template x-if="Object.keys(stats.requests?.by_provider || {}).length === 0">
+                                <div class="text-sm text-gray-500 italic">No requests yet</div>
+                            </template>
+                        </div>
+                    </div>
+
+                    <!-- Per-Model Savings Breakdown -->
+                    <template x-if="Object.keys(stats.cost?.per_model || {}).length > 0">
+                        <div class="bg-surface rounded-lg border border-border overflow-hidden lg:col-span-2">
+                            <div class="px-4 py-3 border-b border-border flex justify-between items-center">
+                                <span class="text-sm font-medium text-gray-300">Per-Model Token Savings</span>
+                                <span class="text-xs text-gray-500">Exact tokens saved per model</span>
+                            </div>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-sm" style="table-layout:fixed">
+                                    <colgroup>
+                                        <col style="width:40%">
+                                        <col style="width:12%">
+                                        <col style="width:18%">
+                                        <col style="width:18%">
+                                        <col style="width:12%">
+                                    </colgroup>
+                                    <thead>
+                                        <tr class="text-xs text-gray-500 uppercase tracking-wide">
+                                            <th class="px-4 py-3 font-medium text-left">Model</th>
+                                            <th class="px-4 py-3 font-medium text-right">Requests</th>
+                                            <th class="px-4 py-3 font-medium text-right">Tokens Saved</th>
+                                            <th class="px-4 py-3 font-medium text-right">Tokens Sent</th>
+                                            <th class="px-4 py-3 font-medium text-right">Reduction</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="divide-y divide-border">
+                                        <template x-for="[model, info] in Object.entries(stats.cost?.per_model || {})" :key="model">
+                                            <tr class="hover:bg-border/30 transition-colors">
+                                                <td class="px-4 py-3 text-left">
+                                                    <span class="px-2 py-0.5 bg-border rounded text-xs" x-text="truncateModel(model)"></span>
+                                                </td>
+                                                <td class="px-4 py-3 text-right font-mono tabular-nums" x-text="info.requests"></td>
+                                                <td class="px-4 py-3 text-right font-mono tabular-nums text-accent" x-text="formatNumber(info.tokens_saved)"></td>
+                                                <td class="px-4 py-3 text-right font-mono tabular-nums" x-text="formatNumber(info.tokens_sent)"></td>
+                                                <td class="px-4 py-3 text-right">
+                                                    <span class="text-accent font-mono tabular-nums" x-text="info.reduction_pct.toFixed(1) + '%'"></span>
+                                                </td>
+                                            </tr>
+                                        </template>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
                     </template>
                 </div>
 
-                <!-- Credits section (mirrors Anthropic extra-usage section) -->
-                <template x-if="stats.codex_rate_limits.credits">
-                    <div class="border-t border-border pt-3 mb-3">
-                        <div class="flex justify-between items-center">
-                            <span class="text-xs text-gray-400 uppercase tracking-wide">Credits</span>
-                            <span class="text-sm font-mono font-medium"
-                                  :class="stats.codex_rate_limits.credits.unlimited ? 'text-purple-400' : stats.codex_rate_limits.credits.has_credits ? 'text-emerald-400' : 'text-red-400'"
-                                  x-text="stats.codex_rate_limits.credits.unlimited ? '∞ Unlimited' : stats.codex_rate_limits.credits.balance ? stats.codex_rate_limits.credits.balance : (stats.codex_rate_limits.credits.has_credits ? 'Active' : 'No Credits')"></span>
-                        </div>
-                        <template x-if="stats.codex_rate_limits.credits.balance && !stats.codex_rate_limits.credits.unlimited">
-                            <div class="text-xs text-gray-500 mt-0.5">Pay-as-you-go credits balance</div>
-                        </template>
+                <!-- Recent Requests Table (with expandable rows) -->
+                <div class="bg-surface rounded-lg border border-border overflow-hidden mb-6">
+                    <div class="px-4 py-3 border-b border-border flex justify-between items-center">
+                        <span class="text-sm font-medium text-gray-300">Recent Requests</span>
+                        <span class="text-xs text-gray-500">Last 25 &mdash; click row to expand</span>
                     </div>
-                </template>
-
-                <!-- Promo message -->
-                <template x-if="stats.codex_rate_limits.promo_message">
-                    <div class="mt-2 text-xs text-blue-400 italic"
-                         x-text="stats.codex_rate_limits.promo_message"></div>
-                </template>
-            </div>
-        </template>
-
-        <!-- GitHub Copilot Quota -->
-        <template x-if="stats.copilot_quota && stats.copilot_quota.latest">
-            <div class="bg-surface rounded-lg p-4 border border-border mb-6">
-                <div class="flex justify-between items-center mb-4">
-                    <div class="text-sm font-medium text-gray-300">GitHub Copilot Quota</div>
-                    <div class="flex items-center gap-2">
-                        <template x-if="stats.copilot_quota.latest.copilot_plan">
-                            <span class="text-xs text-gray-500 font-mono capitalize" x-text="stats.copilot_quota.latest.copilot_plan + ' plan'"></span>
-                        </template>
-                        <template x-if="stats.copilot_quota.latest.login">
-                            <span class="text-xs text-gray-400" x-text="'@' + stats.copilot_quota.latest.login"></span>
-                        </template>
-                    </div>
-                </div>
-
-                <!-- Per-category quota grid (3 columns, mirrors Anthropic 5h/7d structure) -->
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-                    <template x-for="[catKey, catLabel] in [['chat','Chat'],['completions','Completions'],['premium_interactions','Premium']]" :key="catKey">
-                        <template x-if="stats.copilot_quota.latest.categories[catKey]">
-                            <div>
-                                <div class="flex justify-between text-xs mb-1">
-                                    <span class="text-gray-400 uppercase tracking-wide" x-text="catLabel"></span>
-                                    <template x-if="stats.copilot_quota.latest.categories[catKey].unlimited">
-                                        <span class="text-purple-400 font-mono">∞</span>
-                                    </template>
-                                    <template x-if="!stats.copilot_quota.latest.categories[catKey].unlimited">
-                                        <span class="tabular-nums font-mono"
-                                              :class="(stats.copilot_quota.latest.categories[catKey].used_percent||0) > 80 ? 'text-red-400' : (stats.copilot_quota.latest.categories[catKey].used_percent||0) > 50 ? 'text-amber-400' : 'text-emerald-400'"
-                                              x-text="(stats.copilot_quota.latest.categories[catKey].used_percent||0).toFixed(0) + '%'"></span>
-                                    </template>
-                                </div>
-                                <!-- Used / entitlement count (big number like Anthropic window) -->
-                                <template x-if="!stats.copilot_quota.latest.categories[catKey].unlimited">
-                                    <div class="flex items-baseline gap-1 mb-1">
-                                        <span class="text-lg font-light tabular-nums"
-                                              :class="(stats.copilot_quota.latest.categories[catKey].used_percent||0) > 80 ? 'text-red-400' : (stats.copilot_quota.latest.categories[catKey].used_percent||0) > 50 ? 'text-amber-400' : 'text-emerald-400'"
-                                              x-text="stats.copilot_quota.latest.categories[catKey].used ?? '-'"></span>
-                                        <span class="text-xs text-gray-500 font-mono"
-                                              x-text="'/ ' + (stats.copilot_quota.latest.categories[catKey].entitlement ?? '∞')"></span>
-                                        <span class="text-xs text-gray-500 ml-auto font-mono"
-                                              x-text="(stats.copilot_quota.latest.categories[catKey].remaining ?? '') + ' left'"></span>
+                    <div class="overflow-x-auto">
+                        <div>
+                            <!-- Header -->
+                            <div class="grid text-xs text-gray-500 uppercase tracking-wide border-b border-border"
+                                 style="grid-template-columns: 2rem 12fr 22fr 15fr 12fr 10fr 14fr">
+                                <div class="px-2 py-3"></div>
+                                <div class="px-4 py-3 font-medium">Time</div>
+                                <div class="px-4 py-3 font-medium">Model</div>
+                                <div class="px-4 py-3 font-medium text-right">Input</div>
+                                <div class="px-4 py-3 font-medium text-right">Output</div>
+                                <div class="px-4 py-3 font-medium text-right">Saved</div>
+                                <div class="px-4 py-3 font-medium text-right">Latency</div>
+                            </div>
+                            <!-- Data rows -->
+                            <div class="divide-y divide-border">
+                                <template x-for="req in (stats.recent_requests || [])" :key="req.request_id">
+                                    <div>
+                                        <div class="cursor-pointer" @click="toggleExpanded(req.request_id)">
+                                            <div class="grid hover:bg-border/30 transition-colors"
+                                                 style="grid-template-columns: 2rem 12fr 22fr 15fr 12fr 10fr 14fr">
+                                                <div class="px-2 py-3 text-gray-500 flex items-center justify-center">
+                                                    <span x-text="expandedRows[req.request_id] ? '-' : '+'"></span>
+                                                </div>
+                                                <div class="px-4 py-3 font-mono text-gray-400 truncate" x-text="formatTime(req.timestamp)"></div>
+                                                <div class="px-4 py-3 min-w-0">
+                                                    <span class="px-2 py-0.5 bg-border rounded text-xs truncate" x-text="truncateModel(req.model)"></span>
+                                                </div>
+                                                <div class="px-4 py-3 text-right font-mono tabular-nums" x-text="formatNumber(req.input_tokens_optimized)"></div>
+                                                <div class="px-4 py-3 text-right font-mono tabular-nums" x-text="formatNumber(req.output_tokens || 0)"></div>
+                                                <div class="px-4 py-3 text-right">
+                                                    <span class="text-accent font-mono tabular-nums" x-text="req.savings_percent.toFixed(0) + '%'"></span>
+                                                </div>
+                                                <div class="px-4 py-3 text-right font-mono tabular-nums text-gray-400" x-text="(req.total_latency_ms || 0).toFixed(0) + 'ms'"></div>
+                                            </div>
+                                        </div>
+                                        <!-- Expanded detail row -->
+                                        <template x-if="expandedRows[req.request_id]">
+                                            <div class="px-8 py-4 border-t border-border" style="background: var(--card-alt-bg);">
+                                                <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 text-xs">
+                                                    <div>
+                                                        <div class="text-gray-500 uppercase tracking-wide mb-1">Original Tokens</div>
+                                                        <div class="font-mono" x-text="formatNumber(req.input_tokens_original)"></div>
+                                                    </div>
+                                                    <div>
+                                                        <div class="text-gray-500 uppercase tracking-wide mb-1">Compressed Tokens</div>
+                                                        <div class="font-mono" x-text="formatNumber(req.input_tokens_optimized)"></div>
+                                                    </div>
+                                                    <div>
+                                                        <div class="text-gray-500 uppercase tracking-wide mb-1">Tokens Removed</div>
+                                                        <div class="font-mono text-accent" x-text="formatNumber(req.tokens_saved)"></div>
+                                                    </div>
+                                                    <div>
+                                                        <div class="text-gray-500 uppercase tracking-wide mb-1">Optimization Time</div>
+                                                        <div class="font-mono" x-text="(req.optimization_latency_ms || 0).toFixed(0) + 'ms'"></div>
+                                                    </div>
+                                                </div>
+                                                <!-- Transforms Applied -->
+                                                <template x-if="(req.transforms_applied || []).length > 0">
+                                                    <div class="mt-3">
+                                                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Transforms Applied</div>
+                                                        <div class="flex flex-wrap gap-1">
+                                                            <template x-for="t in req.transforms_applied" :key="t">
+                                                                <span class="px-2 py-0.5 bg-border rounded text-xs font-mono" x-text="t"></span>
+                                                            </template>
+                                                        </div>
+                                                    </div>
+                                                </template>
+                                                <!-- Waste Signals for this request -->
+                                                <template x-if="req.waste_signals && Object.keys(req.waste_signals).length > 0">
+                                                    <div class="mt-3">
+                                                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Waste Detected</div>
+                                                        <div class="flex flex-wrap gap-2">
+                                                            <template x-for="[signal, tokens] in Object.entries(req.waste_signals).filter(([,v]) => v > 0)" :key="signal">
+                                                                <span class="px-2 py-0.5 rounded text-xs font-mono"
+                                                                      :class="wasteSignalBadgeColor(signal)"
+                                                                      x-text="wasteSignalLabel(signal) + ': ' + formatNumber(tokens)"></span>
+                                                            </template>
+                                                        </div>
+                                                    </div>
+                                                </template>
+                                            </div>
+                                        </template>
                                     </div>
                                 </template>
-                                <template x-if="stats.copilot_quota.latest.categories[catKey].unlimited">
-                                    <div class="text-lg font-light text-purple-400 mb-1">Unlimited</div>
+                                <template x-if="(stats.recent_requests || []).length === 0">
+                                    <div class="px-4 py-8 text-center text-gray-500 italic">
+                                        No requests yet. Start using the proxy to see activity here.
+                                    </div>
                                 </template>
-                                <!-- Progress bar -->
-                                <template x-if="!stats.copilot_quota.latest.categories[catKey].unlimited">
+                        </div>
+                    </div>
+                </div>
+                </div>
+
+                <!-- Capacity & Quotas -->
+                <!-- Anthropic Subscription Window -->
+                <template x-if="stats.subscription_window && stats.subscription_window.latest">
+                    <div class="bg-surface rounded-lg p-4 border border-border mb-6">
+                        <div class="flex justify-between items-center mb-4">
+                            <div class="text-sm font-medium text-gray-300">Anthropic Subscription Window</div>
+                            <div class="flex items-center gap-2">
+                                <span class="w-2 h-2 rounded-full pulse-live"
+                                      :class="stats.subscription_window.last_active_at ? 'bg-emerald-400' : 'bg-gray-600'"></span>
+                                <span class="text-xs text-gray-500" x-text="stats.subscription_window.last_active_at ? 'Active' : 'Idle'"></span>
+                            </div>
+                        </div>
+
+                        <!-- 5h / 7d progress bars -->
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                            <!-- 5-hour window -->
+                            <template x-if="stats.subscription_window.latest.five_hour">
+                                <div>
+                                    <div class="flex justify-between text-xs mb-1">
+                                        <span class="text-gray-400 uppercase tracking-wide">5-Hour Window</span>
+                                        <span class="tabular-nums font-mono"
+                                              :class="stats.subscription_window.latest.five_hour.utilization_pct > 80 ? 'text-red-400' : stats.subscription_window.latest.five_hour.utilization_pct > 60 ? 'text-amber-400' : 'text-emerald-400'"
+                                              x-text="(stats.subscription_window.latest.five_hour.utilization_pct || 0).toFixed(1) + '%'"></span>
+                                    </div>
                                     <div class="w-full h-3 bg-border rounded-full overflow-hidden">
                                         <div class="h-full rounded-full transition-all duration-500"
-                                             :class="(stats.copilot_quota.latest.categories[catKey].used_percent||0) > 80 ? 'bg-red-500' : (stats.copilot_quota.latest.categories[catKey].used_percent||0) > 50 ? 'bg-amber-500' : 'bg-emerald-500'"
-                                             :style="'width: ' + Math.min(stats.copilot_quota.latest.categories[catKey].used_percent||0, 100) + '%'"></div>
+                                             :class="stats.subscription_window.latest.five_hour.utilization_pct > 80 ? 'bg-red-500' : stats.subscription_window.latest.five_hour.utilization_pct > 60 ? 'bg-amber-500' : 'bg-emerald-500'"
+                                             :style="'width: ' + Math.min(stats.subscription_window.latest.five_hour.utilization_pct || 0, 100) + '%'"></div>
                                     </div>
-                                </template>
-                                <!-- Overage info -->
-                                <template x-if="stats.copilot_quota.latest.categories[catKey].overage_count > 0">
-                                    <div class="text-xs text-amber-400 mt-1"
-                                         x-text="stats.copilot_quota.latest.categories[catKey].overage_count + ' overage uses'"></div>
-                                </template>
-                                <div class="mt-1">
-                                    <span class="text-xs"
-                                          :class="stats.copilot_quota.latest.categories[catKey].overage_permitted ? 'text-gray-500' : 'text-gray-600'"
-                                          x-text="stats.copilot_quota.latest.categories[catKey].overage_permitted ? 'Overage allowed' : 'No overage'"></span>
+                                    <div class="text-xs text-gray-500 mt-1"
+                                         x-text="'Resets in ' + formatResetTime(stats.subscription_window.latest.five_hour.seconds_to_reset)"></div>
                                 </div>
-                            </div>
-                        </template>
-                    </template>
-                </div>
+                            </template>
 
-                <!-- Monthly reset section (mirrors Anthropic extra-usage border section) -->
-                <div class="border-t border-border pt-3">
-                    <div class="flex justify-between text-xs mb-2">
-                        <span class="text-gray-400 uppercase tracking-wide">Monthly Reset</span>
-                        <template x-if="stats.copilot_quota.latest.quota_reset_date_utc">
-                            <span class="text-gray-400 font-mono"
-                                  x-text="formatMonthlyReset(stats.copilot_quota.latest.quota_reset_date_utc)"></span>
-                        </template>
-                    </div>
-                    <template x-if="stats.copilot_quota.latest.quota_reset_date_utc">
-                        <div>
-                            <!-- Month-elapsed bar: filled = time elapsed, empty = time remaining -->
-                            <div class="w-full h-2 bg-border rounded-full overflow-hidden">
-                                <div class="h-full bg-accent/50 rounded-full transition-all duration-500"
-                                     :style="'width: ' + (100 - Math.min(100, Math.max(0, (new Date(stats.copilot_quota.latest.quota_reset_date_utc) - new Date()) / (30 * 86400000) * 100))) + '%'"></div>
-                            </div>
-                            <div class="flex justify-between text-xs text-gray-600 mt-0.5">
-                                <span>Month start</span>
-                                <span x-text="new Date(stats.copilot_quota.latest.quota_reset_date_utc).toLocaleDateString(undefined, {month:'short', day:'numeric'})"></span>
-                            </div>
-                        </div>
-                    </template>
-                </div>
-            </div>
-        </template>
-
-        <!-- Card renders on live cache traffic OR persisted lifetime cache savings —
-             the lifetime figure must survive a restart with zero traffic. -->
-        <template x-if="cacheSessionActive || (stats.persistent_savings?.lifetime?.cache_read_tokens || 0) > 0">
-            <div class="bg-surface rounded-lg p-4 border border-border mb-6">
-                <div class="flex justify-between items-center mb-3">
-                    <div class="text-sm font-medium text-gray-300">Prefix Cache Impact</div>
-                    <div class="text-xs text-emerald-400 font-mono"
-                         x-show="cacheSessionActive"
-                         x-text="'Net savings: $' + formatCurrency(stats.prefix_cache?.totals?.net_savings_usd || 0)"></div>
-                    <div class="text-xs text-gray-500 font-mono"
-                         x-show="!cacheSessionActive">no activity since restart</div>
-                </div>
-                <!-- Totals row -->
-                <div class="grid grid-cols-2 md:grid-cols-5 gap-4 mb-4">
-                    <div>
-                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Reads (lifetime)</div>
-                        <div class="text-2xl font-light tabular-nums text-emerald-400" x-text="formatNumber(stats.persistent_savings?.lifetime?.cache_read_tokens || 0)"></div>
-                        <!-- Three-way zero state mirrors the Proxy $ Saved tile: real value /
-                             unpriced-but-healthy / litellm unavailable. -->
-                        <div class="text-xs text-emerald-400/70"
-                             x-show="(stats.persistent_savings?.lifetime?.cache_savings_usd || 0) > 0"
-                             x-text="'$' + formatCurrency(stats.persistent_savings?.lifetime?.cache_savings_usd || 0) + ' saved'"></div>
-                        <div class="text-xs text-gray-500"
-                             x-show="!((stats.persistent_savings?.lifetime?.cache_savings_usd || 0) > 0) && stats.litellm_available !== false">savings not priced yet</div>
-                        <div class="text-xs text-gray-500"
-                             x-show="!((stats.persistent_savings?.lifetime?.cache_savings_usd || 0) > 0) && stats.litellm_available === false">pricing needs LiteLLM</div>
-                    </div>
-                    <div>
-                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Writes</div>
-                        <div class="text-2xl font-light tabular-nums text-amber-400"
-                             x-show="cacheSessionActive"
-                             x-text="formatNumber(stats.prefix_cache?.totals?.cache_write_tokens || 0)"></div>
-                        <div class="text-2xl font-light tabular-nums text-gray-600"
-                             x-show="!cacheSessionActive">&mdash;</div>
-                        <div class="text-xs text-amber-400/70"
-                             x-show="cacheSessionActive"
-                             x-text="'$' + formatCurrency(stats.prefix_cache?.totals?.write_premium_usd || 0) + ' write premium'"></div>
-                        <div class="text-xs text-gray-500"
-                             x-show="!cacheSessionActive">no activity since restart</div>
-                    </div>
-                    <div>
-                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Hit Rate</div>
-                        <div class="text-2xl font-light tabular-nums" x-show="cacheSessionActive" :class="(stats.prefix_cache?.totals?.hit_rate || 0) > 80 ? 'text-emerald-400' : (stats.prefix_cache?.totals?.hit_rate || 0) > 50 ? 'text-amber-400' : 'text-red-400'" x-text="(stats.prefix_cache?.totals?.hit_rate || 0).toFixed(0) + '%'"></div>
-                        <div class="text-2xl font-light tabular-nums text-gray-600" x-show="!cacheSessionActive">&mdash;</div>
-                        <div class="text-xs text-gray-500" x-show="cacheSessionActive" x-text="(stats.prefix_cache?.totals?.hit_requests || 0) + ' / ' + (stats.prefix_cache?.totals?.requests || 0) + ' requests'"></div>
-                        <div class="text-xs text-gray-500" x-show="!cacheSessionActive">no activity since restart</div>
-                    </div>
-                    <div>
-                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Busts</div>
-                        <div class="text-2xl font-light tabular-nums" x-show="cacheSessionActive" :class="(stats.prefix_cache?.totals?.bust_count || 0) > 5 ? 'text-red-400' : (stats.prefix_cache?.totals?.bust_count || 0) > 0 ? 'text-amber-400' : 'text-emerald-400'" x-text="stats.prefix_cache?.totals?.bust_count || 0"></div>
-                        <div class="text-2xl font-light tabular-nums text-gray-600" x-show="!cacheSessionActive">&mdash;</div>
-                        <div class="text-xs text-gray-500" x-show="cacheSessionActive" x-text="formatNumber(stats.prefix_cache?.totals?.bust_write_tokens || 0) + ' tokens re-written'"></div>
-                        <div class="text-xs text-gray-500" x-show="!cacheSessionActive">no activity since restart</div>
-                    </div>
-                    <div>
-                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Providers</div>
-                        <div class="text-2xl font-light tabular-nums text-gray-300" x-show="cacheSessionActive" x-text="Object.keys(stats.prefix_cache?.by_provider || {}).length"></div>
-                        <div class="text-2xl font-light tabular-nums text-gray-600" x-show="!cacheSessionActive">&mdash;</div>
-                        <div class="text-xs text-gray-500" x-show="cacheSessionActive">with cache data</div>
-                        <div class="text-xs text-gray-500" x-show="!cacheSessionActive">no activity since restart</div>
-                    </div>
-                </div>
-                <!-- Cache efficiency bar (session-scoped; hidden until traffic arrives) -->
-                <div x-show="cacheSessionActive">
-                    <div class="flex justify-between text-xs text-gray-500 mb-1">
-                        <span>Cache Efficiency</span>
-                        <span x-text="cacheSavingsPercent + '% of input served from cache'"></span>
-                    </div>
-                    <div class="w-full h-3 bg-border rounded-full overflow-hidden flex">
-                        <div class="h-full bg-emerald-500 transition-all duration-500"
-                             :style="'width: ' + cacheSavingsPercent + '%'"></div>
-                        <div class="h-full bg-amber-500 transition-all duration-500"
-                             :style="'width: ' + cacheWritePercent + '%'"></div>
-                    </div>
-                    <div class="flex gap-4 mt-1 text-xs text-gray-500">
-                        <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-emerald-500 inline-block"></span> Reads (discounted)</span>
-                        <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-amber-500 inline-block"></span> Writes</span>
-                        <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-border inline-block"></span> Uncached</span>
-                    </div>
-                </div>
-                <template x-if="hasObservedTtlBuckets">
-                    <div class="mt-5 border-t border-border pt-4">
-                        <div class="flex items-center justify-between mb-3">
-                            <div>
-                                <div class="text-xs text-gray-500 uppercase tracking-[0.22em]">Observed TTL Buckets</div>
-                                <div class="text-sm text-gray-300 mt-1">Provider-reported cache write mix</div>
-                            </div>
-                            <div class="text-xs text-gray-500 font-mono" x-text="observedTtlWindowLabel"></div>
-                        </div>
-                        <div class="grid grid-cols-1 xl:grid-cols-[1.3fr_0.9fr] gap-4">
-                            <div class="ttl-bucket-gradient-card rounded-2xl border border-cyan-500/20 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-                        <div class="flex items-start justify-between gap-3">
-                            <div>
-                                <div class="text-[11px] uppercase tracking-[0.22em] text-cyan-300/75">Bucket Mix</div>
-                                <div class="mt-1 text-2xl font-light text-cyan-50">
-                                    <span data-testid="ttl-bucket-mix-1h-total" x-text="formatNumber(stats.prefix_cache?.totals?.cache_write_1h_tokens || 0)"></span>
-                                    <span class="text-sm text-cyan-300/70">1h</span>
-                                    <span class="mx-2 text-cyan-500/60">/</span>
-                                    <span data-testid="ttl-bucket-mix-5m-total" x-text="formatNumber(stats.prefix_cache?.totals?.cache_write_5m_tokens || 0)"></span>
-                                    <span class="text-sm text-cyan-300/70">5m</span>
-                                </div>
-                            </div>
-                            <div data-testid="ttl-bucket-headline" class="rounded-full border border-cyan-400/20 bg-black/20 px-3 py-1 text-[11px] uppercase tracking-[0.18em] text-cyan-200/80" x-text="observedTtlHeadline"></div>
-                                </div>
-                                <div class="mt-4">
-                                    <div class="flex justify-between text-xs text-gray-500 mb-1">
-                                        <span>Observed write-token split</span>
-                                        <span x-text="(stats.prefix_cache?.totals?.observed_ttl_mix?.active_buckets || []).join(' + ')"></span>
+                            <!-- 7-day window -->
+                            <template x-if="stats.subscription_window.latest.seven_day">
+                                <div>
+                                    <div class="flex justify-between text-xs mb-1">
+                                        <span class="text-gray-400 uppercase tracking-wide">7-Day Window</span>
+                                        <span class="tabular-nums font-mono"
+                                              :class="stats.subscription_window.latest.seven_day.utilization_pct > 80 ? 'text-red-400' : stats.subscription_window.latest.seven_day.utilization_pct > 60 ? 'text-amber-400' : 'text-emerald-400'"
+                                              x-text="(stats.subscription_window.latest.seven_day.utilization_pct || 0).toFixed(1) + '%'"></span>
                                     </div>
-                                    <div class="h-3 overflow-hidden rounded-full bg-black/30 ring-1 ring-white/5 flex">
-                                        <div class="h-full bg-cyan-400 transition-all duration-500" :style="'width:' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['1h_pct'] || 0) + '%'"></div>
-                                        <div class="h-full bg-violet-400 transition-all duration-500" :style="'width:' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['5m_pct'] || 0) + '%'"></div>
+                                    <div class="w-full h-3 bg-border rounded-full overflow-hidden">
+                                        <div class="h-full rounded-full transition-all duration-500"
+                                             :class="stats.subscription_window.latest.seven_day.utilization_pct > 80 ? 'bg-red-500' : stats.subscription_window.latest.seven_day.utilization_pct > 60 ? 'bg-amber-500' : 'bg-emerald-500'"
+                                             :style="'width: ' + Math.min(stats.subscription_window.latest.seven_day.utilization_pct || 0, 100) + '%'"></div>
                                     </div>
-                                    <div class="mt-2 flex flex-wrap gap-3 text-xs text-gray-400">
-                                        <span class="inline-flex items-center gap-1.5"><span class="inline-block h-2 w-2 rounded-full bg-cyan-400"></span><span data-testid="ttl-bucket-mix-1h-pct" x-text="'1h ' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['1h_pct'] || 0).toFixed(1) + '%'"></span></span>
-                                        <span class="inline-flex items-center gap-1.5"><span class="inline-block h-2 w-2 rounded-full bg-violet-400"></span><span data-testid="ttl-bucket-mix-5m-pct" x-text="'5m ' + (stats.prefix_cache?.totals?.observed_ttl_mix?.['5m_pct'] || 0).toFixed(1) + '%'"></span></span>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-1 gap-3">
-                                <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                    <div class="text-[11px] uppercase tracking-[0.18em] text-cyan-300/75">1h Cache Writes</div>
-                                    <div data-testid="ttl-bucket-1h-value" class="mt-2 text-3xl font-light text-cyan-50" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['1h']?.tokens || 0)"></div>
-                                    <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['1h']?.requests || 0) + ' requests observed'"></div>
-                                </div>
-                                <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                    <div class="text-[11px] uppercase tracking-[0.18em] text-violet-300/75">5m Cache Writes</div>
-                                    <div data-testid="ttl-bucket-5m-value" class="mt-2 text-3xl font-light text-violet-50" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['5m']?.tokens || 0)"></div>
-                                    <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.totals?.observed_ttl_buckets?.['5m']?.requests || 0) + ' requests observed'"></div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </template>
-                <!-- Compression vs cache: net impact of prefix-mutating layers -->
-                <template x-if="hasCompressionVsCache">
-                    <div class="mt-5 border-t border-border pt-4">
-                        <div class="flex items-center justify-between mb-3">
-                            <div>
-                                <div class="text-xs text-gray-500 uppercase tracking-wide">Compression vs Cache</div>
-                                <div class="text-[11px] text-gray-600 mt-0.5">Tokens saved by compression against cached-prefix tokens its mutations invalidated</div>
-                            </div>
-                            <div data-testid="cvc-net-headline" class="rounded-full border bg-black/20 px-3 py-1 text-[11px] uppercase tracking-[0.18em]" :class="compressionVsCacheNet >= 0 ? 'border-emerald-400/20 text-emerald-300/90' : 'border-red-400/25 text-red-300/90'" x-text="compressionVsCacheNet >= 0 ? 'Net positive' : 'Net negative'"></div>
-                        </div>
-                        <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-                            <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                <div class="text-[11px] uppercase tracking-[0.18em] text-emerald-300/75">Saved by Compression</div>
-                                <div data-testid="cvc-saved-value" class="mt-2 text-3xl font-light text-emerald-50" x-text="formatNumber(stats.prefix_cache?.compression_vs_cache?.tokens_saved_by_compression || 0)"></div>
-                                <div class="mt-1 text-xs text-gray-500">tokens removed before send</div>
-                            </div>
-                            <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                <div class="text-[11px] uppercase tracking-[0.18em] text-red-300/75">Lost to Cache Busts</div>
-                                <div data-testid="cvc-bust-value" class="mt-2 text-3xl font-light text-red-50" x-text="formatNumber(stats.prefix_cache?.compression_vs_cache?.tokens_lost_to_cache_bust || 0)"></div>
-                                <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.compression_vs_cache?.cache_bust_count || 0) + ' busts observed'"></div>
-                            </div>
-                            <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                <div class="text-[11px] uppercase tracking-[0.18em] text-gray-400">Net</div>
-                                <div data-testid="cvc-net-value" class="mt-2 text-3xl font-light" :class="compressionVsCacheNet >= 0 ? 'text-emerald-400' : 'text-red-400'" x-text="(compressionVsCacheNet >= 0 ? '+' : '-') + formatNumber(Math.abs(compressionVsCacheNet))"></div>
-                                <div class="mt-1 text-xs text-gray-500">saved minus bust losses</div>
-                            </div>
-                            <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                <div class="text-[11px] uppercase tracking-[0.18em] text-cyan-300/75">Prefix Freeze Net</div>
-                                <div data-testid="freeze-net-value" class="mt-2 text-3xl font-light" :class="prefixFreezeNet >= 0 ? 'text-cyan-50' : 'text-red-400'" x-text="(prefixFreezeNet >= 0 ? '+' : '-') + formatNumber(Math.abs(prefixFreezeNet))"></div>
-                                <div class="mt-1 text-xs text-gray-500" x-text="formatNumber(stats.prefix_cache?.prefix_freeze?.busts_avoided || 0) + ' busts avoided, ' + formatNumber(stats.prefix_cache?.prefix_freeze?.compression_foregone_tokens || 0) + ' foregone'"></div>
-                            </div>
-                        </div>
-                    </div>
-                </template>
-                <!-- Cache miss attribution: why expected-cache turns missed (#1313) -->
-                <template x-if="hasMissAttribution">
-                    <div class="mt-5 border-t border-border pt-4">
-                        <div class="flex items-center justify-between mb-3">
-                            <div>
-                                <div class="text-xs text-gray-500 uppercase tracking-wide">Cache Miss Attribution</div>
-                                <div class="text-[11px] text-gray-600 mt-0.5">Why turns that expected a prompt-cache hit missed — TTL lapse (consider a longer TTL) vs the cacheable prefix changing</div>
-                            </div>
-                            <div data-testid="miss-attr-headline" class="rounded-full border bg-black/20 px-3 py-1 text-[11px] uppercase tracking-[0.18em]"
-                                 :class="(missAttribution.ttl_expiry_pct || 0) >= (missAttribution.prefix_change_pct || 0) ? 'border-violet-400/25 text-violet-300/90' : 'border-amber-400/25 text-amber-300/90'"
-                                 x-text="(missAttribution.ttl_expiry_pct || 0) >= (missAttribution.prefix_change_pct || 0) ? 'Mostly TTL lapse' : 'Mostly prefix change'"></div>
-                        </div>
-                        <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-                            <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                <div class="text-[11px] uppercase tracking-[0.18em] text-violet-300/75">TTL Expiry</div>
-                                <div data-testid="miss-attr-ttl-value" class="mt-2 text-3xl font-light text-violet-50" x-text="formatNumber(missAttribution.ttl_expiry || 0)"></div>
-                                <div class="mt-1 text-xs text-gray-500" x-text="(missAttribution.ttl_expiry_pct || 0).toFixed(1) + '% of attributed — idle past cache TTL'"></div>
-                            </div>
-                            <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                <div class="text-[11px] uppercase tracking-[0.18em] text-amber-300/75">Prefix Change</div>
-                                <div data-testid="miss-attr-prefix-value" class="mt-2 text-3xl font-light text-amber-50" x-text="formatNumber(missAttribution.prefix_change || 0)"></div>
-                                <div class="mt-1 text-xs text-gray-500" x-text="(missAttribution.prefix_change_pct || 0).toFixed(1) + '% of attributed — cached prefix shifted'"></div>
-                            </div>
-                            <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                <div class="text-[11px] uppercase tracking-[0.18em] text-gray-400">Unknown</div>
-                                <div data-testid="miss-attr-unknown-value" class="mt-2 text-3xl font-light text-gray-300" x-text="formatNumber(missAttribution.unknown || 0)"></div>
-                                <div class="mt-1 text-xs text-gray-500">stable prefix, within TTL</div>
-                            </div>
-                            <div class="rounded-2xl border border-white/8 bg-black/20 p-4">
-                                <div class="text-[11px] uppercase tracking-[0.18em] text-gray-400">Total Misses</div>
-                                <div data-testid="miss-attr-total-value" class="mt-2 text-3xl font-light text-gray-100" x-text="formatNumber(missAttribution.total || 0)"></div>
-                                <div class="mt-1 text-xs text-gray-500">expected a cache hit, got none</div>
-                            </div>
-                        </div>
-                    </div>
-                </template>
-                <!-- Per-provider breakdown -->
-                <template x-if="Object.keys(stats.prefix_cache?.by_provider || {}).length > 0">
-                    <div class="mt-4 border-t border-border pt-3">
-                        <div class="text-xs text-gray-500 uppercase tracking-wide mb-2">Per-Provider Breakdown</div>
-                        <div class="space-y-3">
-                            <template x-for="[prov, pc] in Object.entries(stats.prefix_cache?.by_provider || {})" :key="prov">
-                                <div class="flex items-center justify-between">
-                                    <div class="flex items-center gap-3">
-                                        <span class="px-2 py-0.5 bg-border rounded text-xs font-mono" x-text="prov"></span>
-                                        <span class="text-xs text-gray-500" x-text="pc.label"></span>
-                                    </div>
-                                    <div class="flex flex-wrap items-center justify-end gap-4 text-xs font-mono">
-                                        <span class="text-emerald-400" x-text="formatNumber(pc.cache_read_tokens) + ' reads (' + pc.read_discount + ' off)'"></span>
-                                        <template x-if="pc.write_premium !== 'none'">
-                                            <span class="text-amber-400" x-text="formatNumber(pc.cache_write_tokens) + ' writes (+' + pc.write_premium + ')'"></span>
-                                        </template>
-                                        <template x-if="pc.observed_ttl_mix">
-                                            <span class="text-cyan-300" x-text="'TTL 1h ' + (pc.observed_ttl_mix['1h_pct'] || 0).toFixed(1) + '% / 5m ' + (pc.observed_ttl_mix['5m_pct'] || 0).toFixed(1) + '%'"></span>
-                                        </template>
-                                        <span :class="pc.bust_count > 0 ? 'text-red-400' : 'text-gray-500'" x-text="pc.bust_count + ' busts'"></span>
-                                        <span class="text-emerald-400" x-text="'$' + formatCurrency(pc.net_savings_usd)"></span>
-                                    </div>
+                                    <div class="text-xs text-gray-500 mt-1"
+                                         x-text="'Resets in ' + formatResetTime(stats.subscription_window.latest.seven_day.seconds_to_reset)"></div>
                                 </div>
                             </template>
                         </div>
+
+                        <!-- Overage / extra usage -->
+                        <template x-if="stats.subscription_window.latest.extra_usage && stats.subscription_window.latest.extra_usage.is_enabled">
+                            <div class="border-t border-border pt-3 mb-3">
+                                <div class="flex justify-between text-xs mb-1">
+                                    <span class="text-gray-400 uppercase tracking-wide">Extra Usage (Overage)</span>
+                                    <span class="text-amber-400 tabular-nums font-mono"
+                                          x-text="'$' + formatCurrency(stats.subscription_window.latest.extra_usage.used_credits_usd || 0) + (stats.subscription_window.latest.extra_usage.monthly_limit_usd ? ' / $' + formatCurrency(stats.subscription_window.latest.extra_usage.monthly_limit_usd) : '')"></span>
+                                </div>
+                                <template x-if="stats.subscription_window.latest.extra_usage.utilization_pct != null">
+                                    <div class="w-full h-2 bg-border rounded-full overflow-hidden">
+                                        <div class="h-full bg-amber-500 rounded-full transition-all duration-500"
+                                             :style="'width: ' + Math.min(stats.subscription_window.latest.extra_usage.utilization_pct || 0, 100) + '%'"></div>
+                                    </div>
+                                </template>
+                            </div>
+                        </template>
+
+                        <!-- Headroom contribution row -->
+                        <template x-if="stats.subscription_window.contribution && stats.subscription_window.contribution.tokens_submitted > 0">
+                            <div class="border-t border-border pt-3">
+                                <div class="text-xs text-gray-400 uppercase tracking-wide mb-2">Headroom Contribution This Window</div>
+                                <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+                                    <div>
+                                        <div class="text-xs text-gray-500 mb-0.5">Efficiency</div>
+                                        <div class="text-lg font-light tabular-nums text-accent"
+                                             x-text="(stats.subscription_window.contribution.efficiency_pct || 0).toFixed(1) + '%'"></div>
+                                    </div>
+                                    <div>
+                                        <div class="text-xs text-gray-500 mb-0.5">Tokens Saved</div>
+                                        <div class="text-lg font-light tabular-nums text-emerald-400"
+                                             x-text="formatNumber(stats.subscription_window.contribution.tokens_saved?.total || 0)"></div>
+                                    </div>
+                                    <div>
+                                        <div class="text-xs text-gray-500 mb-0.5">Compression</div>
+                                        <div class="text-sm tabular-nums text-gray-300"
+                                             x-text="formatNumber(stats.subscription_window.contribution.tokens_saved?.compression || 0) + ' tok'"></div>
+                                    </div>
+                                    <div>
+                                        <div class="text-xs text-gray-500 mb-0.5">Cache Reads</div>
+                                        <div class="text-sm tabular-nums text-cyan-400"
+                                             x-text="formatNumber(stats.subscription_window.contribution.tokens_saved?.cache_reads || 0) + ' tok'"></div>
+                                    </div>
+                                </div>
+
+                                <!-- Efficiency bar: tokens submitted vs what would have been sent without headroom -->
+                                <template x-if="stats.subscription_window.contribution.raw_without_headroom > 0">
+                                    <div class="mt-3">
+                                        <div class="flex justify-between text-xs text-gray-500 mb-1">
+                                            <span>Raw vs Submitted</span>
+                                            <span x-text="formatNumber(stats.subscription_window.contribution.tokens_submitted) + ' / ' + formatNumber(stats.subscription_window.contribution.raw_without_headroom) + ' tokens forwarded'"></span>
+                                        </div>
+                                        <div class="w-full h-2 bg-border rounded-full overflow-hidden flex">
+                                            <div class="h-full bg-accent rounded-l-full"
+                                                 :style="'width: ' + ((stats.subscription_window.contribution.tokens_submitted / stats.subscription_window.contribution.raw_without_headroom) * 100).toFixed(1) + '%'"></div>
+                                        </div>
+                                        <div class="flex gap-4 mt-1 text-xs text-gray-500">
+                                            <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-accent inline-block"></span>Forwarded to Anthropic</span>
+                                            <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-border inline-block"></span>Saved by Headroom</span>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                        </template>
+
+                        <!-- Discrepancies -->
+                        <template x-if="stats.subscription_window.discrepancies && stats.subscription_window.discrepancies.length > 0">
+                            <div class="border-t border-border pt-3 mt-3">
+                                <div class="text-xs text-amber-400 uppercase tracking-wide mb-2">⚠ Anomalies Detected</div>
+                                <template x-for="d in stats.subscription_window.discrepancies" :key="d.kind + d.description">
+                                    <div class="text-xs mb-1"
+                                         :class="d.severity === 'alert' ? 'text-red-400' : 'text-amber-400'"
+                                         x-text="d.description"></div>
+                                </template>
+                            </div>
+                        </template>
                     </div>
                 </template>
-            </div>
-        </template>
+                <!-- Codex Rate-Limit Window -->
+                <template x-if="stats.codex_rate_limits && stats.codex_rate_limits.primary">
+                    <div class="bg-surface rounded-lg p-4 border border-border mb-6">
+                        <div class="flex justify-between items-center mb-4">
+                            <div class="text-sm font-medium text-gray-300">OpenAI Codex Rate-Limit Window</div>
+                            <template x-if="stats.codex_rate_limits.limit_name">
+                                <span class="text-xs text-gray-500 font-mono" x-text="stats.codex_rate_limits.limit_name"></span>
+                            </template>
+                        </div>
 
-        <!-- New: Waste Signal Breakdown + Cumulative Savings Trend -->
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
-            <!-- What Headroom Removed -->
-            <div class="bg-surface rounded-lg p-4 border border-border">
-                <div class="text-sm font-medium mb-4 text-gray-300">What Headroom Removed</div>
-                <template x-if="Object.keys(stats.waste_signals || {}).length > 0">
-                    <div class="space-y-3">
-                        <template x-for="[signal, tokens] in sortedWasteSignals" :key="signal">
+                        <!-- Primary / Secondary window grid (mirrors Anthropic 5h/7d layout) -->
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                            <!-- Primary window -->
                             <div>
-                                <div class="flex justify-between items-center mb-1">
-                                    <span class="text-sm text-gray-400" x-text="wasteSignalLabel(signal)"></span>
-                                    <span class="font-mono text-sm text-accent" x-text="formatNumber(tokens) + ' tokens'"></span>
+                                <div class="flex justify-between text-xs mb-1">
+                                    <span class="text-gray-400 uppercase tracking-wide">Primary
+                                        <template x-if="stats.codex_rate_limits.primary.window_label">
+                                            <span class="text-gray-600 normal-case font-mono ml-1"
+                                                  x-text="'(' + stats.codex_rate_limits.primary.window_label + ')'"></span>
+                                        </template>
+                                    </span>
+                                    <span class="tabular-nums font-mono"
+                                          :class="(stats.codex_rate_limits.primary.used_percent||0) > 80 ? 'text-red-400' : (stats.codex_rate_limits.primary.used_percent||0) > 60 ? 'text-amber-400' : 'text-emerald-400'"
+                                          x-text="(stats.codex_rate_limits.primary.used_percent||0).toFixed(1) + '%'"></span>
                                 </div>
-                                <div class="w-full h-2 bg-border rounded-full overflow-hidden">
+                                <div class="w-full h-3 bg-border rounded-full overflow-hidden">
                                     <div class="h-full rounded-full transition-all duration-500"
-                                         :class="wasteSignalColor(signal)"
-                                         :style="'width: ' + getWastePercent(tokens) + '%'"></div>
+                                         :class="(stats.codex_rate_limits.primary.used_percent||0) > 80 ? 'bg-red-500' : (stats.codex_rate_limits.primary.used_percent||0) > 60 ? 'bg-amber-500' : 'bg-emerald-500'"
+                                         :style="'width: ' + Math.min(stats.codex_rate_limits.primary.used_percent||0, 100) + '%'"></div>
                                 </div>
+                                <template x-if="stats.codex_rate_limits.primary.seconds_until_reset !== null">
+                                    <div class="text-xs text-gray-500 mt-1"
+                                         x-text="'Resets in ' + formatResetTime(stats.codex_rate_limits.primary.seconds_until_reset)"></div>
+                                </template>
                             </div>
-                        </template>
-                    </div>
-                </template>
-                <template x-if="Object.keys(stats.waste_signals || {}).length === 0">
-                    <div class="text-sm text-gray-500 italic py-8 text-center">
-                        No waste signals detected yet. Data appears after requests are processed.
-                    </div>
-                </template>
-            </div>
-
-            <!-- Cumulative Savings Trend -->
-            <div class="bg-surface rounded-lg p-4 border border-border">
-                <div class="flex justify-between items-center mb-4">
-                    <span class="text-sm font-medium text-gray-300">Savings Over Time</span>
-                    <span class="text-xs text-gray-500 font-mono" x-text="formatNumber(stats.tokens?.saved || 0) + ' tokens total'"></span>
-                </div>
-                <template x-if="(stats.savings_history || []).length >= 2">
-                    <div class="h-32">
-                        <svg class="w-full h-full" viewBox="0 0 200 64" preserveAspectRatio="none">
-                            <defs>
-                                <linearGradient id="trend-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                                    <stop offset="0%" style="stop-color:#22d3ee;stop-opacity:0.2"/>
-                                    <stop offset="100%" style="stop-color:#22d3ee;stop-opacity:0"/>
-                                </linearGradient>
-                            </defs>
-                            <path class="trend-area" :d="getTrendArea(stats.savings_history)"></path>
-                            <path class="trend-line" :d="getTrendLine(stats.savings_history)"></path>
-                        </svg>
-                    </div>
-                </template>
-                <template x-if="(stats.savings_history || []).length < 2">
-                    <div class="h-32 flex items-center justify-center text-sm text-gray-500 italic">
-                        Trend data will appear after multiple requests.
-                    </div>
-                </template>
-            </div>
-        </div>
-
-        <!-- Main Grid -->
-        <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
-            <!-- Token Usage -->
-            <div class="bg-surface rounded-lg p-4 border border-border">
-                <div class="text-sm font-medium mb-4 text-gray-300">Token Usage</div>
-                <div class="space-y-3">
-                    <div class="flex justify-between items-center">
-                        <span class="text-sm text-gray-400">Before Compression</span>
-                        <span class="font-mono text-sm" x-text="formatNumber(stats.tokens?.total_before_compression || 0)"></span>
-                    </div>
-                    <div class="flex justify-between items-center" x-show="cliFilteringAvailable">
-                        <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
-                        <span class="font-mono text-sm text-emerald-400" x-text="formatNumber(cliFilteringSaved)"></span>
-                    </div>
-                    <div class="flex justify-between items-center" x-show="!cliFilteringAvailable">
-                        <span class="text-sm text-gray-400" x-text="cliFilteringLabel + ' Filtered (this session)'"></span>
-                        <span class="font-mono text-sm text-gray-600">not installed</span>
-                    </div>
-                    <div class="flex justify-between items-center" x-show="cliFilteringAvailable && cliFilteringLifetime > 0">
-                        <span class="text-sm text-gray-500" x-text="cliFilteringLabel + ' Filtered (lifetime)'"></span>
-                        <span class="font-mono text-sm text-emerald-400/70" x-text="formatNumber(cliFilteringLifetime)"></span>
-                    </div>
-                    <div class="flex justify-between items-center">
-                        <span class="text-sm text-gray-400">Proxy Removed</span>
-                        <span class="font-mono text-sm text-accent" x-text="formatNumber(stats.tokens?.proxy_compression_saved || 0)"></span>
-                    </div>
-                    <div class="flex justify-between items-center">
-                        <span class="text-sm text-gray-400">After Compression (sent)</span>
-                        <span class="font-mono text-sm" x-text="formatNumber(stats.tokens?.input || 0)"></span>
-                    </div>
-                    <div class="border-t border-border my-2"></div>
-                    <div class="flex justify-between items-center">
-                        <span class="text-sm text-gray-400">Output Tokens</span>
-                        <span class="font-mono text-sm" x-text="formatNumber(stats.tokens?.output || 0)"></span>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Providers -->
-            <div class="bg-surface rounded-lg p-4 border border-border">
-                <div class="text-sm font-medium mb-4 text-gray-300">Providers</div>
-                <div class="space-y-2">
-                    <template x-for="(count, provider) in (stats.requests?.by_provider || {})" :key="provider">
-                        <div class="flex justify-between items-center">
-                            <span class="text-sm text-gray-400" x-text="provider"></span>
-                            <div class="flex items-center gap-2">
-                                <div class="w-24 h-1.5 bg-border rounded-full overflow-hidden">
-                                    <div class="h-full bg-accent rounded-full"
-                                         :style="'width: ' + getProviderPercent(count) + '%'"></div>
-                                </div>
-                                <span class="font-mono text-sm w-12 text-right" x-text="formatNumber(count)"></span>
-                            </div>
-                        </div>
-                    </template>
-                    <template x-if="Object.keys(stats.requests?.by_provider || {}).length === 0">
-                        <div class="text-sm text-gray-500 italic">No requests yet</div>
-                    </template>
-                </div>
-            </div>
-
-            <!-- Performance -->
-            <div class="bg-surface rounded-lg p-4 border border-border">
-                <div class="text-sm font-medium mb-4 text-gray-300">Performance</div>
-                <div class="space-y-3">
-                    <div class="flex justify-between items-center">
-                        <span class="text-sm text-gray-400">Overhead Range</span>
-                        <span class="font-mono text-sm" x-text="(stats.overhead?.min_ms || 0).toFixed(0) + ' - ' + (stats.overhead?.max_ms || 0).toFixed(0) + 'ms'"></span>
-                    </div>
-                    <div class="flex justify-between items-center">
-                        <span class="text-sm text-gray-400">TTFB Range</span>
-                        <span class="font-mono text-sm" x-text="((stats.ttfb?.min_ms || 0) / 1000).toFixed(2) + ' - ' + ((stats.ttfb?.max_ms || 0) / 1000).toFixed(2) + 's'"></span>
-                    </div>
-                    <div class="flex justify-between items-center">
-                        <span class="text-sm text-gray-400">Failed Requests</span>
-                        <span class="font-mono text-sm" x-text="stats.requests?.failed || 0"></span>
-                    </div>
-                    <!-- Per-transform timing breakdown -->
-                    <template x-if="Object.keys(stats.pipeline_timing || {}).length > 0">
-                        <div>
-                            <div class="border-t border-border my-2"></div>
-                            <div class="text-xs text-gray-500 uppercase tracking-wide mb-2">Pipeline Breakdown</div>
-                            <template x-for="[name, t] in Object.entries(stats.pipeline_timing || {})" :key="name">
-                                <div class="flex justify-between items-center mb-1">
-                                    <span class="text-xs text-gray-400 font-mono truncate mr-2" x-text="name"></span>
-                                    <span class="text-xs font-mono whitespace-nowrap"
-                                          :class="t.average_ms > 100 ? 'text-amber-400' : t.average_ms > 50 ? 'text-yellow-400' : 'text-gray-400'"
-                                          x-text="t.average_ms.toFixed(0) + 'ms avg / ' + t.max_ms.toFixed(0) + 'ms max'"></span>
+                            <!-- Secondary window -->
+                            <template x-if="stats.codex_rate_limits.secondary">
+                                <div>
+                                    <div class="flex justify-between text-xs mb-1">
+                                        <span class="text-gray-400 uppercase tracking-wide">Secondary
+                                            <template x-if="stats.codex_rate_limits.secondary.window_label">
+                                                <span class="text-gray-600 normal-case font-mono ml-1"
+                                                      x-text="'(' + stats.codex_rate_limits.secondary.window_label + ')'"></span>
+                                            </template>
+                                        </span>
+                                        <span class="tabular-nums font-mono"
+                                              :class="(stats.codex_rate_limits.secondary.used_percent||0) > 80 ? 'text-red-400' : (stats.codex_rate_limits.secondary.used_percent||0) > 60 ? 'text-amber-400' : 'text-emerald-400'"
+                                              x-text="(stats.codex_rate_limits.secondary.used_percent||0).toFixed(1) + '%'"></span>
+                                    </div>
+                                    <div class="w-full h-3 bg-border rounded-full overflow-hidden">
+                                        <div class="h-full rounded-full transition-all duration-500"
+                                             :class="(stats.codex_rate_limits.secondary.used_percent||0) > 80 ? 'bg-red-500' : (stats.codex_rate_limits.secondary.used_percent||0) > 60 ? 'bg-amber-500' : 'bg-emerald-500'"
+                                             :style="'width: ' + Math.min(stats.codex_rate_limits.secondary.used_percent||0, 100) + '%'"></div>
+                                    </div>
+                                    <template x-if="stats.codex_rate_limits.secondary.seconds_until_reset !== null">
+                                        <div class="text-xs text-gray-500 mt-1"
+                                             x-text="'Resets in ' + formatResetTime(stats.codex_rate_limits.secondary.seconds_until_reset)"></div>
+                                    </template>
                                 </div>
                             </template>
                         </div>
-                    </template>
-                </div>
-            </div>
-        </div>
 
-        <!-- Per-Model Savings Breakdown -->
-        <template x-if="Object.keys(stats.cost?.per_model || {}).length > 0">
-            <div class="bg-surface rounded-lg border border-border overflow-hidden mb-6">
-                <div class="px-4 py-3 border-b border-border flex justify-between items-center">
-                    <span class="text-sm font-medium text-gray-300">Per-Model Token Savings</span>
-                    <span class="text-xs text-gray-500">Exact tokens saved per model</span>
-                </div>
-                <div class="overflow-x-auto">
-                    <table class="w-full text-sm" style="table-layout:fixed">
-                        <colgroup>
-                            <col style="width:40%">
-                            <col style="width:12%">
-                            <col style="width:18%">
-                            <col style="width:18%">
-                            <col style="width:12%">
-                        </colgroup>
-                        <thead>
-                            <tr class="text-xs text-gray-500 uppercase tracking-wide">
-                                <th class="px-4 py-3 font-medium text-left">Model</th>
-                                <th class="px-4 py-3 font-medium text-right">Requests</th>
-                                <th class="px-4 py-3 font-medium text-right">Tokens Saved</th>
-                                <th class="px-4 py-3 font-medium text-right">Tokens Sent</th>
-                                <th class="px-4 py-3 font-medium text-right">Reduction</th>
-                            </tr>
-                        </thead>
-                        <tbody class="divide-y divide-border">
-                            <template x-for="[model, info] in Object.entries(stats.cost?.per_model || {})" :key="model">
-                                <tr class="hover:bg-border/30 transition-colors">
-                                    <td class="px-4 py-3 text-left">
-                                        <span class="px-2 py-0.5 bg-border rounded text-xs" x-text="truncateModel(model)"></span>
-                                    </td>
-                                    <td class="px-4 py-3 text-right font-mono tabular-nums" x-text="info.requests"></td>
-                                    <td class="px-4 py-3 text-right font-mono tabular-nums text-accent" x-text="formatNumber(info.tokens_saved)"></td>
-                                    <td class="px-4 py-3 text-right font-mono tabular-nums" x-text="formatNumber(info.tokens_sent)"></td>
-                                    <td class="px-4 py-3 text-right">
-                                        <span class="text-accent font-mono tabular-nums" x-text="info.reduction_pct.toFixed(1) + '%'"></span>
-                                    </td>
-                                </tr>
-                            </template>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </template>
-
-        <!-- Per-Project Savings Breakdown -->
-        <div class="bg-surface rounded-lg border border-border overflow-hidden mb-6">
-            <div class="px-4 py-3 border-b border-border flex justify-between items-center">
-                <div>
-                    <span class="text-sm font-medium text-gray-300">Per-Project Savings</span>
-                    <div class="text-xs text-gray-500 mt-0.5">Lifetime totals — attributed requests only</div>
-                </div>
-                <span class="text-xs text-gray-500 font-mono"
-                      x-text="Object.keys(stats.savings?.per_project || {}).length + ' project(s)'"></span>
-            </div>
-
-            <!-- Empty state: no project data yet -->
-            <template x-if="Object.keys(stats.savings?.per_project || {}).length === 0">
-                <div class="px-4 py-8 text-center">
-                    <div class="text-xs text-gray-500 mb-3">No per-project data yet.</div>
-                    <div class="text-xs text-gray-600 font-mono leading-relaxed">
-                        Add to each project's <span class="text-gray-400">.claude/settings.local.json</span>:<br>
-                        <span class="text-accent" x-text="'ANTHROPIC_BASE_URL: ' + window.location.origin + '/p/<project-name>'"></span>
-                    </div>
-                </div>
-            </template>
-
-            <!-- Project rows -->
-            <template x-if="Object.keys(stats.savings?.per_project || {}).length > 0">
-                <div class="overflow-x-auto">
-                    <table class="w-full text-sm" style="table-layout:fixed">
-                        <colgroup>
-                            <col style="width:25%">
-                            <col style="width:10%">
-                            <col style="width:15%">
-                            <col style="width:12%">
-                            <col style="width:18%">
-                            <col style="width:20%">
-                        </colgroup>
-                        <thead>
-                            <tr class="text-xs text-gray-500 uppercase tracking-wide">
-                                <th class="px-4 py-3 font-medium text-left">Project</th>
-                                <th class="px-4 py-3 font-medium text-right">Requests</th>
-                                <th class="px-4 py-3 font-medium text-right">Tokens Saved</th>
-                                <th class="px-4 py-3 font-medium text-right">Saved $</th>
-                                <th class="px-4 py-3 font-medium text-right">Savings %</th>
-                                <th class="px-4 py-3 font-medium text-right hidden md:table-cell">Last Active</th>
-                            </tr>
-                        </thead>
-                        <tbody class="divide-y divide-border">
-                            <template x-for="[project, info] in Object.entries(stats.savings?.per_project || {})" :key="project">
-                                <tr class="hover:bg-border/30 transition-colors">
-                                    <td class="px-4 py-3 text-left">
-                                        <span class="px-2 py-0.5 bg-border rounded text-xs font-mono" x-text="project"></span>
-                                    </td>
-                                    <td class="px-4 py-3 text-right font-mono tabular-nums" x-text="info.requests"></td>
-                                    <td class="px-4 py-3 text-right font-mono tabular-nums text-accent" x-text="formatNumber(info.tokens_saved)"></td>
-                                    <td class="px-4 py-3 text-right font-mono tabular-nums text-emerald-400"
-                                        x-text="'$' + formatCurrency(info.compression_savings_usd || 0)"></td>
-                                    <td class="px-4 py-3 text-right">
-                                        <div class="flex items-center justify-end gap-2">
-                                            <div class="w-16 h-1.5 bg-border rounded-full overflow-hidden">
-                                                <div class="h-full bg-accent rounded-full"
-                                                     :style="'width:' + Math.min(info.savings_percent || 0, 100) + '%'"></div>
-                                            </div>
-                                            <span class="text-accent font-mono tabular-nums text-xs w-10 text-right"
-                                                  x-text="(info.savings_percent || 0).toFixed(1) + '%'"></span>
-                                        </div>
-                                    </td>
-                                    <td class="px-4 py-3 text-right text-xs text-gray-500 font-mono hidden md:table-cell"
-                                        x-text="info.last_activity_at ? new Date(info.last_activity_at).toLocaleString() : '—'"></td>
-                                </tr>
-                            </template>
-                        </tbody>
-                    </table>
-                </div>
-            </template>
-        </div>
-
-        <!-- Recent Requests Table (with expandable rows) -->
-        <div class="bg-surface rounded-lg border border-border overflow-hidden">
-            <div class="px-4 py-3 border-b border-border flex justify-between items-center">
-                <span class="text-sm font-medium text-gray-300">Recent Requests</span>
-                <span class="text-xs text-gray-500">Last 10 &mdash; click row to expand</span>
-            </div>
-            <div class="overflow-x-auto">
-                <div>
-                    <!-- Header -->
-                    <div class="grid text-xs text-gray-500 uppercase tracking-wide border-b border-border"
-                         style="grid-template-columns: 2rem 12fr 22fr 15fr 12fr 10fr 14fr">
-                        <div class="px-2 py-3"></div>
-                        <div class="px-4 py-3 font-medium">Time</div>
-                        <div class="px-4 py-3 font-medium">Model</div>
-                        <div class="px-4 py-3 font-medium text-right">Input</div>
-                        <div class="px-4 py-3 font-medium text-right">Output</div>
-                        <div class="px-4 py-3 font-medium text-right">Saved</div>
-                        <div class="px-4 py-3 font-medium text-right">Latency</div>
-                    </div>
-                    <!-- Data rows -->
-                    <div class="divide-y divide-border">
-                        <template x-for="req in (stats.recent_requests || [])" :key="req.request_id">
-                            <div>
-                                <div class="cursor-pointer" @click="toggleExpanded(req.request_id)">
-                                    <div class="grid hover:bg-border/30 transition-colors"
-                                         style="grid-template-columns: 2rem 12fr 22fr 15fr 12fr 10fr 14fr">
-                                        <div class="px-2 py-3 text-gray-500 flex items-center justify-center">
-                                            <span x-text="expandedRows[req.request_id] ? '-' : '+'"></span>
-                                        </div>
-                                        <div class="px-4 py-3 font-mono text-gray-400 truncate" x-text="formatTime(req.timestamp)"></div>
-                                        <div class="px-4 py-3 min-w-0">
-                                            <span class="px-2 py-0.5 bg-border rounded text-xs truncate" x-text="truncateModel(req.model)"></span>
-                                        </div>
-                                        <div class="px-4 py-3 text-right font-mono tabular-nums" x-text="formatOptionalNumber(req.input_tokens_optimized)"></div>
-                                        <div class="px-4 py-3 text-right font-mono tabular-nums" x-text="formatOptionalNumber(req.output_tokens)"></div>
-                                        <div class="px-4 py-3 text-right">
-                                            <span class="text-accent font-mono tabular-nums" x-text="formatOptionalPercent(req.savings_percent)"></span>
-                                        </div>
-                                        <div class="px-4 py-3 text-right font-mono tabular-nums text-gray-400" x-text="formatOptionalMs(req.total_latency_ms)"></div>
-                                    </div>
+                        <!-- Credits section (mirrors Anthropic extra-usage section) -->
+                        <template x-if="stats.codex_rate_limits.credits">
+                            <div class="border-t border-border pt-3 mb-3">
+                                <div class="flex justify-between items-center">
+                                    <span class="text-xs text-gray-400 uppercase tracking-wide">Credits</span>
+                                    <span class="text-sm font-mono font-medium"
+                                          :class="stats.codex_rate_limits.credits.unlimited ? 'text-purple-400' : stats.codex_rate_limits.credits.has_credits ? 'text-emerald-400' : 'text-red-400'"
+                                          x-text="stats.codex_rate_limits.credits.unlimited ? '∞ Unlimited' : stats.codex_rate_limits.credits.balance ? stats.codex_rate_limits.credits.balance : (stats.codex_rate_limits.credits.has_credits ? 'Active' : 'No Credits')"></span>
                                 </div>
-                                <!-- Expanded detail row -->
-                                <template x-if="expandedRows[req.request_id]">
-                                    <div class="px-8 py-4 border-t border-border" style="background: var(--card-alt-bg);">
-                                        <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 text-xs">
-                                            <div>
-                                                <div class="text-gray-500 uppercase tracking-wide mb-1">Original Tokens</div>
-                                                <div class="font-mono" x-text="formatOptionalNumber(req.input_tokens_original)"></div>
-                                            </div>
-                                            <div>
-                                                <div class="text-gray-500 uppercase tracking-wide mb-1">Compressed Tokens</div>
-                                                <div class="font-mono" x-text="formatOptionalNumber(req.input_tokens_optimized)"></div>
-                                            </div>
-                                            <div>
-                                                <div class="text-gray-500 uppercase tracking-wide mb-1">Tokens Removed</div>
-                                                <div class="font-mono text-accent" x-text="formatOptionalNumber(req.tokens_saved)"></div>
-                                            </div>
-                                            <div>
-                                                <div class="text-gray-500 uppercase tracking-wide mb-1">Optimization Time</div>
-                                                <div class="font-mono" x-text="formatOptionalMs(req.optimization_latency_ms)"></div>
-                                            </div>
-                                        </div>
-                                        <!-- Transforms Applied -->
-                                        <template x-if="(req.transforms_applied || []).length > 0">
-                                            <div class="mt-3">
-                                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Transforms Applied</div>
-                                                <div class="flex flex-wrap gap-1">
-                                                    <template x-for="t in req.transforms_applied" :key="t">
-                                                        <span class="px-2 py-0.5 bg-border rounded text-xs font-mono" x-text="t"></span>
-                                                    </template>
-                                                </div>
-                                            </div>
-                                        </template>
-                                        <!-- Waste Signals for this request -->
-                                        <template x-if="req.waste_signals && Object.keys(req.waste_signals).length > 0">
-                                            <div class="mt-3">
-                                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Waste Detected</div>
-                                                <div class="flex flex-wrap gap-2">
-                                                    <template x-for="[signal, tokens] in Object.entries(req.waste_signals).filter(([,v]) => v > 0)" :key="signal">
-                                                        <span class="px-2 py-0.5 rounded text-xs font-mono"
-                                                              :class="wasteSignalBadgeColor(signal)"
-                                                              x-text="wasteSignalLabel(signal) + ': ' + formatNumber(tokens)"></span>
-                                                    </template>
-                                                </div>
-                                            </div>
-                                        </template>
-                                    </div>
+                                <template x-if="stats.codex_rate_limits.credits.balance && !stats.codex_rate_limits.credits.unlimited">
+                                    <div class="text-xs text-gray-500 mt-0.5">Pay-as-you-go credits balance</div>
                                 </template>
                             </div>
                         </template>
-                        <template x-if="(stats.recent_requests || []).length === 0">
-                            <div class="px-4 py-8 text-center text-gray-500 italic">
-                                No requests yet. Start using the proxy to see activity here.
-                            </div>
+
+                        <!-- Promo message -->
+                        <template x-if="stats.codex_rate_limits.promo_message">
+                            <div class="mt-2 text-xs text-blue-400 italic"
+                                 x-text="stats.codex_rate_limits.promo_message"></div>
                         </template>
                     </div>
-                </div>
+                </template>
+
+                <!-- GitHub Copilot Quota -->
+                <template x-if="stats.copilot_quota && stats.copilot_quota.latest">
+                    <div class="bg-surface rounded-lg p-4 border border-border mb-6">
+                        <div class="flex justify-between items-center mb-4">
+                            <div class="text-sm font-medium text-gray-300">GitHub Copilot Quota</div>
+                            <div class="flex items-center gap-2">
+                                <template x-if="stats.copilot_quota.latest.copilot_plan">
+                                    <span class="text-xs text-gray-500 font-mono capitalize" x-text="stats.copilot_quota.latest.copilot_plan + ' plan'"></span>
+                                </template>
+                                <template x-if="stats.copilot_quota.latest.login">
+                                    <span class="text-xs text-gray-400" x-text="'@' + stats.copilot_quota.latest.login"></span>
+                                </template>
+                            </div>
+                        </div>
+
+                        <!-- Per-category quota grid (3 columns, mirrors Anthropic 5h/7d structure) -->
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+                            <template x-for="[catKey, catLabel] in [['chat','Chat'],['completions','Completions'],['premium_interactions','Premium']]" :key="catKey">
+                                <template x-if="stats.copilot_quota.latest.categories[catKey]">
+                                    <div>
+                                        <div class="flex justify-between text-xs mb-1">
+                                            <span class="text-gray-400 uppercase tracking-wide" x-text="catLabel"></span>
+                                            <template x-if="stats.copilot_quota.latest.categories[catKey].unlimited">
+                                                <span class="text-purple-400 font-mono">∞</span>
+                                            </template>
+                                            <template x-if="!stats.copilot_quota.latest.categories[catKey].unlimited">
+                                                <span class="tabular-nums font-mono"
+                                                      :class="(stats.copilot_quota.latest.categories[catKey].used_percent||0) > 80 ? 'text-red-400' : (stats.copilot_quota.latest.categories[catKey].used_percent||0) > 50 ? 'text-amber-400' : 'text-emerald-400'"
+                                                      x-text="(stats.copilot_quota.latest.categories[catKey].used_percent||0).toFixed(0) + '%'"></span>
+                                            </template>
+                                        </div>
+                                        <!-- Used / entitlement count (big number like Anthropic window) -->
+                                        <template x-if="!stats.copilot_quota.latest.categories[catKey].unlimited">
+                                            <div class="flex items-baseline gap-1 mb-1">
+                                                <span class="text-lg font-light tabular-nums"
+                                                      :class="(stats.copilot_quota.latest.categories[catKey].used_percent||0) > 80 ? 'text-red-400' : (stats.copilot_quota.latest.categories[catKey].used_percent||0) > 50 ? 'text-amber-400' : 'text-emerald-400'"
+                                                      x-text="stats.copilot_quota.latest.categories[catKey].used ?? '-'"></span>
+                                                <span class="text-xs text-gray-500 font-mono"
+                                                      x-text="'/ ' + (stats.copilot_quota.latest.categories[catKey].entitlement ?? '∞')"></span>
+                                                <span class="text-xs text-gray-500 ml-auto font-mono"
+                                                      x-text="(stats.copilot_quota.latest.categories[catKey].remaining ?? '') + ' left'"></span>
+                                            </div>
+                                        </template>
+                                        <template x-if="stats.copilot_quota.latest.categories[catKey].unlimited">
+                                            <div class="text-lg font-light text-purple-400 mb-1">Unlimited</div>
+                                        </template>
+                                        <!-- Progress bar -->
+                                        <template x-if="!stats.copilot_quota.latest.categories[catKey].unlimited">
+                                            <div class="w-full h-3 bg-border rounded-full overflow-hidden">
+                                                <div class="h-full rounded-full transition-all duration-500"
+                                                     :class="(stats.copilot_quota.latest.categories[catKey].used_percent||0) > 80 ? 'bg-red-500' : (stats.copilot_quota.latest.categories[catKey].used_percent||0) > 50 ? 'bg-amber-500' : 'bg-emerald-500'"
+                                                     :style="'width: ' + Math.min(stats.copilot_quota.latest.categories[catKey].used_percent||0, 100) + '%'"></div>
+                                            </div>
+                                        </template>
+                                        <!-- Overage info -->
+                                        <template x-if="stats.copilot_quota.latest.categories[catKey].overage_count > 0">
+                                            <div class="text-xs text-amber-400 mt-1"
+                                                 x-text="stats.copilot_quota.latest.categories[catKey].overage_count + ' overage uses'"></div>
+                                        </template>
+                                        <div class="mt-1">
+                                            <span class="text-xs"
+                                                  :class="stats.copilot_quota.latest.categories[catKey].overage_permitted ? 'text-gray-500' : 'text-gray-600'"
+                                                  x-text="stats.copilot_quota.latest.categories[catKey].overage_permitted ? 'Overage allowed' : 'No overage'"></span>
+                                        </div>
+                                    </div>
+                                </template>
+                            </template>
+                        </div>
+
+                        <!-- Monthly reset section (mirrors Anthropic extra-usage border section) -->
+                        <div class="border-t border-border pt-3">
+                            <div class="flex justify-between text-xs mb-2">
+                                <span class="text-gray-400 uppercase tracking-wide">Monthly Reset</span>
+                                <template x-if="stats.copilot_quota.latest.quota_reset_date_utc">
+                                    <span class="text-gray-400 font-mono"
+                                          x-text="formatMonthlyReset(stats.copilot_quota.latest.quota_reset_date_utc)"></span>
+                                </template>
+                            </div>
+                            <template x-if="stats.copilot_quota.latest.quota_reset_date_utc">
+                                <div>
+                                    <!-- Month-elapsed bar: filled = time elapsed, empty = time remaining -->
+                                    <div class="w-full h-2 bg-border rounded-full overflow-hidden">
+                                        <div class="h-full bg-accent/50 rounded-full transition-all duration-500"
+                                             :style="'width: ' + (100 - Math.min(100, Math.max(0, (new Date(stats.copilot_quota.latest.quota_reset_date_utc) - new Date()) / (30 * 86400000) * 100))) + '%'"></div>
+                                    </div>
+                                    <div class="flex justify-between text-xs text-gray-600 mt-0.5">
+                                        <span>Month start</span>
+                                        <span x-text="new Date(stats.copilot_quota.latest.quota_reset_date_utc).toLocaleDateString(undefined, {month:'short', day:'numeric'})"></span>
+                                    </div>
+                                </div>
+                            </template>
+                        </div>
+                    </div>
+                </template>
             </div>
-        </div>
+        </template>
+
+        <!-- Lifetime view: durable aggregate metrics only -->
+        <template x-if="viewMode === 'lifetime'">
+            <div>
+                <div class="mb-6 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <p class="text-xs text-gray-500" x-text="'Lifetime data since ' + (lifetimeStats.started_at || '—')"></p>
+                        <p class="text-xs text-gray-500" x-text="'Full metric coverage since ' + (lifetimeStats.full_fidelity_started_at || '—')"></p>
+                    </div>
+                    <div class="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-gray-500">
+                        <span>Durable local savings history from <span class="font-mono">/stats-lifetime</span></span>
+                        <span aria-hidden="true">-</span>
+                        <span :class="lifetimeStats.persistence?.healthy === false ? 'text-amber-400' : 'text-emerald-400'"
+                              x-text="lifetimeStats.persistence?.healthy === false ? ('Persistence degraded: ' + (lifetimeStats.persistence?.error || 'unknown error')) : 'Persistence healthy'"></span>
+                    </div>
+                </div>
+                <div class="grid grid-cols-2 gap-4 mb-6 md:grid-cols-4">
+                    <div class="bg-surface rounded-lg p-4 border border-border"><div class="text-xs text-gray-500">Requests</div><div class="text-2xl tabular-nums" x-text="formatNumber(lifetimeStats.requests?.total || 0)"></div></div>
+                    <div class="bg-surface rounded-lg p-4 border border-border"><div class="text-xs text-gray-500">Failed</div><div class="text-2xl tabular-nums text-red-400" x-text="formatNumber(lifetimeStats.requests?.failed || 0)"></div></div>
+                    <div class="bg-surface rounded-lg p-4 border border-border"><div class="text-xs text-gray-500">Rate Limited</div><div class="text-2xl tabular-nums text-amber-400" x-text="formatNumber(lifetimeStats.requests?.rate_limited || 0)"></div></div>
+                    <div class="bg-surface rounded-lg p-4 border border-border"><div class="text-xs text-gray-500">Cached</div><div class="text-2xl tabular-nums text-cyan-400" x-text="formatNumber(lifetimeStats.requests?.cached || 0)"></div></div>
+                </div>
+
+                <div class="grid grid-cols-1 gap-4 mb-6 lg:grid-cols-3">
+                    <section class="bg-surface rounded-lg p-4 border border-border"><h3 class="mb-3 text-sm text-gray-300">Tokens</h3><dl class="space-y-2 text-sm"><div class="flex justify-between"><dt>Input</dt><dd x-text="formatNumber(lifetimeStats.tokens?.input || 0)"></dd></div><div class="flex justify-between"><dt>Output</dt><dd x-text="formatNumber(lifetimeStats.tokens?.output || 0)"></dd></div><div class="flex justify-between"><dt>Attempted Input</dt><dd x-text="formatNumber(lifetimeStats.tokens?.attempted_input || 0)"></dd></div><div class="flex justify-between"><dt>Saved</dt><dd class="text-emerald-400" x-text="formatNumber(lifetimeStats.tokens?.saved || 0)"></dd></div><div class="flex justify-between"><dt>Token Savings</dt><dd x-text="lifetimeStats.tokens?.token_savings_percent == null ? '—' : lifetimeStats.tokens.token_savings_percent.toFixed(1) + '%'"></dd></div></dl></section>
+                    <section class="bg-surface rounded-lg p-4 border border-border"><h3 class="mb-3 text-sm text-gray-300">Cost</h3><dl class="space-y-2 text-sm"><div class="flex justify-between"><dt>Input cost</dt><dd x-text="'$' + formatCurrency(lifetimeStats.cost?.input_usd || 0)"></dd></div><div class="flex justify-between"><dt>Compression saved</dt><dd class="text-emerald-400" x-text="'$' + formatCurrency(lifetimeStats.cost?.compression_savings_usd || 0)"></dd></div><div class="flex justify-between"><dt>Prefix Cache saved</dt><dd class="text-cyan-400" x-text="'$' + formatCurrency(lifetimeStats.cost?.cache_savings_usd || 0)"></dd></div></dl></section>
+                    <section class="bg-surface rounded-lg p-4 border border-border"><h3 class="mb-3 text-sm text-gray-300">Prefix Cache</h3><dl class="space-y-2 text-sm"><div class="flex justify-between"><dt>Hits / requests</dt><dd x-text="formatNumber(lifetimeStats.prefix_cache?.hit_requests || 0) + ' / ' + formatNumber(lifetimeStats.prefix_cache?.requests || 0)"></dd></div><div class="flex justify-between"><dt>Hit rate</dt><dd x-text="lifetimeStats.prefix_cache?.cache_hit_rate == null ? '—' : lifetimeStats.prefix_cache.cache_hit_rate.toFixed(1) + '%'"></dd></div><div class="flex justify-between"><dt>Read / write</dt><dd x-text="formatNumber(lifetimeStats.prefix_cache?.cache_read_tokens || 0) + ' / ' + formatNumber(lifetimeStats.prefix_cache?.cache_write_tokens || 0)"></dd></div><div class="flex justify-between"><dt>TTL 1h / 5m</dt><dd x-text="(lifetimeStats.prefix_cache?.ttl_1h_percent == null ? '—' : lifetimeStats.prefix_cache.ttl_1h_percent.toFixed(0) + '%') + ' / ' + (lifetimeStats.prefix_cache?.ttl_5m_percent == null ? '—' : lifetimeStats.prefix_cache.ttl_5m_percent.toFixed(0) + '%')"></dd></div><div class="flex justify-between"><dt>Cache bust</dt><dd x-text="formatNumber(lifetimeStats.prefix_cache?.bust_count || 0) + ' / ' + formatNumber(lifetimeStats.prefix_cache?.bust_tokens || 0)"></dd></div></dl></section>
+                </div>
+
+                <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                    <section class="bg-surface rounded-lg p-4 border border-border"><h3 class="mb-3 text-sm text-gray-300">Cache Miss Attribution</h3><template x-for="[name, count] in Object.entries(lifetimeStats.prefix_cache?.misses_by_reason || {})" :key="name"><div class="flex justify-between text-sm"><span x-text="name"></span><span x-text="formatNumber(count)"></span></div></template></section>
+                    <section class="bg-surface rounded-lg p-4 border border-border"><h3 class="mb-3 text-sm text-gray-300">Waste Signals</h3><template x-for="[name, count] in Object.entries(lifetimeStats.waste_signals || {})" :key="name"><div class="flex justify-between text-sm"><span x-text="name"></span><span x-text="formatNumber(count)"></span></div></template></section>
+                </div>
+
+                <div class="grid grid-cols-1 gap-4 mt-4 lg:grid-cols-3">
+                    <section class="bg-surface rounded-lg p-4 border border-border"><h3 class="mb-3 text-sm text-gray-300">Providers</h3><template x-for="[name, count] in Object.entries(lifetimeStats.requests?.by_provider || {})" :key="name"><div class="flex justify-between text-sm"><span x-text="name"></span><span x-text="formatNumber(count)"></span></div></template></section>
+                    <section class="bg-surface rounded-lg p-4 border border-border"><h3 class="mb-3 text-sm text-gray-300">Stacks</h3><template x-for="[name, count] in Object.entries(lifetimeStats.requests?.by_stack || {})" :key="name"><div class="flex justify-between text-sm"><span x-text="name"></span><span x-text="formatNumber(count)"></span></div></template></section>
+                    <section class="bg-surface rounded-lg p-4 border border-border"><h3 class="mb-3 text-sm text-gray-300">Top Models + Other</h3><template x-for="[name, metric] in Object.entries(lifetimeStats.by_model || {})" :key="name"><div class="flex justify-between text-sm"><span class="truncate pr-3" x-text="name"></span><span x-text="formatNumber(metric.input_tokens + metric.output_tokens)"></span></div></template></section>
+                </div>
             </div>
         </template>
 
@@ -1463,6 +1393,92 @@
 
                 <template x-if="hasHistoricalData">
                     <div>
+                        <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
+                            <div class="bg-surface rounded-lg p-4 border border-border">
+                                <div class="text-sm font-medium mb-4 text-gray-300">Daily Savings</div>
+                                <template x-if="(historyStats.series?.daily || []).length > 0">
+                                    <div class="space-y-3">
+                                        <template x-for="point in recentDailyHistory" :key="point.timestamp">
+                                            <div class="flex items-center justify-between">
+                                                <div>
+                                                    <div class="text-sm text-gray-300" x-text="formatDate(point.timestamp)"></div>
+                                                    <div class="text-xs text-gray-500"
+                                                         x-text="formatNumber(point.total_tokens_saved) + ' cumulative'"></div>
+                                                </div>
+                                                <div class="text-right">
+                                                    <div class="font-mono text-sm text-accent"
+                                                         x-text="formatNumber(point.tokens_saved) + ' tokens'"></div>
+                                                    <div class="text-xs text-emerald-400"
+                                                         x-text="'$' + formatCurrency(point.compression_savings_usd_delta || 0)"></div>
+                                                </div>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </template>
+                                <template x-if="(historyStats.series?.daily || []).length === 0">
+                                    <div class="text-sm text-gray-500 italic py-8 text-center">
+                                        Daily rollups will appear after persisted history spans at least one checkpoint.
+                                    </div>
+                                </template>
+                            </div>
+
+                            <div class="bg-surface rounded-lg p-4 border border-border">
+                                <div class="text-sm font-medium mb-4 text-gray-300">Weekly Savings</div>
+                                <template x-if="(historyStats.series?.weekly || []).length > 0">
+                                    <div class="space-y-3">
+                                        <template x-for="point in recentWeeklyHistory" :key="point.timestamp">
+                                            <div class="flex items-center justify-between">
+                                                <div>
+                                                    <div class="text-sm text-gray-300" x-text="formatDate(point.timestamp)"></div>
+                                                    <div class="text-xs text-gray-500"
+                                                         x-text="formatNumber(point.total_tokens_saved) + ' cumulative'"></div>
+                                                </div>
+                                                <div class="text-right">
+                                                    <div class="font-mono text-sm text-accent"
+                                                         x-text="formatNumber(point.tokens_saved) + ' tokens'"></div>
+                                                    <div class="text-xs text-emerald-400"
+                                                         x-text="'$' + formatCurrency(point.compression_savings_usd_delta || 0)"></div>
+                                                </div>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </template>
+                                <template x-if="(historyStats.series?.weekly || []).length === 0">
+                                    <div class="text-sm text-gray-500 italic py-8 text-center">
+                                        Weekly rollups will appear after persisted history spans multiple days.
+                                    </div>
+                                </template>
+                            </div>
+
+                            <div class="bg-surface rounded-lg p-4 border border-border">
+                                <div class="text-sm font-medium mb-4 text-gray-300">Monthly Savings</div>
+                                <template x-if="(historyStats.series?.monthly || []).length > 0">
+                                    <div class="space-y-3">
+                                        <template x-for="point in recentMonthlyHistory" :key="point.timestamp">
+                                            <div class="flex items-center justify-between">
+                                                <div>
+                                                    <div class="text-sm text-gray-300" x-text="formatMonth(point.timestamp)"></div>
+                                                    <div class="text-xs text-gray-500"
+                                                         x-text="formatNumber(point.total_tokens_saved) + ' cumulative'"></div>
+                                                </div>
+                                                <div class="text-right">
+                                                    <div class="font-mono text-sm text-accent"
+                                                         x-text="formatNumber(point.tokens_saved) + ' tokens'"></div>
+                                                    <div class="text-xs text-emerald-400"
+                                                         x-text="'$' + formatCurrency(point.compression_savings_usd_delta || 0)"></div>
+                                                </div>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </template>
+                                <template x-if="(historyStats.series?.monthly || []).length === 0">
+                                    <div class="text-sm text-gray-500 italic py-8 text-center">
+                                        Monthly rollups will appear after persisted history spans multiple months.
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+
                         <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
                             <div class="bg-surface rounded-lg p-4 border border-border lg:col-span-2">
                                 <div class="flex flex-col gap-3 mb-4 lg:flex-row lg:items-center lg:justify-between">
@@ -1635,92 +1651,6 @@
                             </div>
                         </div>
 
-                        <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
-                            <div class="bg-surface rounded-lg p-4 border border-border">
-                                <div class="text-sm font-medium mb-4 text-gray-300">Daily Savings</div>
-                                <template x-if="(historyStats.series?.daily || []).length > 0">
-                                    <div class="space-y-3">
-                                        <template x-for="point in recentDailyHistory" :key="point.timestamp">
-                                            <div class="flex items-center justify-between">
-                                                <div>
-                                                    <div class="text-sm text-gray-300" x-text="formatDate(point.timestamp)"></div>
-                                                    <div class="text-xs text-gray-500"
-                                                         x-text="formatNumber(point.total_tokens_saved) + ' cumulative'"></div>
-                                                </div>
-                                                <div class="text-right">
-                                                    <div class="font-mono text-sm text-accent"
-                                                         x-text="formatNumber(point.tokens_saved) + ' tokens'"></div>
-                                                    <div class="text-xs text-emerald-400"
-                                                         x-text="'$' + formatCurrency(point.compression_savings_usd_delta || 0)"></div>
-                                                </div>
-                                            </div>
-                                        </template>
-                                    </div>
-                                </template>
-                                <template x-if="(historyStats.series?.daily || []).length === 0">
-                                    <div class="text-sm text-gray-500 italic py-8 text-center">
-                                        Daily rollups will appear after persisted history spans at least one checkpoint.
-                                    </div>
-                                </template>
-                            </div>
-
-                            <div class="bg-surface rounded-lg p-4 border border-border">
-                                <div class="text-sm font-medium mb-4 text-gray-300">Weekly Savings</div>
-                                <template x-if="(historyStats.series?.weekly || []).length > 0">
-                                    <div class="space-y-3">
-                                        <template x-for="point in recentWeeklyHistory" :key="point.timestamp">
-                                            <div class="flex items-center justify-between">
-                                                <div>
-                                                    <div class="text-sm text-gray-300" x-text="formatDate(point.timestamp)"></div>
-                                                    <div class="text-xs text-gray-500"
-                                                         x-text="formatNumber(point.total_tokens_saved) + ' cumulative'"></div>
-                                                </div>
-                                                <div class="text-right">
-                                                    <div class="font-mono text-sm text-accent"
-                                                         x-text="formatNumber(point.tokens_saved) + ' tokens'"></div>
-                                                    <div class="text-xs text-emerald-400"
-                                                         x-text="'$' + formatCurrency(point.compression_savings_usd_delta || 0)"></div>
-                                                </div>
-                                            </div>
-                                        </template>
-                                    </div>
-                                </template>
-                                <template x-if="(historyStats.series?.weekly || []).length === 0">
-                                    <div class="text-sm text-gray-500 italic py-8 text-center">
-                                        Weekly rollups will appear after persisted history spans multiple days.
-                                    </div>
-                                </template>
-                            </div>
-
-                            <div class="bg-surface rounded-lg p-4 border border-border">
-                                <div class="text-sm font-medium mb-4 text-gray-300">Monthly Savings</div>
-                                <template x-if="(historyStats.series?.monthly || []).length > 0">
-                                    <div class="space-y-3">
-                                        <template x-for="point in recentMonthlyHistory" :key="point.timestamp">
-                                            <div class="flex items-center justify-between">
-                                                <div>
-                                                    <div class="text-sm text-gray-300" x-text="formatMonth(point.timestamp)"></div>
-                                                    <div class="text-xs text-gray-500"
-                                                         x-text="formatNumber(point.total_tokens_saved) + ' cumulative'"></div>
-                                                </div>
-                                                <div class="text-right">
-                                                    <div class="font-mono text-sm text-accent"
-                                                         x-text="formatNumber(point.tokens_saved) + ' tokens'"></div>
-                                                    <div class="text-xs text-emerald-400"
-                                                         x-text="'$' + formatCurrency(point.compression_savings_usd_delta || 0)"></div>
-                                                </div>
-                                            </div>
-                                        </template>
-                                    </div>
-                                </template>
-                                <template x-if="(historyStats.series?.monthly || []).length === 0">
-                                    <div class="text-sm text-gray-500 italic py-8 text-center">
-                                        Monthly rollups will appear after persisted history spans multiple months.
-                                    </div>
-                                </template>
-                            </div>
-                        </div>
-
                         <div class="bg-surface rounded-lg p-4 border border-border">
                             <div class="text-sm font-medium mb-4 text-gray-300">Recent Historical Checkpoints</div>
                             <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -1811,6 +1741,7 @@
         function dashboard() {
             return {
                 stats: {},
+                lifetimeStats: {},
                 historyStats: {},
                 healthy: true,
                 version: 'loading',
@@ -1824,8 +1755,10 @@
                 expandedRows: {},
                 pollInterval: null,
                 statsPollMs: 5000,
+                lifetimePollMs: 30000,
                 historyPollMs: 30000,
                 feedPollMs: 5000,
+                lastLifetimeFetchMs: 0,
                 lastHistoryFetchMs: 0,
                 lastFeedFetchMs: 0,
                 feedOpen: false,
@@ -1858,6 +1791,9 @@
                     await this.fetchStats();
 
                     const now = Date.now();
+                    if (this.viewMode === 'lifetime' && (force || now - this.lastLifetimeFetchMs >= this.lifetimePollMs)) {
+                        await this.fetchLifetimeStats();
+                    }
                     if (this.viewMode === 'history' && (force || now - this.lastHistoryFetchMs >= this.historyPollMs)) {
                         await this.fetchHistoryStats();
                     }
@@ -1868,6 +1804,9 @@
 
                 async setViewMode(mode) {
                     this.viewMode = mode;
+                    if (mode === 'lifetime') {
+                        await this.fetchLifetimeStats();
+                    }
                     if (mode === 'history') {
                         await this.fetchHistoryStats();
                     }
@@ -1914,6 +1853,17 @@
                     }
                 },
 
+                async fetchLifetimeStats() {
+                    try {
+                        const response = await fetch('/stats-lifetime');
+                        if (response.ok) {
+                            this.lifetimeStats = await response.json();
+                            this.lastLifetimeFetchMs = Date.now();
+                        }
+                    } catch (e) {
+                        console.error('Failed to fetch lifetime stats:', e);
+                    }
+                },
                 async fetchHistoryStats() {
                     try {
                         const response = await fetch('/stats-history');
@@ -2054,26 +2004,10 @@
 
                 // --- Formatting ---
 
-                hasNumber(n) {
-                    return typeof n === 'number' && Number.isFinite(n);
-                },
-
                 formatNumber(n) {
                     if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
                     if (n >= 1000) return (n / 1000).toFixed(1) + 'k';
                     return n.toString();
-                },
-
-                formatOptionalNumber(n) {
-                    return this.hasNumber(n) ? this.formatNumber(n) : 'unknown';
-                },
-
-                formatOptionalPercent(n) {
-                    return this.hasNumber(n) ? n.toFixed(0) + '%' : 'unknown';
-                },
-
-                formatOptionalMs(n) {
-                    return this.hasNumber(n) ? n.toFixed(0) + 'ms' : 'unknown';
                 },
 
                 formatCurrency(n) {

--- a/headroom/proxy/forwarded_headers.py
+++ b/headroom/proxy/forwarded_headers.py
@@ -72,7 +72,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "TRUSTED_DASHBOARD_CLIENT_CIDRS_ENV",
     "TRUSTED_GATEWAY_CIDRS_ENV",
+    "load_trusted_dashboard_client_cidrs",
     "load_trusted_gateway_cidrs",
     "peer_is_trusted_gateway",
     "resolve_client_ip",
@@ -82,6 +84,7 @@ __all__ = [
 
 #: Environment variable that holds the comma-separated CIDR allow-list.
 TRUSTED_GATEWAY_CIDRS_ENV = "HEADROOM_PROXY_TRUSTED_GATEWAY_CIDRS"
+TRUSTED_DASHBOARD_CLIENT_CIDRS_ENV = "HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS"
 
 
 def _parse_cidr_list(
@@ -113,6 +116,20 @@ def load_trusted_gateway_cidrs(
     if raw is None:
         raw = os.environ.get(TRUSTED_GATEWAY_CIDRS_ENV, "")
     return _parse_cidr_list(raw)
+
+
+def load_trusted_dashboard_client_cidrs(
+    raw: str | None = None,
+) -> tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]:
+    """Parse the Dashboard client CIDR allow-list from its environment variable."""
+    if raw is None:
+        raw = os.environ.get(TRUSTED_DASHBOARD_CLIENT_CIDRS_ENV, "")
+    try:
+        return _parse_cidr_list(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid {TRUSTED_DASHBOARD_CLIENT_CIDRS_ENV} entry: {exc}"
+        ) from exc
 
 
 def _normalize_ip(

--- a/headroom/proxy/loopback_guard.py
+++ b/headroom/proxy/loopback_guard.py
@@ -50,6 +50,7 @@ except ImportError:  # pragma: no cover - fastapi is a hard dep in practice
 
 __all__ = [
     "LOOPBACK_HOSTS",
+    "is_ip_literal_host_header",
     "is_loopback_host",
     "is_loopback_host_header",
     "require_loopback",
@@ -126,6 +127,46 @@ def is_loopback_host_header(header_value: str | None) -> bool:
     else:
         host_part = candidate
     return is_loopback_host(host_part)
+
+
+def is_ip_literal_host_header(header_value: str | None) -> bool:
+    """Return whether ``Host:`` contains an IPv4 or bracketed IPv6 literal.
+
+    Dashboard clients may use a non-loopback server address, but retaining an
+    IP-literal Host requirement prevents DNS-rebinding requests from using an
+    attacker-controlled hostname. Ports are accepted in normal HTTP forms.
+    """
+    if not header_value:
+        return False
+
+    candidate = header_value.strip()
+    if not candidate or "/" in candidate or "@" in candidate:
+        return False
+
+    if candidate.startswith("["):
+        closing = candidate.find("]")
+        if closing == -1 or candidate.count("[") != 1 or candidate.count("]") != 1:
+            return False
+        host_part = candidate[1:closing]
+        suffix = candidate[closing + 1 :]
+        if suffix and (not suffix.startswith(":") or not suffix[1:].isdigit()):
+            return False
+        try:
+            return isinstance(ipaddress.ip_address(host_part), ipaddress.IPv6Address)
+        except ValueError:
+            return False
+
+    if candidate.count(":") == 1:
+        host_part, port = candidate.rsplit(":", 1)
+        if not port.isdigit():
+            return False
+    else:
+        host_part = candidate
+
+    try:
+        return isinstance(ipaddress.ip_address(host_part), ipaddress.IPv4Address)
+    except ValueError:
+        return False
 
 
 def require_loopback(request: Request) -> None:  # type: ignore[valid-type]

--- a/headroom/proxy/persistent_metrics.py
+++ b/headroom/proxy/persistent_metrics.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import math
+from collections.abc import Callable
 from copy import deepcopy
 from datetime import datetime, timezone
-import math
-from typing import Any, Callable
-
+from typing import Any
 
 SCHEMA_VERSION = 5
 MAX_PROVIDER_VALUES = 32
@@ -112,6 +112,10 @@ def _empty_state() -> dict[str, Any]:
     }
 
 
+def _dict_or_empty(value: Any) -> dict[Any, Any]:
+    return value if isinstance(value, dict) else {}
+
+
 class PersistentMetricsState:
     """In-memory Lifetime aggregate with deterministic, bounded dimensions."""
 
@@ -133,7 +137,7 @@ class PersistentMetricsState:
             if isinstance(value, str):
                 result[timestamp_key] = value
 
-        raw_requests = source.get("requests") if isinstance(source.get("requests"), dict) else {}
+        raw_requests = _dict_or_empty(source.get("requests"))
         for key in ("total", "cached", "failed", "rate_limited"):
             result["requests"][key] = _coerce_int(raw_requests.get(key))
         result["requests"]["by_provider"] = self._normalize_count_map(
@@ -143,11 +147,11 @@ class PersistentMetricsState:
             raw_requests.get("by_stack"), MAX_STACK_VALUES
         )
 
-        raw_tokens = source.get("tokens") if isinstance(source.get("tokens"), dict) else {}
+        raw_tokens = _dict_or_empty(source.get("tokens"))
         for key in ("input", "output", "attempted_input", "saved"):
             result["tokens"][key] = _coerce_int(raw_tokens.get(key))
 
-        raw_cache = source.get("prefix_cache") if isinstance(source.get("prefix_cache"), dict) else {}
+        raw_cache = _dict_or_empty(source.get("prefix_cache"))
         for key in (
             "requests",
             "hit_requests",
@@ -167,15 +171,15 @@ class PersistentMetricsState:
             raw_cache.get("misses_by_reason"), KNOWN_MISS_REASONS
         )
 
-        raw_cost = source.get("cost") if isinstance(source.get("cost"), dict) else {}
+        raw_cost = _dict_or_empty(source.get("cost"))
         for key in ("input_usd", "compression_savings_usd", "cache_savings_usd"):
             result["cost"][key] = round(_coerce_float(raw_cost.get(key)), 6)
         result["waste_signals"] = self._normalize_enum_map(
             source.get("waste_signals"), KNOWN_WASTE_SIGNALS
         )
 
-        raw_models = source.get("models") if isinstance(source.get("models"), dict) else {}
-        raw_tracked = raw_models.get("tracked") if isinstance(raw_models.get("tracked"), dict) else {}
+        raw_models = _dict_or_empty(source.get("models"))
+        raw_tracked = _dict_or_empty(raw_models.get("tracked"))
         for name, entry in raw_tracked.items():
             normalized_name = self._model_name(name)
             if normalized_name == "other":
@@ -183,7 +187,7 @@ class PersistentMetricsState:
                 continue
             result["models"]["tracked"][normalized_name] = _model_entry(entry)
         self._merge_model_entry(result["models"]["other"], _model_entry(raw_models.get("other")))
-        raw_persistence = source.get("persistence") if isinstance(source.get("persistence"), dict) else {}
+        raw_persistence = _dict_or_empty(source.get("persistence"))
         if isinstance(raw_persistence.get("last_saved_at"), str):
             result["persistence"]["last_saved_at"] = raw_persistence["last_saved_at"]
         return result
@@ -240,7 +244,13 @@ class PersistentMetricsState:
 
     @staticmethod
     def _merge_model_entry(destination: dict[str, Any], source: dict[str, Any]) -> None:
-        for key in ("requests", "input_tokens", "output_tokens", "attempted_input_tokens", "tokens_saved"):
+        for key in (
+            "requests",
+            "input_tokens",
+            "output_tokens",
+            "attempted_input_tokens",
+            "tokens_saved",
+        ):
             destination[key] += _coerce_int(source.get(key))
         if destination["last_activity_at"] is None or (
             source["last_activity_at"] is not None
@@ -277,7 +287,11 @@ class PersistentMetricsState:
     ) -> None:
         name = self._model_name(model)
         models = self._state["models"]
-        entry = models["other"] if name == "other" else models["tracked"].setdefault(name, _model_entry())
+        entry = (
+            models["other"]
+            if name == "other"
+            else models["tracked"].setdefault(name, _model_entry())
+        )
         entry["requests"] += 1
         entry["input_tokens"] += input_tokens
         entry["output_tokens"] += output_tokens
@@ -346,12 +360,16 @@ class PersistentMetricsState:
         cost["compression_savings_usd"] = round(
             cost["compression_savings_usd"] + _coerce_float(compression_savings_usd), 6
         )
-        cost["cache_savings_usd"] = round(cost["cache_savings_usd"] + _coerce_float(cache_savings_usd), 6)
+        cost["cache_savings_usd"] = round(
+            cost["cache_savings_usd"] + _coerce_float(cache_savings_usd), 6
+        )
 
         if isinstance(waste_signals, dict):
             for name, token_count in waste_signals.items():
                 bucket = name if isinstance(name, str) and name in KNOWN_WASTE_SIGNALS else "other"
-                self._state["waste_signals"][bucket] = self._state["waste_signals"].get(bucket, 0) + _coerce_int(token_count)
+                self._state["waste_signals"][bucket] = self._state["waste_signals"].get(
+                    bucket, 0
+                ) + _coerce_int(token_count)
 
         self._record_model(
             model=model,
@@ -445,5 +463,8 @@ class PersistentMetricsState:
             "cost": deepcopy(self._state["cost"]),
             "waste_signals": deepcopy(self._state["waste_signals"]),
             "by_model": self._by_model_snapshot(),
-            "persistence": {**deepcopy(persistence), "last_saved_at": self._state["persistence"]["last_saved_at"]},
+            "persistence": {
+                **deepcopy(persistence),
+                "last_saved_at": self._state["persistence"]["last_saved_at"],
+            },
         }

--- a/headroom/proxy/persistent_metrics.py
+++ b/headroom/proxy/persistent_metrics.py
@@ -1,0 +1,449 @@
+"""Pure, bounded aggregate state for the durable Dashboard Lifetime view."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import math
+from typing import Any, Callable
+
+
+SCHEMA_VERSION = 5
+MAX_PROVIDER_VALUES = 32
+MAX_STACK_VALUES = 64
+MAX_TRACKED_MODELS = 200
+MAX_EXPOSED_MODELS = 100
+MAX_LABEL_LENGTH = 128
+
+KNOWN_MISS_REASONS = frozenset({"ttl_expiry", "prefix_change", "unknown"})
+KNOWN_WASTE_SIGNALS = frozenset(
+    {
+        "json_noise",
+        "html_noise",
+        "base64",
+        "whitespace",
+        "dynamic_date",
+        "repetition",
+        "reread",
+        "reread_compressed",
+    }
+)
+
+
+def utc_now() -> datetime:
+    """Return the current UTC time without sub-second noise in persisted state."""
+
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _to_iso(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _coerce_int(value: Any) -> int:
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _coerce_float(value: Any) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0.0
+    return result if math.isfinite(result) and result >= 0 else 0.0
+
+
+def _label(value: Any) -> str:
+    if not isinstance(value, str):
+        return "other"
+    value = value.strip()
+    return value[:MAX_LABEL_LENGTH] if value else "other"
+
+
+def _model_entry(raw: Any = None) -> dict[str, Any]:
+    raw = raw if isinstance(raw, dict) else {}
+    return {
+        "requests": _coerce_int(raw.get("requests")),
+        "input_tokens": _coerce_int(raw.get("input_tokens")),
+        "output_tokens": _coerce_int(raw.get("output_tokens")),
+        "attempted_input_tokens": _coerce_int(raw.get("attempted_input_tokens")),
+        "tokens_saved": _coerce_int(raw.get("tokens_saved")),
+        "last_activity_at": raw.get("last_activity_at")
+        if isinstance(raw.get("last_activity_at"), str)
+        else None,
+    }
+
+
+def _empty_state() -> dict[str, Any]:
+    return {
+        "started_at": None,
+        "last_activity_at": None,
+        "full_fidelity_started_at": None,
+        "requests": {
+            "total": 0,
+            "cached": 0,
+            "failed": 0,
+            "rate_limited": 0,
+            "by_provider": {},
+            "by_stack": {},
+        },
+        "tokens": {"input": 0, "output": 0, "attempted_input": 0, "saved": 0},
+        "prefix_cache": {
+            "requests": 0,
+            "hit_requests": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "cache_write_5m_tokens": 0,
+            "cache_write_1h_tokens": 0,
+            "uncached_input_tokens": 0,
+            "bust_count": 0,
+            "bust_tokens": 0,
+            "misses_by_reason": {},
+            "by_provider": {},
+        },
+        "cost": {"input_usd": 0.0, "compression_savings_usd": 0.0, "cache_savings_usd": 0.0},
+        "waste_signals": {},
+        "models": {"tracked": {}, "other": _model_entry()},
+        "persistence": {"last_saved_at": None},
+    }
+
+
+class PersistentMetricsState:
+    """In-memory Lifetime aggregate with deterministic, bounded dimensions."""
+
+    def __init__(
+        self,
+        raw: dict[str, Any] | None = None,
+        *,
+        now: Callable[[], datetime] = utc_now,
+    ) -> None:
+        self._now = now
+        self._state = self._normalize(raw)
+        self._compact_models()
+
+    def _normalize(self, raw: dict[str, Any] | None) -> dict[str, Any]:
+        source = raw if isinstance(raw, dict) else {}
+        result = _empty_state()
+        for timestamp_key in ("started_at", "last_activity_at", "full_fidelity_started_at"):
+            value = source.get(timestamp_key)
+            if isinstance(value, str):
+                result[timestamp_key] = value
+
+        raw_requests = source.get("requests") if isinstance(source.get("requests"), dict) else {}
+        for key in ("total", "cached", "failed", "rate_limited"):
+            result["requests"][key] = _coerce_int(raw_requests.get(key))
+        result["requests"]["by_provider"] = self._normalize_count_map(
+            raw_requests.get("by_provider"), MAX_PROVIDER_VALUES
+        )
+        result["requests"]["by_stack"] = self._normalize_count_map(
+            raw_requests.get("by_stack"), MAX_STACK_VALUES
+        )
+
+        raw_tokens = source.get("tokens") if isinstance(source.get("tokens"), dict) else {}
+        for key in ("input", "output", "attempted_input", "saved"):
+            result["tokens"][key] = _coerce_int(raw_tokens.get(key))
+
+        raw_cache = source.get("prefix_cache") if isinstance(source.get("prefix_cache"), dict) else {}
+        for key in (
+            "requests",
+            "hit_requests",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "cache_write_5m_tokens",
+            "cache_write_1h_tokens",
+            "uncached_input_tokens",
+            "bust_count",
+            "bust_tokens",
+        ):
+            result["prefix_cache"][key] = _coerce_int(raw_cache.get(key))
+        result["prefix_cache"]["by_provider"] = self._normalize_count_map(
+            raw_cache.get("by_provider"), MAX_PROVIDER_VALUES
+        )
+        result["prefix_cache"]["misses_by_reason"] = self._normalize_enum_map(
+            raw_cache.get("misses_by_reason"), KNOWN_MISS_REASONS
+        )
+
+        raw_cost = source.get("cost") if isinstance(source.get("cost"), dict) else {}
+        for key in ("input_usd", "compression_savings_usd", "cache_savings_usd"):
+            result["cost"][key] = round(_coerce_float(raw_cost.get(key)), 6)
+        result["waste_signals"] = self._normalize_enum_map(
+            source.get("waste_signals"), KNOWN_WASTE_SIGNALS
+        )
+
+        raw_models = source.get("models") if isinstance(source.get("models"), dict) else {}
+        raw_tracked = raw_models.get("tracked") if isinstance(raw_models.get("tracked"), dict) else {}
+        for name, entry in raw_tracked.items():
+            normalized_name = self._model_name(name)
+            if normalized_name == "other":
+                self._merge_model_entry(result["models"]["other"], _model_entry(entry))
+                continue
+            result["models"]["tracked"][normalized_name] = _model_entry(entry)
+        self._merge_model_entry(result["models"]["other"], _model_entry(raw_models.get("other")))
+        raw_persistence = source.get("persistence") if isinstance(source.get("persistence"), dict) else {}
+        if isinstance(raw_persistence.get("last_saved_at"), str):
+            result["persistence"]["last_saved_at"] = raw_persistence["last_saved_at"]
+        return result
+
+    @staticmethod
+    def _normalize_count_map(raw: Any, limit: int) -> dict[str, int]:
+        result: dict[str, int] = {}
+        if not isinstance(raw, dict):
+            return result
+        for key, value in raw.items():
+            label = _label(key)
+            result[label] = result.get(label, 0) + _coerce_int(value)
+        PersistentMetricsState._compact_count_map(result, limit)
+        return result
+
+    @staticmethod
+    def _normalize_enum_map(raw: Any, allowed: frozenset[str]) -> dict[str, int]:
+        result: dict[str, int] = {}
+        if not isinstance(raw, dict):
+            return result
+        for key, value in raw.items():
+            label = key if isinstance(key, str) and key in allowed else "unknown"
+            result[label] = result.get(label, 0) + _coerce_int(value)
+        return result
+
+    @staticmethod
+    def _compact_count_map(values: dict[str, int], limit: int) -> None:
+        named = [key for key in values if key != "other"]
+        while len(named) > limit:
+            evicted = min(named, key=lambda key: (values[key], key))
+            values["other"] = values.get("other", 0) + values.pop(evicted)
+            named.remove(evicted)
+
+    def _record_activity(self) -> str:
+        timestamp = _to_iso(self._now())
+        if self._state["started_at"] is None:
+            self._state["started_at"] = timestamp
+        if self._state["full_fidelity_started_at"] is None:
+            self._state["full_fidelity_started_at"] = timestamp
+        self._state["last_activity_at"] = timestamp
+        return timestamp or ""
+
+    @staticmethod
+    def _increment_count(values: dict[str, int], label: str, limit: int) -> None:
+        values[label] = values.get(label, 0) + 1
+        PersistentMetricsState._compact_count_map(values, limit)
+
+    @staticmethod
+    def _model_name(value: Any) -> str:
+        """Never retain the legacy unknown model bucket as a named model."""
+
+        label = _label(value)
+        return "other" if label.lower() == "unknown" else label
+
+    @staticmethod
+    def _merge_model_entry(destination: dict[str, Any], source: dict[str, Any]) -> None:
+        for key in ("requests", "input_tokens", "output_tokens", "attempted_input_tokens", "tokens_saved"):
+            destination[key] += _coerce_int(source.get(key))
+        if destination["last_activity_at"] is None or (
+            source["last_activity_at"] is not None
+            and source["last_activity_at"] > destination["last_activity_at"]
+        ):
+            destination["last_activity_at"] = source["last_activity_at"]
+
+    @staticmethod
+    def _model_rank(item: tuple[str, dict[str, Any]]) -> tuple[int, str, str]:
+        name, entry = item
+        observed_tokens = entry["input_tokens"] + entry["output_tokens"]
+        return (-observed_tokens, entry["last_activity_at"] or "", name)
+
+    def _compact_models(self) -> None:
+        tracked = self._state["models"]["tracked"]
+        if len(tracked) <= MAX_TRACKED_MODELS:
+            return
+        ranked = sorted(tracked.items(), key=self._model_rank)
+        kept = dict(ranked[:MAX_EXPOSED_MODELS])
+        other = self._state["models"]["other"]
+        for _, entry in ranked[MAX_EXPOSED_MODELS:]:
+            self._merge_model_entry(other, entry)
+        self._state["models"]["tracked"] = kept
+
+    def _record_model(
+        self,
+        *,
+        model: str | None,
+        timestamp: str,
+        input_tokens: int,
+        output_tokens: int,
+        attempted_input_tokens: int,
+        tokens_saved: int,
+    ) -> None:
+        name = self._model_name(model)
+        models = self._state["models"]
+        entry = models["other"] if name == "other" else models["tracked"].setdefault(name, _model_entry())
+        entry["requests"] += 1
+        entry["input_tokens"] += input_tokens
+        entry["output_tokens"] += output_tokens
+        entry["attempted_input_tokens"] += attempted_input_tokens
+        entry["tokens_saved"] += tokens_saved
+        entry["last_activity_at"] = timestamp
+        self._compact_models()
+
+    def record_request(
+        self,
+        *,
+        provider: str | None,
+        stack: str | None,
+        model: str | None,
+        input_tokens: Any = 0,
+        output_tokens: Any = 0,
+        attempted_input_tokens: Any = 0,
+        tokens_saved: Any = 0,
+        cached: bool = False,
+        record_stack: bool = True,
+        cache_read_tokens: Any = 0,
+        cache_write_tokens: Any = 0,
+        cache_write_5m_tokens: Any = 0,
+        cache_write_1h_tokens: Any = 0,
+        uncached_input_tokens: Any = 0,
+        input_usd: Any = 0.0,
+        compression_savings_usd: Any = 0.0,
+        cache_savings_usd: Any = 0.0,
+        waste_signals: dict[str, Any] | None = None,
+    ) -> None:
+        """Accumulate one completed top-level request after coercing all deltas."""
+
+        timestamp = self._record_activity()
+        input_delta = _coerce_int(input_tokens)
+        output_delta = _coerce_int(output_tokens)
+        attempted_delta = _coerce_int(attempted_input_tokens)
+        saved_delta = _coerce_int(tokens_saved)
+        provider_label = _label(provider)
+        stack_label = _label(stack)
+
+        requests = self._state["requests"]
+        requests["total"] += 1
+        requests["cached"] += int(bool(cached))
+        self._increment_count(requests["by_provider"], provider_label, MAX_PROVIDER_VALUES)
+        if record_stack:
+            self._increment_count(requests["by_stack"], stack_label, MAX_STACK_VALUES)
+
+        tokens = self._state["tokens"]
+        tokens["input"] += input_delta
+        tokens["output"] += output_delta
+        tokens["attempted_input"] += attempted_delta
+        tokens["saved"] += saved_delta
+
+        cache = self._state["prefix_cache"]
+        cache["requests"] += 1
+        cache["hit_requests"] += int(bool(cached))
+        cache["cache_read_tokens"] += _coerce_int(cache_read_tokens)
+        cache["cache_write_tokens"] += _coerce_int(cache_write_tokens)
+        cache["cache_write_5m_tokens"] += _coerce_int(cache_write_5m_tokens)
+        cache["cache_write_1h_tokens"] += _coerce_int(cache_write_1h_tokens)
+        cache["uncached_input_tokens"] += _coerce_int(uncached_input_tokens)
+        self._increment_count(cache["by_provider"], provider_label, MAX_PROVIDER_VALUES)
+
+        cost = self._state["cost"]
+        cost["input_usd"] = round(cost["input_usd"] + _coerce_float(input_usd), 6)
+        cost["compression_savings_usd"] = round(
+            cost["compression_savings_usd"] + _coerce_float(compression_savings_usd), 6
+        )
+        cost["cache_savings_usd"] = round(cost["cache_savings_usd"] + _coerce_float(cache_savings_usd), 6)
+
+        if isinstance(waste_signals, dict):
+            for name, token_count in waste_signals.items():
+                bucket = name if isinstance(name, str) and name in KNOWN_WASTE_SIGNALS else "other"
+                self._state["waste_signals"][bucket] = self._state["waste_signals"].get(bucket, 0) + _coerce_int(token_count)
+
+        self._record_model(
+            model=model,
+            timestamp=timestamp,
+            input_tokens=input_delta,
+            output_tokens=output_delta,
+            attempted_input_tokens=attempted_delta,
+            tokens_saved=saved_delta,
+        )
+
+    def record_stack(self, stack: str | None) -> None:
+        """Accumulate the existing inbound stack label without adding a request."""
+
+        if stack is None:
+            return
+        self._record_activity()
+        self._increment_count(self._state["requests"]["by_stack"], _label(stack), MAX_STACK_VALUES)
+
+    def record_failed(self, *, provider: str | None = None, model: str | None = None) -> None:
+        """Record a failed request without changing the completed-request denominator."""
+
+        self._record_activity()
+        self._state["requests"]["failed"] += 1
+
+    def record_rate_limited(self, *, provider: str | None = None, model: str | None = None) -> None:
+        """Record a rate-limited request without redefining total request semantics."""
+
+        self._record_activity()
+        self._state["requests"]["rate_limited"] += 1
+
+    def record_cache_bust(self, *, tokens_lost: Any = 0) -> None:
+        self._record_activity()
+        cache = self._state["prefix_cache"]
+        cache["bust_count"] += 1
+        cache["bust_tokens"] += _coerce_int(tokens_lost)
+
+    def record_cache_miss(self, *, provider: str | None, reason: str | None) -> None:
+        self._record_activity()
+        bucket = reason if isinstance(reason, str) and reason in KNOWN_MISS_REASONS else "unknown"
+        misses = self._state["prefix_cache"]["misses_by_reason"]
+        misses[bucket] = misses.get(bucket, 0) + 1
+
+    def set_last_saved_at(self, value: str | None) -> None:
+        self._state["persistence"]["last_saved_at"] = value
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the persisted form without derived values or I/O metadata."""
+
+        return deepcopy(self._state)
+
+    @staticmethod
+    def _percent(numerator: int, denominator: int) -> float | None:
+        if denominator <= 0:
+            return None
+        return round(numerator / denominator * 100, 6)
+
+    def _by_model_snapshot(self) -> dict[str, dict[str, Any]]:
+        ranked = sorted(self._state["models"]["tracked"].items(), key=self._model_rank)
+        visible = ranked[:MAX_EXPOSED_MODELS]
+        other = _model_entry(self._state["models"]["other"])
+        for _, entry in ranked[MAX_EXPOSED_MODELS:]:
+            self._merge_model_entry(other, entry)
+        result = {name: deepcopy(entry) for name, entry in visible}
+        result["other"] = other
+        return result
+
+    def snapshot(self, *, persistence: dict[str, Any]) -> dict[str, Any]:
+        """Return an API-safe aggregate and derive all percentages at read time."""
+
+        cache = self._state["prefix_cache"]
+        cache_write_total = cache["cache_write_1h_tokens"] + cache["cache_write_5m_tokens"]
+        tokens = self._state["tokens"]
+        return {
+            "scope": "lifetime",
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": _to_iso(self._now()),
+            "started_at": self._state["started_at"],
+            "last_activity_at": self._state["last_activity_at"],
+            "full_fidelity_started_at": self._state["full_fidelity_started_at"],
+            "requests": deepcopy(self._state["requests"]),
+            "tokens": {
+                **deepcopy(tokens),
+                "token_savings_percent": self._percent(tokens["saved"], tokens["attempted_input"]),
+            },
+            "prefix_cache": {
+                **deepcopy(cache),
+                "cache_hit_rate": self._percent(cache["hit_requests"], cache["requests"]),
+                "ttl_1h_percent": self._percent(cache["cache_write_1h_tokens"], cache_write_total),
+                "ttl_5m_percent": self._percent(cache["cache_write_5m_tokens"], cache_write_total),
+            },
+            "cost": deepcopy(self._state["cost"]),
+            "waste_signals": deepcopy(self._state["waste_signals"]),
+            "by_model": self._by_model_snapshot(),
+            "persistence": {**deepcopy(persistence), "last_saved_at": self._state["persistence"]["last_saved_at"]},
+        }

--- a/headroom/proxy/prometheus_metrics.py
+++ b/headroom/proxy/prometheus_metrics.py
@@ -420,6 +420,7 @@ class PrometheusMetrics:
         ):
             return
         self.requests_by_stack[slug] += 1
+        self.savings_tracker.record_lifetime_stack(slug)
 
     def record_compression(
         self,
@@ -682,6 +683,24 @@ class PrometheusMetrics:
             if len(self.savings_history) > 500:
                 self.savings_history = self.savings_history[-500:]
 
+            self.savings_tracker.record_lifetime_request(
+                persist=False,
+                provider=provider,
+                stack=None,
+                record_stack=False,
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                attempted_input_tokens=attempted_input_tokens,
+                tokens_saved=tokens_saved,
+                cached=cached,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+                cache_write_5m_tokens=cache_write_5m_tokens,
+                cache_write_1h_tokens=cache_write_1h_tokens,
+                uncached_input_tokens=uncached_input_tokens,
+                waste_signals=waste_signals,
+            )
             total_input_tokens, total_input_cost_usd = self._current_savings_tracker_totals()
             self.savings_tracker.record_request(
                 model=model,
@@ -769,6 +788,7 @@ class PrometheusMetrics:
         async with self._lock:
             self.cache_bust_tokens_lost += tokens_lost
             self.cache_bust_count += 1
+        self.savings_tracker.record_lifetime_cache_bust(tokens_lost=tokens_lost)
         self._get_otel_metrics().record_proxy_cache_bust(tokens_lost=tokens_lost)
 
     async def record_cache_miss_attribution(self, provider: str, reason: str) -> None:
@@ -782,6 +802,7 @@ class PrometheusMetrics:
         """
         async with self._lock:
             self.cache_miss_attribution_by_provider[provider][reason] += 1
+        self.savings_tracker.record_lifetime_cache_miss(provider=provider, reason=reason)
 
     # ------------------------------------------------------------------
     # Unit 3: WS session lifecycle gauges / histogram
@@ -827,11 +848,13 @@ class PrometheusMetrics:
     async def record_rate_limited(self, *, provider: str | None = None, model: str | None = None):
         async with self._lock:
             self.requests_rate_limited += 1
+        self.savings_tracker.record_lifetime_rate_limited(provider=provider, model=model)
         self._get_otel_metrics().record_proxy_rate_limited(provider=provider, model=model)
 
     async def record_failed(self, *, provider: str | None = None, model: str | None = None):
         async with self._lock:
             self.requests_failed += 1
+        self.savings_tracker.record_lifetime_failed(provider=provider, model=model)
         self._get_otel_metrics().record_proxy_failed(provider=provider, model=model)
 
     async def export(self) -> str:

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -945,7 +945,7 @@ class SavingsTracker:
         """Return the durable aggregate used only by ``/stats-lifetime``."""
 
         with self._lock:
-            return self._persistent_metrics.snapshot(
+            response = self._persistent_metrics.snapshot(
                 persistence={
                     "enabled": not self._stateless,
                     "healthy": self._persistence_healthy,
@@ -957,6 +957,8 @@ class SavingsTracker:
                     "pending_records": 0 if self._stateless else self._since_save,
                 }
             )
+            response["projects"] = self._projects_snapshot_locked()
+            return response
 
     def stats_preview(self, recent_points: int = 20) -> dict[str, Any]:
         """Return a compact preview for `/stats`."""

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from headroom import paths as _paths
 from headroom.proxy import project_name_policy
+from headroom.proxy.persistent_metrics import PersistentMetricsState
 
 PROJECT_NAME_MAX_LENGTH = project_name_policy.PROJECT_NAME_MAX_LENGTH
 sanitize_project_name = project_name_policy.sanitize_project_name
@@ -31,7 +32,7 @@ logger = logging.getLogger(__name__)
 HEADROOM_SAVINGS_PATH_ENV_VAR = _paths.HEADROOM_SAVINGS_PATH_ENV
 DEFAULT_SAVINGS_DIR = ".headroom"
 DEFAULT_SAVINGS_FILE = "proxy_savings.json"
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 DEFAULT_MAX_HISTORY_POINTS = 5000
 DEFAULT_MAX_PROJECTS = 50
 DEFAULT_MAX_HISTORY_AGE_DAYS = 365
@@ -537,7 +538,13 @@ class SavingsTracker:
         self._save_flush_every = max(_coerce_int(save_flush_every, 1), 1)
         self._since_save = 0
         self._lock = threading.Lock()
+        self._persistence_healthy = True
+        self._persistence_error: str | None = None
+        self._needs_schema_save = False
         self._state = self._load_state()
+        self._persistent_metrics = PersistentMetricsState(
+            self._state.pop("lifetime_metrics", None)
+        )
 
     @property
     def storage_path(self) -> str:
@@ -767,6 +774,66 @@ class SavingsTracker:
             self._maybe_save_locked()
             return True
 
+    def record_lifetime_request(self, *, persist: bool = True, **metrics: Any) -> None:
+        """Record one completed request in the durable Lifetime aggregate."""
+
+        model = _normalize_model(metrics.get("model"))
+        input_tokens = _coerce_int(metrics.get("input_tokens"))
+        cache_read_tokens = _coerce_int(metrics.get("cache_read_tokens"))
+        cache_write_tokens = _coerce_int(metrics.get("cache_write_tokens"))
+        uncached_input_tokens = _coerce_int(metrics.get("uncached_input_tokens"))
+        metrics.setdefault(
+            "input_usd",
+            _estimate_input_cost_usd(
+                model,
+                input_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+                uncached_input_tokens=uncached_input_tokens,
+            ),
+        )
+        metrics.setdefault(
+            "compression_savings_usd",
+            _estimate_compression_savings_usd(model, _coerce_int(metrics.get("tokens_saved"))),
+        )
+        metrics.setdefault("cache_savings_usd", _estimate_cache_savings_usd(model, cache_read_tokens))
+        with self._lock:
+            self._persistent_metrics.record_request(**metrics)
+            if persist:
+                self._maybe_save_locked()
+
+    def record_lifetime_stack(self, stack: str | None) -> None:
+        """Mirror the existing inbound stack dimension without another save."""
+
+        with self._lock:
+            self._persistent_metrics.record_stack(stack)
+
+    def record_lifetime_failed(self, *, provider: str | None = None, model: str | None = None) -> None:
+        """Record a failed proxy request without changing legacy history."""
+
+        with self._lock:
+            self._persistent_metrics.record_failed(provider=provider, model=model)
+            self._maybe_save_locked()
+
+    def record_lifetime_rate_limited(
+        self, *, provider: str | None = None, model: str | None = None
+    ) -> None:
+        """Record a rate-limited proxy request without changing legacy history."""
+
+        with self._lock:
+            self._persistent_metrics.record_rate_limited(provider=provider, model=model)
+            self._maybe_save_locked()
+
+    def record_lifetime_cache_bust(self, *, tokens_lost: int) -> None:
+        with self._lock:
+            self._persistent_metrics.record_cache_bust(tokens_lost=tokens_lost)
+            self._maybe_save_locked()
+
+    def record_lifetime_cache_miss(self, *, provider: str | None, reason: str | None) -> None:
+        with self._lock:
+            self._persistent_metrics.record_cache_miss(provider=provider, reason=reason)
+            self._maybe_save_locked()
+
     def _record_project_locked(
         self,
         project: str | None,
@@ -874,6 +941,22 @@ class SavingsTracker:
             )
             result[model] = view
         return result
+    def lifetime_response(self) -> dict[str, Any]:
+        """Return the durable aggregate used only by ``/stats-lifetime``."""
+
+        with self._lock:
+            return self._persistent_metrics.snapshot(
+                persistence={
+                    "enabled": not self._stateless,
+                    "healthy": self._persistence_healthy,
+                    "error": (
+                        "Lifetime metrics unavailable in stateless mode"
+                        if self._stateless
+                        else self._persistence_error
+                    ),
+                    "pending_records": 0 if self._stateless else self._since_save,
+                }
+            )
 
     def stats_preview(self, recent_points: int = 20) -> dict[str, Any]:
         """Return a compact preview for `/stats`."""
@@ -1014,9 +1097,29 @@ class SavingsTracker:
                 raw = json.load(f)
         except (json.JSONDecodeError, OSError) as e:
             logger.warning("Failed to load savings history from %s: %s", self._path, e)
+            self._persistence_healthy = False
+            self._persistence_error = str(e)
+            self._preserve_corrupt_file()
             return self._default_state()
 
+        if not isinstance(raw, dict):
+            self._persistence_healthy = False
+            self._persistence_error = "Savings state root must be a JSON object"
+            self._preserve_corrupt_file()
+            return self._default_state()
+        if _coerce_int(raw.get("schema_version")) != SCHEMA_VERSION:
+            self._needs_schema_save = True
         return self._sanitize_state(raw)
+
+    def _preserve_corrupt_file(self) -> None:
+        """Best-effort retention of unreadable state before starting fresh."""
+
+        timestamp = _to_utc_iso(_utc_now()).replace(":", "-")
+        corrupt_path = self._path.with_name(f"{self._path.name}.corrupt-{timestamp}")
+        try:
+            self._path.replace(corrupt_path)
+        except OSError:
+            logger.warning("Could not preserve corrupt savings history at %s", self._path)
 
     def _sanitize_state(self, raw: Any) -> dict[str, Any]:
         if not isinstance(raw, dict):
@@ -1084,6 +1187,12 @@ class SavingsTracker:
             "projects": _normalize_projects(raw.get("projects")),
             "by_model": _normalize_by_model(raw.get("by_model")),
         }
+        raw_lifetime_metrics = raw.get("lifetime_metrics")
+        if isinstance(raw_lifetime_metrics, dict):
+            state["lifetime_metrics"] = raw_lifetime_metrics
+        else:
+            state["lifetime_metrics"] = self._migrate_v4_lifetime_metrics(state)
+            self._needs_schema_save = True
 
         if normalized_history:
             reference_time = _parse_timestamp(normalized_history[-1]["timestamp"]) or _utc_now()
@@ -1097,6 +1206,49 @@ class SavingsTracker:
                     self._state = original_state
 
         return state
+
+    def _migrate_v4_lifetime_metrics(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Seed the v5 aggregate from the best information available in v4."""
+
+        history = state["history"]
+        display_session = state["display_session"]
+        started_at = (
+            history[0]["timestamp"]
+            if history
+            else display_session.get("started_at") or _to_utc_iso(_utc_now())
+        )
+        last_activity_at = (
+            history[-1]["timestamp"] if history else display_session.get("last_activity_at")
+        )
+        legacy = state["lifetime"]
+        return {
+            "started_at": started_at,
+            "last_activity_at": last_activity_at,
+            "full_fidelity_started_at": _to_utc_iso(_utc_now()),
+            "requests": {"total": legacy["requests"]},
+            "tokens": {
+                "input": legacy["total_input_tokens"],
+                "attempted_input": legacy["total_input_tokens"] + legacy["tokens_saved"],
+                "saved": legacy["tokens_saved"],
+            },
+            "prefix_cache": {"cache_read_tokens": legacy["cache_read_tokens"]},
+            "cost": {
+                "input_usd": legacy["total_input_cost_usd"],
+                "compression_savings_usd": legacy["compression_savings_usd"],
+                "cache_savings_usd": legacy["cache_savings_usd"],
+            },
+            "models": {
+                "tracked": {},
+                "other": {
+                    "requests": legacy["requests"],
+                    "input_tokens": legacy["total_input_tokens"],
+                    "attempted_input_tokens": legacy["total_input_tokens"]
+                    + legacy["tokens_saved"],
+                    "tokens_saved": legacy["tokens_saved"],
+                    "last_activity_at": last_activity_at,
+                },
+            },
+        }
 
     def _trim_history_locked(self, reference_time: datetime | None = None) -> None:
         history = self._state["history"]
@@ -1173,7 +1325,7 @@ class SavingsTracker:
         recent requests. No-op when nothing is buffered.
         """
         with self._lock:
-            if self._since_save > 0:
+            if self._since_save > 0 or self._needs_schema_save:
                 self._save_locked()
 
     def _maybe_save_locked(self) -> None:
@@ -1189,9 +1341,13 @@ class SavingsTracker:
         if self._stateless:
             # Stateless mode: live counters stay in memory; nothing is persisted.
             self._since_save = 0
+            self._needs_schema_save = False
             return
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
+            saved_at = _to_utc_iso(_utc_now())
+            lifetime_metrics = self._persistent_metrics.to_dict()
+            lifetime_metrics["persistence"]["last_saved_at"] = saved_at
             payload = {
                 "schema_version": SCHEMA_VERSION,
                 "lifetime": self._state["lifetime"],
@@ -1199,6 +1355,7 @@ class SavingsTracker:
                 "history": self._state["history"],
                 "projects": self._state.get("projects", {}),
                 "by_model": self._state.get("by_model", {}),
+                "lifetime_metrics": lifetime_metrics,
             }
             json_data = json.dumps(payload, indent=2)
 
@@ -1238,9 +1395,15 @@ class SavingsTracker:
 
             # Reset only after a durable write. A failed save leaves the counter
             # untouched so the next record retries instead of waiting a full window.
+            self._persistent_metrics.set_last_saved_at(saved_at)
+            self._persistence_healthy = True
+            self._persistence_error = None
+            self._needs_schema_save = False
             self._since_save = 0
         except OSError as e:
             logger.warning("Failed to save savings history to %s: %s", self._path, e)
+            self._persistence_healthy = False
+            self._persistence_error = str(e)
 
     def _display_session_snapshot_locked(
         self,

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -3757,6 +3757,21 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
             payload.pop("request_logs", None)
         return payload
 
+    @app.get("/stats-lifetime")
+    async def stats_lifetime(request: Request):
+        """Return persisted lifetime aggregates with sensitive fields gated."""
+        payload = dict(proxy.metrics.savings_tracker.lifetime_response())
+        include_sensitive = _request_can_view_dashboard_metadata(
+            request,
+            trusted_dashboard_client_cidrs,
+        )
+        if not include_sensitive:
+            payload.pop("projects", None)
+            persistence = payload.get("persistence")
+            if isinstance(persistence, dict):
+                payload["persistence"] = {**persistence, "error": None}
+        return payload
+
     @app.post("/stats/reset", dependencies=[Depends(_require_loopback)])
     async def stats_reset():
         """Reset in-memory proxy stats for local test/debug isolation."""

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -28,6 +28,7 @@ import asyncio
 import concurrent.futures
 import contextlib
 import hmac
+import ipaddress
 import json
 import logging
 import math
@@ -2036,6 +2037,32 @@ def _request_is_loopback(request: Request) -> bool:
     return peer_is_trusted_gateway(client_host, load_trusted_gateway_cidrs())
 
 
+def _request_can_view_dashboard_metadata(
+    request: Request,
+    trusted_dashboard_client_cidrs: tuple[
+        ipaddress.IPv4Network | ipaddress.IPv6Network, ...
+    ],
+) -> bool:
+    """Authorize sensitive ``/stats`` metadata without widening admin access."""
+    if _request_is_loopback(request):
+        return True
+
+    from headroom.proxy.forwarded_headers import peer_is_trusted_gateway, resolve_client_ip
+    from headroom.proxy.loopback_guard import is_ip_literal_host_header
+
+    try:
+        host_header = request.headers.get("host")
+    except AttributeError:
+        return False
+    if not is_ip_literal_host_header(host_header):
+        return False
+
+    return peer_is_trusted_gateway(
+        resolve_client_ip(request),
+        trusted_dashboard_client_cidrs,
+    )
+
+
 _is_known_websocket_callback_failure = is_known_websocket_callback_failure
 
 
@@ -2046,6 +2073,11 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
     """Create FastAPI application."""
     if not FASTAPI_AVAILABLE:
         raise ImportError("FastAPI required. Install: pip install fastapi uvicorn httpx")
+
+    from headroom.proxy.forwarded_headers import load_trusted_dashboard_client_cidrs
+
+    # Parse once at startup so invalid operator configuration fails loudly.
+    trusted_dashboard_client_cidrs = load_trusted_dashboard_client_cidrs()
 
     from contextlib import asynccontextmanager
 
@@ -3659,7 +3691,10 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         only for loopback callers — the local dashboard. Network callers still
         get the aggregate counters but never the per-request metadata.
         """
-        include_sensitive = _request_is_loopback(request)
+        include_sensitive = _request_can_view_dashboard_metadata(
+            request,
+            trusted_dashboard_client_cidrs,
+        )
         if cached:
             payload = dict(await _get_cached_stats_payload())
             if include_sensitive:

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -3071,7 +3071,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
     def _build_recent_request_payload(limit: int = RECENT_REQUEST_LOG_WINDOW) -> dict[str, Any]:
         recent_request_logs = proxy.logger.get_recent(limit) if proxy.logger else []
         dashboard_recent_requests = []
-        for log in recent_request_logs:
+        for log in reversed(recent_request_logs):
             token_accounting_status = _recent_request_token_accounting_status(log)
             dashboard_recent_requests.append(
                 {
@@ -3099,7 +3099,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                     "tool_schema_saved_tokens": _tool_schema_saved_from_tags(log.get("tags")),
                 }
             )
-        dashboard_recent_requests = dashboard_recent_requests[-10:]
+        dashboard_recent_requests = dashboard_recent_requests[:25]
         return {
             "request_logs": recent_request_logs[-10:],
             "recent_requests": dashboard_recent_requests,

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -41,6 +41,7 @@ from dataclasses import fields, is_dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
+from urllib.parse import urlsplit
 
 if TYPE_CHECKING:
     from ..backends.base import Backend
@@ -2057,10 +2058,55 @@ def _request_can_view_dashboard_metadata(
     if not is_ip_literal_host_header(host_header):
         return False
 
+    # CIDR authorization makes this endpoint usable by a remote dashboard, but
+    # it must not let an unrelated site read sensitive metadata through a
+    # victim's browser. Native CLI clients usually send neither header, so
+    # absence remains valid. If either browser provenance header is present,
+    # require it to identify this exact scheme/host/port.
+    if not _request_has_same_origin_or_no_provenance(request, host_header):
+        return False
+
     return peer_is_trusted_gateway(
         resolve_client_ip(request),
         trusted_dashboard_client_cidrs,
     )
+
+
+def _request_has_same_origin_or_no_provenance(
+    request: Request, host_header: str
+) -> bool:
+    """Accept no browser provenance, otherwise require same-origin headers."""
+
+    from headroom.proxy.forwarded_headers import trusted_forwarded_headers
+
+    forwarded_proto = trusted_forwarded_headers(request)["proto"]
+    request_scheme = forwarded_proto or request.url.scheme
+    expected_origin = _normalized_http_origin(f"{request_scheme}://{host_header}")
+    if expected_origin is None:
+        return False
+
+    for header_name in ("origin", "referer"):
+        header_value = request.headers.get(header_name)
+        if header_value and _normalized_http_origin(header_value) != expected_origin:
+            return False
+    return True
+
+
+def _normalized_http_origin(value: str) -> tuple[str, str, int] | None:
+    """Return a normalized HTTP(S) origin tuple."""
+
+    try:
+        parsed = urlsplit(value.strip())
+        port = parsed.port
+    except ValueError:
+        return None
+
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    if port is None:
+        port = 80 if scheme == "http" else 443
+    return scheme, parsed.hostname.lower(), port
 
 
 _is_known_websocket_callback_failure = is_known_websocket_callback_failure

--- a/tests/test_forwarded_headers.py
+++ b/tests/test_forwarded_headers.py
@@ -19,7 +19,9 @@ from fastapi.testclient import TestClient
 from starlette.datastructures import Headers, State
 
 from headroom.proxy.forwarded_headers import (
+    TRUSTED_DASHBOARD_CLIENT_CIDRS_ENV,
     TRUSTED_GATEWAY_CIDRS_ENV,
+    load_trusted_dashboard_client_cidrs,
     load_trusted_gateway_cidrs,
     peer_is_trusted_gateway,
     resolve_client_ip,
@@ -113,6 +115,36 @@ def test_load_cidrs_reads_env_by_default(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setenv(TRUSTED_GATEWAY_CIDRS_ENV, "10.0.0.0/8")
     cidrs = load_trusted_gateway_cidrs()
     assert [str(c) for c in cidrs] == ["10.0.0.0/8"]
+
+
+def test_load_dashboard_client_cidrs_uses_their_own_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        TRUSTED_DASHBOARD_CLIENT_CIDRS_ENV,
+        "100.90.0.5/32, fd7a:115c:a1e0::/48",
+    )
+
+    cidrs = load_trusted_dashboard_client_cidrs()
+
+    assert [str(cidr) for cidr in cidrs] == [
+        "100.90.0.5/32",
+        "fd7a:115c:a1e0::/48",
+    ]
+
+
+def test_load_dashboard_client_cidrs_unset_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(TRUSTED_DASHBOARD_CLIENT_CIDRS_ENV, raising=False)
+    assert load_trusted_dashboard_client_cidrs() == ()
+
+
+def test_load_dashboard_client_cidrs_empty_and_malformed_values() -> None:
+    assert load_trusted_dashboard_client_cidrs("") == ()
+    assert load_trusted_dashboard_client_cidrs("   ") == ()
+    with pytest.raises(ValueError, match=TRUSTED_DASHBOARD_CLIENT_CIDRS_ENV):
+        load_trusted_dashboard_client_cidrs("100.90.0.5/32,not-a-cidr")
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/tests/test_persistent_metrics.py
+++ b/tests/test_persistent_metrics.py
@@ -1,0 +1,156 @@
+"""Tests for durable, aggregate-only proxy Lifetime metrics."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from headroom.proxy.persistent_metrics import PersistentMetricsState
+
+
+FIXED_NOW = datetime(2026, 7, 14, 8, 30, tzinfo=timezone.utc)
+
+
+def _new_state() -> PersistentMetricsState:
+    return PersistentMetricsState(now=lambda: FIXED_NOW)
+
+
+def test_snapshot_accumulates_request_token_cache_cost_and_waste_metrics() -> None:
+    state = _new_state()
+
+    state.record_request(
+        provider="anthropic",
+        stack="codex",
+        model="claude-test",
+        input_tokens=100,
+        output_tokens=20,
+        attempted_input_tokens=150,
+        tokens_saved=50,
+        cached=True,
+        cache_read_tokens=80,
+        cache_write_tokens=40,
+        cache_write_5m_tokens=10,
+        cache_write_1h_tokens=30,
+        uncached_input_tokens=20,
+        input_usd=0.4,
+        compression_savings_usd=0.2,
+        cache_savings_usd=0.1,
+        waste_signals={"repetition": 7},
+    )
+    state.record_failed(provider="anthropic", model="claude-test")
+    state.record_rate_limited(provider="anthropic", model="claude-test")
+    state.record_cache_bust(tokens_lost=9)
+    state.record_cache_miss(provider="anthropic", reason="prefix_change")
+
+    snapshot = state.snapshot(persistence={"enabled": True, "healthy": True})
+
+    assert snapshot["scope"] == "lifetime"
+    assert snapshot["requests"] == {
+        "total": 1,
+        "cached": 1,
+        "failed": 1,
+        "rate_limited": 1,
+        "by_provider": {"anthropic": 1},
+        "by_stack": {"codex": 1},
+    }
+    assert snapshot["tokens"] == {
+        "input": 100,
+        "output": 20,
+        "attempted_input": 150,
+        "saved": 50,
+        "token_savings_percent": pytest.approx(50 / 150 * 100),
+    }
+    assert snapshot["prefix_cache"]["requests"] == 1
+    assert snapshot["prefix_cache"]["hit_requests"] == 1
+    assert snapshot["prefix_cache"]["cache_read_tokens"] == 80
+    assert snapshot["prefix_cache"]["cache_write_tokens"] == 40
+    assert snapshot["prefix_cache"]["cache_hit_rate"] == 100.0
+    assert snapshot["prefix_cache"]["ttl_1h_percent"] == 75.0
+    assert snapshot["prefix_cache"]["ttl_5m_percent"] == 25.0
+    assert snapshot["prefix_cache"]["bust_count"] == 1
+    assert snapshot["prefix_cache"]["bust_tokens"] == 9
+    assert snapshot["prefix_cache"]["misses_by_reason"] == {"prefix_change": 1}
+    assert snapshot["cost"] == {
+        "input_usd": 0.4,
+        "compression_savings_usd": 0.2,
+        "cache_savings_usd": 0.1,
+    }
+    assert snapshot["waste_signals"] == {"repetition": 7}
+    assert snapshot["by_model"]["claude-test"]["input_tokens"] == 100
+
+
+def test_snapshot_uses_null_for_ratios_without_a_denominator() -> None:
+    snapshot = _new_state().snapshot(persistence={"enabled": True, "healthy": True})
+
+    assert snapshot["tokens"]["token_savings_percent"] is None
+    assert snapshot["prefix_cache"]["cache_hit_rate"] is None
+    assert snapshot["prefix_cache"]["ttl_1h_percent"] is None
+    assert snapshot["prefix_cache"]["ttl_5m_percent"] is None
+
+
+def test_candidate_models_remain_available_until_the_two_hundred_and_first_model() -> None:
+    state = _new_state()
+    for index in range(200):
+        state.record_request(
+            provider="provider",
+            stack="stack",
+            model=f"model-{index:03}",
+            input_tokens=index + 1,
+        )
+
+    persisted = state.to_dict()
+    snapshot = state.snapshot(persistence={"enabled": True, "healthy": True})
+
+    assert len(persisted["models"]["tracked"]) == 200
+    assert "model-000" not in snapshot["by_model"]
+    assert snapshot["by_model"]["other"]["input_tokens"] == sum(range(1, 101))
+
+
+def test_two_hundred_and_first_model_permanently_compacts_non_top_candidates() -> None:
+    state = _new_state()
+    for index in range(201):
+        state.record_request(
+            provider="provider",
+            stack="stack",
+            model=f"model-{index:03}",
+            input_tokens=index + 1,
+        )
+
+    persisted = state.to_dict()
+    snapshot = state.snapshot(persistence={"enabled": True, "healthy": True})
+
+    assert len(persisted["models"]["tracked"]) == 100
+    assert set(snapshot["by_model"]) == {
+        *(f"model-{index:03}" for index in range(101, 201)),
+        "other",
+    }
+    assert snapshot["by_model"]["other"]["input_tokens"] == sum(range(1, 102))
+
+
+def test_state_normalizes_invalid_values_and_unknown_dimension_labels() -> None:
+    state = PersistentMetricsState(
+        {
+            "requests": {"total": "not-a-number"},
+            "tokens": {"input": float("nan"), "output": -3},
+            "models": {"tracked": {"unknown": {"input_tokens": "7"}}},
+        },
+        now=lambda: FIXED_NOW,
+    )
+    state.record_request(
+        provider=" ",
+        stack=None,
+        model=" ",
+        input_tokens=-1,
+        output_tokens=float("inf"),
+        waste_signals={"unrecognized": 9},
+    )
+
+    snapshot = state.snapshot(persistence={"enabled": True, "healthy": True})
+
+    assert snapshot["tokens"]["input"] == 0
+    assert snapshot["tokens"]["output"] == 0
+    assert snapshot["requests"]["by_provider"] == {"other": 1}
+    assert snapshot["requests"]["by_stack"] == {"other": 1}
+    assert snapshot["by_model"]["other"]["input_tokens"] == 7
+    assert snapshot["waste_signals"] == {"other": 9}

--- a/tests/test_persistent_metrics.py
+++ b/tests/test_persistent_metrics.py
@@ -8,7 +8,6 @@ import pytest
 
 from headroom.proxy.persistent_metrics import PersistentMetricsState
 
-
 FIXED_NOW = datetime(2026, 7, 14, 8, 30, tzinfo=timezone.utc)
 
 

--- a/tests/test_persistent_metrics_integration.py
+++ b/tests/test_persistent_metrics_integration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+
 from headroom.proxy.prometheus_metrics import PrometheusMetrics
 from headroom.proxy.savings_tracker import SavingsTracker
 

--- a/tests/test_persistent_metrics_integration.py
+++ b/tests/test_persistent_metrics_integration.py
@@ -1,0 +1,48 @@
+"""Tests forwarding existing proxy metric events to Lifetime storage."""
+
+from __future__ import annotations
+
+import asyncio
+from headroom.proxy.prometheus_metrics import PrometheusMetrics
+from headroom.proxy.savings_tracker import SavingsTracker
+
+
+def test_runtime_metric_events_feed_lifetime_without_resetting_runtime_counters(tmp_path) -> None:
+    tracker = SavingsTracker(path=str(tmp_path / "proxy_savings.json"), save_flush_every=25)
+    metrics = PrometheusMetrics(savings_tracker=tracker)
+
+    metrics.record_stack("codex")
+    asyncio.run(
+        metrics.record_request(
+            provider="anthropic",
+            model="claude-test",
+            input_tokens=10,
+            output_tokens=3,
+            tokens_saved=2,
+            latency_ms=1,
+            cached=True,
+            attempted_input_tokens=12,
+            cache_read_tokens=5,
+            cache_write_1h_tokens=2,
+            waste_signals={"repetition": 4},
+        )
+    )
+    asyncio.run(metrics.record_failed(provider="anthropic", model="claude-test"))
+    asyncio.run(metrics.record_rate_limited(provider="anthropic", model="claude-test"))
+    asyncio.run(metrics.record_cache_bust(tokens_lost=7))
+    asyncio.run(metrics.record_cache_miss_attribution("anthropic", "prefix_change"))
+
+    lifetime = tracker.lifetime_response()
+
+    assert lifetime["requests"]["total"] == 1
+    assert lifetime["requests"]["cached"] == 1
+    assert lifetime["requests"]["failed"] == 1
+    assert lifetime["requests"]["rate_limited"] == 1
+    assert lifetime["requests"]["by_provider"] == {"anthropic": 1}
+    assert lifetime["requests"]["by_stack"] == {"codex": 1}
+    assert lifetime["tokens"]["output"] == 3
+    assert lifetime["tokens"]["attempted_input"] == 12
+    assert lifetime["prefix_cache"]["bust_tokens"] == 7
+    assert lifetime["prefix_cache"]["misses_by_reason"] == {"prefix_change": 1}
+    assert lifetime["waste_signals"] == {"repetition": 4}
+    assert metrics.requests_total == 1

--- a/tests/test_persistent_metrics_persistence.py
+++ b/tests/test_persistent_metrics_persistence.py
@@ -1,0 +1,87 @@
+"""Tests schema v5 persistence around the pure Lifetime aggregate."""
+
+from __future__ import annotations
+
+import json
+
+from headroom.proxy.savings_tracker import SavingsTracker
+
+
+def test_savings_tracker_migrates_v4_lifetime_to_v5_metrics_and_preserves_legacy_state(tmp_path):
+    path = tmp_path / "proxy_savings.json"
+    legacy_state = {
+        "schema_version": 4,
+        "lifetime": {
+            "requests": 7,
+            "tokens_saved": 20,
+            "compression_savings_usd": 0.5,
+            "cache_read_tokens": 5,
+            "cache_savings_usd": 0.2,
+            "total_input_tokens": 80,
+            "total_input_cost_usd": 1.5,
+        },
+        "display_session": {
+            "requests": 2,
+            "tokens_saved": 4,
+            "compression_savings_usd": 0.1,
+            "cache_read_tokens": 1,
+            "cache_savings_usd": 0.01,
+            "total_input_tokens": 10,
+            "total_input_cost_usd": 0.2,
+            "started_at": "2026-07-01T00:00:00Z",
+            "last_activity_at": "2026-07-02T00:00:00Z",
+        },
+        "history": [
+            {
+                "timestamp": "2026-07-02T00:00:00Z",
+                "total_tokens_saved": 20,
+                "compression_savings_usd": 0.5,
+                "total_input_tokens": 80,
+                "total_input_cost_usd": 1.5,
+            }
+        ],
+        "projects": {"keep-me": {"requests": 1}},
+    }
+    path.write_text(json.dumps(legacy_state), encoding="utf-8")
+
+    tracker = SavingsTracker(path=str(path), save_flush_every=25)
+    lifetime = tracker.lifetime_response()
+
+    assert lifetime["schema_version"] == 5
+    assert lifetime["requests"]["total"] == 7
+    assert lifetime["tokens"]["input"] == 80
+    assert lifetime["tokens"]["attempted_input"] == 100
+    assert lifetime["tokens"]["saved"] == 20
+    assert lifetime["prefix_cache"]["cache_read_tokens"] == 5
+    assert lifetime["cost"] == {
+        "input_usd": 1.5,
+        "compression_savings_usd": 0.5,
+        "cache_savings_usd": 0.2,
+    }
+    assert lifetime["by_model"]["other"]["input_tokens"] == 80
+
+    tracker.flush()
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    assert saved["schema_version"] == 5
+    assert saved["lifetime"] == legacy_state["lifetime"]
+    assert saved["display_session"]["requests"] == 2
+    assert saved["projects"]["keep-me"]["requests"] == 1
+    assert saved["lifetime_metrics"]["models"]["other"]["input_tokens"] == 80
+    assert isinstance(saved["lifetime_metrics"]["persistence"]["last_saved_at"], str)
+
+
+def test_lifetime_response_reports_stateless_mode_without_writing(tmp_path):
+    path = tmp_path / "proxy_savings.json"
+    tracker = SavingsTracker(path=str(path), stateless=True, save_flush_every=1)
+
+    tracker.record_lifetime_request(provider="openai", stack="codex", model="gpt-test", input_tokens=3)
+
+    response = tracker.lifetime_response()
+    assert response["persistence"] == {
+        "enabled": False,
+        "healthy": True,
+        "error": "Lifetime metrics unavailable in stateless mode",
+        "pending_records": 0,
+        "last_saved_at": None,
+    }
+    assert path.exists() is False

--- a/tests/test_proxy_loopback_gating.py
+++ b/tests/test_proxy_loopback_gating.py
@@ -17,6 +17,7 @@ from fastapi.testclient import TestClient
 from headroom.cache.backends import InMemoryBackend
 from headroom.cache.compression_store import get_compression_store, reset_compression_store
 from headroom.proxy.server import ProxyConfig, create_app
+from headroom.proxy.loopback_guard import is_ip_literal_host_header
 
 GATED = [
     ("get", "/transformations/feed"),
@@ -112,6 +113,22 @@ def test_dns_rebinding_host_header_rejected() -> None:
     assert resp.status_code == 404, resp.text
 
 
+@pytest.mark.parametrize(
+    "host_header",
+    ["100.82.0.2", "100.82.0.2:8787", "[fd7a:115c:a1e0::2]", "[fd7a:115c:a1e0::2]:8787"],
+)
+def test_ip_literal_host_header_accepts_ip_addresses(host_header: str) -> None:
+    assert is_ip_literal_host_header(host_header) is True
+
+
+@pytest.mark.parametrize(
+    "host_header",
+    [None, "", "attacker.example", "localhost", "user@100.82.0.2", "100.82.0.2/path", "[fd7a::1"],
+)
+def test_ip_literal_host_header_rejects_non_addresses(host_header: str | None) -> None:
+    assert is_ip_literal_host_header(host_header) is False
+
+
 def _client(*, loopback: bool) -> TestClient:
     app = _make_app()
     if loopback:
@@ -185,3 +202,100 @@ def test_stats_metadata_served_to_trusted_gateway_peer(
     rebind = TestClient(app, base_url="http://attacker.example", client=(gateway_ip, 54321))
     payload = rebind.get("/stats").json()
     assert "recent_requests" not in payload
+
+
+@pytest.mark.parametrize("cached", [False, True])
+def test_dashboard_client_cidr_grants_stats_metadata_for_ip_literal_host(
+    monkeypatch: pytest.MonkeyPatch,
+    cached: bool,
+) -> None:
+    monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.5/32")
+    app = _make_app()
+    client = TestClient(
+        app,
+        base_url="http://100.82.0.2:8787",
+        client=("100.90.0.5", 12345),
+    )
+
+    payload = client.get("/stats", params={"cached": int(cached)}).json()
+
+    assert "recent_requests" in payload
+    assert "request_logs" in payload
+    assert "config" in payload
+
+
+def test_dashboard_client_cidr_rejects_unlisted_clients_and_hostname_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.5/32")
+    app = _make_app()
+
+    unlisted = TestClient(
+        app,
+        base_url="http://100.82.0.2:8787",
+        client=("100.90.0.6", 12345),
+    ).get("/stats").json()
+    hostname = TestClient(
+        app,
+        base_url="http://100.82.0.2:8787",
+        client=("100.90.0.5", 12345),
+    ).get("/stats", headers={"host": "attacker.example"}).json()
+
+    for payload in (unlisted, hostname):
+        assert "recent_requests" not in payload
+        assert "request_logs" not in payload
+        assert "config" not in payload
+
+
+def test_dashboard_client_cidr_only_accepts_forwarded_client_from_trusted_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.5/32")
+    monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_GATEWAY_CIDRS", "172.18.0.0/16")
+    app = _make_app()
+
+    trusted = TestClient(
+        app,
+        base_url="http://100.82.0.2:8787",
+        client=("172.18.0.1", 12345),
+    ).get("/stats", headers={"x-forwarded-for": "100.90.0.5"}).json()
+    forged = TestClient(
+        app,
+        base_url="http://100.82.0.2:8787",
+        client=("198.51.100.10", 12345),
+    ).get("/stats", headers={"x-forwarded-for": "100.90.0.5"}).json()
+
+    assert "recent_requests" in trusted
+    assert "recent_requests" not in forged
+
+
+def test_dashboard_client_cidr_normalizes_ipv4_mapped_ipv6(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.0/24")
+    app = _make_app()
+    payload = TestClient(
+        app,
+        base_url="http://100.82.0.2:8787",
+        client=("::ffff:100.90.0.5", 12345),
+    ).get("/stats").json()
+
+    assert "recent_requests" in payload
+
+
+def test_dashboard_client_cidr_does_not_expand_other_management_endpoints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.5/32")
+    client = TestClient(
+        _make_app(),
+        base_url="http://100.82.0.2:8787",
+        client=("100.90.0.5", 12345),
+    )
+
+    health = client.get("/health")
+    assert health.status_code == 200
+    assert "config" not in health.json()
+    assert client.get("/admin/upstream").status_code == 404
+    assert client.get("/debug/tasks").status_code == 404
+    assert client.post("/stats/reset").status_code == 404

--- a/tests/test_proxy_loopback_gating.py
+++ b/tests/test_proxy_loopback_gating.py
@@ -16,8 +16,8 @@ from fastapi.testclient import TestClient
 
 from headroom.cache.backends import InMemoryBackend
 from headroom.cache.compression_store import get_compression_store, reset_compression_store
-from headroom.proxy.server import ProxyConfig, create_app
 from headroom.proxy.loopback_guard import is_ip_literal_host_header
+from headroom.proxy.server import ProxyConfig, create_app
 
 GATED = [
     ("get", "/transformations/feed"),
@@ -76,6 +76,57 @@ def test_loopback_caller_allowed(method: str, path: str) -> None:
 
 
 # CCR data endpoints — cached session content, gated to 404 off-loopback (#1227).
+def test_stats_lifetime_route_uses_dashboard_metadata_access_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS",
+        "100.90.0.5/32",
+    )
+    app = _make_app()
+    expected = {
+        "requests": {"total": 7},
+        "projects": {"headroom": {"requests": 3}},
+        "persistence": {
+            "enabled": True,
+            "healthy": False,
+            "error": "D:/private/proxy_savings.json: access denied",
+        },
+    }
+    monkeypatch.setattr(
+        app.state.proxy.metrics.savings_tracker,
+        "lifetime_response",
+        lambda: expected,
+    )
+
+    network = TestClient(app).get("/stats-lifetime")
+    assert network.status_code == 200, network.text
+    assert network.json() == {
+        "requests": {"total": 7},
+        "persistence": {
+            "enabled": True,
+            "healthy": False,
+            "error": None,
+        },
+    }
+
+    loopback = TestClient(
+        app,
+        base_url="http://127.0.0.1",
+        client=("127.0.0.1", 12345),
+    ).get("/stats-lifetime")
+    assert loopback.status_code == 200, loopback.text
+    assert loopback.json() == expected
+
+    trusted_dashboard = TestClient(
+        app,
+        base_url="http://100.82.0.2:8787",
+        client=("100.90.0.5", 12345),
+    ).get("/stats-lifetime")
+    assert trusted_dashboard.status_code == 200, trusted_dashboard.text
+    assert trusted_dashboard.json() == expected
+
+
 CCR_GATED = [
     ("post", "/v1/retrieve"),
     ("get", "/v1/retrieve/stats"),

--- a/tests/test_proxy_loopback_gating.py
+++ b/tests/test_proxy_loopback_gating.py
@@ -224,6 +224,104 @@ def test_dashboard_client_cidr_grants_stats_metadata_for_ip_literal_host(
     assert "config" in payload
 
 
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"origin": "http://100.82.0.2:8787"},
+        {"referer": "http://100.82.0.2:8787/dashboard"},
+    ],
+)
+@pytest.mark.parametrize("cached", [False, True])
+def test_dashboard_client_cidr_grants_stats_metadata_to_same_origin_browser(
+    monkeypatch: pytest.MonkeyPatch, headers: dict[str, str], cached: bool
+) -> None:
+    monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.5/32")
+    client = TestClient(
+        _make_app(),
+        base_url="http://100.82.0.2:8787",
+        client=("100.90.0.5", 12345),
+    )
+
+    payload = client.get(
+        "/stats", params={"cached": int(cached)}, headers=headers
+    ).json()
+
+    assert "recent_requests" in payload
+    assert "request_logs" in payload
+    assert "config" in payload
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"origin": "http://attacker.example"},
+        {"referer": "http://attacker.example/dashboard"},
+    ],
+)
+@pytest.mark.parametrize("cached", [False, True])
+def test_dashboard_client_cidr_hides_stats_metadata_from_cross_origin_browser(
+    monkeypatch: pytest.MonkeyPatch, headers: dict[str, str], cached: bool
+) -> None:
+    monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.5/32")
+    client = TestClient(
+        _make_app(),
+        base_url="http://100.82.0.2:8787",
+        client=("100.90.0.5", 12345),
+    )
+
+    response = client.get(
+        "/stats", params={"cached": int(cached)}, headers=headers
+    )
+    payload = response.json()
+
+    assert response.status_code == 200
+    assert "tokens" in payload
+    assert "recent_requests" not in payload
+    assert "request_logs" not in payload
+    assert "config" not in payload
+
+
+def test_dashboard_client_cidr_only_uses_forwarded_proto_from_trusted_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.5/32")
+    monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_GATEWAY_CIDRS", "172.18.0.0/16")
+    client = TestClient(
+        _make_app(),
+        base_url="http://100.82.0.2:8787",
+        client=("172.18.0.1", 12345),
+    )
+
+    payload = client.get(
+        "/stats",
+        headers={
+            "origin": "https://100.82.0.2:8787",
+            "x-forwarded-for": "100.90.0.5",
+            "x-forwarded-proto": "https",
+        },
+    ).json()
+
+    assert "recent_requests" in payload
+    assert "request_logs" in payload
+    assert "config" in payload
+
+    spoofed = TestClient(
+        _make_app(),
+        base_url="http://100.82.0.2:8787",
+        client=("100.90.0.5", 12345),
+    ).get(
+        "/stats",
+        headers={
+            "origin": "https://100.82.0.2:8787",
+            "x-forwarded-proto": "https",
+        },
+    ).json()
+
+    assert "recent_requests" not in spoofed
+    assert "request_logs" not in spoofed
+    assert "config" not in spoofed
+
+
 def test_dashboard_client_cidr_rejects_unlisted_clients_and_hostname_hosts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_proxy_project_savings.py
+++ b/tests/test_proxy_project_savings.py
@@ -122,6 +122,7 @@ def test_tracker_accumulates_per_project_and_persists(tmp_path):
     # Survives a restart via the persisted JSON state.
     reloaded = SavingsTracker(path=str(path))
     assert reloaded.stats_preview()["projects"]["api"]["tokens_saved"] == 500
+    assert reloaded.lifetime_response()["projects"]["api"]["tokens_saved"] == 500
 
 
 def test_tracker_migrates_v2_state_without_projects(tmp_path):

--- a/tests/test_proxy_stats_recent_requests.py
+++ b/tests/test_proxy_stats_recent_requests.py
@@ -81,7 +81,7 @@ def test_stats_refreshes_recent_requests_when_cached() -> None:
         assert second_response.status_code == 200
         second_payload = second_response.json()
 
-    assert second_payload["recent_requests"][-1]["model"] == "claude-sonnet"
+    assert second_payload["recent_requests"][0]["model"] == "claude-sonnet"
     assert second_payload["request_logs"][-1]["model"] == "claude-sonnet"
 
 
@@ -148,18 +148,18 @@ def test_stats_recent_requests_includes_token_incomplete_requests() -> None:
     assert response.status_code == 200
     payload = response.json()
     assert [req["model"] for req in payload["recent_requests"]] == [
-        "claude-haiku",
-        "claude-haiku",
         "claude-sonnet",
+        "claude-haiku",
+        "claude-haiku",
     ]
-    assert payload["recent_requests"][0]["input_tokens_optimized"] is None
-    assert payload["recent_requests"][0]["token_accounting_status"] == "missing"
-    assert payload["recent_requests"][0]["has_exact_tokens"] is False
+    assert payload["recent_requests"][0]["token_accounting_status"] == "complete"
+    assert payload["recent_requests"][0]["has_exact_tokens"] is True
     assert payload["recent_requests"][1]["output_tokens"] is None
     assert payload["recent_requests"][1]["token_accounting_status"] == "partial"
     assert payload["recent_requests"][1]["tokens_saved"] == 0
-    assert payload["recent_requests"][2]["token_accounting_status"] == "complete"
-    assert payload["recent_requests"][2]["has_exact_tokens"] is True
+    assert payload["recent_requests"][2]["input_tokens_optimized"] is None
+    assert payload["recent_requests"][2]["token_accounting_status"] == "missing"
+    assert payload["recent_requests"][2]["has_exact_tokens"] is False
     assert payload["summary"]["uncompressed_requests"]["unknown_token_accounting"] == 2
     assert payload["request_logs"][-1]["model"] == "claude-sonnet"
 


### PR DESCRIPTION
## Description

Persist bounded, aggregate-only Lifetime dashboard metrics across proxy restarts and expose them through a new `/stats-lifetime` endpoint. The change keeps session/runtime stats separate from durable lifetime stats, gates sensitive dashboard metadata for loopback or explicitly trusted dashboard clients, and updates the dashboard Lifetime view to consume the new endpoint.

Closes #2137

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring (no functional changes)

## Changes Made

- Added bounded persistent lifetime metrics state and wired proxy metric events into it.
- Added `/stats-lifetime` with sensitive project/persistence details gated behind dashboard metadata access checks.
- Extended loopback/dashboard metadata access policy for trusted dashboard client CIDRs without widening admin/debug endpoints.
- Reorganized dashboard session/lifetime presentation around runtime counters versus durable aggregates.
- Added focused tests for persistent aggregation, persistence, endpoint registration, loopback gating, trusted dashboard CIDRs, and recent request ordering.
- Fixed current Ruff/mypy issues in the lifetime metrics normalization code.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
uv run --extra proxy --with pytest --with pytest-asyncio pytest tests/test_persistent_metrics.py tests/test_persistent_metrics_integration.py tests/test_persistent_metrics_persistence.py tests/test_proxy_loopback_gating.py tests/test_proxy_stats_recent_requests.py -q
53 passed, 1 warning

uvx ruff==0.15.17 check headroom/proxy/forwarded_headers.py headroom/proxy/loopback_guard.py headroom/proxy/persistent_metrics.py headroom/proxy/savings_tracker.py headroom/proxy/server.py tests/test_forwarded_headers.py tests/test_persistent_metrics.py tests/test_persistent_metrics_integration.py tests/test_persistent_metrics_persistence.py tests/test_proxy_loopback_gating.py tests/test_proxy_project_savings.py tests/test_proxy_stats_recent_requests.py
All checks passed!

uv run --extra proxy --with mypy mypy headroom/proxy/persistent_metrics.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows review worktree, Python 3.13.3 via uv.
- Exact command / steps: Ran the focused persistent metrics, persistence, loopback gating, and recent request tests; ran CI-matching Ruff on touched files; ran mypy on the new persistent metrics module.
- Observed result: `/stats-lifetime` is registered, non-loopback callers receive only non-sensitive aggregate data, loopback/trusted dashboard clients receive the full lifetime payload, admin/debug endpoints remain loopback-only, and persistent metrics normalize malformed stored state without type/lint errors.
- Not tested: Full repository pytest suite, full dashboard browser screenshot pass, or live long-running proxy traffic.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

No changelog entry is required for this dashboard/internal metrics iteration. The endpoint intentionally exposes only aggregate lifetime data to ordinary network callers and strips project/persistence details unless the caller passes the dashboard metadata access policy.