### PR TITLE
fix: replace computer_call_output with apply_patch_call_output in output_shaper

### DIFF
--- a/headroom/proxy/output_shaper.py
+++ b/headroom/proxy/output_shaper.py
@@ -364,10 +364,10 @@ _RESPONSES_EFFORT_RANK = {"minimal": 0, "low": 1, "medium": 2, "high": 3, "xhigh
 # model — the Responses counterpart of an Anthropic ``tool_result`` block.
 _RESPONSES_TOOL_OUTPUT_TYPES = frozenset(
     {
-        "function_call_output",
         "custom_tool_call_output",
+        "function_call_output",
         "local_shell_call_output",
-        "computer_call_output",
+        "apply_patch_call_output",
     }
 )
 

--- a/tests/test_output_shaper_responses.py
+++ b/tests/test_output_shaper_responses.py
@@ -75,6 +75,10 @@ class TestClassifyResponsesTurn:
         items = _mechanical_input()[:-1] + [_fn_output(item_type="custom_tool_call_output")]
         assert classify_responses_turn(items) == TurnKind.MECHANICAL_CONTINUATION
 
+    def test_apply_patch_call_output_is_mechanical(self):
+        items = _mechanical_input()[:-1] + [_fn_output(item_type="apply_patch_call_output")]
+        assert classify_responses_turn(items) == TurnKind.MECHANICAL_CONTINUATION
+
     def test_trailing_user_message_is_new_ask(self):
         items = _mechanical_input() + [_user_message("also check bar.py")]
         assert classify_responses_turn(items) == TurnKind.NEW_USER_ASK


### PR DESCRIPTION
The _RESPONSES_TOOL_OUTPUT_TYPES frozenset in output_shaper.py had computer_call_output instead of apply_patch_call_output, making it inconsistent with the canonical definitions in handlers/openai.py and output_turn_policy.py. This caused apply_patch_call_output items to be misclassified, preventing effort routing optimization for those turns.