### PR TITLE
fix(compression): stop JSON truncation fallback from splitting escape pairs

### DIFF
--- a/headroom/compression/universal.py
+++ b/headroom/compression/universal.py
@@ -198,25 +198,34 @@ class UniversalCompressor:
 
     @staticmethod
     def _safe_truncate_boundary(text: str, pos: int) -> int:
-        """Nudge a truncation boundary past a backslash escape pair it would split.
+        """Nudge a truncation boundary to the next position that doesn't split
+        a JSON backslash escape.
 
         A span passed here may be raw JSON string content (quotes and escapes
-        intact, not decoded), so cutting between a backslash and the character
-        it escapes (e.g. "...\\" | "n..." -> a dangling "\\") produces invalid
-        JSON. Counting the run of backslashes immediately before `pos` is
-        enough to tell: an odd run means `pos` sits mid-escape (including
-        mid "\\uXXXX", though only the first character of the pair is
-        realigned there), an even run means every backslash before `pos`
-        already pairs off cleanly.
+        intact, not decoded), so cutting inside an escape - a 2-character form
+        like "\\n"/"\\""/"\\\\", or the 6-character "\\uXXXX" unicode form -
+        produces invalid JSON (a dangling backslash, or a truncated \\u with
+        fewer than 4 hex digits).
+
+        Walks `text` as a sequence of JSON string tokens from the start,
+        treating "\\" + the next character as one atomic unit (expanded to 6
+        characters when that next character is "u"), and returns the first
+        token boundary at or after `pos`. Backslash-run parity alone isn't
+        enough here: it correctly flags a split 2-character escape, but a cut
+        landing among the hex digits of "\\uXXXX" (after the "u", not
+        immediately after the backslash) has no backslash immediately before
+        it at all, so a purely backward-looking check misses it.
         """
         if pos <= 0 or pos >= len(text):
             return pos
-        backslash_run = 0
-        i = pos - 1
-        while i >= 0 and text[i] == "\\":
-            backslash_run += 1
-            i -= 1
-        return pos + 1 if backslash_run % 2 == 1 else pos
+        i = 0
+        n = len(text)
+        while i < pos:
+            if text[i] == "\\" and i + 1 < n:
+                i += 6 if text[i + 1] == "u" else 2
+            else:
+                i += 1
+        return i
 
     def _simple_compress(self, text: str) -> str:
         """Simple compression fallback (truncation with indicator).

--- a/headroom/compression/universal.py
+++ b/headroom/compression/universal.py
@@ -196,6 +196,28 @@ class UniversalCompressor:
             logger.warning("Kompress compression failed: %s", e)
             return self._simple_compress(text)
 
+    @staticmethod
+    def _safe_truncate_boundary(text: str, pos: int) -> int:
+        """Nudge a truncation boundary past a backslash escape pair it would split.
+
+        A span passed here may be raw JSON string content (quotes and escapes
+        intact, not decoded), so cutting between a backslash and the character
+        it escapes (e.g. "...\\" | "n..." -> a dangling "\\") produces invalid
+        JSON. Counting the run of backslashes immediately before `pos` is
+        enough to tell: an odd run means `pos` sits mid-escape (including
+        mid "\\uXXXX", though only the first character of the pair is
+        realigned there), an even run means every backslash before `pos`
+        already pairs off cleanly.
+        """
+        if pos <= 0 or pos >= len(text):
+            return pos
+        backslash_run = 0
+        i = pos - 1
+        while i >= 0 and text[i] == "\\":
+            backslash_run += 1
+            i -= 1
+        return pos + 1 if backslash_run % 2 == 1 else pos
+
     def _simple_compress(self, text: str) -> str:
         """Simple compression fallback (truncation with indicator).
 
@@ -214,6 +236,18 @@ class UniversalCompressor:
         # JSON string value, and a raw newline there produces invalid JSON.
         keep_start = target_len * 2 // 3
         keep_end = target_len // 3
+
+        # Same reasoning applies to where the cut itself falls: nudge both
+        # boundaries off a split backslash escape pair (e.g. a truncated
+        # "\n" or "\"") rather than just the separator between them. Cap the
+        # end boundary so a nudge can't zero out an originally-nonzero
+        # keep_end (text[-0:] is the whole string, not empty).
+        keep_start = self._safe_truncate_boundary(text, keep_start)
+        end_boundary = self._safe_truncate_boundary(text, len(text) - keep_end)
+        if keep_end > 0:
+            end_boundary = min(end_boundary, len(text) - 1)
+        keep_start = min(keep_start, end_boundary)
+        keep_end = len(text) - end_boundary
 
         return text[:keep_start] + " ...[compressed]... " + text[-keep_end:]
 

--- a/tests/test_compression/test_universal.py
+++ b/tests/test_compression/test_universal.py
@@ -397,3 +397,21 @@ class TestSecurityAuditRegressions:
             ).compress(payload, content_type=ContentType.JSON)
             assert "\n" not in res.compressed, f"raw newline leaked (use_kompress={use_kompress})"
             json.loads(res.compressed)  # must not raise
+
+    def test_sec03_json_fallback_does_not_split_escape_pair(self):
+        """SEC-03: the truncation cut itself must not land inside an escape pair.
+
+        SEC-02 fixed the separator between the kept portions; the boundaries of
+        the cut can independently land between a backslash and the character it
+        escapes (e.g. splitting "\\n" into a trailing "\\" plus "n..."), which is
+        just as invalid. Sweeps prefix lengths so the cut point lands on the
+        escape at least once regardless of the exact keep_start/keep_end math.
+        """
+        compressor = UniversalCompressor(
+            config=UniversalCompressorConfig(use_magika=False, use_kompress=False, ccr_enabled=False)
+        )
+        for prefix_len in range(90, 105):
+            payload_value = ("x" * prefix_len) + "\n" + ("y" * 200)
+            content = json.dumps({"msg": payload_value})
+            res = compressor.compress(content, content_type=ContentType.JSON)
+            json.loads(res.compressed)  # must not raise, regardless of prefix_len

--- a/tests/test_compression/test_universal.py
+++ b/tests/test_compression/test_universal.py
@@ -415,3 +415,22 @@ class TestSecurityAuditRegressions:
             content = json.dumps({"msg": payload_value})
             res = compressor.compress(content, content_type=ContentType.JSON)
             json.loads(res.compressed)  # must not raise, regardless of prefix_len
+
+    def test_sec04_json_fallback_does_not_split_unicode_escape(self):
+        """SEC-04: the truncation cut must not land inside a \\uXXXX escape.
+
+        SEC-03 covered the 2-character escapes (\\n, \\", \\\\); a non-ASCII
+        character serialized by json.dumps() (ensure_ascii=True by default)
+        becomes a 6-character \\uXXXX escape, and a cut landing among its hex
+        digits (not immediately after the backslash) is just as invalid, but
+        isn't caught by a backslash-run check alone. Sweeps prefix lengths so
+        the cut lands inside the escape at least once.
+        """
+        compressor = UniversalCompressor(
+            config=UniversalCompressorConfig(use_magika=False, use_kompress=False, ccr_enabled=False)
+        )
+        for prefix_len in range(60, 75):
+            payload_value = ("x" * prefix_len) + "é" + ("y" * 300)
+            content = json.dumps({"msg": payload_value})
+            res = compressor.compress(content, content_type=ContentType.JSON)
+            json.loads(res.compressed)  # must not raise, regardless of prefix_len


### PR DESCRIPTION
## Description

`_simple_compress`'s truncation fallback (`headroom/compression/universal.py`) slices JSON string-value spans by raw character offset with no awareness of JSON escape sequences. When the computed cut lands between a backslash and the character it escapes, the result has a dangling backslash — invalid JSON per RFC 8259 §7.

`JSONStructureHandler` marks a full JSON string value, quotes and raw escape sequences intact, as one compressible span. `SEC-02` (merged 2026-06-28) already fixed a related but distinct bug in this same function — a raw newline embedded in the separator string itself — and added `test_sec02_json_fallback_stays_valid_json`. That test only uses plain-word string values with no `\`, `\"`, or `\n` escapes, so it never exercised a mid-escape truncation cut, and this deeper flaw survived untouched.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `_safe_truncate_boundary`, which nudges a candidate cut position past a split backslash escape pair by counting the run of consecutive backslashes immediately before it (odd run means mid-escape, even run means every backslash before it already pairs off cleanly).
- Applied it to both `keep_start` and the end boundary in `_simple_compress`, with the end boundary capped so the nudge can't zero out an originally-nonzero `keep_end` (`text[-0:]` is the whole string, not empty).
- Added `test_sec03_json_fallback_does_not_split_escape_pair`, sweeping a range of prefix lengths so the cut lands on the escape at least once regardless of the exact `keep_start`/`keep_end` arithmetic.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

I could not build the package through its normal tooling in my environment (no Rust toolchain for the `maturin` build), so I did not run the actual `pytest`/`ruff`/`mypy` commands. I verified by loading just the affected modules directly (`headroom.compression.universal`, `.masks`, `.detector`, and the `handlers` package) via `importlib`, bypassing the top-level `headroom/__init__.py` import chain, and running the fix against real code execution. This exercises the exact same code paths as the actual test suite would, just outside `pytest`.

### Test Output

```text
prefix_len=97 case: OK, valid JSON, compressed len = 179 vs original 310
Swept 1200 cases across 4 escape types x 300 prefix lengths: all valid JSON.

SEC-01 (existing): PASS
SEC-02 (existing): PASS
SEC-03 (new): PASS
Plain-text truncation still works: PASS
```

## Real Behavior Proof

- Environment: Windows, Python 3.12.10, `headroom` loaded via `importlib.util.spec_from_file_location` against the affected modules directly (not the installed/built package — see note above on the Rust toolchain).
- Exact command / steps: `UniversalCompressor(config=UniversalCompressorConfig(use_kompress=False, compression_ratio_target=0.5)).compress(content, content_type=ContentType.JSON)` for `content = json.dumps({"msg": ("x" * 97) + "\n" + ("y" * 200)})`, then `json.loads()` on the result.
- Observed result: before the fix, this raises `json.JSONDecodeError: Invalid \escape: line 1 column 107 (char 106)` — the compressed output is `'...xxxxx\\ ...[compressed]... yyyy...'`, a dangling backslash. After the fix, `json.loads()` succeeds. Ran a sweep of 1200 cases (4 escape types × 300 prefix lengths) confirming every one produces valid JSON after the fix, plus the two pre-existing `SEC-01`/`SEC-02` regression tests to confirm no behavior change there.
- Not tested: the `use_kompress=True` path (Kompress unavailable/not installed in my environment, so only the `_simple_compress` fallback path itself was exercised — this is also the only path the fix touches); the actual `pytest`/`ruff`/`mypy` commands through the project's own tooling; splitting a `\uXXXX` (6-character) unicode escape mid-sequence specifically — the fix corrects the common 2-character escapes (`\n`, `\"`, `\\`, `\t`, etc.) demonstrated in the repro, but a cut landing between the 4 hex digits of `\uXXXX` (rather than right after the backslash) isn't covered by the backslash-run check and would need separate handling.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

Left the CHANGELOG and "new/existing unit tests pass locally" checkboxes unchecked rather than guessing: I verified via the isolated-import approach described above, not the project's actual `pytest` run, and didn't want to claim a checkbox I can't back with real tooling output. Happy to add a CHANGELOG entry if a maintainer confirms the expected format/section for this scope of fix.

This PR was fully generated with an AI assistant (Claude). I reviewed the change, traced the bug mechanism against the actual source (the tokenizer's own escape-walking logic in `json_handler.py` vs. `_simple_compress`'s lack of it), and ran the verification described above myself before opening this.
