### PR TITLE
fix(tests): unbreak two stale CI test failures on main

### DIFF
--- a/tests/test_proxy_dashboard_stats_cache.py
+++ b/tests/test_proxy_dashboard_stats_cache.py
@@ -740,7 +740,10 @@ def test_dashboard_uses_cached_stats_and_lazy_history_feed_polling() -> None:
     assert "Lean-ctx" in html
     assert "Context Tool" in html
     assert "cliFilteringLabel + ' Filtered (this session)'" in html
-    assert "cliFilteringLabel + ' Filtered (lifetime)'" in html
+    # Lifetime CLI-filtering savings moved to the persisted "Lifetime Saved"
+    # card in the History view (#2198); it still uses the generic
+    # cliFilteringLabel binding rather than a hardcoded "RTK".
+    assert "(historyStats.cli_filtering?.label || cliFilteringLabel) + ' Lifetime Saved'" in html
 
 
 def test_dashboard_session_metrics_do_not_repeat_proxy_tokens_without_new_context() -> None:

--- a/tests/test_transforms_content_router.py
+++ b/tests/test_transforms_content_router.py
@@ -693,11 +693,14 @@ def test_smart_crusher_log_fallback_runs_for_valid_json(
 
     monkeypatch.setattr(router, "_get_smart_crusher", lambda: NoopSmartCrusher())
     monkeypatch.setattr(router, "_get_log_compressor", lambda: ShrinkingLogCompressor())
-    # Kompress no-op → Log fallback fires.
+    # Kompress no-op → returns the content unchanged with its estimated token
+    # count (mirroring the real ``_try_ml_compressor``, which always reports
+    # ``_estimate_tokens``). Because that equals the SmartCrusher result, the
+    # router sees no Kompress savings and the Log fallback fires.
     monkeypatch.setattr(
         router,
         "_try_ml_compressor",
-        lambda content, context, question=None: (content, len(content.split())),
+        lambda content, context, question=None: (content, _estimate_tokens(content)),
     )
 
     compressed, _compressed_tokens, strategy_chain = router._apply_strategy_to_content(


### PR DESCRIPTION
## Description

Two tests are red on `main`'s CI (`test (4)` and `test (3)`, inherited by every open PR). Both assert against outdated expectations — the **production code is correct**; the fixes are test-only. Diagnosed each via `git` history.

1. **`test_smart_crusher_log_fallback_runs_for_valid_json`** — the test's `_try_ml_compressor` mock returned `len(content.split())`, but every production `_try_ml_compressor` return path reports `_estimate_tokens` (the JSON-aware counter). The mismatched token count made the Kompress-vs-Log decision (`if fallback_tokens < compressed_tokens`) take the Kompress branch, so the Log fallback the test asserts never ran. A realistic mock (`_estimate_tokens(content)`, matching a real Kompress no-op) makes `fallback == compressed`, so the Log fallback fires — the behavior the test's own docstring describes. If production had regressed, the corrected test would still fail; it passes, confirming production is correct.

2. **`test_dashboard_uses_cached_stats_and_lazy_history_feed_polling`** — `0537cbfd` ("feat(dashboard): persist lifetime proxy metrics", #2198) intentionally moved the CLI-filtering *lifetime* savings out of the inline Token-Usage row into a dedicated persisted **"Lifetime Saved"** card; the assertion still expected the old `… + ' Filtered (lifetime)'` string. Updated to the new label — which still uses the generic `cliFilteringLabel` binding, preserving the test's intent (the neighboring `"RTK Filtered" not in html` assertions still hold).

## Type of Change

- [x] Bug fix (test-only; unblocks red CI on `main`)

## Changes Made

- `tests/test_transforms_content_router.py`: mock `_try_ml_compressor` now returns `_estimate_tokens(content)` (already imported), mirroring production.
- `tests/test_proxy_dashboard_stats_cache.py`: assertion updated to the `#2198` "Lifetime Saved" label.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff`)
- [x] Reproduced both failures on clean `main` first, then verified the fixes

### Test Output

```text
$ pytest tests/test_transforms_content_router.py::test_smart_crusher_log_fallback_runs_for_valid_json \
         tests/test_proxy_dashboard_stats_cache.py::test_dashboard_uses_cached_stats_and_lazy_history_feed_polling
2 passed

$ pytest tests/test_transforms_content_router.py      # 57 passed
$ pytest tests/test_proxy_dashboard_stats_cache.py    # 14 passed, 1 skipped
$ ruff check <both files>                              # All checks passed!
```

## Real Behavior Proof

- Environment: macOS (Darwin), Python in a uv venv, `_core` rebuilt from `main`, branch `fix/ci-test-regressions` off `main` (`eac49656`).
- Exact command / steps: reproduced both failures on clean `main` (`assert 'log' in ['smart_crusher','kompress']` and the missing dashboard label), traced the divergence with `git log -S` / `git blame`, then applied the test-only fixes and re-ran the individual tests and their whole files.
- Observed result: both target tests pass; the full files pass (57 and 14+1); the router test passing proves production still fires the Log fallback (a real regression would keep it red). No product code changed.
- Not tested: N/A — test-only changes; the production behavior they assert is already correct on `main`.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective — these ARE the tests; they now reflect production
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md — N/A (test-only)

## Additional Notes

- Part of unbreaking `main`'s CI (the `lint` job and `test (1)` are addressed in separate PRs). After these land, the CI workflow should be green again for all open PRs.
