### PR TITLE
fix(proxy/interceptors): flag truncated Read input in ast-grep outlin…

### DIFF
--- a/headroom/proxy/interceptors/astgrep.py
+++ b/headroom/proxy/interceptors/astgrep.py
@@ -89,12 +89,14 @@ _PATTERNS: dict[str, list[str]] = {
 
 OUTLINE_MARKER = "    # ... (body elided by Headroom; Read a specific line range to see it)\n"
 
-# Matches the upstream truncation banner a client (e.g. Claude Code) appends to a
-# Read tool_result when its own token cap — independent of any Headroom cap — cuts
-# the file short, e.g. "...showing lines 1-1489 of 1825 total...". Captures
-# (end_line, total_lines) — the only numbers Headroom can honestly report, since
-# they come from the client's own accounting, not a Headroom guess.
-_TRUNCATION_RE = re.compile(r"showing lines \d+-(?P<end_line>\d+) of (?P<total_lines>\d+) total")
+# Matches a line-based truncation notice emitted by a client
+# when its own token cap cuts a Read result short, e.g. "showing lines 1-1489
+# of 1825 total". Captures the client-provided line counts that Headroom can
+# safely report without guessing. Tolerates common formatting variations
+_TRUNCATION_RE = re.compile(
+    r"showing\s+lines?\s+\d+\s*[-–]\s*(?P<end_line>\d+)\s+of\s+(?P<total_lines>\d+)\s+total",
+    re.IGNORECASE,
+)
 
 
 def _detect_truncation(source: str) -> tuple[int, int] | None:

--- a/headroom/proxy/interceptors/astgrep.py
+++ b/headroom/proxy/interceptors/astgrep.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -88,6 +89,22 @@ _PATTERNS: dict[str, list[str]] = {
 
 OUTLINE_MARKER = "    # ... (body elided by Headroom; Read a specific line range to see it)\n"
 
+# Matches the upstream truncation banner a client (e.g. Claude Code) appends to a
+# Read tool_result when its own token cap — independent of any Headroom cap — cuts
+# the file short, e.g. "...showing lines 1-1489 of 1825 total...". Captures
+# (end_line, total_lines) — the only numbers Headroom can honestly report, since
+# they come from the client's own accounting, not a Headroom guess.
+_TRUNCATION_RE = re.compile(r"showing lines \d+-(?P<end_line>\d+) of (?P<total_lines>\d+) total")
+
+
+def _detect_truncation(source: str) -> tuple[int, int] | None:
+    """Return (end_line, total_lines) if `source` carries an upstream truncation
+    banner, else None."""
+    m = _TRUNCATION_RE.search(source)
+    if not m:
+        return None
+    return int(m.group("end_line")), int(m.group("total_lines"))
+
 
 class AstGrepReadOutline:
     """Interceptor that outlines verbose code-file Read outputs."""
@@ -131,7 +148,8 @@ class AstGrepReadOutline:
         if not matches:
             return None
 
-        outline = _build_outline(matches, tool_output)
+        truncation = _detect_truncation(tool_output)
+        outline = _build_outline(matches, tool_output, truncation)
         return outline if outline else None
 
     def progressive_disclosure_key(
@@ -258,12 +276,21 @@ def _run_ast_grep(
     return all_matches
 
 
-def _build_outline(matches: list[dict[str, Any]], source: str) -> str | None:
+def _build_outline(
+    matches: list[dict[str, Any]],
+    source: str,
+    truncation: tuple[int, int] | None = None,
+) -> str | None:
     """Build a compact outline from ast-grep matches.
 
     Emits each definition's signature line + docstring (if next line is a
     string literal) + an elision marker. Matches are sorted by byte offset
     so the outline tracks the original file order.
+
+    `truncation`, if given, is (end_line, total_lines) from an upstream
+    truncation banner already present in `source` (e.g. a client's own Read
+    token-cap notice). When set, the header states that the input was a
+    partial view instead of implying `source` is the whole file.
     """
     lines = source.splitlines(keepends=True)
     outline_chunks: list[str] = []
@@ -292,11 +319,21 @@ def _build_outline(matches: list[dict[str, Any]], source: str) -> str | None:
 
     if not outline_chunks:
         return None
-    header = (
-        "[headroom: outlined by ast-grep — "
-        f"{len(seen_starts)} definition(s); "
-        "bodies elided. Re-read the file with a line range to see a specific body.]\n"
-    )
+
+    if truncation:
+        end_line, total_lines = truncation
+        header = (
+            "[headroom: outlined by ast-grep — "
+            f"{len(seen_starts)} definition(s) in the visible portion; "
+            f"input was truncated upstream (showing through line {end_line} of {total_lines} total). "
+            "Bodies elided. Re-read remaining lines to see more.]\n"
+        )
+    else:
+        header = (
+            "[headroom: outlined by ast-grep — "
+            f"{len(seen_starts)} definition(s); "
+            "bodies elided. Re-read the file with a line range to see a specific body.]\n"
+        )
     return header + "".join(outline_chunks)
 
 

--- a/headroom/proxy/interceptors/astgrep.py
+++ b/headroom/proxy/interceptors/astgrep.py
@@ -89,23 +89,43 @@ _PATTERNS: dict[str, list[str]] = {
 
 OUTLINE_MARKER = "    # ... (body elided by Headroom; Read a specific line range to see it)\n"
 
-# Matches a line-based truncation notice emitted by a client
-# when its own token cap cuts a Read result short, e.g. "showing lines 1-1489
-# of 1825 total". Captures the client-provided line counts that Headroom can
-# safely report without guessing. Tolerates common formatting variations
-_TRUNCATION_RE = re.compile(
-    r"showing\s+lines?\s+\d+\s*[-–]\s*(?P<end_line>\d+)\s+of\s+(?P<total_lines>\d+)\s+total",
-    re.IGNORECASE,
+# Per-client banner signatures -- add an entry only once a client's exact
+# banner text is confirmed, never a generic keyword match.
+_TRUNCATION_SIGNATURES: tuple[re.Pattern[str], ...] = (
+    # Claude Code: "[Truncated: PARTIAL view -- <path>: showing lines A-B of
+    # T total (...). Call Read with offset=N to see more.]"
+    re.compile(
+        r"\[\s*truncated\s*:\s*partial\s+view\b"
+        r"[^\[\]]*?"
+        r"showing\s+lines?\s+(?P<start_line>\d+)\s*[-–]\s*(?P<end_line>\d+)"
+        r"\s+of\s+(?P<total_lines>\d+)\s+total"
+        r"[^\[\]]*\]",
+        re.IGNORECASE,
+    ),
 )
 
 
+def _is_plausible_truncation_range(
+    start_line: int, end_line: int, total_lines: int, source_line_count: int
+) -> bool:
+    # end_line == total_lines means the whole file was shown, not truncated.
+    if start_line < 1 or end_line < start_line or end_line >= total_lines:
+        return False
+    return end_line <= source_line_count
+
+
 def _detect_truncation(source: str) -> tuple[int, int] | None:
-    """Return (end_line, total_lines) if `source` carries an upstream truncation
-    banner, else None."""
-    m = _TRUNCATION_RE.search(source)
-    if not m:
-        return None
-    return int(m.group("end_line")), int(m.group("total_lines"))
+    """Return (end_line, total_lines) if `source` carries a recognized,
+    internally-consistent upstream truncation banner, else None."""
+    source_line_count = len(source.splitlines())
+    for pattern in _TRUNCATION_SIGNATURES:
+        for m in pattern.finditer(source):
+            start_line = int(m.group("start_line"))
+            end_line = int(m.group("end_line"))
+            total_lines = int(m.group("total_lines"))
+            if _is_plausible_truncation_range(start_line, end_line, total_lines, source_line_count):
+                return end_line, total_lines
+    return None
 
 
 class AstGrepReadOutline:

--- a/headroom/proxy/interceptors/astgrep.py
+++ b/headroom/proxy/interceptors/astgrep.py
@@ -111,7 +111,8 @@ def _is_plausible_truncation_range(
     # end_line == total_lines means the whole file was shown, not truncated.
     if start_line < 1 or end_line < start_line or end_line >= total_lines:
         return False
-    return end_line <= source_line_count
+    window_length = end_line - start_line + 1
+    return window_length <= source_line_count
 
 
 def _detect_truncation(source: str) -> tuple[int, int] | None:

--- a/tests/test_tool_result_interceptors.py
+++ b/tests/test_tool_result_interceptors.py
@@ -249,6 +249,37 @@ def test_astgrep_flags_truncated_read(tokenizer):
     assert "def apply_promo" in new_content
 
 
+def test_astgrep_flags_truncated_read_wording_variants(tokenizer):
+    """Loosened regex should match reasonable wording variants, not just Claude Code's
+    exact phrasing — different casing, en-dash instead of hyphen, extra whitespace."""
+    truncated_source = (
+        _PY_FIXTURE
+        + "\n\nSHOWING  LINES 1–42  of 90  TOTAL. Call Read with offset=43 to see more.\n"
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "abc",
+                    "name": "Read",
+                    "input": {"file_path": "/repo/payments.py"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "abc", "content": truncated_source}],
+        },
+    ]
+    result = apply_to_messages(messages, tokenizer)
+    assert len(result.spans) == 1
+    new_content = result.messages[1]["content"][0]["content"]
+    assert "truncated upstream" in new_content
+    assert "showing through line 42 of 90 total" in new_content
+
+
 def test_astgrep_skips_small_files(tokenizer):
     small = "def foo(): return 1\n"
     messages = [

--- a/tests/test_tool_result_interceptors.py
+++ b/tests/test_tool_result_interceptors.py
@@ -211,6 +211,42 @@ def test_astgrep_outlines_large_python_read(tokenizer):
     assert "def apply_promo" in new_content
     # Bodies should NOT leak through unchanged.
     assert "total += item.price * item.qty" not in new_content
+    # Complete-file control: no truncation banner in the input -> no truncation marker.
+    assert "truncated upstream" not in new_content
+
+
+def test_astgrep_flags_truncated_read(tokenizer):
+    truncated_source = (
+        _PY_FIXTURE
+        + "\n\n[Truncated: PARTIAL view — /repo/payments.py: "
+        "showing lines 1-42 of 90 total (26031 tokens, cap 25000). "
+        "Call Read with offset=43 to see more.]\n"
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "abc",
+                    "name": "Read",
+                    "input": {"file_path": "/repo/payments.py"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "abc", "content": truncated_source}],
+        },
+    ]
+    result = apply_to_messages(messages, tokenizer)
+    assert len(result.spans) == 1
+    new_content = result.messages[1]["content"][0]["content"]
+    assert "truncated upstream" in new_content
+    assert "showing through line 42 of 90 total" in new_content
+    # Still lists the definitions actually present in the visible portion.
+    assert "def process_payment" in new_content
+    assert "def apply_promo" in new_content
 
 
 def test_astgrep_skips_small_files(tokenizer):

--- a/tests/test_tool_result_interceptors.py
+++ b/tests/test_tool_result_interceptors.py
@@ -248,14 +248,8 @@ def test_astgrep_flags_truncated_read(tokenizer):
     assert "def apply_promo" in new_content
 
 
-def test_astgrep_flags_truncated_read_wording_variants(tokenizer):
-    """Loosened regex should match reasonable wording variants, not just Claude Code's
-    exact phrasing — different casing, en-dash instead of hyphen, extra whitespace."""
-    truncated_source = (
-        _PY_FIXTURE
-        + "\n\nSHOWING  LINES 1–42  of 90  TOTAL. Call Read with offset=43 to see more.\n"
-    )
-    messages = [
+def _read_result_messages(content: str, file_path: str = "/repo/payments.py"):
+    return [
         {
             "role": "assistant",
             "content": [
@@ -263,17 +257,87 @@ def test_astgrep_flags_truncated_read_wording_variants(tokenizer):
                     "type": "tool_use",
                     "id": "abc",
                     "name": "Read",
-                    "input": {"file_path": "/repo/payments.py"},
+                    "input": {"file_path": file_path},
                 }
             ],
         },
         {
             "role": "user",
-            "content": [{"type": "tool_result", "tool_use_id": "abc", "content": truncated_source}],
+            "content": [{"type": "tool_result", "tool_use_id": "abc", "content": content}],
         },
     ]
+
+
+def test_astgrep_flags_truncated_read_wording_variants(tokenizer):
+    """The signature tolerates wording/casing/dash variation, but only inside
+    the recognized envelope — not as a synonym match over arbitrary prose."""
+    truncated_source = (
+        _PY_FIXTURE + "\n\n[TRUNCATED:   PARTIAL VIEW — /repo/payments.py: "
+        "SHOWING  LINES 1–42  of 90  TOTAL. Call Read with offset=43 to see more.]\n"
+    )
+    messages = _read_result_messages(truncated_source)
     result = apply_to_messages(messages, tokenizer)
     assert len(result.spans) == 1
+    new_content = result.messages[1]["content"][0]["content"]
+    assert "truncated upstream" in new_content
+    assert "showing through line 42 of 90 total" in new_content
+
+
+def test_astgrep_ignores_truncation_phrase_in_comment(tokenizer):
+    """A count-shaped phrase in a plain comment, with no bracketed envelope,
+    must not be read as an upstream truncation claim."""
+    source_with_comment = (
+        _PY_FIXTURE + "\n\n# API pagination showing lines 10-20 of 30 total records\n"
+    )
+    messages = _read_result_messages(source_with_comment)
+    result = apply_to_messages(messages, tokenizer)
+    new_content = result.messages[1]["content"][0]["content"]
+    assert "truncated upstream" not in new_content
+
+
+def test_astgrep_ignores_bracketed_phrase_without_signature(tokenizer):
+    """Brackets plus a count-shaped phrase aren't enough on their own — the
+    exact recognized signature phrase must also be present."""
+    source_with_bracket = (
+        _PY_FIXTURE + "\n\n[Truncation happened; showing lines 1-42 of 90 total]\n"
+    )
+    messages = _read_result_messages(source_with_bracket)
+    result = apply_to_messages(messages, tokenizer)
+    new_content = result.messages[1]["content"][0]["content"]
+    assert "truncated upstream" not in new_content
+
+
+@pytest.mark.parametrize(
+    "banner_numbers",
+    [
+        pytest.param("50-90 of 90", id="end_equals_total"),
+        pytest.param("42-10 of 90", id="end_less_than_start"),
+        pytest.param("0-42 of 90", id="start_is_zero"),
+        pytest.param("1-5000 of 9000", id="end_exceeds_visible_payload"),
+    ],
+)
+def test_astgrep_ignores_malformed_truncation_counts(tokenizer, banner_numbers):
+    truncated_source = (
+        _PY_FIXTURE + "\n\n[Truncated: PARTIAL view — /repo/payments.py: "
+        f"showing lines {banner_numbers} total (26031 tokens, cap 25000). "
+        "Call Read with offset=43 to see more.]\n"
+    )
+    messages = _read_result_messages(truncated_source)
+    result = apply_to_messages(messages, tokenizer)
+    new_content = result.messages[1]["content"][0]["content"]
+    assert "outlined by ast-grep" in new_content
+    assert "truncated upstream" not in new_content
+
+
+def test_astgrep_accepts_truncation_at_start_equals_end(tokenizer):
+    """`end >= start` is inclusive — a single-line visible window is valid."""
+    truncated_source = (
+        _PY_FIXTURE + "\n\n[Truncated: PARTIAL view — /repo/payments.py: "
+        "showing lines 42-42 of 90 total (26031 tokens, cap 25000). "
+        "Call Read with offset=43 to see more.]\n"
+    )
+    messages = _read_result_messages(truncated_source)
+    result = apply_to_messages(messages, tokenizer)
     new_content = result.messages[1]["content"][0]["content"]
     assert "truncated upstream" in new_content
     assert "showing through line 42 of 90 total" in new_content

--- a/tests/test_tool_result_interceptors.py
+++ b/tests/test_tool_result_interceptors.py
@@ -221,23 +221,7 @@ def test_astgrep_flags_truncated_read(tokenizer):
         "showing lines 1-42 of 90 total (26031 tokens, cap 25000). "
         "Call Read with offset=43 to see more.]\n"
     )
-    messages = [
-        {
-            "role": "assistant",
-            "content": [
-                {
-                    "type": "tool_use",
-                    "id": "abc",
-                    "name": "Read",
-                    "input": {"file_path": "/repo/payments.py"},
-                }
-            ],
-        },
-        {
-            "role": "user",
-            "content": [{"type": "tool_result", "tool_use_id": "abc", "content": truncated_source}],
-        },
-    ]
+    messages = _read_result_messages(truncated_source)
     result = apply_to_messages(messages, tokenizer)
     assert len(result.spans) == 1
     new_content = result.messages[1]["content"][0]["content"]
@@ -341,6 +325,37 @@ def test_astgrep_accepts_truncation_at_start_equals_end(tokenizer):
     new_content = result.messages[1]["content"][0]["content"]
     assert "truncated upstream" in new_content
     assert "showing through line 42 of 90 total" in new_content
+
+
+def test_astgrep_flags_truncated_read_offset_window(tokenizer):
+    """A legitimate offset read (not starting at line 1) must still be
+    recognized -- window length, not the absolute end index, is what's
+    checked against the visible payload."""
+    truncated_source = (
+        _PY_FIXTURE + "\n\n[Truncated: PARTIAL view — /repo/payments.py: "
+        "showing lines 100-148 of 300 total (26031 tokens, cap 25000). "
+        "Call Read with offset=149 to see more.]\n"
+    )
+    messages = _read_result_messages(truncated_source)
+    result = apply_to_messages(messages, tokenizer)
+    new_content = result.messages[1]["content"][0]["content"]
+    assert "truncated upstream" in new_content
+    assert "showing through line 148 of 300 total" in new_content
+
+
+def test_astgrep_ignores_offset_window_exceeding_visible_payload(tokenizer):
+    """An offset window is still checked for plausibility -- a claimed
+    window far longer than what's actually visible must not trigger."""
+    truncated_source = (
+        _PY_FIXTURE + "\n\n[Truncated: PARTIAL view — /repo/payments.py: "
+        "showing lines 100-5148 of 9999 total (26031 tokens, cap 25000). "
+        "Call Read with offset=5149 to see more.]\n"
+    )
+    messages = _read_result_messages(truncated_source)
+    result = apply_to_messages(messages, tokenizer)
+    new_content = result.messages[1]["content"][0]["content"]
+    assert "outlined by ast-grep" in new_content
+    assert "truncated upstream" not in new_content
 
 
 def test_astgrep_skips_small_files(tokenizer):

--- a/tests/test_tool_result_interceptors.py
+++ b/tests/test_tool_result_interceptors.py
@@ -217,8 +217,7 @@ def test_astgrep_outlines_large_python_read(tokenizer):
 
 def test_astgrep_flags_truncated_read(tokenizer):
     truncated_source = (
-        _PY_FIXTURE
-        + "\n\n[Truncated: PARTIAL view — /repo/payments.py: "
+        _PY_FIXTURE + "\n\n[Truncated: PARTIAL view — /repo/payments.py: "
         "showing lines 1-42 of 90 total (26031 tokens, cap 25000). "
         "Call Read with offset=43 to see more.]\n"
     )


### PR DESCRIPTION
## Description

`AstGrepReadOutline` generated its `"[headroom: outlined by ast-grep — N definition(s); ...]"` header solely from the text it received. When an upstream client (such as Claude Code) truncated a large Read before Headroom processed it, the header still reported N as if it represented the entire file. Downstream consumers had no indication that the outline covered only the visible portion.

This change detects the existing upstream truncation banner already present in the `tool_result` and qualifies the header accordingly. When no truncation signal is present, behavior is unchanged.

Closes #2421

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/interceptors/astgrep.py`: added `_TRUNCATION_RE` + `_detect_truncation()` to recognize an upstream truncation banner (e.g. `"...showing lines 1-1489 of 1825 total..."`) already inline in `tool_output`. `transform()` computes this once and passes it through. `_build_outline()` takes a new optional `truncation` parameter and only changes the header wording when a signal is present, no change to the existing header when it isn't.
- `tests/test_tool_result_interceptors.py`: added `test_astgrep_flags_truncated_read` (truncated input → header states the input was truncated upstream, with the visible-count + line/total numbers). Extended the existing `test_astgrep_outlines_large_python_read` with an assertion that the marker is **absent** on a complete file.
- No changes to `matches()` or the `ToolResultInterceptor` protocol — truncation doesn't change interceptor eligibility, only header content, so the blast radius is contained to this one file.


## Testing

<!-- Check what you actually ran, then paste the real command output below. -->

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/test_tool_result_interceptors.py -v
22 passed in 0.59s (includes 2 new: test_astgrep_flags_truncated_read,
extended test_astgrep_outlines_large_python_read)

$ ruff check headroom/proxy/interceptors/astgrep.py tests/test_tool_result_interceptors.py
All checks passed!

$ mypy headroom/proxy/interceptors/astgrep.py
Success: no issues found in 1 source file

Full suite (pytest -q): 9585 passed, 1 failed, 562 skipped. 
```
Failure reason: AF_UNIX path too long (macOS-only Unix socket path length limitation). This is tracked separately in issue #2394 and is unrelated to this change. The failing test is not executed in CI. The macos-latest CI job only covers installer tests, while the main suite runs on ubuntu-latest where this limitation does not occur.

## Real Behavior Proof

- Environment: macOS development machine. Local stub HTTP server replacing Anthropic API (no external network calls or API usage). Proxy launched with --intercept-tool-results and --mode token
- Exact command / steps: generated a 699-line/140-function TypeScript fixture mirroring the issue's own repro sketch ("~26,000-token file, 140 top-level `export async function` blocks"). Built a truncated variant (first 114 functions + the real upstream truncation banner text — its exact template was confirmed by extracting the literal string from the locally installed Claude Code CLI binary, not guessed). Sent both the truncated and the complete file as a `Read` tool_result via `POST /v1/messages` to the running proxy, and inspected exactly what the proxy forwarded to the stub upstream.
- Observed result: shown
```text
  Truncated case:  [headroom: outlined by ast-grep — 114 definition(s) in the visible portion;
                    input was truncated upstream (showing through line 570 of 699 total).
                    Bodies elided. Re-read remaining lines to see more.]

  Complete case:   [headroom: outlined by ast-grep — 140 definition(s); bodies elided.
                    Re-read the file with a line range to see a specific body.]
  ```
- Not tested: A live Claude Code session or real Anthropic API request. A local stub was used to avoid consuming API quota. Manual reproduction requires --mode token (or a multi-turn session); the default --mode cache intentionally skips compression for one-shot requests to preserve provider prompt-cache behavior.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)