### PR TITLE
feat(text-crusher): Korean sub-eojeol bigrams lift CJK relevance (ko 50%->65%)

### DIFF
--- a/crates/headroom-core/src/transforms/text_crusher/crusher.rs
+++ b/crates/headroom-core/src/transforms/text_crusher/crusher.rs
@@ -391,6 +391,34 @@ fn tokens_icu(text: &str) -> Vec<String> {
     out
 }
 
+/// True for a precomposed Hangul syllable. Korean text is overwhelmingly
+/// precomposed syllables in this block.
+fn is_hangul(c: char) -> bool {
+    matches!(c as u32, 0xAC00..=0xD7AF)
+}
+
+/// Relevance forms of a token list: each token, plus -- for a Hangul token --
+/// its overlapping character bigrams. ICU ships no Korean dictionary, so it
+/// splits Korean on spaces into coarse eojeol and a query eojeol only matches a
+/// doc eojeol verbatim; the sub-eojeol bigrams give partial matching. Used for
+/// relevance ONLY (salience/dedup keep the original tokens). Non-Hangul tokens
+/// (zh/ja ICU words, ASCII) pass through unchanged, so those paths are untouched.
+fn augment_hangul(toks: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(toks.len());
+    for t in toks {
+        if t.chars().any(is_hangul) {
+            let chars: Vec<char> = t.chars().collect();
+            for w in chars.windows(2) {
+                if w.iter().all(|&c| is_hangul(c)) {
+                    out.push(w.iter().collect());
+                }
+            }
+        }
+        out.push(t.clone());
+    }
+    out
+}
+
 /// BM25 relevance over the segments' ICU word tokens. This is INTENTIONALLY a
 /// separate scorer from the shared [`BM25Scorer`](crate::relevance): that one is
 /// parity-locked to Python and tokenizes with an ASCII-only regex, so it scores
@@ -402,12 +430,14 @@ fn tokens_icu(text: &str) -> Vec<String> {
 fn relevance_cjk(seg_tokens: &[Vec<String>], context: &str) -> Vec<f64> {
     use std::collections::HashMap;
     let n = seg_tokens.len();
-    let qtokens: HashSet<String> = tokens(context).into_iter().collect();
+    // Augment Hangul tokens with sub-eojeol bigrams for relevance only.
+    let seg: Vec<Vec<String>> = seg_tokens.iter().map(|t| augment_hangul(t)).collect();
+    let qtokens: HashSet<String> = augment_hangul(&tokens(context)).into_iter().collect();
     if n == 0 || qtokens.is_empty() {
         return vec![0.0; n];
     }
     let mut df: HashMap<&str, usize> = HashMap::new();
-    for toks in seg_tokens {
+    for toks in &seg {
         let uniq: HashSet<&str> = toks.iter().map(|s| s.as_str()).collect();
         for t in uniq {
             *df.entry(t).or_insert(0) += 1;
@@ -419,9 +449,9 @@ fn relevance_cjk(seg_tokens: &[Vec<String>], context: &str) -> Vec<f64> {
         (((nf - d + 0.5) / (d + 0.5)) + 1.0).ln()
     };
     let (k1, b) = (1.2_f64, 0.75_f64);
-    let avgdl = (seg_tokens.iter().map(|t| t.len()).sum::<usize>() as f64 / nf).max(1.0);
+    let avgdl = (seg.iter().map(|t| t.len()).sum::<usize>() as f64 / nf).max(1.0);
     let mut out = vec![0.0f64; n];
-    for (i, toks) in seg_tokens.iter().enumerate() {
+    for (i, toks) in seg.iter().enumerate() {
         let mut tf: HashMap<&str, usize> = HashMap::new();
         for t in toks {
             *tf.entry(t.as_str()).or_insert(0) += 1;
@@ -512,6 +542,40 @@ mod tests {
             .map(|i| format!("Sentence number {i} describes a distinct topic {i} in some detail."))
             .collect::<Vec<_>>()
             .join(" ")
+    }
+
+    #[test]
+    fn augment_hangul_adds_sub_eojeol_bigrams() {
+        // A Hangul token yields its overlapping bigrams plus itself; a non-Hangul
+        // token passes through unchanged (so zh/ja/ASCII paths are untouched).
+        let aug = augment_hangul(&["데이터".to_string()]);
+        assert!(aug.contains(&"데이".to_string()));
+        assert!(aug.contains(&"이터".to_string()));
+        assert!(aug.contains(&"데이터".to_string()));
+        assert_eq!(
+            augment_hangul(&["database".to_string()]),
+            vec!["database".to_string()]
+        );
+    }
+
+    #[test]
+    fn korean_relevance_matches_sub_eojeol() {
+        // Query "데이터" (data) vs a segment holding "데이터베이스" (database):
+        // different eojeol, shared sub-eojeol bigrams. Coarse-eojeol BM25 alone
+        // scores 0; the bigram augment gives the right segment nonzero relevance.
+        let seg_tokens = vec![
+            tokens("데이터베이스 연결 정보"),
+            tokens("네트워크 설정 확인"),
+        ];
+        let rel = relevance_cjk(&seg_tokens, "데이터");
+        assert!(
+            rel[0] > 0.0,
+            "sub-eojeol bigram match should be nonzero: {rel:?}"
+        );
+        assert!(
+            rel[0] > rel[1],
+            "the 데이터베이스 segment must outscore the unrelated one: {rel:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

After #1504 made TextCrusher CJK-aware, Korean answer-retention lagged Chinese and Japanese. Root cause: ICU4X ships no Korean dictionary, so its `WordSegmenter` splits Korean on spaces into coarse **eojeol** units — a query eojeol only matches a document eojeol *verbatim*. So the BM25 in `relevance_cjk` misses partial Korean overlaps (e.g. query `데이터` "data" vs a segment holding `데이터베이스` "database" — different eojeol, no match), and answer-bearing Korean segments get dropped under compression.

This augments each Hangul token with its overlapping **character bigrams**, **for relevance only** — salience and near-dup dedup keep the original eojeol tokens, so their behavior is unchanged. Non-Hangul tokens (zh/ja ICU words, ASCII) pass through untouched, so those paths don't move.

## Measured impact (committed i18n eval)

`benchmarks/i18n_compression_eval.py` — Part A, multi-wiki-qa answer-retention, n=80/lang, target_ratio=0.3:

| lang | before | after |
|---|---|---|
| **ko** | **50%** | **65%** (+15pp) |
| zh-cn | 74% | 74% (unchanged) |
| ja | 70% | 70% (unchanged) |

Korean is now much closer to zh/ja; zh and ja are byte-unchanged because they're non-Hangul and therefore not augmented.

## Type of Change

- [x] Enhancement (non-breaking; improves Korean retention, no regression elsewhere)

## Changes Made

- `crates/headroom-core/src/transforms/text_crusher/crusher.rs`: `is_hangul(c)` + `augment_hangul(toks)` (token + sub-eojeol Hangul bigrams); `relevance_cjk` runs BM25 over the augmented tokens (both doc segments and query).
- Tests: `augment_hangul` unit (Hangul → bigrams + self; ASCII unchanged); `korean_relevance_matches_sub_eojeol` (query `데이터` scores the `데이터베이스` segment > 0 and above an unrelated one — coarse-eojeol BM25 alone would score 0).

## Testing

- [x] Unit tests pass (`cargo test`)
- [x] Parity fixtures pass, byte-unchanged
- [x] Linting passes (`cargo clippy` / `cargo fmt`)
- [x] New tests added
- [x] Eval-measured (see Measured impact)

### Test Output

```text
$ cargo test -p headroom-core --lib text_crusher
test result: ok. 14 passed
$ pytest tests/test_transforms/test_text_crusher_parity.py
7 passed   # fixtures byte-unchanged (no Korean-with-query scenario recorded)
$ cargo clippy / fmt   # clean
```

## Real Behavior Proof

- Environment: macOS (Darwin), Rust via cargo + Python in a uv venv (`_core` rebuilt), branch `feat/text-crusher-korean` off `main`.
- Exact command / steps: `.venv/bin/python benchmarks/i18n_compression_eval.py` before and after the change; plus the Rust unit/relevance tests.
- Observed result: ko answer-retention rose 50% → 65% (+15pp) while zh (74%) and ja (70%) were byte-identical; the `korean_relevance_matches_sub_eojeol` test confirms a sub-eojeol query now retrieves the right Korean segment (nonzero, and above an unrelated segment), which coarse-eojeol BM25 could not.
- Not tested: no Python side (shim). The augment is Hangul-gated, so Chinese/Japanese/ASCII relevance is provably unchanged.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A
- [x] My changes generate no new warnings
- [x] I have added tests that prove my change is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md — happy to add an entry if preferred.

## Additional Notes

- Follow-up to #1504. Scoped to relevance so it can't dilute the salience/dedup token counts; kept Hangul-gated so zh/ja are provably untouched.
