### PR TITLE
feat(proxy): allow trusted dashboard clients to manage settings

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -3165,7 +3165,16 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
     # (Phase 3's /settings/apply drives that).
     from headroom import settings_store
 
-    @app.get("/settings/schema", dependencies=[Depends(_require_loopback)])
+    async def _require_dashboard_settings_access(request: Request) -> None:
+        """Allow local or CIDR-approved clients to use Dashboard Settings."""
+        if _request_can_view_dashboard_metadata(
+            request,
+            trusted_dashboard_client_cidrs,
+        ):
+            return
+        raise HTTPException(status_code=404, detail="Not found")
+
+    @app.get("/settings/schema", dependencies=[Depends(_require_dashboard_settings_access)])
     async def settings_schema(_request: Request):
         """Registry + grouped fields + effective values for the settings form."""
         schema = settings_store.to_schema()
@@ -3182,12 +3191,18 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
             schema["supervised"] = False
         return JSONResponse(status_code=200, content=schema)
 
-    @app.get("/settings", dependencies=[Depends(_require_loopback)])
+    @app.get("/settings", dependencies=[Depends(_require_dashboard_settings_access)])
     async def settings_get(_request: Request):
         """Return stored (file) values only; secret fields masked."""
         return JSONResponse(status_code=200, content=settings_store.stored_values())
 
-    @app.post("/settings", dependencies=[Depends(_require_loopback), Depends(_require_same_origin)])
+    @app.post(
+        "/settings",
+        dependencies=[
+            Depends(_require_dashboard_settings_access),
+            Depends(_require_same_origin),
+        ],
+    )
     async def settings_post(request: Request):
         """Persist settings. Unknown key -> 400; bad type/enum/range -> 422.
 
@@ -3232,7 +3247,11 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         )
 
     @app.post(
-        "/settings/apply", dependencies=[Depends(_require_loopback), Depends(_require_same_origin)]
+        "/settings/apply",
+        dependencies=[
+            Depends(_require_dashboard_settings_access),
+            Depends(_require_same_origin),
+        ],
     )
     async def settings_apply(request: Request):
         """Persist settings (optional body) then restart the proxy to apply them.
@@ -3295,7 +3314,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
     @app.get(
         "/dashboard/settings",
         response_class=HTMLResponse,
-        dependencies=[Depends(_require_loopback)],
+        dependencies=[Depends(_require_dashboard_settings_access)],
     )
     async def dashboard_settings():
         """Serve the Headroom settings GUI."""

--- a/tests/test_proxy_settings_endpoints.py
+++ b/tests/test_proxy_settings_endpoints.py
@@ -145,6 +145,75 @@ class TestLoopbackGating:
     def test_settings_page_rejected_off_loopback(self, network_client):
         assert network_client.get("/dashboard/settings").status_code == 404
 
+    def test_trusted_dashboard_client_can_use_settings_routes(self, workspace, monkeypatch):
+        from headroom.install import runtime as install_runtime
+
+        monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.5/32")
+        monkeypatch.setattr(
+            install_runtime,
+            "detect_current_deployment",
+            lambda: (None, "foreground"),
+        )
+        monkeypatch.setattr(
+            install_runtime,
+            "restart_current_deployment",
+            lambda: {"restarted": False, "mode": "foreground"},
+        )
+        client = TestClient(
+            _make_app(),
+            base_url="http://100.82.0.2:8787",
+            client=("100.90.0.5", 12345),
+        )
+
+        assert client.get("/dashboard/settings").status_code == 200
+        assert client.get("/settings/schema").status_code == 200
+        assert client.get("/settings").status_code == 200
+        assert client.post("/settings", json={"values": {}}).status_code == 200
+        assert client.post("/settings/apply", json={}).status_code == 200
+
+    def test_untrusted_dashboard_clients_cannot_use_settings_routes(self, workspace, monkeypatch):
+        monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.5/32")
+        app = _make_app()
+        clients = (
+            TestClient(
+                app,
+                base_url="http://100.82.0.2:8787",
+                client=("100.90.0.6", 12345),
+            ),
+            TestClient(
+                app,
+                base_url="http://attacker.example",
+                client=("100.90.0.5", 12345),
+            ),
+        )
+
+        for client in clients:
+            assert client.get("/dashboard/settings").status_code == 404
+            assert client.get("/settings/schema").status_code == 404
+            assert client.post("/settings", json={"values": {}}).status_code == 404
+            assert client.post("/settings/apply", json={}).status_code == 404
+
+    def test_settings_trusts_forwarded_client_only_from_trusted_gateway(
+        self, workspace, monkeypatch
+    ):
+        monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS", "100.90.0.5/32")
+        monkeypatch.setenv("HEADROOM_PROXY_TRUSTED_GATEWAY_CIDRS", "172.18.0.0/16")
+        app = _make_app()
+        trusted = TestClient(
+            app,
+            base_url="http://100.82.0.2:8787",
+            client=("172.18.0.1", 12345),
+        )
+        forged = TestClient(
+            app,
+            base_url="http://100.82.0.2:8787",
+            client=("198.51.100.10", 12345),
+        )
+
+        headers = {"x-forwarded-for": "100.90.0.5"}
+        assert trusted.get("/settings/schema", headers=headers).status_code == 200
+        assert forged.get("/settings/schema", headers=headers).status_code == 404
+
 
 class TestSameOriginGuard:
     """CSRF: a same-machine (loopback) attacker page can still send a


### PR DESCRIPTION
## Summary
- allow clients in HEADROOM_PROXY_TRUSTED_DASHBOARD_CLIENT_CIDRS to open /dashboard/settings
- apply the same authorization to the Settings read, write, and apply APIs
- preserve IP-literal Host validation, trusted gateway forwarding, same-origin write protection, and loopback-only access for unrelated management endpoints

## Tests
- .venv/Scripts/python.exe -m pytest tests/test_proxy_settings_endpoints.py tests/test_proxy_loopback_gating.py -q (66 passed)
- .venv/Scripts/python.exe -m ruff check headroom/proxy/server.py tests/test_proxy_settings_endpoints.py