### PR TITLE
Fix(proxy) vertex model override propagation

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -737,7 +737,13 @@ class AnthropicHandlerMixin:
                 sanitize_anthropic_model_id(raw_model) if isinstance(raw_model, str) else raw_model
             )
             body_model = body.get("model")
-            if isinstance(body_model, str) and model != body_model:
+            # Only inject model for LiteLLM-backed requests: native Vertex passthrough
+            # preserves the rawPredict wire format, where the model only exists in the URL.
+            if (isinstance(body_model, str) and model != body_model) or (
+                body_model is None
+                and model_override is not None
+                and self.anthropic_backend is not None
+            ):
                 body["model"] = model
                 body_mutation_tracker.mark_mutated("sanitize_model_id")
             messages = body.get("messages", [])

--- a/tests/test_proxy_anthropic_vertex_model_override.py
+++ b/tests/test_proxy_anthropic_vertex_model_override.py
@@ -1,0 +1,177 @@
+"""Regression coverage for #2363: litellm-vertex silently defaulting to
+claude-3-5-sonnet-20241022 because the URL-derived Vertex model never made it
+into ``body["model"]`` before reaching the backend.
+
+Vertex's rawPredict/streamRawPredict wire format carries the model as a URL
+path segment, never as a body field, so ``handle_anthropic_messages``'s
+mutation guard (which only fired when an existing ``body["model"]`` string
+needed sanitizing) silently dropped the resolved model whenever the body had
+no ``model`` key at all -- which is every Vertex request.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from headroom.backends.base import BackendResponse
+from headroom.proxy.server import ProxyConfig, create_app
+
+
+def _vertex_body() -> dict[str, Any]:
+    # Real Vertex rawPredict shape: no top-level "model" key.
+    return {
+        "anthropic_version": "vertex-2023-10-16",
+        "max_tokens": 10,
+        "stream": False,
+        "messages": [{"role": "user", "content": "2+2"}],
+    }
+
+
+class _FakeAnthropicBackend:
+    """Stand-in for LiteLLMBackend: only cares what body it's handed."""
+
+    name = "fake-litellm-vertex"
+
+    def __init__(self) -> None:
+        self.captured_body: dict[str, Any] | None = None
+
+    async def send_message(self, body: dict[str, Any], headers: dict[str, str]) -> BackendResponse:
+        del headers
+        self.captured_body = dict(body)
+        return BackendResponse(
+            body={
+                "id": "msg_fake",
+                "type": "message",
+                "role": "assistant",
+                "model": body.get("model", "unknown"),
+                "content": [{"type": "text", "text": "ok"}],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 1,
+                    "cache_read_input_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                },
+            },
+            status_code=200,
+        )
+
+
+def _app() -> Any:
+    return create_app(
+        ProxyConfig(
+            optimize=False,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=False,
+            log_requests=False,
+            ccr_inject_tool=False,
+            ccr_handle_responses=False,
+            ccr_context_tracking=False,
+            image_optimize=False,
+        )
+    )
+
+
+def test_vertex_rawpredict_propagates_url_model_to_backend_when_body_has_none() -> None:
+    """The primary bug: with a backend configured (e.g. litellm-vertex), the
+    model resolved from the Vertex URL path must reach body["model"] even
+    though the request body never had a "model" key."""
+    app = _app()
+    fake_backend = _FakeAnthropicBackend()
+    app.state.proxy.anthropic_backend = fake_backend  # type: ignore[assignment]
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/projects/p/locations/europe-west1/publishers/anthropic/models/"
+        "claude-sonnet-4-6:rawPredict",
+        json=_vertex_body(),
+    )
+
+    assert response.status_code == 200, response.text
+    assert fake_backend.captured_body is not None
+    assert fake_backend.captured_body["model"] == "claude-sonnet-4-6"
+
+
+def test_vertex_native_passthrough_body_unaffected_when_no_backend_configured() -> None:
+    """Guardrail for the scoping decision: when no backend is configured
+    (self.anthropic_backend is None, e.g. plain `--backend vertex`), the body
+    forwarded to the real Vertex endpoint must stay byte-for-byte as before --
+    no "model" key should be injected into a shape Vertex has never received
+    from Headroom."""
+    app = _app()
+    assert app.state.proxy.anthropic_backend is None
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_retry(
+        method: str,  # noqa: ARG001
+        url: str,  # noqa: ARG001
+        headers: dict[str, str],  # noqa: ARG001
+        body: dict[str, Any],
+        body_mutated: bool,
+        mutation_reasons: list[str],
+        **kwargs: Any,
+    ) -> httpx.Response:
+        captured["body"] = dict(body)
+        captured["body_mutated"] = body_mutated
+        captured["mutation_reasons"] = list(mutation_reasons)
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_native",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-6",
+                "content": [{"type": "text", "text": "ok"}],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 1,
+                    "cache_read_input_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                },
+            },
+        )
+
+    app.state.proxy._retry_request = _fake_retry  # type: ignore[assignment]
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/projects/p/locations/europe-west1/publishers/anthropic/models/"
+        "claude-sonnet-4-6:rawPredict",
+        json=_vertex_body(),
+    )
+
+    assert response.status_code == 200, response.text
+    assert "model" not in captured["body"]
+
+
+def test_missing_model_and_no_override_does_not_write_unknown_into_body() -> None:
+    """Third guard clause: even with a backend configured, a request that
+    supplies neither a body model nor a model_override (e.g. a malformed
+    direct /v1/messages call) must not have body["model"] set to the
+    "unknown" fallback string -- that would be a new failure mode, not a fix."""
+    app = _app()
+    fake_backend = _FakeAnthropicBackend()
+    app.state.proxy.anthropic_backend = fake_backend  # type: ignore[assignment]
+
+    client = TestClient(app)
+    response = client.post(
+        "/v1/messages",
+        headers={"x-api-key": "test-key", "anthropic-version": "2023-06-01"},
+        json={
+            "max_tokens": 10,
+            "stream": False,
+            "messages": [{"role": "user", "content": "2+2"}],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert fake_backend.captured_body is not None
+    assert "model" not in fake_backend.captured_body


### PR DESCRIPTION
## Description

Vertex `rawPredict` requests provide the model through the URL path rather than `body["model"]`. `handle_anthropic_messages` correctly resolved this model through `model_override`, but the existing mutation guard only updated the body when a `model` field already existed. Since Vertex requests do not include `body["model"]`, the resolved model was dropped, causing `LiteLLMBackend` to fall back to its default `claude-3-5-sonnet-v2@20241022` model.

Closes #2363

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Updated `headroom/proxy/handlers/anthropic.py` to propagate `model_override` into `body["model"]` for LiteLLM-backed Vertex requests when the original body does not include a model.
- Preserved native Vertex passthrough behavior by avoiding mutation of raw Vertex request bodies.
- Added regression tests covering model propagation, passthrough behavior, and missing-model edge cases.
- Left `headroom/backends/litellm.py` unchanged since the fallback is avoided once the model is correctly propagated upstream.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output
```
$ uv run pytest tests/test_proxy_anthropic_vertex_model_override.py tests/test_vertex_claude_compression.py \
    tests/test_proxy_anthropic_model_sanitization.py tests/test_proxy_anthropic_cache_stability.py \
    tests/test_proxy_anthropic_compression_diagnostics.py tests/test_provider_vertex_runtime.py -q

tests/test_proxy_anthropic_vertex_model_override.py ...                  [  6%]
tests/test_vertex_claude_compression.py ............                     [ 30%]
tests/test_proxy_anthropic_model_sanitization.py .                       [ 32%]
tests/test_proxy_anthropic_cache_stability.py .........................  [ 83%]
tests/test_proxy_anthropic_compression_diagnostics.py ..                 [ 87%]
tests/test_provider_vertex_runtime.py ......                             [100%]
49 passed, 1 warning in 4.53s

$ uv run mypy headroom/proxy/handlers/anthropic.py
Success: no issues found in 1 source file

$ uv run ruff check headroom/proxy/handlers/anthropic.py tests/test_proxy_anthropic_vertex_model_override.py
All checks passed!

$ uv run ruff format --check headroom/proxy/handlers/anthropic.py tests/test_proxy_anthropic_vertex_model_override.py
2 files already formatted
```

## Real Behavior Proof

- Environment: macOS; repo dev venv used for handler tests; separate Python 3.12 venv used for LiteLLM backend verification because `litellm` is excluded under Python 3.14 in `pyproject.toml`.
- Exact command / steps: Ran the real FastAPI app via `uvicorn` on a real socket with the actual `LiteLLMBackend(provider="vertex_ai")` attached. Stubbed only `litellm.acompletion` to inspect the final model passed to LiteLLM without requiring real GCP/Vertex credentials. Sent `curl -X POST` requests to a Vertex `rawPredict` route with no `model` key in the request body, first against pre-fix `main`, then against the fix.
- Observed result: before and after:
```
  # before: bug reproduces
  body["model"] received by backend = None

  # after: URL model claude-opus-4-6
  map_model_id() -> litellm.acompletion(model='vertex_ai/claude-opus-4-6')

  # after: URL model claude-3-5-sonnet-20241022 (old hardcoded default, for cross-check)
  map_model_id() -> litellm.acompletion(model='vertex_ai/claude-3-5-sonnet-v2@20241022')
  # matches the exact string the original issue's logs showed on *every* request

  # no backend configured (native Vertex passthrough): body unaffected
  forwarded body keys = ['anthropic_version', 'max_tokens', 'messages', 'stream']
```
- Not tested: real GCP/Vertex credentials (verification stops at the `acompletion` call
  boundary); `streamRawPredict` wasn't driven live, though the fix is in shared pre-branch
  code and covered by existing `test_vertex_claude_compression.py` streaming tests.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

The 2nd suggested fix in the issue is out of scope for this PR but I would be happy to open an issue and address this in a new PR if wanted:
```adding a HEADROOM_VERTEX_MODEL_MAP-style env override for _VERTEX_MODEL_MAP, mirroring the existing HEADROOM_BEDROCK_MODEL_MAP. Even with fix https://github.com/headroomlabs-ai/headroom/issues/1 in place, any model not already in the static map would still fail — an override gives users a way to unblock themselves on newly-released models without waiting for a Headroom release.```