### PR TITLE
fix(proxy): warn when --compressor selection matches no built-in

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -683,9 +683,10 @@ def _apply_compressor_selection(
     keeps its dataclass default, so behavior is byte-identical to today. When a
     selection is given, each recognized built-in in :data:`BUILTIN_COMPRESSOR_FLAGS`
     is enabled iff it (or the wildcard ``"*"``) was selected, and disabled
-    otherwise. Unrecognized names are ignored (reserved for the compressor
-    registry). This maps a selection onto the existing flags without adding any
-    dispatch logic.
+    otherwise. Unrecognized names select no flag (reserved for the compressor
+    registry) but are surfaced with a warning, because a typo'd selection is
+    otherwise indistinguishable from "compress nothing" (#2384). This maps a
+    selection onto the existing flags without adding any dispatch logic.
     """
     if compressors is None:
         return
@@ -693,6 +694,23 @@ def _apply_compressor_selection(
     if not selected:
         return
     select_all = "*" in selected
+    unmatched = sorted(selected - set(BUILTIN_COMPRESSOR_FLAGS) - {"*"})
+    if unmatched:
+        if select_all or selected & set(BUILTIN_COMPRESSOR_FLAGS):
+            logger.warning(
+                "compressor selection: %s match no built-in compressor "
+                "(assumed registry names); built-ins: %s",
+                ", ".join(unmatched),
+                ", ".join(sorted(BUILTIN_COMPRESSOR_FLAGS)),
+            )
+        else:
+            logger.warning(
+                "compressor selection %s matches no built-in compressor — every "
+                "built-in compressor is now disabled. If this is a typo, valid "
+                "names are: %s (or '*' for all).",
+                ", ".join(unmatched),
+                ", ".join(sorted(BUILTIN_COMPRESSOR_FLAGS)),
+            )
     for name, flag in BUILTIN_COMPRESSOR_FLAGS.items():
         setattr(router_config, flag, select_all or name in selected)
 

--- a/tests/test_compressor_selection.py
+++ b/tests/test_compressor_selection.py
@@ -14,6 +14,7 @@ Covers the two behavior-safe halves of the router/registry integration:
 from __future__ import annotations
 
 import dataclasses
+import logging
 
 import pytest
 
@@ -142,6 +143,44 @@ def test_unrecognized_names_are_ignored_but_recognized_still_apply() -> None:
     flags = _enable_flags(config)
     assert flags["enable_kompress"] is True
     # No crash / no spurious flag creation for the unknown name.
+
+
+# ────────────────── unmatched-name warning (#2384, no behavior change) ────────
+
+
+def test_only_unmatched_selection_warns_that_builtins_are_disabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A typo'd selection must be diagnosable from the startup log."""
+    config = ContentRouterConfig()
+    with caplog.at_level(logging.WARNING, logger="headroom.proxy"):
+        _apply_compressor_selection(config, {"smart_krusher"})
+    # Behavior is unchanged — the opt-in "exactly these" contract still holds.
+    assert not any(_enable_flags(config).values())
+    text = " ".join(r.getMessage() for r in caplog.records)
+    assert "smart_krusher" in text
+    assert "disabled" in text.lower()
+    assert "smart_crusher" in text  # valid names listed for the typo case
+
+
+def test_mixed_selection_warns_only_about_unmatched_names(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = ContentRouterConfig()
+    with caplog.at_level(logging.WARNING, logger="headroom.proxy"):
+        _apply_compressor_selection(config, {"kompress", "does_not_exist"})
+    assert _enable_flags(config)["enable_kompress"] is True
+    text = " ".join(r.getMessage() for r in caplog.records)
+    assert "does_not_exist" in text
+    assert "disabled" not in text.lower()  # built-ins were not all turned off
+
+
+def test_matched_selection_emits_no_warning(caplog: pytest.LogCaptureFixture) -> None:
+    for selection in ({"kompress"}, {"*"}):
+        config = ContentRouterConfig()
+        with caplog.at_level(logging.WARNING, logger="headroom.proxy"):
+            _apply_compressor_selection(config, selection)
+    assert not caplog.records
 
 
 # ─────────────────────────── ProxyConfig field ───────────────────────────────


### PR DESCRIPTION
## Description

A `--compressor` selection that matches no built-in name (e.g. `smart_krusher`, a typo of `smart_crusher`) silently disables **all** built-in compression: the proxy starts healthy, the dashboard shows ~0 savings, and nothing explains why.

The all-off *semantics* is deliberate and stays untouched — `test_only_external_name_disables_all_builtins` pins the opt-in "exactly these" contract, and external/registry names are a legitimate input class. What's missing is any **signal**: a typo and an external compressor name are indistinguishable at this seam, and the registry's own unregistered-name warning (`CompressorRegistry.select`) never runs on this path.

Fix: `_apply_compressor_selection` now logs one warning when the selection contains unmatched names —
- **nothing matched** (the typo case): says plainly that every built-in compressor is now disabled and lists the valid names + `*`;
- **mixed**: names the unmatched entries as assumed registry names.

Selection results are byte-identical before/after.

Fixes #2384.

## Type of Change

- [x] Bug fix (observability for a silent misconfiguration; no behavior change)

## Changes Made

- `headroom/proxy/server.py`: `_apply_compressor_selection` computes the unmatched set and emits one `headroom.proxy` warning (two phrasings: nothing-matched vs mixed); docstring updated.
- `tests/test_compressor_selection.py`: 3 new tests — typo-only selection warns (and flags stay all-off, pinning the unchanged contract), mixed selection warns only about the unmatched name, matched/wildcard selections stay warning-free.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff` + `mypy`, CI-pinned settings)
- [x] Wrote the failing tests first, then the warning

### Test Output

```text
$ .venv/bin/python -m pytest tests/test_compressor_selection.py -q
26 passed

# Before the fix the two new warning tests fail (no log records emitted).

$ ruff check headroom/proxy/server.py tests/test_compressor_selection.py   # All checks passed!
$ ruff format --check <both>                                               # formatted
$ mypy headroom/proxy/server.py --ignore-missing-imports                   # Success: no issues
```

## Real Behavior Proof

- Environment: macOS (Darwin), Python in a uv venv, branch `fix/compressor-selection-warn` off `main` (`56c7d4a5`).
- Exact command / steps: configured stdlib logging at WARNING and called `_apply_compressor_selection(ContentRouterConfig(), {"smart_krusher"})` — the exact typo scenario from #2384.
- Observed result: `WARNING headroom.proxy: compressor selection smart_krusher matches no built-in compressor — every built-in compressor is now disabled. If this is a typo, valid names are: code_aware, config, html, image, kompress, log, search, smart_crusher, tabular (or '*' for all).` with `enable_smart_crusher = False` (contract unchanged). Before the fix the same call produced zero log output.
- Not tested: a full `headroom proxy --compressor smart_krusher` process launch; the seam is exercised directly and the proxy wires it unconditionally.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A (docstring updated)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md — N/A

## Additional Notes

- Deliberately warn-only: erroring here would break legitimate external/registry selections and could brick startup on a stale `HEADROOM_COMPRESSORS` settings value. If you'd rather hard-fail just the CLI-typed path, happy to follow up.
