### PR TITLE
feat(text-crusher): keep do-not-drop anchors (URLs, CLI flags, absolute paths)

### DIFF
--- a/crates/headroom-core/src/transforms/text_crusher/crusher.rs
+++ b/crates/headroom-core/src/transforms/text_crusher/crusher.rs
@@ -470,8 +470,32 @@ fn shingles(words: &[String], k: usize) -> HashSet<String> {
 
 /// A word carries specific, hard-to-reconstruct information if it has a digit,
 /// is an error/status keyword, is ALLCAPS (2+ letters), or is a dotted
-/// identifier (`foo.bar`).
+/// identifier (`foo.bar`). It is also salient if it is a "do-not-drop" anchor
+/// that agent workflows depend on: a CLI flag (`-v`, `--verbose`), an absolute
+/// path (`/etc/nginx`, `~/notes`), or a URL (`https://...`). The anchor checks
+/// are deliberately narrow to avoid making ordinary English words salient.
 fn is_salient(word: &str) -> bool {
+    // Cheapest first: single-byte prefix peeks, no allocation or full scan.
+
+    // CLI flag: `-v`, `--verbose`. Requires an alphabetic char so a bare
+    // `-`/`--` (or a stray dash) is not treated as an anchor. Hyphenated
+    // English like `well-known` does not start with `-`, so it is unaffected.
+    if word.starts_with('-') && word.chars().any(|c| c.is_ascii_alphabetic()) {
+        return true;
+    }
+
+    // Absolute path: `/etc/nginx`, `~/notes.md`. The length guard rejects a
+    // lone `/`. Relative tokens (`src/main`, `and/or`) don't start with `/`
+    // or `~/`, so they stay non-salient.
+    if (word.starts_with('/') || word.starts_with("~/")) && word.chars().count() > 1 {
+        return true;
+    }
+
+    // URL: any scheme-bearing token (`http://`, `https://`, `ws://`, ...).
+    if word.contains("://") {
+        return true;
+    }
+
     if word.chars().any(|c| c.is_ascii_digit()) {
         return true;
     }
@@ -656,6 +680,61 @@ mod tests {
         );
         assert!(r.compressed_tokens < r.original_tokens);
         assert!(r.compression_ratio > 0.0 && r.compression_ratio <= 1.0);
+    }
+
+    #[test]
+    fn anchors_are_salient() {
+        // URLs, CLI flags, and absolute paths are "do-not-drop" anchors.
+        assert!(is_salient("https://example.com/x"));
+        assert!(is_salient("--verbose"));
+        assert!(is_salient("-v"));
+        assert!(is_salient("/etc/nginx/nginx.conf"));
+        assert!(is_salient("~/notes.md"));
+    }
+
+    #[test]
+    fn anchor_rules_do_not_over_keep() {
+        // Ordinary/relative tokens must stay non-salient (no over-keeping).
+        assert!(!is_salient("and/or")); // no leading '/'
+        assert!(!is_salient("well-known")); // does not start with '-'
+        assert!(!is_salient("hello"));
+        assert!(!is_salient("the"));
+        assert!(!is_salient("-")); // bare dash, no alphabetic char
+        assert!(!is_salient("/")); // lone slash
+        assert!(!is_salient("src/main")); // relative path: no leading '/', no dot
+    }
+
+    #[test]
+    fn anchor_sentence_survives_aggressive_compression() {
+        // 40 anchor-free filler sentences of similar length/recency, with a
+        // single middle sentence carrying an absolute-path anchor. Under
+        // aggressive compression the anchor sentence must survive while a
+        // comparable filler sentence is dropped. Deterministic input.
+        let anchor_idx = 20;
+        let content = (0..40)
+            .map(|i| {
+                if i == anchor_idx {
+                    format!("Config value alpha bravo lives in /etc/service/config number {i}.")
+                } else {
+                    format!("Config value alpha bravo charlie delta echo foxtrot golf number {i}.")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        let r = TextCrusher::default().compress(&content, "", Some(0.3));
+        assert!(r.compressed_tokens < r.original_tokens, "must compress");
+        assert!(
+            r.compressed.contains("/etc/service/config"),
+            "anchor-bearing sentence must survive: {}",
+            r.compressed
+        );
+        // A comparable filler sentence far from the anchor is dropped, so the
+        // anchor's survival is due to salience, not wholesale retention.
+        assert!(
+            !r.compressed.contains("number 3."),
+            "a comparable filler sentence should be dropped: {}",
+            r.compressed
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

TextCrusher's `is_salient` decides which words count as "must-keep" signal (it feeds the salience score that protects a segment from being dropped). It recognized digits, error/status keywords, ALLCAPS, and dotted identifiers — but not the "do-not-drop" anchors agent workflows depend on: **URLs, CLI flags, and absolute paths**. So a segment whose only distinctive content was a URL or a path could be dropped under aggressive compression.

This adds three narrow anchor checks to `is_salient`: CLI flag (`-v` / `--verbose`), absolute path (`/etc/x`, `~/x`), and URL (`://`). `is_salient` is shared by the English (`split_whitespace`) and CJK (ICU token) paths, so both benefit. The checks are deliberately conservative — ordinary/relative English tokens (`and/or`, `well-known`, `src/main`) stay non-salient, and the 6 recorded parity fixtures are byte-unchanged (no English regression). Rust-only: `headroom/transforms/text_crusher.py` is a thin shim over `_core`.

## Type of Change

- [x] Enhancement (non-breaking change that improves retention of do-not-drop anchors)

## Changes Made

- `crates/headroom-core/src/transforms/text_crusher/crusher.rs`, `is_salient`: add CLI-flag / absolute-path / URL checks (cheapest-first prefix peeks; all existing checks retained).
- Tests: the three anchors are salient; a no-over-keeping test (`and/or`, `well-known`, `src/main`, bare `-`, bare `/`, plain words stay non-salient); a behavior test (a middle sentence carrying `/etc/service/config` survives `target_ratio=0.3` while a comparable filler sentence drops).

## Testing

- [x] Unit tests pass (`cargo test`)
- [x] Parity fixtures pass, byte-unchanged
- [x] Linting passes (`cargo clippy` / `cargo fmt`)
- [x] New tests added

### Test Output

```text
$ cargo test -p headroom-core --lib text_crusher
test result: ok. 15 passed
$ pytest tests/test_transforms/test_text_crusher_parity.py
7 passed   # the 6 recorded fixtures are byte-identical — no re-recording needed
$ cargo clippy / fmt   # clean
```

## Real Behavior Proof

- Environment: macOS (Darwin), Rust via cargo, branch `feat/text-crusher-anchor-salience` off `main`.
- Exact command / steps: `cargo test -p headroom-core --lib text_crusher` plus the parity suite.
- Observed result: the three new anchors are salient; `and/or` / `well-known` / `src/main` / bare `-` / bare `/` stay non-salient (no over-keeping); a 40-sentence doc with one `/etc/service/config` sentence keeps that sentence at `ratio=0.3` while a comparable filler is dropped — the anchor survives due to salience, not wholesale retention. The 6 parity fixtures are byte-identical, confirming no ASCII/English regression.
- Not tested: no Python side (shim). The i18n eval's Part-B salient-retention lift is left as future validation — its `salient_set` doesn't yet count URL/flag/path anchors, so it would need extending to measure this directly.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A
- [x] My changes generate no new warnings
- [x] I have added tests that prove my change is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md — happy to add an entry if preferred.

## Additional Notes

- Follow-up to #1504. The anchor set is intentionally minimal (unambiguous "do-not-drop" spans); happy to broaden it (ports, env vars, command names) in a follow-up if you'd like.
