### PR TITLE
feat(opencode): add repeatable --extra-model flag for custom wrap-time models

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -153,8 +153,10 @@ from headroom.providers.opencode.config import (
     _MCP_MARKER_START,
     _PROVIDER_MARKER_END,  # noqa: F401
     _PROVIDER_MARKER_START,
+    extra_models_from_env,
     inject_opencode_provider_config,
     opencode_config_paths,
+    parse_extra_model_spec,
     snapshot_opencode_config_if_unwrapped,
     strip_opencode_headroom_blocks,
 )
@@ -7688,6 +7690,12 @@ def openclaw(
 )
 @click.option("--anyllm-provider", default=None, help="Provider for any-llm backend")
 @click.option("--region", default=None, help="Cloud region for Bedrock/Vertex")
+@click.option(
+    "--extra-model",
+    "extra_model_specs",
+    multiple=True,
+    help="Extra model for the headroom provider, format id[:name[:context_window]] (repeatable)",
+)
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
 @click.option("--prepare-only", is_flag=True, hidden=True)
 @click.argument("opencode_args", nargs=-1, type=click.UNPROCESSED)
@@ -7705,6 +7713,7 @@ def opencode(
     backend: str | None,
     anyllm_provider: str | None,
     region: str | None,
+    extra_model_specs: tuple,
     verbose: bool,
     prepare_only: bool,
     opencode_args: tuple,
@@ -7727,7 +7736,17 @@ def opencode(
         headroom wrap opencode --port 9999             # Custom proxy port
         headroom wrap opencode --backend anyllm --anyllm-provider groq
         headroom wrap opencode --copilot-subscription # Use a GitHub Copilot subscription
+        headroom wrap opencode --extra-model deepseek-chat:"DeepSeek Chat":65536
     """
+    # Env-provided extras persist across re-wraps; flag specs win on id collision.
+    try:
+        extra_models = extra_models_from_env()
+        for spec in extra_model_specs:
+            model_id, entry = parse_extra_model_spec(spec)
+            extra_models[model_id] = entry
+    except ValueError as exc:
+        raise click.BadParameter(str(exc), param_hint="--extra-model") from exc
+
     subscription_resolution = None
     if copilot_subscription:
         effective_backend = backend or os.environ.get("HEADROOM_BACKEND")
@@ -7801,7 +7820,7 @@ def opencode(
         _inject_memory_agents_md(agents_md)
 
     if prepare_only:
-        inject_opencode_provider_config(port)
+        inject_opencode_provider_config(port, extra_models)
         return
 
     opencode_bin = shutil.which("opencode")
@@ -7852,11 +7871,15 @@ def opencode(
         if subscription_resolution is not None:
             _scrub_copilot_subscription_launch_env(launch_environ)
         env, env_vars_display = _build_opencode_launch_env(
-            actual_port, launch_environ, project=_project_name_from_cwd(), include_mcp=not no_mcp
+            actual_port,
+            launch_environ,
+            project=_project_name_from_cwd(),
+            include_mcp=not no_mcp,
+            extra_models=extra_models,
         )
 
         # Inject Headroom provider into OpenCode config so traffic routes through proxy.
-        inject_opencode_provider_config(actual_port)
+        inject_opencode_provider_config(actual_port, extra_models)
         if memory:
             mem_dir = Path.cwd() / ".headroom"
             _inject_memory_mcp_config(

--- a/headroom/providers/opencode/config.py
+++ b/headroom/providers/opencode/config.py
@@ -60,13 +60,66 @@ HEADROOM_OPENCODE_MODELS: dict[str, Any] = {
 }
 
 
-def headroom_provider_entry(port: int) -> dict[str, Any]:
+# Env var holding comma-separated extra model specs (same format as the
+# `--extra-model` flag) so custom models survive re-wraps.
+HEADROOM_OPENCODE_EXTRA_MODELS_ENV = "HEADROOM_OPENCODE_EXTRA_MODELS"
+
+# Defaults for extra models when the spec omits limits.
+_EXTRA_MODEL_DEFAULT_CONTEXT = 200000
+_EXTRA_MODEL_DEFAULT_OUTPUT = 16384
+
+
+def parse_extra_model_spec(spec: str) -> tuple[str, dict[str, Any]]:
+    """Parse an ``id[:name[:context_window]]`` extra-model spec.
+
+    Returns a ``(model_id, entry)`` pair shaped like the values in
+    ``HEADROOM_OPENCODE_MODELS``. ``name`` defaults to the id and
+    ``context_window`` defaults to 200000. Raises ``ValueError`` on an
+    empty id or a non-integer context window.
+    """
+    parts = spec.split(":", 2)
+    model_id = parts[0].strip()
+    if not model_id:
+        raise ValueError(f"extra model spec has an empty model id: {spec!r}")
+    name = parts[1].strip() if len(parts) > 1 and parts[1].strip() else model_id
+    context = _EXTRA_MODEL_DEFAULT_CONTEXT
+    if len(parts) > 2 and parts[2].strip():
+        try:
+            context = int(parts[2].strip())
+        except ValueError:
+            raise ValueError(
+                f"extra model spec has a non-integer context window: {spec!r}"
+            ) from None
+        if context <= 0:
+            raise ValueError(f"extra model spec has a non-positive context window: {spec!r}")
+    return model_id, {
+        "name": name,
+        "limit": {"context": context, "output": _EXTRA_MODEL_DEFAULT_OUTPUT},
+    }
+
+
+def extra_models_from_env() -> dict[str, Any]:
+    """Parse extra models from ``HEADROOM_OPENCODE_EXTRA_MODELS`` (comma-separated)."""
+    raw = os.environ.get(HEADROOM_OPENCODE_EXTRA_MODELS_ENV, "")
+    models: dict[str, Any] = {}
+    for spec in raw.split(","):
+        spec = spec.strip()
+        if not spec:
+            continue
+        model_id, entry = parse_extra_model_spec(spec)
+        models[model_id] = entry
+    return models
+
+
+def headroom_provider_entry(
+    port: int, extra_models: dict[str, Any] | None = None
+) -> dict[str, Any]:
     """Return the `headroom` provider block pointed at the local proxy."""
     return {
         "npm": "@ai-sdk/openai-compatible",
         "name": "Headroom Proxy",
         "options": {"baseURL": f"http://127.0.0.1:{port}/v1"},
-        "models": HEADROOM_OPENCODE_MODELS,
+        "models": {**HEADROOM_OPENCODE_MODELS, **(extra_models or {})},
     }
 
 
@@ -118,9 +171,9 @@ def strip_opencode_headroom_blocks(content: str, *, remove_mcp: bool = True) -> 
     return content.strip()
 
 
-def _render_provider_block(port: int) -> str:
+def _render_provider_block(port: int, extra_models: dict[str, Any] | None = None) -> str:
     """Render a Headroom provider block as a JSON comment-wrapped snippet."""
-    provider = {"headroom": headroom_provider_entry(port)}
+    provider = {"headroom": headroom_provider_entry(port, extra_models)}
     lines = [
         _PROVIDER_MARKER_START,
         f'"provider": {json.dumps(provider, indent=2)},',
@@ -184,7 +237,7 @@ def append_headroom_plugin(config: dict[str, object]) -> bool:
     return True
 
 
-def inject_opencode_provider_config(port: int) -> None:
+def inject_opencode_provider_config(port: int, extra_models: dict[str, Any] | None = None) -> None:
     """Inject a Headroom model provider into OpenCode's config file.
 
     Safe to call multiple times — the injected block is fully replaced on
@@ -213,7 +266,7 @@ def inject_opencode_provider_config(port: int) -> None:
             data = _parse_json_loose(content)
 
         # Merge provider into the JSON data structure.
-        provider = {"headroom": headroom_provider_entry(port)}
+        provider = {"headroom": headroom_provider_entry(port, extra_models)}
         data = _inject_key_into_json(data, "provider", provider)
 
         # Write back as formatted JSON (opencode uses standard JSON with comments).

--- a/headroom/providers/opencode/runtime.py
+++ b/headroom/providers/opencode/runtime.py
@@ -6,6 +6,7 @@ import json
 import os
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 from headroom.mcp_registry.install import DEFAULT_PROXY_URL
 
@@ -45,6 +46,7 @@ def build_opencode_config_content(
     port: int,
     include_mcp: bool = True,
     include_plugin: bool = True,
+    extra_models: dict[str, Any] | None = None,
 ) -> dict[str, object]:
     """Build JSON payload for ``OPENCODE_CONFIG_CONTENT``.
 
@@ -74,7 +76,7 @@ def build_opencode_config_content(
         "provider": {
             "anthropic": {"options": {"baseURL": base_url}},
             "openai": {"options": {"baseURL": base_url}},
-            "headroom": headroom_provider_entry(port),
+            "headroom": headroom_provider_entry(port, extra_models),
         }
     }
     if include_mcp:
@@ -105,6 +107,7 @@ def build_launch_env(
     *,
     include_mcp: bool = True,
     include_plugin: bool = True,
+    extra_models: dict[str, Any] | None = None,
 ) -> tuple[dict[str, str], list[str]]:
     """Build environment variables for launching OpenCode through Headroom.
 
@@ -119,6 +122,7 @@ def build_launch_env(
         port=port,
         include_mcp=include_mcp,
         include_plugin=include_plugin,
+        extra_models=extra_models,
     )
     env["OPENCODE_CONFIG_CONTENT"] = json.dumps(config_content, separators=(",", ":"))
 

--- a/tests/test_cli/test_wrap_opencode.py
+++ b/tests/test_cli/test_wrap_opencode.py
@@ -447,6 +447,76 @@ def test_wrap_opencode_extra_models_env_var(
     assert config["provider"]["headroom"]["models"]["deepseek-chat"]["limit"]["context"] == 65536
 
 
+def test_wrap_opencode_extra_model_flag_in_launch_env(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Extra models reach OPENCODE_CONFIG_CONTENT on the normal launch path."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    monkeypatch.delenv("HEADROOM_OPENCODE_EXTRA_MODELS", raising=False)
+    _set_test_home(monkeypatch, tmp_path)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                result = runner.invoke(
+                    main,
+                    [
+                        "wrap",
+                        "opencode",
+                        "--port",
+                        "9000",
+                        "--no-mcp",
+                        "--extra-model",
+                        "deepseek-chat:DeepSeek Chat:65536",
+                    ],
+                )
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+    models = config["provider"]["headroom"]["models"]
+    assert models["deepseek-chat"]["name"] == "DeepSeek Chat"
+    assert models["deepseek-chat"]["limit"]["context"] == 65536
+    assert "claude-sonnet-4-6" in models
+
+
+def test_wrap_opencode_extra_models_env_var_in_launch_env(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env-sourced extra models reach OPENCODE_CONFIG_CONTENT on launch."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    monkeypatch.setenv("HEADROOM_OPENCODE_EXTRA_MODELS", "kimi-k2:Kimi K2")
+    _set_test_home(monkeypatch, tmp_path)
+
+    captured: dict[str, object] = {}
+
+    def fake_launch_tool(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+                result = runner.invoke(main, ["wrap", "opencode", "--port", "9000", "--no-mcp"])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+    assert config["provider"]["headroom"]["models"]["kimi-k2"]["name"] == "Kimi K2"
+
+
 def test_wrap_opencode_extra_model_invalid_spec_errors(
     runner: CliRunner,
     tmp_path: Path,

--- a/tests/test_cli/test_wrap_opencode.py
+++ b/tests/test_cli/test_wrap_opencode.py
@@ -390,6 +390,84 @@ def test_wrap_opencode_prepare_only_injects_config(
     assert config["provider"]["headroom"]["options"]["baseURL"] == "http://127.0.0.1:9000/v1"
 
 
+def test_wrap_opencode_extra_model_flag_injects_config(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--extra-model` specs are merged into the injected provider models."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    monkeypatch.delenv("HEADROOM_OPENCODE_EXTRA_MODELS", raising=False)
+    _set_test_home(monkeypatch, tmp_path)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
+        with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+            result = runner.invoke(
+                main,
+                [
+                    "wrap",
+                    "opencode",
+                    "--prepare-only",
+                    "--extra-model",
+                    "deepseek-chat:DeepSeek Chat:65536",
+                    "--extra-model",
+                    "kimi-k2",
+                ],
+            )
+
+    assert result.exit_code == 0, result.output
+    config_file = tmp_path / ".config" / "opencode" / "opencode.json"
+    config = json.loads(config_file.read_text(encoding="utf-8"))
+    models = config["provider"]["headroom"]["models"]
+    assert models["deepseek-chat"]["name"] == "DeepSeek Chat"
+    assert models["deepseek-chat"]["limit"]["context"] == 65536
+    assert models["kimi-k2"]["name"] == "kimi-k2"
+    assert "claude-sonnet-4-6" in models
+
+
+def test_wrap_opencode_extra_models_env_var(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HEADROOM_OPENCODE_EXTRA_MODELS persists extra models across wraps."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    monkeypatch.setenv("HEADROOM_OPENCODE_EXTRA_MODELS", "deepseek-chat:DeepSeek Chat:65536")
+    _set_test_home(monkeypatch, tmp_path)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
+        with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+            result = runner.invoke(main, ["wrap", "opencode", "--prepare-only"])
+
+    assert result.exit_code == 0, result.output
+    config_file = tmp_path / ".config" / "opencode" / "opencode.json"
+    config = json.loads(config_file.read_text(encoding="utf-8"))
+    assert config["provider"]["headroom"]["models"]["deepseek-chat"]["limit"]["context"] == 65536
+
+
+def test_wrap_opencode_extra_model_invalid_spec_errors(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed --extra-model spec fails with a usage error, not a traceback."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    _set_test_home(monkeypatch, tmp_path)
+
+    with patch.object(wrap_mod.shutil, "which", return_value="opencode"):
+        with patch.object(wrap_mod, "_ensure_rtk_binary", return_value=Path("/tmp/rtk")):
+            result = runner.invoke(
+                main,
+                ["wrap", "opencode", "--prepare-only", "--extra-model", "bad:name:abc"],
+            )
+
+    assert result.exit_code != 0
+    assert "non-integer context window" in result.output
+
+
 def test_wrap_opencode_prepare_only_registers_serena_with_agent_context(
     runner: CliRunner,
     tmp_path: Path,

--- a/tests/test_providers_opencode_config.py
+++ b/tests/test_providers_opencode_config.py
@@ -288,6 +288,19 @@ def test_inject_provider_config_with_extra_models(
     assert "claude-sonnet-4-6" in models
 
 
+def test_build_opencode_config_content_with_extra_models() -> None:
+    """build_opencode_config_content threads extra models into the headroom provider."""
+    from headroom.providers.opencode.runtime import build_opencode_config_content
+
+    _, entry = parse_extra_model_spec("deepseek-chat:DeepSeek Chat:65536")
+    config = build_opencode_config_content(
+        port=8787, include_mcp=False, include_plugin=False, extra_models={"deepseek-chat": entry}
+    )
+    models = config["provider"]["headroom"]["models"]
+    assert models["deepseek-chat"]["name"] == "DeepSeek Chat"
+    assert "claude-sonnet-4-6" in models
+
+
 # ---------------------------------------------------------------------------
 # Edge cases — JSON parsing
 # ---------------------------------------------------------------------------

--- a/tests/test_providers_opencode_config.py
+++ b/tests/test_providers_opencode_config.py
@@ -8,12 +8,16 @@ from pathlib import Path
 import pytest
 
 from headroom.providers.opencode.config import (
+    HEADROOM_OPENCODE_EXTRA_MODELS_ENV,
     HEADROOM_OPENCODE_PLUGIN,
     _inject_key_into_json,
     _parse_json_loose,
     append_headroom_plugin,
+    extra_models_from_env,
+    headroom_provider_entry,
     inject_opencode_provider_config,
     opencode_config_paths,
+    parse_extra_model_spec,
     snapshot_opencode_config_if_unwrapped,
     strip_opencode_headroom_blocks,
 )
@@ -213,6 +217,75 @@ def test_inject_provider_config_idempotent(tmp_path: Path, monkeypatch: pytest.M
     config_file = tmp_path / ".config" / "opencode" / "opencode.json"
     config = _parse_json_loose(config_file.read_text())
     assert config["provider"]["headroom"]["options"]["baseURL"] == "http://127.0.0.1:9999/v1"
+
+
+# ---------------------------------------------------------------------------
+# Extra models
+# ---------------------------------------------------------------------------
+
+
+def test_parse_extra_model_spec_full() -> None:
+    """Full id:name:context spec parses into a provider models entry."""
+    model_id, entry = parse_extra_model_spec("deepseek-chat:DeepSeek Chat:65536")
+    assert model_id == "deepseek-chat"
+    assert entry["name"] == "DeepSeek Chat"
+    assert entry["limit"]["context"] == 65536
+    assert entry["limit"]["output"] > 0
+
+
+def test_parse_extra_model_spec_defaults() -> None:
+    """Name defaults to the id and context to 200000 when omitted."""
+    model_id, entry = parse_extra_model_spec("deepseek-chat")
+    assert model_id == "deepseek-chat"
+    assert entry["name"] == "deepseek-chat"
+    assert entry["limit"]["context"] == 200000
+
+    _, named = parse_extra_model_spec("deepseek-chat:DeepSeek Chat")
+    assert named["name"] == "DeepSeek Chat"
+    assert named["limit"]["context"] == 200000
+
+
+@pytest.mark.parametrize("spec", ["", ":name:1000", "id:name:abc", "id:name:0"])
+def test_parse_extra_model_spec_invalid(spec: str) -> None:
+    """Empty id or a bad context window raises ValueError."""
+    with pytest.raises(ValueError):
+        parse_extra_model_spec(spec)
+
+
+def test_extra_models_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HEADROOM_OPENCODE_EXTRA_MODELS parses comma-separated specs."""
+    monkeypatch.setenv(
+        HEADROOM_OPENCODE_EXTRA_MODELS_ENV,
+        "deepseek-chat:DeepSeek Chat:65536, kimi-k2",
+    )
+    models = extra_models_from_env()
+    assert models["deepseek-chat"]["limit"]["context"] == 65536
+    assert models["kimi-k2"]["name"] == "kimi-k2"
+
+    monkeypatch.delenv(HEADROOM_OPENCODE_EXTRA_MODELS_ENV)
+    assert extra_models_from_env() == {}
+
+
+def test_headroom_provider_entry_merges_extra_models() -> None:
+    """Extra models are merged alongside the built-in model list."""
+    _, entry = parse_extra_model_spec("deepseek-chat:DeepSeek Chat:65536")
+    provider = headroom_provider_entry(8787, {"deepseek-chat": entry})
+    assert "claude-sonnet-4-6" in provider["models"]
+    assert provider["models"]["deepseek-chat"]["name"] == "DeepSeek Chat"
+
+
+def test_inject_provider_config_with_extra_models(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """inject_opencode_provider_config writes extra models into the config."""
+    _set_test_home(monkeypatch, tmp_path)
+    _, entry = parse_extra_model_spec("deepseek-chat:DeepSeek Chat:65536")
+    inject_opencode_provider_config(port=8787, extra_models={"deepseek-chat": entry})
+    config_file = tmp_path / ".config" / "opencode" / "opencode.json"
+    config = _parse_json_loose(config_file.read_text())
+    models = config["provider"]["headroom"]["models"]
+    assert models["deepseek-chat"]["limit"]["context"] == 65536
+    assert "claude-sonnet-4-6" in models
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`headroom wrap opencode` injects a hardcoded model list (`HEADROOM_OPENCODE_MODELS`) into the `headroom` provider block of `opencode.json`. There is no way to add custom models (e.g. free-tier DeepSeek) at wrap time — hand-patching `opencode.json` is the only workaround, and the next wrap overwrites it.

This PR adds a repeatable `--extra-model` flag and a `HEADROOM_OPENCODE_EXTRA_MODELS` env var, both accepting `id[:name[:context_window]]` specs. Extra models are merged into the injected provider block alongside the built-ins (flag specs win over env specs on id collision). `name` defaults to the id, `context_window` to 200000.

Closes #2359

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- `headroom/providers/opencode/config.py`: new `parse_extra_model_spec()` (validates spec, `ValueError` on empty id / non-integer or non-positive context), `extra_models_from_env()` (comma-separated specs from `HEADROOM_OPENCODE_EXTRA_MODELS`), and `extra_models` parameter threaded through `headroom_provider_entry()`, `_render_provider_block()` and `inject_opencode_provider_config()`; extras are merged as `{**HEADROOM_OPENCODE_MODELS, **extra_models}`.
- `headroom/cli/wrap.py`: repeatable `--extra-model` Click option on the `opencode` subcommand (same `multiple=True` idiom as `--gateway-provider-id`); env + flag specs parsed up front, malformed specs raise `click.BadParameter`; merged dict passed to both `inject_opencode_provider_config` call sites (prepare-only and normal launch); docstring example added.
- Tests: 6 new unit tests in `tests/test_providers_opencode_config.py` (spec parsing incl. invalid cases, env parsing, provider-entry merge, end-to-end inject) and 3 new CLI tests in `tests/test_cli/test_wrap_opencode.py` (flag reaches `opencode.json`, env var persists across wraps, malformed spec exits non-zero with a usage error).

## Testing

- [x] Unit tests pass locally
- [x] Lint/format/type checks pass locally

```
$ python -m pytest tests/test_providers_opencode_config.py tests/test_cli/test_wrap_opencode.py -q --deselect tests/test_providers_opencode_config.py::test_build_launch_env_with_project
89 passed

$ ruff check headroom/providers/opencode/config.py headroom/cli/wrap.py tests/test_providers_opencode_config.py tests/test_cli/test_wrap_opencode.py
All checks passed!

$ ruff format --check <same files>
4 files already formatted

$ mypy headroom --ignore-missing-imports
(no errors; notes only)
```

(`test_build_launch_env_with_project` fails identically on a clean `upstream/main` checkout on this Windows machine — pre-existing path-escaping issue, unrelated to this change.)

## Real Behavior Proof

- Environment: Windows 11, Python 3.13.11, repo at this branch, `HOME` pointed at a temp dir.
- Exact command / steps: `headroom wrap opencode --prepare-only --extra-model "deepseek-chat:DeepSeek Chat:65536" --extra-model kimi-k2`, then inspected `~/.config/opencode/opencode.json`.
- Observed result: `provider.headroom.models` contains all built-in models plus `deepseek-chat` (`name: "DeepSeek Chat"`, `limit.context: 65536`, `limit.output: 16384`) and `kimi-k2` (name defaulted to id, context defaulted to 200000). Re-running with only `HEADROOM_OPENCODE_EXTRA_MODELS=deepseek-chat:DeepSeek Chat:65536` set (no flag) produces the same `deepseek-chat` entry, confirming persistence across re-wraps. `--extra-model bad:name:abc` exits non-zero with `Invalid value for '--extra-model': extra model spec has a non-integer context window`.
- Not tested: a full (non-prepare-only) wrap launching the real OpenCode binary; the OpenCode TS plugin side (extras are user-supplied and intentionally not synced into `plugins/opencode/src/provider.ts` `DEFAULT_MODELS`).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review