### PR TITLE
fix(claude): treat non-zero claude --version exit as version-unknown …

### DIFF
--- a/headroom/providers/claude/runtime.py
+++ b/headroom/providers/claude/runtime.py
@@ -218,6 +218,13 @@ def detect_claude_code_version(claude_bin: str | None = None) -> tuple[int, int,
         proc = run([binary, "--version"], capture_output=True, text=True, timeout=10)
     except (OSError, subprocess.SubprocessError):
         return None
+    # A non-zero exit is a detection failure, per this function's contract: a
+    # failing `claude --version` may still print a version-shaped string, and
+    # trusting it would surface a false *exact*-version warning instead of the
+    # self-qualified "2.1.196+ / unknown" path the callers rely on. getattr with
+    # a success default keeps stubbed CompletedProcess objects working.
+    if getattr(proc, "returncode", 0) != 0:
+        return None
     # getattr, not attribute access: a stubbed CompletedProcess (e.g. a test's
     # SimpleNamespace) may lack stdout/stderr — degrade to "unknown", never raise.
     stdout = getattr(proc, "stdout", "") or ""

--- a/tests/test_issue_1779_remote_control_gate.py
+++ b/tests/test_issue_1779_remote_control_gate.py
@@ -168,6 +168,23 @@ def test_detect_claude_code_version_parses_wrapper_output(monkeypatch) -> None:
     assert detect_claude_code_version("claude") == (2, 1, 196)
 
 
+def test_detect_claude_code_version_nonzero_exit_is_none(monkeypatch) -> None:
+    # Review follow-up (PR #1883, @JerrettDavis): a non-zero exit is a detection
+    # failure even when the failing command still prints a version-shaped string.
+    # Trusting it would emit a false *exact*-version Remote Control warning
+    # instead of the self-qualified "2.1.196+ / unknown" path. Must return None.
+    from types import SimpleNamespace
+
+    import headroom._subprocess as _sub
+
+    monkeypatch.setattr(
+        _sub,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="2.1.196 (Claude Code)\n", stderr=""),
+    )
+    assert detect_claude_code_version("claude") is None
+
+
 # ---------------------------------------------------------------------------
 # Sibling co-report (#746 / #1158)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Treat a non-zero `claude --version` exit as an unknown Claude Code version, even if the failing command prints a version-shaped string to stdout or stderr.

This is a follow-up to the Remote Control gate work for #1779/#1883. The callers rely on `None` to use the self-qualified "2.1.196+ / unknown" warning path; accepting a version from a failed command can produce a false exact-version warning.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/providers/claude/runtime.py`: return `None` from `detect_claude_code_version` when the `claude --version` subprocess has a non-zero return code.
- `tests/test_issue_1779_remote_control_gate.py`: add a regression test where a failing process still prints `2.1.196 (Claude Code)` and must be treated as unknown.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ uv run pytest tests/test_issue_1779_remote_control_gate.py -q
50 passed

$ uvx ruff==0.15.17 check headroom/providers/claude/runtime.py tests/test_issue_1779_remote_control_gate.py --output-format concise
All checks passed!

$ uvx ruff==0.15.17 format --check headroom/providers/claude/runtime.py tests/test_issue_1779_remote_control_gate.py
2 files already formatted
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12/3.13 test environment, local checkout of this PR branch.
- Exact command / steps: ran the focused Remote Control gate test file, including the new regression that stubs `claude --version` as `returncode=1` with version-shaped stdout.
- Observed result: `detect_claude_code_version("claude")` returns `None` for the failed command, preserving the unknown-version path; existing parser/gate tests still pass.
- Not tested: an actual failing Claude Code binary invocation on a user machine; the subprocess behavior is covered by the regression stub.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
