### PR TITLE
fix(ci): restore green lint (ruff-format drift + a None-guard for mypy)

### DIFF
--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -1107,9 +1107,7 @@ def proxy(
     if _anyllm_source is click.core.ParameterSource.COMMANDLINE:
         effective_anyllm_provider = anyllm_provider
     else:
-        effective_anyllm_provider = (
-            os.environ.get("HEADROOM_ANYLLM_PROVIDER") or anyllm_provider
-        )
+        effective_anyllm_provider = os.environ.get("HEADROOM_ANYLLM_PROVIDER") or anyllm_provider
 
     # Resolve mode: CLI flag > env var > default. Default is CACHE (Headroom's
     # coding posture): delta-only compression at ~0 prefix-cache busts.

--- a/headroom/proxy/forwarded_headers.py
+++ b/headroom/proxy/forwarded_headers.py
@@ -127,9 +127,7 @@ def load_trusted_dashboard_client_cidrs(
     try:
         return _parse_cidr_list(raw)
     except ValueError as exc:
-        raise ValueError(
-            f"Invalid {TRUSTED_DASHBOARD_CLIENT_CIDRS_ENV} entry: {exc}"
-        ) from exc
+        raise ValueError(f"Invalid {TRUSTED_DASHBOARD_CLIENT_CIDRS_ENV} entry: {exc}") from exc
 
 
 def _normalize_ip(

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -581,9 +581,7 @@ class SavingsTracker:
         self._persistence_error: str | None = None
         self._needs_schema_save = False
         self._state = self._load_state()
-        self._persistent_metrics = PersistentMetricsState(
-            self._state.pop("lifetime_metrics", None)
-        )
+        self._persistent_metrics = PersistentMetricsState(self._state.pop("lifetime_metrics", None))
 
     @property
     def storage_path(self) -> str:
@@ -859,7 +857,9 @@ class SavingsTracker:
             "compression_savings_usd",
             _estimate_compression_savings_usd(model, _coerce_int(metrics.get("tokens_saved"))),
         )
-        metrics.setdefault("cache_savings_usd", _estimate_cache_savings_usd(model, cache_read_tokens))
+        metrics.setdefault(
+            "cache_savings_usd", _estimate_cache_savings_usd(model, cache_read_tokens)
+        )
         with self._lock:
             self._persistent_metrics.record_request(**metrics)
             if persist:
@@ -871,7 +871,9 @@ class SavingsTracker:
         with self._lock:
             self._persistent_metrics.record_stack(stack)
 
-    def record_lifetime_failed(self, *, provider: str | None = None, model: str | None = None) -> None:
+    def record_lifetime_failed(
+        self, *, provider: str | None = None, model: str | None = None
+    ) -> None:
         """Record a failed proxy request without changing legacy history."""
 
         with self._lock:
@@ -1004,6 +1006,7 @@ class SavingsTracker:
             )
             result[model] = view
         return result
+
     def lifetime_response(self) -> dict[str, Any]:
         """Return the durable aggregate used only by ``/stats-lifetime``."""
 
@@ -1309,8 +1312,7 @@ class SavingsTracker:
                 "other": {
                     "requests": legacy["requests"],
                     "input_tokens": legacy["total_input_tokens"],
-                    "attempted_input_tokens": legacy["total_input_tokens"]
-                    + legacy["tokens_saved"],
+                    "attempted_input_tokens": legacy["total_input_tokens"] + legacy["tokens_saved"],
                     "tokens_saved": legacy["tokens_saved"],
                     "last_activity_at": last_activity_at,
                 },

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2064,9 +2064,7 @@ def _request_is_loopback(request: Request) -> bool:
 
 def _request_can_view_dashboard_metadata(
     request: Request,
-    trusted_dashboard_client_cidrs: tuple[
-        ipaddress.IPv4Network | ipaddress.IPv6Network, ...
-    ],
+    trusted_dashboard_client_cidrs: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...],
 ) -> bool:
     """Authorize sensitive ``/stats`` metadata without widening admin access."""
     if _request_is_loopback(request):
@@ -2079,7 +2077,7 @@ def _request_can_view_dashboard_metadata(
         host_header = request.headers.get("host")
     except AttributeError:
         return False
-    if not is_ip_literal_host_header(host_header):
+    if host_header is None or not is_ip_literal_host_header(host_header):
         return False
 
     # CIDR authorization makes this endpoint usable by a remote dashboard, but
@@ -2096,9 +2094,7 @@ def _request_can_view_dashboard_metadata(
     )
 
 
-def _request_has_same_origin_or_no_provenance(
-    request: Request, host_header: str
-) -> bool:
+def _request_has_same_origin_or_no_provenance(request: Request, host_header: str) -> bool:
     """Accept no browser provenance, otherwise require same-origin headers."""
 
     from headroom.proxy.forwarded_headers import trusted_forwarded_headers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ def _scrub_developer_headroom_env(monkeypatch):
             monkeypatch.delenv(key, raising=False)
     monkeypatch.delenv("ANTHROPIC_CUSTOM_HEADERS", raising=False)
 
+
 # =============================================================================
 # Global test hooks
 # =============================================================================

--- a/tests/test_persistent_metrics_persistence.py
+++ b/tests/test_persistent_metrics_persistence.py
@@ -74,7 +74,9 @@ def test_lifetime_response_reports_stateless_mode_without_writing(tmp_path):
     path = tmp_path / "proxy_savings.json"
     tracker = SavingsTracker(path=str(path), stateless=True, save_flush_every=1)
 
-    tracker.record_lifetime_request(provider="openai", stack="codex", model="gpt-test", input_tokens=3)
+    tracker.record_lifetime_request(
+        provider="openai", stack="codex", model="gpt-test", input_tokens=3
+    )
 
     response = tracker.lifetime_response()
     assert response["persistence"] == {

--- a/tests/test_proxy_loopback_gating.py
+++ b/tests/test_proxy_loopback_gating.py
@@ -293,9 +293,7 @@ def test_dashboard_client_cidr_grants_stats_metadata_to_same_origin_browser(
         client=("100.90.0.5", 12345),
     )
 
-    payload = client.get(
-        "/stats", params={"cached": int(cached)}, headers=headers
-    ).json()
+    payload = client.get("/stats", params={"cached": int(cached)}, headers=headers).json()
 
     assert "recent_requests" in payload
     assert "request_logs" in payload
@@ -320,9 +318,7 @@ def test_dashboard_client_cidr_hides_stats_metadata_from_cross_origin_browser(
         client=("100.90.0.5", 12345),
     )
 
-    response = client.get(
-        "/stats", params={"cached": int(cached)}, headers=headers
-    )
+    response = client.get("/stats", params={"cached": int(cached)}, headers=headers)
     payload = response.json()
 
     assert response.status_code == 200
@@ -356,17 +352,21 @@ def test_dashboard_client_cidr_only_uses_forwarded_proto_from_trusted_gateway(
     assert "request_logs" in payload
     assert "config" in payload
 
-    spoofed = TestClient(
-        _make_app(),
-        base_url="http://100.82.0.2:8787",
-        client=("100.90.0.5", 12345),
-    ).get(
-        "/stats",
-        headers={
-            "origin": "https://100.82.0.2:8787",
-            "x-forwarded-proto": "https",
-        },
-    ).json()
+    spoofed = (
+        TestClient(
+            _make_app(),
+            base_url="http://100.82.0.2:8787",
+            client=("100.90.0.5", 12345),
+        )
+        .get(
+            "/stats",
+            headers={
+                "origin": "https://100.82.0.2:8787",
+                "x-forwarded-proto": "https",
+            },
+        )
+        .json()
+    )
 
     assert "recent_requests" not in spoofed
     assert "request_logs" not in spoofed
@@ -379,16 +379,24 @@ def test_dashboard_client_cidr_rejects_unlisted_clients_and_hostname_hosts(
     monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.5/32")
     app = _make_app()
 
-    unlisted = TestClient(
-        app,
-        base_url="http://100.82.0.2:8787",
-        client=("100.90.0.6", 12345),
-    ).get("/stats").json()
-    hostname = TestClient(
-        app,
-        base_url="http://100.82.0.2:8787",
-        client=("100.90.0.5", 12345),
-    ).get("/stats", headers={"host": "attacker.example"}).json()
+    unlisted = (
+        TestClient(
+            app,
+            base_url="http://100.82.0.2:8787",
+            client=("100.90.0.6", 12345),
+        )
+        .get("/stats")
+        .json()
+    )
+    hostname = (
+        TestClient(
+            app,
+            base_url="http://100.82.0.2:8787",
+            client=("100.90.0.5", 12345),
+        )
+        .get("/stats", headers={"host": "attacker.example"})
+        .json()
+    )
 
     for payload in (unlisted, hostname):
         assert "recent_requests" not in payload
@@ -403,16 +411,24 @@ def test_dashboard_client_cidr_only_accepts_forwarded_client_from_trusted_gatewa
     monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_GATEWAY_CIDRS", "172.18.0.0/16")
     app = _make_app()
 
-    trusted = TestClient(
-        app,
-        base_url="http://100.82.0.2:8787",
-        client=("172.18.0.1", 12345),
-    ).get("/stats", headers={"x-forwarded-for": "100.90.0.5"}).json()
-    forged = TestClient(
-        app,
-        base_url="http://100.82.0.2:8787",
-        client=("198.51.100.10", 12345),
-    ).get("/stats", headers={"x-forwarded-for": "100.90.0.5"}).json()
+    trusted = (
+        TestClient(
+            app,
+            base_url="http://100.82.0.2:8787",
+            client=("172.18.0.1", 12345),
+        )
+        .get("/stats", headers={"x-forwarded-for": "100.90.0.5"})
+        .json()
+    )
+    forged = (
+        TestClient(
+            app,
+            base_url="http://100.82.0.2:8787",
+            client=("198.51.100.10", 12345),
+        )
+        .get("/stats", headers={"x-forwarded-for": "100.90.0.5"})
+        .json()
+    )
 
     assert "recent_requests" in trusted
     assert "recent_requests" not in forged
@@ -423,11 +439,15 @@ def test_dashboard_client_cidr_normalizes_ipv4_mapped_ipv6(
 ) -> None:
     monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.0/24")
     app = _make_app()
-    payload = TestClient(
-        app,
-        base_url="http://100.82.0.2:8787",
-        client=("::ffff:100.90.0.5", 12345),
-    ).get("/stats").json()
+    payload = (
+        TestClient(
+            app,
+            base_url="http://100.82.0.2:8787",
+            client=("::ffff:100.90.0.5", 12345),
+        )
+        .get("/stats")
+        .json()
+    )
 
     assert "recent_requests" in payload
 


### PR DESCRIPTION
## Description

The `lint` job in CI (`ci.yml`) is red on `main`, which blocks every open PR (they all inherit the failure on merge). Two causes:

1. **`ruff format --check .` drift** — 7 files no longer match `ruff 0.15.17`'s formatting (the CI-pinned version). None were touched by this change; running `ruff format` on them is a no-op behaviorally.
2. **mypy 1.20.2** — once ruff passes and mypy runs, it flags one error: `_request_can_view_dashboard_metadata` (`headroom/proxy/server.py`) passes `host_header` — a `str | None` from `request.headers.get("host")` — to `_request_has_same_origin_or_no_provenance`, which expects `str`. At runtime `host_header` is already non-`None` at that call (the `is_ip_literal_host_header(None)` guard just above returns `False` and bails), but mypy can't narrow it. Adding an explicit `host_header is None` to that guard makes the narrowing visible with **identical behavior** (a `None` host still returns `False`).

After this, the lint job passes all three steps: `ruff check .`, `ruff format --check .`, and `mypy headroom --ignore-missing-imports`.

## Type of Change

- [x] CI / chore (unblocks the red lint job for all PRs)

## Changes Made

- `ruff format` on the 7 drifted files (`headroom/cli/proxy.py`, `headroom/proxy/{forwarded_headers,savings_tracker,server}.py`, `tests/{conftest,test_persistent_metrics_persistence,test_proxy_loopback_gating}.py`) — whitespace/formatting only.
- `headroom/proxy/server.py`: add `host_header is None or …` to the existing guard so mypy narrows `host_header` to `str` before the same-origin check (behavior unchanged).

## Testing

- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 1310 files already formatted
- [x] `mypy headroom --ignore-missing-imports` (v1.20.2, the CI pin) — Success, no issues
- [x] `pytest tests/test_proxy_loopback_gating.py` — 41 passed (the reformatted security-gating tests)

### Test Output

```text
$ ruff check .                 # All checks passed!
$ ruff format --check .        # 1310 files already formatted
$ mypy headroom --ignore-missing-imports   # Success: no issues found in 504 source files
```

## Real Behavior Proof

- Environment: macOS (Darwin), Python in a uv venv, `ruff==0.15.17` + `mypy==1.20.2` (the exact CI pins from `ci.yml`), branch `chore/ruff-format-drift` off `main` (`eac49656`).
- Exact command / steps: reproduced the red lint on clean `main` (`ruff format --check .` → 7 files; `mypy` → 1 error at `server.py:2088`), applied the fixes, re-ran all three lint steps.
- Observed result: all three lint steps pass. The `host_header is None` guard is provably behavior-preserving — `is_ip_literal_host_header(None)` already returns `False`, so a `None` host bailed before and still bails; the reformatted security-gating tests pass (41).
- Not tested: the `test` job's separate flakiness (`test_anthropic_compaction_transforms::test_l2_appends_transform_label` fails in CI but passes locally in isolation) is unrelated to lint and out of scope here.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code — N/A (formatting + a one-token guard)
- [ ] Documentation — N/A
- [x] My changes generate no new warnings
- [ ] New tests — N/A (no behavior change; existing security-gating tests pass)
- [x] New and existing unit tests pass locally with my changes
- [ ] CHANGELOG — N/A (CI fix)

## Additional Notes

- Splitting the `ruff format` and the mypy guard into one PR because the lint job only goes green when both land; happy to split if you'd prefer. This unblocks the lint check for all currently-open PRs.
