### PR TITLE
fix(proxy): record Prometheus metrics for POST /v1/compress

### DIFF
--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -7646,6 +7646,11 @@ class OpenAIHandlerMixin:
                 }
             )
 
+        start_time = time.time()
+        headers = dict(request.headers)
+        tags = extract_tags(headers)
+        client = classify_client(headers)
+
         try:
             # Use OpenAI pipeline (messages are in OpenAI format from TS SDK)
             # Allow optional token_budget to override model's context limit
@@ -7690,6 +7695,33 @@ class OpenAIHandlerMixin:
                 timeout=COMPRESSION_TIMEOUT_SECONDS,
             )
 
+            tokens_before = result.tokens_before
+            tokens_after = result.tokens_after
+            tokens_saved = max(0, tokens_before - tokens_after)
+            latency_ms = (time.time() - start_time) * 1000
+            await self._record_request_outcome(
+                RequestOutcome(
+                    request_id=(
+                        await self._next_request_id()
+                        if hasattr(self, "_next_request_id")
+                        else f"compress_{int(time.time())}"
+                    ),
+                    provider="compress",
+                    model=model if isinstance(model, str) else str(model),
+                    original_tokens=tokens_before,
+                    optimized_tokens=tokens_after,
+                    output_tokens=0,
+                    tokens_saved=tokens_saved,
+                    attempted_input_tokens=tokens_before,
+                    total_latency_ms=latency_ms,
+                    overhead_ms=latency_ms,
+                    num_messages=len(messages) if isinstance(messages, list) else 0,
+                    transforms_applied=tuple(result.transforms_applied or ()),
+                    tags=tags,
+                    client=client,
+                )
+            )
+
             return JSONResponse(
                 {
                     "messages": result.messages,
@@ -7711,6 +7743,29 @@ class OpenAIHandlerMixin:
                 "Compression timed out after %.0fs; failing open with original messages",
                 COMPRESSION_TIMEOUT_SECONDS,
             )
+            self.metrics.record_compression_failed("timeout")
+            latency_ms = (time.time() - start_time) * 1000
+            await self._record_request_outcome(
+                RequestOutcome(
+                    request_id=(
+                        await self._next_request_id()
+                        if hasattr(self, "_next_request_id")
+                        else f"compress_{int(time.time())}"
+                    ),
+                    provider="compress",
+                    model=model if isinstance(model, str) else str(model),
+                    original_tokens=0,
+                    optimized_tokens=0,
+                    output_tokens=0,
+                    tokens_saved=0,
+                    attempted_input_tokens=0,
+                    total_latency_ms=latency_ms,
+                    overhead_ms=latency_ms,
+                    num_messages=len(messages) if isinstance(messages, list) else 0,
+                    tags=tags,
+                    client=client,
+                )
+            )
             return JSONResponse(
                 content={
                     "messages": messages,
@@ -7727,6 +7782,7 @@ class OpenAIHandlerMixin:
             )
         except Exception as e:
             logger.exception("Compression failed: %s", e)
+            await self.metrics.record_failed(provider="compress")
             return JSONResponse(
                 status_code=503,
                 content={

--- a/tests/test_proxy_compress_endpoint.py
+++ b/tests/test_proxy_compress_endpoint.py
@@ -5,6 +5,8 @@ for the TypeScript SDK and other HTTP clients.
 """
 
 import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -250,6 +252,100 @@ class TestCompressEndpointCompression:
         assert data["tokens_before"] >= 0
         assert data["tokens_after"] >= 0
         assert isinstance(data["transforms_applied"], list)
+
+    def test_success_records_request_outcome(self, client, monkeypatch):
+        """A completed compression should update request metrics."""
+        proxy = client.app.state.proxy
+        result = SimpleNamespace(
+            messages=[{"role": "user", "content": "compressed"}],
+            tokens_before=12,
+            tokens_after=7,
+            transforms_applied=["test_transform"],
+            transforms_summary={"test_transform": 1},
+            markers_inserted=[],
+        )
+        run_compression = AsyncMock(return_value=result)
+        record_outcome = AsyncMock()
+        monkeypatch.setattr(proxy, "_run_compression_in_executor", run_compression)
+        monkeypatch.setattr(proxy, "_record_request_outcome", record_outcome)
+
+        response = client.post(
+            "/v1/compress",
+            json={
+                "messages": [{"role": "user", "content": "compress me"}],
+                "model": "gpt-4",
+            },
+        )
+
+        assert response.status_code == 200
+        record_outcome.assert_awaited_once()
+        outcome = record_outcome.await_args.args[0]
+        assert outcome.provider == "compress"
+        assert outcome.model == "gpt-4"
+        assert outcome.original_tokens == 12
+        assert outcome.optimized_tokens == 7
+        assert outcome.tokens_saved == 5
+        assert outcome.attempted_input_tokens == 12
+        assert outcome.num_messages == 1
+        assert outcome.transforms_applied == ("test_transform",)
+        assert outcome.total_latency_ms >= 0
+
+    def test_compression_error_records_failed_request(self, client, monkeypatch):
+        """A hard compression failure should increment failed metrics."""
+        proxy = client.app.state.proxy
+        run_compression = AsyncMock(side_effect=RuntimeError("compression broke"))
+        record_failed = AsyncMock()
+        monkeypatch.setattr(proxy, "_run_compression_in_executor", run_compression)
+        monkeypatch.setattr(proxy.metrics, "record_failed", record_failed)
+
+        response = client.post(
+            "/v1/compress",
+            json={
+                "messages": [{"role": "user", "content": "compress me"}],
+                "model": "gpt-4",
+            },
+        )
+
+        assert response.status_code == 503
+        assert response.json() == {
+            "error": {
+                "type": "compression_error",
+                "message": "compression broke",
+            }
+        }
+        record_failed.assert_awaited_once_with(provider="compress")
+
+    def test_compression_timeout_records_fail_open_outcome(self, client, monkeypatch):
+        """A timeout should count as a zero-savings completed request."""
+        proxy = client.app.state.proxy
+        run_compression = AsyncMock(side_effect=TimeoutError)
+        record_outcome = AsyncMock()
+        record_compression_failed = Mock()
+        monkeypatch.setattr(proxy, "_run_compression_in_executor", run_compression)
+        monkeypatch.setattr(proxy, "_record_request_outcome", record_outcome)
+        monkeypatch.setattr(
+            proxy.metrics,
+            "record_compression_failed",
+            record_compression_failed,
+        )
+        messages = [{"role": "user", "content": "compress me"}]
+
+        response = client.post(
+            "/v1/compress",
+            json={"messages": messages, "model": "gpt-4"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["messages"] == messages
+        assert response.json()["skip_reason"] == "compression_timeout"
+        record_compression_failed.assert_called_once_with("timeout")
+        record_outcome.assert_awaited_once()
+        outcome = record_outcome.await_args.args[0]
+        assert outcome.provider == "compress"
+        assert outcome.model == "gpt-4"
+        assert outcome.original_tokens == 0
+        assert outcome.optimized_tokens == 0
+        assert outcome.tokens_saved == 0
 
 
 class TestCompressEndpointDoesNotBlockLoop:


### PR DESCRIPTION
## Description

`POST /v1/compress` compressed messages correctly but never recorded Prometheus business metrics. Standalone compress microservice deployments (including LiteLLM `guardrail: headroom`) left `headroom_requests_total`, token counters, latency, and by_model/by_provider families at zero.

This wires the existing request-outcome funnel into `handle_compress` so success and timeout paths update the same counters as reverse-proxy handlers, and hard failures call `record_failed`.

Closes #2244

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- On successful compression, record a `RequestOutcome` with `provider="compress"`, model, token before/after/saved, latency, transforms, tags, and client.
- On compression timeout (fail-open), record zero-savings outcome plus `record_compression_failed("timeout")`.
- On hard compression errors (503), call `metrics.record_failed(provider="compress")`.
- Leave bypass header and empty-message early returns unrecorded (no real compression work).
- Response schemas and status codes unchanged.
- Add regression tests for success, timeout, and hard-failure metric recording.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
uv run pytest tests/test_proxy_compress_endpoint.py -q
# 16 passed

uv run ruff check headroom/proxy/handlers/openai.py tests/test_proxy_compress_endpoint.py
# passed
```

## Real Behavior Proof

- Environment: local checkout of this branch; FastAPI TestClient fixtures for `/v1/compress` (loopback client)
- Exact command / steps:
  - `uv run pytest tests/test_proxy_compress_endpoint.py -q`
  - `uv run ruff check headroom/proxy/handlers/openai.py tests/test_proxy_compress_endpoint.py`
- Observed result:
  - Success path awaits `_record_request_outcome` with `tokens_saved = max(0, before-after)` and `provider="compress"`
  - Timeout path records zero-savings outcome and `record_compression_failed("timeout")`
  - Hard failure path awaits `record_failed(provider="compress")` and still returns 503
- Not tested: live multi-process scrape of `GET /metrics` while a real headroom process handles LiteLLM guardrail POSTs

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

- Focused compress endpoint suite only; full-repo mypy was not run.
- No public API or response-schema changes.
