### PR TITLE
fix(mcp): sync server descriptor version

### DIFF
--- a/server.json
+++ b/server.json
@@ -9,13 +9,13 @@
     "source": "github",
     "id": "1129940957"
   },
-  "version": "0.31.0",
+  "version": "0.32.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "headroom-ai",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         {


### PR DESCRIPTION
## Description

Synchronizes the canonical root MCP server descriptor with the project version introduced by #2175.

Current main CI fails at tests/test_mcp_registry/test_server_json.py::test_root_server_json_matches_builder because pyproject.toml and uv.lock report 0.32.0 while server.json still reports 0.31.0.

Main failure: https://github.com/headroomlabs-ai/headroom/actions/runs/29387103614

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- Update the top-level MCP server version to 0.32.0.
- Update the PyPI package version in the same descriptor to 0.32.0.

## Testing

- [x] tests/test_mcp_registry/test_server_json.py: 4 passed
- [x] git diff --check

## Real Behavior Proof

- Before: render_server_json() derives 0.32.0 from project metadata, but the committed descriptor contains 0.31.0.
- After: the committed descriptor is byte-identical to render_server_json().

## Review Readiness

- [x] The change is intentionally limited to the generated publication descriptor.
- [x] This Draft is ready for maintainer confirmation of the release version.

## Checklist

- [x] I have performed a self-review.
- [x] Existing focused tests pass.
- [x] The change contains no credentials or environment-specific data.
