### PR TITLE
ci: repair mypy no-any-return in _win32_pid_alive (#1556 follow-up)

### DIFF
--- a/headroom/_subprocess.py
+++ b/headroom/_subprocess.py
@@ -15,7 +15,8 @@ def _win32_pid_alive(pid: int) -> bool:
         kernel32.CloseHandle(handle)
         return True
     ERROR_ACCESS_DENIED = 5
-    return kernel32.GetLastError() == ERROR_ACCESS_DENIED
+    # ctypes GetLastError() is Any; wrap so mypy sees bool (matches pid_alive below).
+    return bool(kernel32.GetLastError() == ERROR_ACCESS_DENIED)
 
 
 def pid_alive(pid: int) -> bool:


### PR DESCRIPTION
## Description
Main lint went red after #1556: `headroom/_subprocess.py:18` returns `Any` (ctypes `GetLastError()`) from a `-> bool` function → mypy `no-any-return`. Tests were unaffected.

## Changes Made
- Wrap the comparison in `bool(...)`, matching `pid_alive()`'s existing style.

## Testing
```text
mypy headroom --ignore-missing-imports  -> Success: no issues found in 504 source files
ruff check headroom/_subprocess.py      -> All checks passed!
ruff format --check                     -> 1 file already formatted
```

## Real Behavior Proof
- Environment: local .venv (ruff 0.15.17 / mypy 1.20.2, CI-pinned).
- Result: `mypy headroom` clean; behavior unchanged (pure typing fix).