### PR TITLE
fix(diff-compressor): CJK-aware relevance scoring for hunk selection

### DIFF
--- a/crates/headroom-core/src/transforms/diff_compressor.rs
+++ b/crates/headroom-core/src/transforms/diff_compressor.rs
@@ -35,7 +35,7 @@
 //! method returns it alongside the parity-equal result; `compress` is the
 //! parity-only API that just emits a `tracing::info_span`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::OnceLock;
 use std::time::Instant;
 
@@ -840,9 +840,42 @@ fn priority_patterns() -> &'static [Regex] {
     })
 }
 
+/// True for CJK ideographs, kana, and Hangul.
+fn is_cjk_char(c: char) -> bool {
+    matches!(
+        c as u32,
+        0x3040..=0x30FF | 0x3400..=0x4DBF | 0x4E00..=0x9FFF | 0xAC00..=0xD7AF | 0xF900..=0xFAFF
+    )
+}
+
+/// CJK character bigrams from the CJK runs of a (lowercased) query. A spaceless
+/// CJK query rarely appears verbatim in a hunk, but its bigrams do, so these let
+/// a CJK query still boost the hunks it partially overlaps.
+fn cjk_bigrams(text: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let mut run: Vec<char> = Vec::new();
+    for c in text.chars() {
+        if is_cjk_char(c) {
+            run.push(c);
+        } else {
+            for w in run.windows(2) {
+                out.insert(w.iter().collect::<String>());
+            }
+            run.clear();
+        }
+    }
+    for w in run.windows(2) {
+        out.insert(w.iter().collect::<String>());
+    }
+    out
+}
+
 fn score_hunks(files: &mut [DiffFile], context: &str) {
     let context_lower = context.to_lowercase();
     let context_words: Vec<&str> = context_lower.split_whitespace().collect();
+    // Spaceless CJK queries don't survive whitespace-splitting into matchable
+    // words; add CJK character bigrams so they can still boost overlapping hunks.
+    let cjk_bg = cjk_bigrams(&context_lower);
 
     for file in files.iter_mut() {
         for hunk in file.hunks.iter_mut() {
@@ -857,6 +890,11 @@ fn score_hunks(files: &mut [DiffFile], context: &str) {
 
             for word in &context_words {
                 if word.len() > SCORE_CONTEXT_MIN_WORD_LEN && hunk_content_lower.contains(word) {
+                    score += SCORE_CONTEXT_WORD_WEIGHT;
+                }
+            }
+            for bg in &cjk_bg {
+                if hunk_content_lower.contains(bg.as_str()) {
                     score += SCORE_CONTEXT_WORD_WEIGHT;
                 }
             }
@@ -1515,6 +1553,58 @@ mod tests {
             r.compressed.contains("rename to new.py"),
             "missing 'rename to':\n{}",
             r.compressed
+        );
+    }
+
+    #[test]
+    fn cjk_bigrams_from_query_runs() {
+        let b = cjk_bigrams("数据库连接");
+        assert!(
+            b.contains("数据") && b.contains("据库") && b.contains("库连") && b.contains("连接")
+        );
+        assert_eq!(b.len(), 4);
+        assert!(cjk_bigrams("hello world").is_empty()); // ASCII -> no CJK bigrams
+        assert!(cjk_bigrams("a数b据").is_empty()); // isolated CJK chars -> no pair
+    }
+
+    #[test]
+    fn cjk_query_boosts_matching_hunk_into_kept_set() {
+        // Two competing middle hunks, one middle slot. The plain hunk has the
+        // higher change-density base score, so WITHOUT a query it takes the
+        // slot; a CJK query overlapping the CJK hunk boosts it past the plain one.
+        let input = "diff --git a/svc.py b/svc.py\n\
+                     --- a/svc.py\n\
+                     +++ b/svc.py\n\
+                     @@ -1,2 +1,2 @@\n\
+                     -first_old\n\
+                     +first_new\n\
+                     @@ -10,4 +10,4 @@\n\
+                     -plain_a\n\
+                     +plain_b\n\
+                     -plain_c\n\
+                     +plain_d\n\
+                     @@ -20,2 +20,2 @@\n\
+                     -数据库连接失败重试\n\
+                     +数据库连接成功\n\
+                     @@ -30,2 +30,2 @@\n\
+                     -last_old\n\
+                     +last_new\n";
+        let mk = || DiffCompressorConfig {
+            max_hunks_per_file: 3,
+            min_lines_for_ccr: 5,
+            ..Default::default()
+        };
+        let with_cjk = DiffCompressor::new(mk()).compress(input, "数据库连接超时排查");
+        let no_query = DiffCompressor::new(mk()).compress(input, "");
+        assert!(
+            with_cjk.compressed.contains("数据库连接失败重试"),
+            "CJK query should boost the overlapping hunk into the kept set:\n{}",
+            with_cjk.compressed
+        );
+        assert!(
+            !no_query.compressed.contains("数据库连接失败重试"),
+            "without a query the higher-density plain hunk should take the middle slot:\n{}",
+            no_query.compressed
         );
     }
 


### PR DESCRIPTION
## Description

`score_hunks` boosts diff hunks whose content overlaps the query/context (+`SCORE_CONTEXT_WORD_WEIGHT` per match); the resulting score decides which hunks survive when `max_hunks_per_file` fires. It split the context on whitespace, so a spaceless CJK query became one blob that only matched a hunk containing the whole query verbatim — relevant hunks weren't boosted and got dropped.

This adds CJK character bigrams to the query match set so a CJK query boosts the hunks it overlaps. Rust-only (`diff_compressor.py` is a thin shim over Rust; hunk scoring lives only in Rust). CJK-gated: for a pure-ASCII query `cjk_bigrams` returns an empty set and the new loop is a no-op, so non-CJK scoring is byte-identical and the 20 diff parity fixtures stay green.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `crates/headroom-core/src/transforms/diff_compressor.rs`: add `is_cjk_char` + `cjk_bigrams`, and a separate loop in `score_hunks` that boosts hunks containing each CJK query bigram. The existing ASCII word loop is untouched.
- Rust unit test (`cjk_bigrams` extraction) + an end-to-end test (a CJK query promotes the overlapping hunk into the kept set; the no-query baseline drops it).

## Testing

- [x] Unit tests pass (`cargo test`)
- [x] Linting passes (`cargo clippy` / `cargo fmt`)
- [x] New tests added for new functionality
- [x] Manual testing performed (see Real Behavior Proof)

### Test Output

```text
$ cargo test -p headroom-core --lib diff_compressor
test result: ok. 23 passed; 0 failed

$ cargo clippy -p headroom-core   # clean
```

## Real Behavior Proof

- Environment: macOS (Darwin), Rust via cargo, branch `feat/diff-compressor-cjk` off `main`.
- Exact command / steps: `cargo test -p headroom-core --lib diff_compressor` — the `cjk_query_boosts_matching_hunk_into_kept_set` test builds a diff with 4 hunks (first / plain / cjk / last), `max_hunks_per_file = 3` (one contested middle slot between the plain hunk at change-density `0.12` and the CJK hunk at `0.06`), and compresses it once with the CJK context `数据库连接超时排查` and once with no query.
- Observed result: with no query the higher-density plain hunk takes the slot (the CJK hunk `数据库连接失败重试` is dropped); with the CJK context its bigrams (`数据` / `据库` / `库连` / `连接`) match → score `0.06 + 4×0.2 = 0.86` beats the plain hunk's `0.12` → the CJK hunk survives. Both directions are asserted; before this change the spaceless CJK query matched neither hunk and the CJK hunk was always dropped.
- Not tested: the Python side — `diff_compressor.py` is a thin shim that delegates `compress()` straight to Rust, so hunk scoring has no Python twin; and no new parity fixtures were recorded, since the 20 existing diff fixtures contain no CJK and therefore stay byte-identical.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A (internal scoring)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md — N/A: internal relevance-scoring fix, no user-facing surface change

## Additional Notes

- Completes the relevance-scorer CJK sweep across the compressors (search, adaptive sizer, the shared BM25 tokenizer, and now diff). Rust-only — no Python parity mirror is needed because diff hunk scoring has no Python twin (the shim delegates `compress()` straight to Rust).
