### PR TITLE
test(recover-codex): bind AF_UNIX socket via short relative path

### DIFF
--- a/tests/test_cli/test_recover_codex.py
+++ b/tests/test_cli/test_recover_codex.py
@@ -761,7 +761,9 @@ def test_recovery_keeps_newest_divergent_rollout_and_backs_up_both(
     sys.platform == "win32" or not hasattr(socket, "AF_UNIX"),
     reason="requires POSIX Unix domain sockets",
 )
-def test_recovery_records_sockets_and_secures_both_backups(tmp_path: Path) -> None:
+def test_recovery_records_sockets_and_secures_both_backups(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     target = tmp_path / "codex"
     source = tmp_path / "headroom-codex-home-broken"
     target.mkdir(mode=0o755)
@@ -773,8 +775,11 @@ def test_recovery_records_sockets_and_secures_both_backups(tmp_path: Path) -> No
     fifo_path = source / "codex.pipe"
     os.mkfifo(fifo_path)
 
+    # AF_UNIX sun_path is capped (~104 bytes on macOS) and pytest's tmp_path can
+    # exceed it, so bind a short RELATIVE name from inside source.
+    monkeypatch.chdir(source)
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as codex_socket:
-        codex_socket.bind(str(socket_path))
+        codex_socket.bind(socket_path.name)
         report = recover_codex_home(source=source, target=target)
 
     pinned = report.backup_dir / "source-pinned"


### PR DESCRIPTION
## Description

`test_recovery_records_sockets_and_secures_both_backups` binds a Unix domain socket at its absolute path under pytest's `tmp_path`. On macOS the `AF_UNIX` `sun_path` limit (~104 bytes) is shorter than that path, so `bind()` raises `OSError: AF_UNIX path too long` and the test fails locally. It stays green on CI Linux only because `/tmp`-rooted temp paths there are short enough. Bind a short relative name from inside `source` instead; the socket is still created at `source/codex.sock` and the recovery scan behaves identically.

Closes #2394 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/test_cli/test_recover_codex.py`: in  `test_recovery_records_sockets_and_secures_both_backups`, `monkeypatch.chdir`  into `source` and `bind(socket_path.name)` (a short relative name) instead of
  `bind(str(socket_path))` (a long absolute path). Added the `monkeypatch`  fixture to the signature and a one-line comment explaining the `sun_path` cap.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy`)
- [x] Manual testing performed

### Test Output

```text
# BEFORE (on this macOS box, at the branch base):
$ uv run pytest -q \
    "tests/test_cli/test_recover_codex.py::test_recovery_records_sockets_and_secures_both_backups" tests/test_cli/test_recover_codex.py:777: in test_recovery_records_sockets_and_secures_both_backups     codex_socket.bind(str(socket_path))
E   OSError: AF_UNIX path too long
1 failed in 0.70s

# AFTER (whole file, no regressions):
$ uv run pytest -q tests/test_cli/test_recover_codex.py
31 passed in 0.72s

$ uv run ruff format --check tests/test_cli/test_recover_codex.py
1 file already formatted
$ uv run ruff check tests/test_cli/test_recover_codex.py
All checks passed!
$ uv run mypy tests/test_cli/test_recover_codex.py
Success: no issues found in 1 source file
```

<img width="1073" height="200" alt="image" src="https://github.com/user-attachments/assets/82155e76-3005-4c4f-93f4-4802ae5e7405" />

## Real Behavior Proof

- Environment: macOS 26.5 (darwin 25.5.0), Python 3.13.7, ruff 0.14.14,  `tempfile.gettempdir()` = `/var/folders/.../T` (48 chars, before the  `pytest-of-*/pytest-N/test_.../headroom-codex-home-broken/codex.sock` suffix,  which pushes the absolute `sun_path` over the macOS ~104-byte cap).
- Exact command / steps: run the focused test at the branch base (fails with `AF_UNIX path  too long`), apply the one-line relative-bind change, re-run the whole file.
- Observed result: before = 1 failed; after = 31 passed. `ruff`/`mypy` clean.
- Not tested: Linux/Windows (the test is `skipif` on win32 / no `AF_UNIX`; on   Linux it already passed pre-change because temp paths are short). No production  code touched, so no proxy/runtime behavior was re-validated.


## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A: test-only)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works     (this IS the corrected test; it fails before and passes after)
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit `CHANGELOG.md`

## Additional Notes

- Pure test-portability fix; no production behavior change. `test:` type keeps it  out of the release-please changelog, which is correct for a test-only change.
