### PR TITLE
feat(pricing): add custom model pricing, 4-tier cost calculator, and …

### DIFF
--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -402,9 +402,24 @@ Configure context limits and pricing for new or custom models:
       "gpt-5": 256000,
       "ft:gpt-4o:my-org": 128000
     }
+  },
+  "custom_pricing": {
+    "my-custom-model": {
+      "input_per_1m": 2.50,
+      "output_per_1m": 10.00,
+      "cached_input_per_1m": 0.25
+    }
   }
 }
 ```
+
+### Upstream Cost & Fallback Estimation
+
+When upstream providers or gateways (Bedrock, Azure, Portkey, LiteLLM, internal proxies) process requests:
+1. **Provider-Supplied Cost**: If the provider returns a cost header (e.g. `X-Cost-USD`, `X-Request-Cost-USD`, `X-Portkey-Cost`, `X-LiteLLM-Response-Cost`) or JSON usage cost field, Headroom uses the exact reported cost.
+2. **Custom Model Pricing**: If provider cost is missing and a custom rate is configured in `custom_pricing`, Headroom calculates cost using your configured rates.
+3. **LiteLLM Database**: If no custom rate is configured, Headroom falls back to LiteLLM's 100+ model pricing database.
+4. **Unchanged Default**: If no pricing is available for an unknown model, cost defaults to missing/unmeasured without breaking request routing.
 
 Save as `${HEADROOM_CONFIG_DIR}/models.json` (defaults to
 `~/.headroom/config/models.json`), or set `HEADROOM_MODEL_LIMITS` to a

--- a/headroom/pricing/__init__.py
+++ b/headroom/pricing/__init__.py
@@ -13,6 +13,7 @@ from .anthropic_prices import (
 from .anthropic_prices import (
     LAST_UPDATED as ANTHROPIC_LAST_UPDATED,
 )
+from .calculator import CostCalculator
 from .deepseek_prices import (
     DEEPSEEK_PRICES,
     get_deepseek_registry,
@@ -44,6 +45,7 @@ __all__ = [
     "get_model_pricing",
     "list_available_models",
     # Core classes
+    "CostCalculator",
     "CostEstimate",
     "ModelPricing",
     "PricingRegistry",

--- a/headroom/pricing/calculator.py
+++ b/headroom/pricing/calculator.py
@@ -1,0 +1,109 @@
+"""CostCalculator: Encapsulates the 4-tier cost evaluation hierarchy.
+
+Evaluation Hierarchy:
+1. Provider-supplied cost (if present on response/outcome metadata) -> use directly.
+2. User-configured custom model pricing (if present in user PricingRegistry) -> calculate cost.
+3. Default pricing database (LiteLLM / built-in database) -> calculate cost.
+4. Fallback -> return None (preserve existing behavior when no cost or pricing is available).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from headroom.pricing.registry import PricingRegistry
+
+logger = logging.getLogger("headroom.pricing.calculator")
+
+
+class CostCalculator:
+    """Calculates request cost and savings based on provider data and model pricing."""
+
+    def __init__(
+        self,
+        custom_registry: PricingRegistry | None = None,
+        cost_fallback_enabled: bool = True,
+    ):
+        """Initialize CostCalculator.
+
+        Args:
+            custom_registry: Optional user-configured PricingRegistry containing custom model rates.
+            cost_fallback_enabled: Whether to fall back to custom/LiteLLM estimation when provider cost is missing.
+        """
+        self.custom_registry = custom_registry
+        self.cost_fallback_enabled = cost_fallback_enabled
+
+    def set_custom_registry(self, registry: PricingRegistry | None) -> None:
+        """Update or set the user-configured PricingRegistry."""
+        self.custom_registry = registry
+
+    def calculate_request_cost(
+        self,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+        provider_cost_usd: float | None = None,
+    ) -> float | None:
+        """Calculate the total cost in USD for a single request.
+
+        Args:
+            model: Model name/identifier.
+            input_tokens: Non-cached input tokens.
+            output_tokens: Output tokens.
+            cache_read_tokens: Input tokens served from prompt cache.
+            cache_write_tokens: Input tokens written to prompt cache.
+            provider_cost_usd: Cost supplied directly by provider response, if any.
+
+        Returns:
+            Cost in USD as a float, or None if pricing is unavailable.
+        """
+        # Tier 1: Upstream provider supplied exact cost
+        if provider_cost_usd is not None and provider_cost_usd >= 0:
+            return float(provider_cost_usd)
+
+        if not self.cost_fallback_enabled or not model:
+            return None
+
+        # Tier 2: User-configured custom pricing registry
+        if self.custom_registry is not None:
+            pricing = self.custom_registry.get_price(model)
+            if pricing is not None:
+                try:
+                    estimate = self.custom_registry.estimate_cost(
+                        model=pricing.model,
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                        cached_input_tokens=cache_read_tokens,
+                    )
+                    return float(estimate.cost_usd)
+                except Exception as e:
+                    logger.debug(f"Custom pricing estimation failed for model {model}: {e}")
+
+        # Tier 3: Default LiteLLM pricing database lookup
+        try:
+            from headroom.pricing.litellm_pricing import (
+                LITELLM_AVAILABLE,
+                resolve_litellm_model,
+            )
+
+            if LITELLM_AVAILABLE:
+                import litellm
+
+                resolved_model = resolve_litellm_model(model)
+                input_cost, output_cost = litellm.cost_per_token(
+                    model=resolved_model,
+                    prompt_tokens=input_tokens,
+                    completion_tokens=output_tokens,
+                    cache_read_input_tokens=cache_read_tokens,
+                    cache_creation_input_tokens=cache_write_tokens,
+                )
+                total_cost = input_cost + output_cost
+                if total_cost > 0:
+                    return float(total_cost)
+        except Exception as e:
+            logger.debug(f"LiteLLM estimation failed for model {model}: {e}")
+
+        # Tier 4: Fallback (no pricing available)
+        return None

--- a/headroom/pricing/registry.py
+++ b/headroom/pricing/registry.py
@@ -1,7 +1,10 @@
 """Pricing registry for LLM model cost estimation."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import date, timedelta
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -12,14 +15,37 @@ class ModelPricing:
     """
 
     model: str
-    provider: str
     input_per_1m: float
     output_per_1m: float
+    provider: str = ""
     cached_input_per_1m: float | None = None
     batch_input_per_1m: float | None = None
     batch_output_per_1m: float | None = None
     context_window: int | None = None
     notes: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ModelPricing:
+        """Create a ModelPricing instance from a dictionary."""
+        return cls(
+            model=str(data.get("model", "")),
+            input_per_1m=float(data.get("input_per_1m", 0.0)),
+            output_per_1m=float(data.get("output_per_1m", 0.0)),
+            provider=str(data.get("provider", "")),
+            cached_input_per_1m=float(data["cached_input_per_1m"])
+            if data.get("cached_input_per_1m") is not None
+            else None,
+            batch_input_per_1m=float(data["batch_input_per_1m"])
+            if data.get("batch_input_per_1m") is not None
+            else None,
+            batch_output_per_1m=float(data["batch_output_per_1m"])
+            if data.get("batch_output_per_1m") is not None
+            else None,
+            context_window=int(data["context_window"])
+            if data.get("context_window") is not None
+            else None,
+            notes=str(data["notes"]) if data.get("notes") is not None else None,
+        )
 
 
 @dataclass
@@ -41,23 +67,30 @@ class PricingRegistry:
 
     def __init__(
         self,
-        last_updated: date,
+        last_updated: date | None = None,
         source_url: str | None = None,
         prices: dict[str, ModelPricing] | None = None,
     ):
         """Initialize the pricing registry.
 
         Args:
-            last_updated: Date when pricing information was last verified.
+            last_updated: Date when pricing information was last verified (defaults to today).
             source_url: URL to the official pricing page.
             prices: Dictionary mapping model names to ModelPricing objects.
         """
-        self.last_updated = last_updated
+        self.last_updated = last_updated or date.today()
         self.source_url = source_url
         self.prices: dict[str, ModelPricing] = prices or {}
 
+    def register_price(self, pricing: ModelPricing) -> None:
+        """Register or override pricing for a model."""
+        self.prices[pricing.model] = pricing
+
     def get_price(self, model: str) -> ModelPricing | None:
         """Get pricing for a specific model.
+
+        Supports direct lookup, case-insensitive lookup, and provider prefix stripping
+        (e.g., 'azure/gpt-4o' -> 'gpt-4o').
 
         Args:
             model: The model name/identifier.
@@ -65,7 +98,41 @@ class PricingRegistry:
         Returns:
             ModelPricing if found, None otherwise.
         """
-        return self.prices.get(model)
+        if not model:
+            return None
+
+        # 1. Exact match
+        if model in self.prices:
+            return self.prices[model]
+
+        # 2. Case-insensitive match
+        model_lower = model.lower()
+        for k, v in self.prices.items():
+            if k.lower() == model_lower:
+                return v
+
+        # 3. Strip provider prefix (e.g. "azure/gpt-4" -> "gpt-4", "bedrock/us.anthropic..." -> "claude...")
+        if "/" in model:
+            stripped = model.split("/", 1)[1]
+            price = self.get_price(stripped)
+            if price:
+                return price
+
+        return None
+
+    @classmethod
+    def from_dict(cls, custom_pricing_dict: dict[str, Any]) -> PricingRegistry:
+        """Create a PricingRegistry from a dictionary of model pricing configs."""
+        registry = cls()
+        for key, val in custom_pricing_dict.items():
+            if isinstance(val, ModelPricing):
+                registry.register_price(val)
+            elif isinstance(val, dict):
+                data = dict(val)
+                if "model" not in data:
+                    data["model"] = key
+                registry.register_price(ModelPricing.from_dict(data))
+        return registry
 
     def is_stale(self) -> bool:
         """Check if pricing information is potentially outdated.

--- a/headroom/proxy/cost.py
+++ b/headroom/proxy/cost.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from headroom.proxy.modes import PROXY_MODE_CACHE
 
 if TYPE_CHECKING:
+    from headroom.pricing.registry import PricingRegistry
     from headroom.proxy.prometheus_metrics import PrometheusMetrics
 
 LITELLM_AVAILABLE = importlib.util.find_spec("litellm") is not None
@@ -651,9 +652,27 @@ class CostTracker:
     # get_period_cost() undercounts and check_budget() silently under-enforces.
     COST_RETENTION_HOURS = 744  # 31 days
 
-    def __init__(self, budget_limit_usd: float | None = None, budget_period: str = "daily"):
+    def __init__(
+        self,
+        budget_limit_usd: float | None = None,
+        budget_period: str = "daily",
+        custom_pricing: dict | PricingRegistry | None = None,
+        cost_fallback_enabled: bool = True,
+    ):
         self.budget_limit_usd = budget_limit_usd
         self.budget_period = budget_period
+        self.cost_fallback_enabled = cost_fallback_enabled
+
+        from headroom.pricing.calculator import CostCalculator
+        from headroom.pricing.registry import PricingRegistry
+
+        custom_registry = None
+        if isinstance(custom_pricing, PricingRegistry):
+            custom_registry = custom_pricing
+        elif isinstance(custom_pricing, dict):
+            custom_registry = PricingRegistry.from_dict(custom_pricing)
+
+        self.calculator = CostCalculator(custom_registry=custom_registry)
 
         # Cost tracking - using deque for efficient left-side removal
         self._costs: deque[tuple[datetime, float]] = deque(maxlen=self.MAX_COST_ENTRIES)
@@ -670,6 +689,17 @@ class CostTracker:
         self._api_cache_write_5m_by_model: dict[str, int] = {}
         self._api_cache_write_1h_by_model: dict[str, int] = {}
         self._api_uncached_by_model: dict[str, int] = {}
+
+    def set_custom_pricing(self, custom_pricing: dict | PricingRegistry | None) -> None:
+        """Update the custom model pricing registry used by CostTracker."""
+        from headroom.pricing.registry import PricingRegistry
+
+        if isinstance(custom_pricing, PricingRegistry):
+            self.calculator.set_custom_registry(custom_pricing)
+        elif isinstance(custom_pricing, dict):
+            self.calculator.set_custom_registry(PricingRegistry.from_dict(custom_pricing))
+        else:
+            self.calculator.set_custom_registry(None)
 
     def reset_runtime(self) -> None:
         """Reset in-memory cost/token counters for local test/debug use."""
@@ -691,11 +721,9 @@ class CostTracker:
         output_tokens: int,
         cache_read_tokens: int = 0,
         cache_write_tokens: int = 0,
+        provider_cost_usd: float | None = None,
     ) -> float | None:
-        """Estimate cost in USD using LiteLLM's pricing database.
-
-        LiteLLM natively handles cache_read and cache_creation pricing
-        for all providers (Anthropic, OpenAI, Google, etc.) in a single call.
+        """Estimate cost in USD using CostCalculator (Provider -> Custom Pricing -> LiteLLM).
 
         Args:
             model: Model name for pricing lookup
@@ -703,33 +731,16 @@ class CostTracker:
             output_tokens: Output tokens
             cache_read_tokens: Tokens served from cache (~10% of input rate)
             cache_write_tokens: Tokens written to cache (~125% of input rate)
+            provider_cost_usd: Explicit cost returned by provider response, if any
         """
-        litellm = _get_litellm_module()
-        if litellm is None:
-            logger.warning("LiteLLM not available - cannot calculate costs")
-            return None
-
-        try:
-            from headroom.pricing.litellm_pricing import resolve_litellm_model
-
-            resolved_model = resolve_litellm_model(model)
-
-            # litellm.cost_per_token handles all token types natively:
-            # prompt_tokens at input rate, cache_read at ~10%, cache_creation at ~125%
-            input_cost, output_cost = litellm.cost_per_token(
-                model=resolved_model,
-                prompt_tokens=input_tokens,
-                completion_tokens=output_tokens,
-                cache_read_input_tokens=cache_read_tokens,
-                cache_creation_input_tokens=cache_write_tokens,
-            )
-
-            total_cost = input_cost + output_cost
-            return float(total_cost) if total_cost > 0 else None
-
-        except Exception as e:
-            logger.warning(f"Failed to get pricing for model {model}: {e}")
-            return None
+        return self.calculator.calculate_request_cost(
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            provider_cost_usd=provider_cost_usd,
+        )
 
     def _prune_old_costs(self):
         """Remove cost entries older than retention period.
@@ -761,6 +772,7 @@ class CostTracker:
         cache_write_1h_tokens: int = 0,
         uncached_tokens: int = 0,
         output_tokens: int = 0,
+        provider_cost_usd: float | None = None,
     ):
         """Record token counts per model and accumulate request cost for budget enforcement.
 
@@ -772,6 +784,7 @@ class CostTracker:
             cache_write_tokens: Cache write tokens from API response usage.
             uncached_tokens: Non-cached input tokens from API response usage.
             output_tokens: Output tokens from API response usage.
+            provider_cost_usd: Upstream cost supplied by provider response, if any.
         """
         # Post-guard invariant (all providers): Headroom never forwards a request
         # larger than the original (handlers revert any inflation before sending),
@@ -820,6 +833,7 @@ class CostTracker:
             output_tokens=output_tokens,
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
+            provider_cost_usd=provider_cost_usd,
         )
         if cost is not None:
             self._costs.append((datetime.now(), cost))
@@ -849,6 +863,11 @@ class CostTracker:
 
     def _get_list_price(self, model: str) -> float | None:
         """Get list input price per 1M tokens for a model."""
+        if self.calculator.custom_registry is not None:
+            pricing = self.calculator.custom_registry.get_price(model)
+            if pricing is not None:
+                return pricing.input_per_1m
+
         litellm = _get_litellm_module()
         if litellm is None:
             return None
@@ -866,8 +885,20 @@ class CostTracker:
         """Get per-token prices for cache read, cache write, and uncached input.
 
         Returns (cache_read, cache_write, uncached) per-token costs, or None
-        if pricing is unavailable. Uses LiteLLM's native cache pricing data.
+        if pricing is unavailable.
         """
+        if self.calculator.custom_registry is not None:
+            pricing = self.calculator.custom_registry.get_price(model)
+            if pricing is not None:
+                uncached = pricing.input_per_1m / 1_000_000
+                cache_read = (
+                    (pricing.cached_input_per_1m / 1_000_000)
+                    if pricing.cached_input_per_1m is not None
+                    else uncached
+                )
+                cache_write = uncached
+                return (cache_read, cache_write, uncached)
+
         litellm = _get_litellm_module()
         if litellm is None:
             return None

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -3359,6 +3359,13 @@ class AnthropicHandlerMixin:
                     # that were showing 0% active-savings on non-
                     # streaming Anthropic traffic will now show the
                     # correct ratio.
+                    from headroom.proxy.helpers import extract_provider_cost
+
+                    provider_cost = extract_provider_cost(
+                        getattr(response, "headers", None),
+                        resp_json if isinstance(resp_json, dict) else None,
+                        getattr(self.config, "provider_cost_headers", None),
+                    )
                     await self._record_request_outcome(
                         RequestOutcome(
                             request_id=request_id,
@@ -3383,6 +3390,7 @@ class AnthropicHandlerMixin:
                             num_messages=len(messages),
                             tags=tags,
                             client=client,
+                            provider_cost_usd=provider_cost,
                             turn_id=compute_turn_id(
                                 model, body.get("system"), body.get("messages")
                             ),

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -3690,6 +3690,14 @@ class OpenAIHandlerMixin:
                         messages=optimized_messages,
                     )
 
+                    from headroom.proxy.helpers import extract_provider_cost
+
+                    provider_cost = extract_provider_cost(
+                        getattr(backend_response, "headers", None),
+                        backend_response.body if isinstance(backend_response.body, dict) else None,
+                        getattr(self.config, "provider_cost_headers", None),
+                    )
+
                     await self._record_request_outcome(
                         RequestOutcome(
                             request_id=request_id,
@@ -3714,6 +3722,7 @@ class OpenAIHandlerMixin:
                             if getattr(self.config, "log_full_messages", False)
                             else None,
                             client=client,
+                            provider_cost_usd=provider_cost,
                         )
                     )
 

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -12,6 +12,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -3023,3 +3024,69 @@ def inject_tool_search_deferral_openai(
     if deferred == 0:
         return tools  # nothing to defer → don't perturb the request / cache prefix
     return out
+
+
+def extract_provider_cost(
+    headers: Any = None,
+    payload: dict | None = None,
+    header_names: list[str] | None = None,
+) -> float | None:
+    """Extract upstream provider-supplied cost from response headers or JSON payload safely.
+
+    Checks case-insensitively across configured cost headers (e.g. x-cost-usd, x-request-cost-usd)
+    and JSON payload fields (e.g. cost, request_cost, total_cost).
+    Returns cost as float if non-negative and finite, otherwise None.
+    """
+    targets = [
+        h.lower()
+        for h in (
+            header_names
+            or [
+                "x-cost-usd",
+                "x-request-cost-usd",
+                "x-portkey-cost",
+                "x-litellm-response-cost",
+                "x-proxy-cost-usd",
+            ]
+        )
+    ]
+
+    # 1. Check HTTP response headers
+    if headers:
+        try:
+            for key, val in headers.items():
+                if str(key).lower() in targets:
+                    try:
+                        cost_val = float(val)
+                        if math.isfinite(cost_val) and cost_val >= 0:
+                            return cost_val
+                    except (ValueError, TypeError):
+                        pass
+        except Exception:
+            pass
+
+    # 2. Check response JSON payload (usage / metadata / top-level)
+    if isinstance(payload, dict):
+        candidate_dicts = [payload]
+        for nested in ("usage", "metadata", "response_metadata"):
+            sub = payload.get(nested)
+            if isinstance(sub, dict):
+                candidate_dicts.append(sub)
+
+        for d in candidate_dicts:
+            for field in ("cost", "cost_usd", "total_cost", "request_cost", "response_cost"):
+                if field in d:
+                    val = d[field]
+                    if isinstance(val, (int, float)) and not isinstance(val, bool):
+                        cost_val = float(val)
+                        if math.isfinite(cost_val) and cost_val >= 0:
+                            return cost_val
+                    elif isinstance(val, str):
+                        try:
+                            cost_val = float(val)
+                            if math.isfinite(cost_val) and cost_val >= 0:
+                                return cost_val
+                        except ValueError:
+                            pass
+
+    return None

--- a/headroom/proxy/models.py
+++ b/headroom/proxy/models.py
@@ -309,6 +309,17 @@ class ProxyConfig:
     cost_tracking_enabled: bool = True
     budget_limit_usd: float | None = None
     budget_period: Literal["hourly", "daily", "monthly"] = "daily"
+    cost_fallback_enabled: bool = True
+    custom_pricing: dict[str, Any] | None = None
+    provider_cost_headers: list[str] = field(
+        default_factory=lambda: [
+            "x-cost-usd",
+            "x-request-cost-usd",
+            "x-portkey-cost",
+            "x-litellm-response-cost",
+            "x-proxy-cost-usd",
+        ]
+    )
 
     # Logging
     log_requests: bool = True

--- a/headroom/proxy/outcome.py
+++ b/headroom/proxy/outcome.py
@@ -142,6 +142,8 @@ class RequestOutcome:
     tags: dict[str, str] = field(default_factory=dict)
     client: str | None = None
     project: str | None = None
+    # Upstream cost explicitly supplied by provider response (USD), if any.
+    provider_cost_usd: float | None = None
 
     # ── Derived (computed once, no caching needed — properties are cheap) ─
 
@@ -425,6 +427,7 @@ async def emit_request_outcome(handler: Any, outcome: RequestOutcome) -> None:
             cache_write_1h_tokens=outcome.cache_write_1h_tokens,
             uncached_tokens=outcome.uncached_input_tokens,
             output_tokens=outcome.output_tokens,
+            provider_cost_usd=outcome.provider_cost_usd,
         )
 
     # 3. Per-request log (optional). The ``client`` outcome field is

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -800,6 +800,8 @@ class HeadroomProxy(
             CostTracker(
                 budget_limit_usd=config.budget_limit_usd,
                 budget_period=config.budget_period,
+                custom_pricing=config.custom_pricing,
+                cost_fallback_enabled=config.cost_fallback_enabled,
             )
             if config.cost_tracking_enabled
             else None

--- a/headroom/settings_store.py
+++ b/headroom/settings_store.py
@@ -204,6 +204,16 @@ SETTINGS: tuple[SettingField, ...] = (
         help="Period the budget applies to.",
         tier="basic",
     ),
+    SettingField(
+        "HEADROOM_COST_FALLBACK_ENABLED",
+        "cost_fallback_enabled",
+        "Cost Fallback Estimation",
+        "Budget",
+        "bool",
+        default=True,
+        help="Estimate request cost using user/LiteLLM model pricing when provider cost is missing.",
+        tier="advanced",
+    ),
     # --- Networking (baked into the install manifest on supervised deploys) ---
     SettingField(
         "HEADROOM_HOST",

--- a/tests/test_custom_model_pricing.py
+++ b/tests/test_custom_model_pricing.py
@@ -1,0 +1,218 @@
+"""Unit tests for custom model pricing, CostCalculator fallback hierarchy, and provider cost extraction."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from headroom.pricing.calculator import CostCalculator
+from headroom.pricing.litellm_pricing import LITELLM_AVAILABLE
+from headroom.pricing.registry import ModelPricing, PricingRegistry
+from headroom.proxy.cost import CostTracker
+from headroom.proxy.helpers import extract_provider_cost
+
+
+def test_provider_returns_cost_overrides_estimation() -> None:
+    """Test Requirement: Provider returns cost -> exact provider cost is returned."""
+    custom_pricing = {
+        "gpt-4o": {
+            "input_per_1m": 10.0,
+            "output_per_1m": 30.0,
+        }
+    }
+    registry = PricingRegistry.from_dict(custom_pricing)
+    calc = CostCalculator(custom_registry=registry)
+
+    # Provider supplied exact cost $0.0521
+    cost = calc.calculate_request_cost(
+        model="gpt-4o",
+        input_tokens=100_000,
+        output_tokens=50_000,
+        provider_cost_usd=0.0521,
+    )
+    assert cost == 0.0521
+
+
+def test_provider_no_cost_custom_pricing_exists() -> None:
+    """Test Requirement: Provider returns no cost and custom pricing exists -> estimated using custom pricing."""
+    custom_pricing = {
+        "custom-internal-model": ModelPricing(
+            model="custom-internal-model",
+            input_per_1m=5.0,
+            output_per_1m=15.0,
+        )
+    }
+    registry = PricingRegistry.from_dict(custom_pricing)
+    calc = CostCalculator(custom_registry=registry)
+
+    # 100k input ($0.50) + 20k output ($0.30) = $0.80
+    cost = calc.calculate_request_cost(
+        model="custom-internal-model",
+        input_tokens=100_000,
+        output_tokens=20_000,
+        provider_cost_usd=None,
+    )
+    assert cost == pytest.approx(0.80)
+
+
+@pytest.mark.skipif(not LITELLM_AVAILABLE, reason="LiteLLM not installed in environment")
+def test_provider_no_cost_fallback_to_litellm() -> None:
+    """Test Requirement: Provider returns no cost, no custom pricing, but model exists in default LiteLLM database."""
+    calc = CostCalculator(custom_registry=None)
+
+    # gpt-4o exists in LiteLLM DB
+    cost = calc.calculate_request_cost(
+        model="gpt-4o",
+        input_tokens=1_000,
+        output_tokens=1_000,
+        provider_cost_usd=None,
+    )
+    assert cost is not None
+    assert cost > 0
+
+
+def test_litellm_tier3_fallback_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test Tier 3 LiteLLM fallback using monkeypatched litellm module for deterministic coverage across Python versions."""
+    import sys
+
+    fake_litellm = SimpleNamespace(
+        cost_per_token=lambda model, prompt_tokens, completion_tokens, **kwargs: (0.0025, 0.01)
+    )
+    monkeypatch.setattr("headroom.pricing.litellm_pricing.LITELLM_AVAILABLE", True)
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    calc = CostCalculator(custom_registry=None)
+    cost = calc.calculate_request_cost(
+        model="gpt-4o",
+        input_tokens=1_000,
+        output_tokens=1_000,
+        provider_cost_usd=None,
+    )
+    assert cost == pytest.approx(0.0125)
+
+
+def test_unknown_model_returns_none() -> None:
+    """Test Requirement: Unknown model with no pricing -> returns None."""
+    calc = CostCalculator(custom_registry=None)
+
+    cost = calc.calculate_request_cost(
+        model="totally-unknown-model-xyz-12345",
+        input_tokens=1_000,
+        output_tokens=1_000,
+        provider_cost_usd=None,
+    )
+    assert cost is None
+
+
+def test_cost_fallback_disabled() -> None:
+    """Test requirement: cost_fallback_enabled=False suppresses estimation when provider cost is missing."""
+    custom_pricing = {
+        "gpt-4o": {
+            "input_per_1m": 10.0,
+            "output_per_1m": 30.0,
+        }
+    }
+    registry = PricingRegistry.from_dict(custom_pricing)
+    calc = CostCalculator(custom_registry=registry, cost_fallback_enabled=False)
+
+    # Missing provider cost with fallback disabled -> returns None
+    assert (
+        calc.calculate_request_cost(
+            model="gpt-4o",
+            input_tokens=100_000,
+            output_tokens=50_000,
+            provider_cost_usd=None,
+        )
+        is None
+    )
+
+    # Explicit provider cost with fallback disabled -> returns provider cost
+    assert (
+        calc.calculate_request_cost(
+            model="gpt-4o",
+            input_tokens=100_000,
+            output_tokens=50_000,
+            provider_cost_usd=0.05,
+        )
+        == 0.05
+    )
+
+
+def test_partial_pricing_configuration() -> None:
+    """Test Requirement: Partial pricing configuration (e.g., input/output set, cached input missing)."""
+    custom_pricing = {
+        "partial-model": {
+            "model": "partial-model",
+            "input_per_1m": 2.0,
+            "output_per_1m": 4.0,
+            # cached_input_per_1m is None
+        }
+    }
+    registry = PricingRegistry.from_dict(custom_pricing)
+    calc = CostCalculator(custom_registry=registry)
+
+    # Without cached tokens: 50k input ($0.10) + 10k output ($0.04) = $0.14
+    cost = calc.calculate_request_cost(
+        model="partial-model",
+        input_tokens=50_000,
+        output_tokens=10_000,
+    )
+    assert cost == pytest.approx(0.14)
+
+
+def test_existing_behavior_unchanged_when_unconfigured() -> None:
+    """Test Requirement: Existing behavior remains unchanged when no custom pricing is configured."""
+    tracker = CostTracker()
+    assert tracker.calculator.custom_registry is None
+    assert tracker.cost_fallback_enabled is True
+
+
+def test_extract_provider_cost_headers_and_payload() -> None:
+    """Test helper for extracting provider-supplied cost from headers or JSON payload."""
+    # 1. From standard header
+    headers = {"X-Request-Cost-USD": "0.0123"}
+    assert extract_provider_cost(headers=headers) == 0.0123
+
+    # 2. From Portkey header
+    headers_portkey = {"x-portkey-cost": "0.0456"}
+    assert extract_provider_cost(headers=headers_portkey) == 0.0456
+
+    # 3. From payload usage field
+    payload = {"usage": {"cost": 0.0789}}
+    assert extract_provider_cost(payload=payload) == 0.0789
+
+    # 4. Invalid/negative values ignored
+    headers_invalid = {"x-cost-usd": "not-a-number"}
+    assert extract_provider_cost(headers=headers_invalid) is None
+
+    headers_negative = {"x-cost-usd": "-1.5"}
+    assert extract_provider_cost(headers=headers_negative) is None
+
+
+def test_cost_tracker_with_provider_cost_and_custom_pricing() -> None:
+    """Test CostTracker recording and stats calculation with custom model pricing."""
+    custom_pricing = {
+        "my-gateway/custom-claude": {
+            "input_per_1m": 3.0,
+            "output_per_1m": 15.0,
+            "cached_input_per_1m": 0.30,
+        }
+    }
+
+    tracker = CostTracker(custom_pricing=custom_pricing)
+
+    # Record request 1: Provider supplied cost directly ($0.05)
+    tracker.record_tokens(
+        model="my-gateway/custom-claude",
+        tokens_saved=50_000,
+        tokens_sent=50_000,
+        uncached_tokens=50_000,
+        output_tokens=10_000,
+        provider_cost_usd=0.05,
+    )
+
+    stats = tracker.stats()
+    assert stats["total_tokens_saved"] == 50_000
+    # 50,000 saved tokens at $3.00/1M = $0.15 saved
+    assert stats["savings_usd"] == pytest.approx(0.15)


### PR DESCRIPTION
## Description

<!-- Briefly explain the change and why it is needed. -->

Introduces custom model pricing support, exact provider-supplied cost extraction, and a 4-tier cost evaluation hierarchy (`CostCalculator`) in the Headroom proxy.

This allows users to:
1. Use upstream provider-supplied cost headers (`x-cost-usd`, `x-request-cost-usd`, `x-portkey-cost`, `x-litellm-response-cost`, `x-proxy-cost-usd`) or usage JSON cost fields directly.
2. Define custom pricing models (input, output, cached, batch rates) for internal, fine-tuned, or custom gateway models.
3. Fall back to LiteLLM's community pricing database when cost or custom pricing is unconfigured.
4. Toggle cost estimation fallback via `HEADROOM_COST_FALLBACK_ENABLED`.

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- **`headroom/pricing/calculator.py`**: Added `CostCalculator` encapsulating the 4-tier cost calculation hierarchy (Provider -> Custom Pricing -> LiteLLM -> Fallback None).
- **`headroom/pricing/registry.py`**: Extended `PricingRegistry` with `from_dict()` loader and safe default handling for cached token rates.
- **`headroom/proxy/helpers.py`**: Added `extract_provider_cost()` to safely parse costs case-insensitively from response headers or JSON payloads (`usage.cost`, `metadata`, top-level).
- **`headroom/proxy/outcome.py` & `models.py`**: Extended `RequestOutcome` and `ProxyConfig` with `provider_cost_usd`, `custom_pricing`, and `cost_fallback_enabled`.
- **`headroom/proxy/cost.py` & `server.py`**: Integrated `CostCalculator` into `CostTracker` and proxy initialization.
- **`headroom/settings_store.py`**: Registered `HEADROOM_COST_FALLBACK_ENABLED` setting metadata.
- **`docs/content/docs/configuration.mdx`**: Documented custom model pricing and cost fallback configuration options.
- **`tests/test_custom_model_pricing.py`**: Added comprehensive test coverage for exact provider cost overrides, custom pricing rates, LiteLLM fallback, partial pricing, and disabled fallback mode.

## Testing

<!-- Check what you actually ran, then paste the real command output below. -->

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
============================= test session starts ==============================
platform darwin -- Python 3.14.4, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/yaduttampareek/Desktop/Personal/headroom
configfile: pyproject.toml
plugins: cov-7.1.0, asyncio-1.4.0, anyio-4.14.2, langsmith-0.10.6, respx-0.23.1
collected 32 items

tests/test_custom_model_pricing.py::test_provider_returns_cost_overrides_estimation PASSED
tests/test_custom_model_pricing.py::test_provider_no_cost_custom_pricing_exists PASSED
tests/test_custom_model_pricing.py::test_provider_no_cost_fallback_to_litellm SKIPPED
tests/test_custom_model_pricing.py::test_litellm_tier3_fallback_mocked PASSED
tests/test_custom_model_pricing.py::test_unknown_model_returns_none PASSED
tests/test_custom_model_pricing.py::test_cost_fallback_disabled PASSED
tests/test_custom_model_pricing.py::test_partial_pricing_configuration PASSED
tests/test_custom_model_pricing.py::test_existing_behavior_unchanged_when_unconfigured PASSED
tests/test_custom_model_pricing.py::test_extract_provider_cost_headers_and_payload PASSED
tests/test_custom_model_pricing.py::test_cost_tracker_with_provider_cost_and_custom_pricing PASSED
tests/test_pricing.py::test_pricing_public_exports_and_provider_registries PASSED
tests/test_pricing.py::test_model_pricing_is_frozen PASSED
tests/test_pricing.py::test_registry_staleness_and_warning PASSED
tests/test_pricing.py::test_registry_estimate_cost_with_all_token_types PASSED
tests/test_pricing.py::test_registry_estimate_cost_zero_usage_returns_empty_breakdown PASSED
tests/test_pricing_litellm.py::test_litellm_helpers_when_dependency_is_unavailable PASSED
tests/test_pricing_litellm.py::test_litellm_model_pricing_exact_match_and_defaults PASSED
tests/test_pricing_litellm_model_resolution.py::test_prefix_rule_matches_case_insensitively PASSED

======================== 31 passed, 1 skipped in 0.18s =========================

$ ruff check headroom/ tests/
All checks passed!

$ ruff format --check headroom/ tests/
1241 files already formatted
```

## Real Behavior Proof

- Environment: macOS 15.5 x86_64, Python 3.14.4 virtual environment (`.venv`)
- Exact command / steps:
```bash
./.venv/bin/python -m pytest tests/test_custom_model_pricing.py tests/test_pricing.py tests/test_pricing_litellm.py tests/test_pricing_litellm_model_resolution.py -v
./.venv/bin/ruff check headroom/ tests/
./.venv/bin/ruff format --check headroom/ tests/
```
- Observed result:
```text
======================== 31 passed, 1 skipped in 0.19s =========================
All checks passed!
1241 files already formatted
```
- Not tested: None.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)
