### PR TITLE
fix(release): publish Windows wheel + sdist (disable PyPI attestations, #112)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -788,6 +788,7 @@ jobs:
           # recommended pattern for release workflows that may run
           # multiple times against the same version.
           skip-existing: true
+          attestations: false
 
   publish-npm:
     needs: [detect-version, build]


### PR DESCRIPTION
Automated by Headroom + Kimi (Fireworks) in a Modal Sandbox.

Request:
Make ONLY this one change, nothing else: in .github/workflows/release.yml, in the publish-pypi job's step that uses pypa/gh-action-pypi-publish, add exactly one line 'attestations: false' immediately after the 'skip-existing: true' line in its with: block (same indentation). Do NOT edit any other file, do NOT investigate the codebase, do NOT make any other change. Then finish.