### PR TITLE
fix(wrap): emit bare dotted Codex --config keys so custom-provider overrides apply

### DIFF
--- a/tests/test_cli/test_wrap_codex.py
+++ b/tests/test_cli/test_wrap_codex.py
@@ -1176,9 +1176,10 @@ def test_codex_session_launch_settings_preserve_custom_provider_identity(
     assert 'model_providers.company.base_url="http://127.0.0.1:9898/v1"' in args
     assert "model_providers.company.supports_websockets=true" in args
     assert (
-        "model_providers.company.env_http_headers.X-Headroom-Base-Url"
-        '="HEADROOM_CODEX_UPSTREAM_BASE_URL"'
+        "model_providers.company.env_http_headers.X-Headroom-Base-Url="
+        '"HEADROOM_CODEX_UPSTREAM_BASE_URL"'
     ) in args
+    assert not any('"model_providers"' in arg for arg in args)
     assert env[wrap_mod._UPSTREAM_BASE_URL_ENV_VAR] == "https://api.example.test/v1"
     assert config_file.read_text(encoding="utf-8") == original_config
 
@@ -1203,6 +1204,35 @@ def test_codex_dotted_key_quotes_only_unsafe_segments() -> None:
         wrap_mod._codex_dotted_key("model_providers", "my.provider", "base_url")
         == 'model_providers."my.provider".base_url'
     )
+
+
+def test_codex_session_launch_settings_quotes_only_unsafe_provider_segments(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _set_test_home(monkeypatch, tmp_path)
+    codex_home = tmp_path / "custom-codex-home"
+    codex_home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(wrap_mod, "_project_name_from_cwd", lambda: None)
+    config_file = codex_home / "config.toml"
+    config_file.write_text(
+        '[profiles.work]\nmodel_provider = "company.prod"\n\n'
+        '[model_providers."company.prod"]\nbase_url = "https://api.example.test/v1"\n',
+        encoding="utf-8",
+    )
+
+    args, _, _ = wrap_mod._codex_session_launch_settings(
+        port=9898,
+        codex_args=("--profile", "work"),
+        environ={"CODEX_HOME": str(codex_home)},
+    )
+
+    assert 'model_providers."company.prod".base_url="http://127.0.0.1:9898/v1"' in args
+    assert 'model_providers."company.prod".supports_websockets=true' in args
+    assert (
+        'model_providers."company.prod".env_http_headers.X-Headroom-Base-Url='
+        '"HEADROOM_CODEX_UPSTREAM_BASE_URL"'
+    ) in args
 
 
 def test_wrap_codex_rejects_custom_provider_without_upstream_base_url(


### PR DESCRIPTION
## Description

`headroom wrap codex` can preserve an existing custom OpenAI-compatible provider, but it currently emits quoted dotted `--config` keys such as `"model_providers"."litellm_prod"."base_url"=...`. Codex 0.144.5 accepts the launch and ignores those overrides, so the custom provider keeps its original base URL and traffic bypasses Headroom entirely. The value side is already correct. The bug is the key serializer in `_codex_dotted_key()`.

This patch emits bare TOML-safe dotted segments for the Codex override keys and keeps quoted fallback only for unsafe segments, so Codex applies the redirect while the selected custom provider stays intact.

Closes #2358

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- update `_codex_dotted_key()` in `headroom/cli/wrap.py` so TOML-safe segments emit in bare dotted form instead of JSON-quoted per segment
- keep `_codex_toml_value()` and the custom-provider routing call sites unchanged
- flip the focused Codex wrap regression in `tests/test_cli/test_wrap_codex.py` to the bare-key form and add one unsafe-segment fallback case

## Testing

- [x] Unit tests pass (`uv run pytest tests/test_cli/test_wrap_codex.py -q`)
- [x] Linting passes (`uv run ruff check headroom/cli/wrap.py tests/test_cli/test_wrap_codex.py`)
- [ ] Type checking passes (`uv run mypy headroom`)
- [x] New tests added for new functionality when applicable
- [x] Manual testing performed

### Test Output

```text
uv run pytest tests/test_cli/test_wrap_codex.py -q
============================= test session starts =============================
platform win32 -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
rootdir: D:\Repos\headroom-pr-2358-codex-dotted-config-keys
configfile: pyproject.toml
plugins: anyio-4.12.1, langsmith-0.9.3, asyncio-1.3.0, cov-7.0.0, respx-0.23.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 92 items

tests\test_cli\test_wrap_codex.py ...................................... [ 41%]
......................................................                   [100%]

============================= 92 passed in 5.99s ==============================

uv run ruff check headroom/cli/wrap.py tests/test_cli/test_wrap_codex.py
All checks passed!

uv run ruff format headroom/cli/wrap.py tests/test_cli/test_wrap_codex.py --check
2 files already formatted
```

## Real Behavior Proof

- Environment: worktree `D:\Repos\headroom-pr-2358-codex-dotted-config-keys`, `uv sync --extra dev`, local focused pytest plus the bundled issue artifact
- Exact command / steps: compare the helper output and focused Codex wrap regression against `origin/main`, then rerun the full focused file on the branch
- Observed result: base helper output is `"model_providers"."litellm_prod"."base_url"`, branch helper output is `model_providers.litellm_prod.base_url`, and the branch passes `92` focused wrap tests including the new unsafe-segment fallback case
- Not tested: live Codex 0.144.5 run on this host

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

- The fix stays entirely inside the Codex wrap shell. No provider-neutral pipeline or config code learns Codex-specific key rules.
- `CHANGELOG.md` is intentionally unchanged because Headroom derives release notes from conventional commits.
- If Codex 0.144.5 is unavailable in the environment, the issue's A/B capture stays the external reality anchor and the live `codex doctor --json` proof remains deferred.
