### PR TITLE
docs(ccr): correct stale 5-minute TTL hints to 30 minutes

### DIFF
--- a/crates/headroom-core/src/ccr/backends/in_memory.rs
+++ b/crates/headroom-core/src/ccr/backends/in_memory.rs
@@ -20,7 +20,7 @@ use crate::ccr::{CcrStore, DEFAULT_CAPACITY, DEFAULT_TTL};
 /// In-memory CCR store backed by [`DashMap`] for sharded concurrent
 /// access.
 ///
-/// - **TTL**: 5 minutes by default. Entries past their TTL are dropped
+/// - **TTL**: 30 minutes by default. Entries past their TTL are dropped
 ///   on the next `get` (lazy expiry — no background reaper thread).
 /// - **Capacity**: 1000 entries by default. When `put` would push us
 ///   past capacity, the oldest entry (per insertion order) is evicted.
@@ -46,7 +46,7 @@ struct Entry {
 }
 
 impl InMemoryCcrStore {
-    /// Default: 1000 entries, 5-minute TTL.
+    /// Default: 1000 entries, 30-minute TTL.
     pub fn new() -> Self {
         Self::with_capacity_and_ttl(DEFAULT_CAPACITY, DEFAULT_TTL)
     }

--- a/crates/headroom-core/src/ccr/backends/mod.rs
+++ b/crates/headroom-core/src/ccr/backends/mod.rs
@@ -42,7 +42,7 @@ pub enum CcrBackendConfig {
 }
 
 impl CcrBackendConfig {
-    /// Production default: SQLite at `path`, 5-minute TTL.
+    /// Production default: SQLite at `path`, 30-minute TTL.
     pub fn sqlite_default(path: PathBuf) -> Self {
         Self::Sqlite {
             path,

--- a/crates/headroom-core/src/ccr/backends/sqlite.rs
+++ b/crates/headroom-core/src/ccr/backends/sqlite.rs
@@ -49,7 +49,7 @@ use crate::ccr::CcrStore;
 pub struct SqliteCcrStore {
     conn: Mutex<Connection>,
     /// Default TTL applied on every `put`. Mirrors Python's
-    /// `compression_store` 5-minute window.
+    /// `compression_store` 30-minute window.
     default_ttl_seconds: u64,
     /// Path the connection was opened against — kept for diagnostics
     /// and for the proxy-restart simulation test.

--- a/headroom/transforms/smart_crusher.py
+++ b/headroom/transforms/smart_crusher.py
@@ -1144,7 +1144,7 @@ class SmartCrusher(Transform):
         except Exception as e:  # pragma: no cover - defensive
             logger.debug("CCR mirror: cannot get compression_store (%s)", e)
             return
-        # The TTL on the Python store defaults to 5 minutes — same as
+        # The TTL on the Python store defaults to 30 minutes — same as
         # the Rust store's `DEFAULT_TTL` (see crates/headroom-core/src/
         # ccr/mod.rs). No need to override.
         try:

--- a/plugins/openclaw/src/tools/headroom-retrieve.ts
+++ b/plugins/openclaw/src/tools/headroom-retrieve.ts
@@ -62,7 +62,7 @@ export function createHeadroomRetrieveTool(config: RetrieveToolConfig) {
       } catch (error) {
         return JSON.stringify({
           error: `Retrieval failed: ${error}`,
-          hint: "The compressed content may have expired (default TTL: 5 minutes)",
+          hint: "The compressed content may have expired (default TTL: 30 minutes)",
         });
       }
     },

--- a/plugins/opencode/src/retrieve.ts
+++ b/plugins/opencode/src/retrieve.ts
@@ -64,7 +64,7 @@ export function createHeadroomRetrieveTool(config: RetrieveToolConfig) {
       } catch (error) {
         return JSON.stringify({
           error: `Retrieval failed: ${error}`,
-          hint: "The compressed content may have expired (default TTL: 5 minutes)",
+          hint: "The compressed content may have expired (default TTL: 30 minutes)",
         });
       }
     },


### PR DESCRIPTION
## Description

The CCR store default TTL is `DEFAULT_TTL = 1800s` (30 minutes — see `crates/headroom-core/src/ccr/mod.rs` and `config.py store_ttl_seconds=1800`), but several user-facing hints and docstrings still said "5 minutes", the old default. The opencode/openclaw retrieve tools surfaced `(default TTL: 5 minutes)` in their expiry hint — exactly the misleading message reported in #1023. (The CCR cache itself works; the row-drop store bridge that populates the retrieve store landed for #389.)

This corrects the two plugin hints, the `InMemoryCcrStore` docstrings, the SQLite/backend default TTL comments, and the `smart_crusher` mirror comment. The `mod.rs` comment that references "the *old* 5-minute default" is intentionally left unchanged — it correctly describes history.

## Type of Change

- [x] Documentation update

## Changes Made

- `plugins/openclaw/src/tools/headroom-retrieve.ts` + `plugins/opencode/src/retrieve.ts`: retrieve-failure hint `5 minutes` → `30 minutes`.
- `crates/headroom-core/src/ccr/backends/in_memory.rs`: two docstrings (`5 minutes by default`, `5-minute TTL`) → `30 minutes` / `30-minute`.
- `crates/headroom-core/src/ccr/backends/mod.rs` + `sqlite.rs`: SQLite/default backend TTL comments `5-minute` → `30-minute`.
- `headroom/transforms/smart_crusher.py`: mirror comment `defaults to 5 minutes` → `30 minutes`.

## Testing

- [x] Linting passes (`ruff` / `cargo check`)
- [x] Manual verification (see Real Behavior Proof)

### Test Output

```text
$ ruff format --check headroom/transforms/smart_crusher.py   # clean
$ cargo check -p headroom-core                                # Finished, no errors
```

## Real Behavior Proof

- Environment: macOS (Darwin), branch `feat/ccr-ttl-hint-fix` off `main`.
- Exact command / steps: grepped every `5 minutes` / `5-minute` TTL reference across the repo; confirmed the real default is `DEFAULT_TTL = Duration::from_secs(1800)` (`ccr/mod.rs:66`), that `InMemoryCcrStore::new()` uses `DEFAULT_TTL` (not a local 300s), and that `config.py` sets `store_ttl_seconds = 1800  # 30 minutes`.
- Observed result: all stale CCR default-TTL "5 minutes" references now read "30 minutes"; the one historical reference (`mod.rs`: "the old 5-minute default") is left as-is because it is accurate.
- Not tested: nothing runtime changed — these are docstring/comment/hint string edits only, so there is no behavior to exercise.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code — N/A (this PR is comments/strings)
- [x] I have made corresponding changes to the documentation (this *is* the doc change)
- [x] My changes generate no new warnings
- [ ] I have added tests — N/A (no behavior change)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md — N/A: user-facing hint/docstring correction, no functional change

## Additional Notes

- Surfaced while root-causing #1023: the "cache permanently empty / TTL: 5 minutes" report is resolved on `main` (the store-bridge for #389 populates the retrieve store), but the stale "5 minutes" strings the reporter actually saw were still in the tree. This PR fixes those.

