### PR TITLE
test(anthropic): reset tool_desc_max_chars cache so L2 tests are order-independent

### DIFF
--- a/tests/test_anthropic_compaction_transforms.py
+++ b/tests/test_anthropic_compaction_transforms.py
@@ -22,6 +22,24 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _reset_tool_desc_max_chars_cache():
+    """Reset the per-process ``_TOOL_DESC_MAX_CHARS`` cache around each test.
+
+    ``tool_desc_max_chars()`` reads ``HEADROOM_TOOL_DESC_MAX_CHARS`` once and
+    caches it in a module global, never re-reading. So any earlier test (or
+    code) that calls it with the env unset pins the cache to 0, and a later
+    test here that sets the env and expects 20 gets the stale 0 -- green in
+    isolation, red in a full CI shard (``assert 0 == 20``). Clearing the cache
+    before and after each test makes these env-based tests order-independent.
+    """
+    import headroom.proxy.tool_schema_compaction as _mod
+
+    _mod._TOOL_DESC_MAX_CHARS = None
+    yield
+    _mod._TOOL_DESC_MAX_CHARS = None
+
+
 def _make_anthropic_payload_with_tools() -> dict:
     """Minimal Anthropic-style payload with tools that will be compacted."""
     return {


### PR DESCRIPTION
## Description

`test_l2_appends_transform_label` fails in CI (`test (1)` on `main` and every open PR) with `assert 0 == 20`, but passes locally in isolation. Root cause: `tool_desc_max_chars()` reads `HEADROOM_TOOL_DESC_MAX_CHARS` once and caches it in a module global `_TOOL_DESC_MAX_CHARS`, never re-reading. The test sets the env to `20` and reads the value **without resetting that cache**, so when an earlier test in the same CI shard has already called `tool_desc_max_chars()` with the env unset, the cache is pinned to `0` and the test sees `0`. It's green in isolation (no prior caller) and red in a full shard.

The sibling `test_l2_skips_label_when_disabled` already resets the cache manually; this adds an **autouse fixture** that clears the cache before and after every test in the file, making the env-based L2 tests order-independent.

## Type of Change

- [x] Bug fix (test isolation / flaky-in-CI test)

## Changes Made

- `tests/test_anthropic_compaction_transforms.py`: autouse fixture that resets `tool_schema_compaction._TOOL_DESC_MAX_CHARS = None` around each test.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff`)
- [x] Reproduced the CI failure locally, then confirmed the fix

### Test Output

```text
$ .venv/bin/python -m pytest tests/test_anthropic_compaction_transforms.py
7 passed

# Reproduce the CI ordering failure: a prior test caches 0, then the L2 test runs.
# WITH the autouse fixture the file passes even under that ordering:
$ pytest tests/test_aaa_pollution_check.py tests/test_anthropic_compaction_transforms.py
8 passed

$ ruff check tests/test_anthropic_compaction_transforms.py     # All checks passed!
```

## Real Behavior Proof

- Environment: macOS (Darwin), Python in a uv venv, branch `fix/tool-desc-cache-test-isolation` off `main`.
- Exact command / steps: confirmed the mechanism directly (`tool_desc_max_chars()` → `0` caches it; then `setenv(20)` + call still returns `0` until the cache is reset), then added a temporary test that caches `0` and ran it *before* `test_anthropic_compaction_transforms.py` in one pytest session.
- Observed result: **before** the fixture, that ordering makes `test_l2_appends_transform_label` fail with `assert 0 == 20` (the exact CI failure); **with** the fixture the whole file passes (8 passed including the pollution test). No product code changed.
- Not tested: N/A — this is a test-only isolation fix; there is no runtime behavior to exercise beyond the tests themselves.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md — N/A (test-only)

## Additional Notes

- One of several independent failures currently red on `main`'s CI. `test (3)` and `test (4)` fail on unrelated tests (dashboard stats HTML and a content-router fallback assertion) with their own root causes; this PR fixes the `test (1)` one.
