### PR TITLE
fix(proxy): redeclare CCR tool from sessionless Anthropic history (#2440)

### DIFF
--- a/headroom/ccr/tool_injection.py
+++ b/headroom/ccr/tool_injection.py
@@ -173,6 +173,7 @@ class CCRToolInjector:
 
     # Detected compression markers
     _detected_hashes: list[str] = field(default_factory=list)
+    _has_anthropic_ccr_tool_use_history: bool = False
     # Multiple marker patterns to match different compressors:
     # - SmartCrusher: [100 items compressed to 10. Retrieve more: hash=abc123]
     # - Kompress: [100 lines compressed to 10. Retrieve more: hash=abc123]
@@ -213,6 +214,7 @@ class CCRToolInjector:
     def __post_init__(self) -> None:
         # Reset detected hashes
         self._detected_hashes = []
+        self._has_anthropic_ccr_tool_use_history = False
 
     @property
     def has_compressed_content(self) -> bool:
@@ -224,6 +226,11 @@ class CCRToolInjector:
         """Get list of detected compression hashes."""
         return self._detected_hashes.copy()
 
+    @property
+    def has_anthropic_ccr_tool_use_history(self) -> bool:
+        """Whether the scan found an assistant CCR ``tool_use`` block."""
+        return self._has_anthropic_ccr_tool_use_history
+
     def scan_for_markers(self, messages: list[dict[str, Any]]) -> list[str]:
         """Scan messages for compression markers and extract hashes.
 
@@ -234,6 +241,7 @@ class CCRToolInjector:
             List of detected hash keys.
         """
         self._detected_hashes = []
+        self._has_anthropic_ccr_tool_use_history = False
 
         for message in messages:
             content = message.get("content", "")
@@ -246,6 +254,13 @@ class CCRToolInjector:
             elif isinstance(content, list):
                 for block in content:
                     if isinstance(block, dict):
+                        if (
+                            self.provider == "anthropic"
+                            and message.get("role") == "assistant"
+                            and block.get("type") == "tool_use"
+                            and block.get("name") == CCR_TOOL_NAME
+                        ):
+                            self._has_anthropic_ccr_tool_use_history = True
                         # Text blocks
                         if block.get("type") == "text":
                             self._scan_text(block.get("text", ""))

--- a/headroom/proxy/ccr_marker_policy.py
+++ b/headroom/proxy/ccr_marker_policy.py
@@ -35,6 +35,7 @@ def should_inject_ccr_tool(
     configured_inject_tool: bool,
     frozen_message_count: int,
     has_compressed_content: bool,
+    has_ccr_tool_use_history: bool = False,
 ) -> tuple[bool, bool]:
     """Decide whether the CCR retrieval tool must be injected this turn."""
 
@@ -42,4 +43,5 @@ def should_inject_ccr_tool(
     if inject_tool and frozen_message_count > 0:
         inject_tool = False
     is_marker_override = not inject_tool and has_compressed_content
-    return (inject_tool or is_marker_override), is_marker_override
+    is_history_override = configured_inject_tool and not inject_tool and has_ccr_tool_use_history
+    return (inject_tool or is_marker_override or is_history_override), is_marker_override

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -1863,11 +1863,17 @@ class AnthropicHandlerMixin:
                     provider="anthropic",
                 )
 
+                injector_has_ccr_tool_use_history = getattr(
+                    injector,
+                    "has_anthropic_ccr_tool_use_history",
+                    False,
+                )
+
                 should_inject, is_marker_override = should_inject_ccr_tool(
                     configured_inject_tool=configured_inject_tool,
                     frozen_message_count=frozen_message_count,
                     has_compressed_content=has_new_compressed_content,
-                    has_ccr_tool_use_history=injector.has_anthropic_ccr_tool_use_history,
+                    has_ccr_tool_use_history=injector_has_ccr_tool_use_history,
                 )
                 if should_inject:
                     if is_marker_override:
@@ -1885,7 +1891,7 @@ class AnthropicHandlerMixin:
                         request_id=request_id,
                         existing_tools=tools,
                         has_compressed_content_this_turn=has_new_compressed_content,
-                        has_ccr_tool_use_history=injector.has_anthropic_ccr_tool_use_history,
+                        has_ccr_tool_use_history=injector_has_ccr_tool_use_history,
                     )
                     if ccr_tool_injected:
                         logger.debug(
@@ -2501,12 +2507,21 @@ class AnthropicHandlerMixin:
             # Re-scan the exact outbound messages after every message mutator.
             # A late-added CCR tool_use requires its declaration even when the
             # frozen-prefix policy deferred the earlier injection.
-            final_injector = CCRToolInjector(provider="anthropic")
+            final_injector = CCRToolInjector(
+                provider="anthropic",
+                inject_tool=False,
+                inject_system_instructions=False,
+            )
             final_injector.scan_for_markers(body.get("messages", []))
+            final_has_ccr_tool_use_history = getattr(
+                final_injector,
+                "has_anthropic_ccr_tool_use_history",
+                False,
+            )
             if (
                 self.config.ccr_inject_tool
                 and not _bypass
-                and final_injector.has_anthropic_ccr_tool_use_history
+                and final_has_ccr_tool_use_history
                 and not self._has_headroom_retrieve_tool(body.get("tools"))
             ):
                 from headroom.proxy.helpers import apply_session_sticky_ccr_tool

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -2503,8 +2503,11 @@ class AnthropicHandlerMixin:
             # frozen-prefix policy deferred the earlier injection.
             final_injector = CCRToolInjector(provider="anthropic")
             final_injector.scan_for_markers(body.get("messages", []))
-            if final_injector.has_anthropic_ccr_tool_use_history and not self._has_headroom_retrieve_tool(
-                body.get("tools")
+            if (
+                self.config.ccr_inject_tool
+                and not _bypass
+                and final_injector.has_anthropic_ccr_tool_use_history
+                and not self._has_headroom_retrieve_tool(body.get("tools"))
             ):
                 from headroom.proxy.helpers import apply_session_sticky_ccr_tool
 

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -1867,6 +1867,7 @@ class AnthropicHandlerMixin:
                     configured_inject_tool=configured_inject_tool,
                     frozen_message_count=frozen_message_count,
                     has_compressed_content=has_new_compressed_content,
+                    has_ccr_tool_use_history=injector.has_anthropic_ccr_tool_use_history,
                 )
                 if should_inject:
                     if is_marker_override:
@@ -1884,6 +1885,7 @@ class AnthropicHandlerMixin:
                         request_id=request_id,
                         existing_tools=tools,
                         has_compressed_content_this_turn=has_new_compressed_content,
+                        has_ccr_tool_use_history=injector.has_anthropic_ccr_tool_use_history,
                     )
                     if ccr_tool_injected:
                         logger.debug(

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -2498,6 +2498,30 @@ class AnthropicHandlerMixin:
                                 f"{shape_result.labels}"
                             )
 
+            # Re-scan the exact outbound messages after every message mutator.
+            # A late-added CCR tool_use requires its declaration even when the
+            # frozen-prefix policy deferred the earlier injection.
+            final_injector = CCRToolInjector(provider="anthropic")
+            final_injector.scan_for_markers(body.get("messages", []))
+            if final_injector.has_anthropic_ccr_tool_use_history and not self._has_headroom_retrieve_tool(
+                body.get("tools")
+            ):
+                from headroom.proxy.helpers import apply_session_sticky_ccr_tool
+
+                tools, ccr_tool_injected = apply_session_sticky_ccr_tool(
+                    provider="anthropic",
+                    session_id=session_id,
+                    request_id=request_id,
+                    existing_tools=body.get("tools"),
+                    has_compressed_content_this_turn=False,
+                    has_ccr_tool_use_history=True,
+                )
+                if ccr_tool_injected:
+                    body["tools"] = tools
+                    logger.info(
+                        f"[{request_id}] CCR: redeclared retrieval tool for final outbound history"
+                    )
+
             # Unit 2: mark end of pre-upstream phase. Everything after this
             # point is upstream I/O or post-response bookkeeping.
             stage_timer.record(

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -2412,7 +2412,7 @@ def apply_session_sticky_ccr_tool(
         return tools_out, True
 
     # Fresh session — only inject when this turn produced compressed content.
-    if not has_compressed_content_this_turn:
+    if not (has_compressed_content_this_turn or has_ccr_tool_use_history):
         log_tool_injection_decision(
             provider=provider,
             session_id=session_id,

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -2263,6 +2263,7 @@ def should_inject_ccr_tool(
     configured_inject_tool: bool,
     frozen_message_count: int,
     has_compressed_content: bool,
+    has_ccr_tool_use_history: bool = False,
 ) -> tuple[bool, bool]:
     """Decide whether the ``headroom_retrieve`` tool must be injected this turn.
 
@@ -2284,6 +2285,7 @@ def should_inject_ccr_tool(
         configured_inject_tool=configured_inject_tool,
         frozen_message_count=frozen_message_count,
         has_compressed_content=has_compressed_content,
+        has_ccr_tool_use_history=has_ccr_tool_use_history,
     )
 
 
@@ -2294,6 +2296,7 @@ def apply_session_sticky_ccr_tool(
     request_id: str | None,
     existing_tools: list[dict[str, Any]] | None,
     has_compressed_content_this_turn: bool,
+    has_ccr_tool_use_history: bool = False,
 ) -> tuple[list[dict[str, Any]], bool]:
     """Apply sticky-on CCR retrieval-tool injection per :class:`SessionCcrTracker`.
 
@@ -2344,7 +2347,7 @@ def apply_session_sticky_ccr_tool(
 
     # No session_id (e.g. WS path): per-turn decision drives directly.
     if not session_id:
-        if not has_compressed_content_this_turn:
+        if not (has_compressed_content_this_turn or has_ccr_tool_use_history):
             log_tool_injection_decision(
                 provider=provider,
                 session_id=None,

--- a/tests/test_ccr_marker_policy.py
+++ b/tests/test_ccr_marker_policy.py
@@ -87,3 +87,21 @@ def test_should_inject_ccr_tool_injects_configured_tool_without_frozen_prefix() 
         frozen_message_count=0,
         has_compressed_content=False,
     ) == (True, False)
+
+
+def test_should_inject_ccr_tool_sessionless_history_overrides_frozen_deferral() -> None:
+    assert should_inject_ccr_tool(
+        configured_inject_tool=True,
+        frozen_message_count=3,
+        has_compressed_content=False,
+        has_ccr_tool_use_history=True,
+    ) == (True, False)
+
+
+def test_should_inject_ccr_tool_history_does_not_override_disabled_injection() -> None:
+    assert should_inject_ccr_tool(
+        configured_inject_tool=False,
+        frozen_message_count=3,
+        has_compressed_content=False,
+        has_ccr_tool_use_history=True,
+    ) == (False, False)

--- a/tests/test_ccr_tool_always_on.py
+++ b/tests/test_ccr_tool_always_on.py
@@ -242,6 +242,21 @@ def test_sessionless_history_redeclares_tool():
     assert [tool["name"] for tool in tools] == [CCR_TOOL_NAME]
 
 
+def test_tracked_session_history_redeclares_when_tracker_is_empty():
+    tools, injected = apply_session_sticky_ccr_tool(
+        provider="anthropic",
+        session_id="session-with-history-only",
+        request_id="history-tracked",
+        existing_tools=None,
+        has_compressed_content_this_turn=False,
+        has_ccr_tool_use_history=True,
+    )
+
+    assert injected is True
+    assert [tool["name"] for tool in tools] == [CCR_TOOL_NAME]
+    assert get_session_ccr_tracker().has_done_ccr("anthropic", "session-with-history-only")
+
+
 # ─── Byte-stable tool definition ───────────────────────────────────────
 
 

--- a/tests/test_ccr_tool_always_on.py
+++ b/tests/test_ccr_tool_always_on.py
@@ -228,6 +228,20 @@ def test_no_session_id_falls_back_to_per_turn_decision():
     assert _has_ccr_tool(tools)
 
 
+def test_sessionless_history_redeclares_tool():
+    tools, injected = apply_session_sticky_ccr_tool(
+        provider="anthropic",
+        session_id=None,
+        request_id="history",
+        existing_tools=None,
+        has_compressed_content_this_turn=False,
+        has_ccr_tool_use_history=True,
+    )
+
+    assert injected is True
+    assert [tool["name"] for tool in tools] == [CCR_TOOL_NAME]
+
+
 # ─── Byte-stable tool definition ───────────────────────────────────────
 
 

--- a/tests/test_ccr_tool_injection.py
+++ b/tests/test_ccr_tool_injection.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from headroom.ccr import (
     CCR_TOOL_NAME,
     CCRToolInjector,
@@ -506,6 +508,57 @@ class TestSmartCrusherCcrMarkers:
         hash_key = parse_tool_call(tool_call, "anthropic")
 
         assert hash_key == "abc123def456abc123def456"
+
+
+class TestAnthropicToolUseHistory:
+    def test_history_tool_use_sets_signal_only_for_assistant_ccr_block(self):
+        injector = CCRToolInjector(provider="anthropic")
+
+        injector.scan_for_markers(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "name": CCR_TOOL_NAME}],
+                }
+            ]
+        )
+
+        assert injector.has_anthropic_ccr_tool_use_history is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            {
+                "role": "user",
+                "content": [{"type": "tool_use", "name": CCR_TOOL_NAME}],
+            },
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "name": "other_tool"}],
+            },
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": CCR_TOOL_NAME}],
+            },
+            {"role": "assistant", "content": [{"name": CCR_TOOL_NAME}]},
+        ],
+    )
+    def test_history_tool_use_requires_structured_assistant_ccr_block(self, message):
+        injector = CCRToolInjector(provider="anthropic")
+
+        injector.scan_for_markers([message])
+
+        assert injector.has_anthropic_ccr_tool_use_history is False
+
+    def test_history_tool_use_signal_resets_between_scans(self):
+        injector = CCRToolInjector(provider="anthropic")
+        injector.scan_for_markers(
+            [{"role": "assistant", "content": [{"type": "tool_use", "name": CCR_TOOL_NAME}]}]
+        )
+
+        injector.scan_for_markers([])
+
+        assert injector.has_anthropic_ccr_tool_use_history is False
 
 
 class TestSystemInstructions:

--- a/tests/test_issue_2440_sessionless_ccr_history.py
+++ b/tests/test_issue_2440_sessionless_ccr_history.py
@@ -6,6 +6,14 @@ from headroom.ccr.tool_injection import CCR_TOOL_NAME, CCRToolInjector
 from headroom.proxy.helpers import (
     _reset_session_ccr_tracker_for_test,
     apply_session_sticky_ccr_tool,
+    get_session_ccr_tracker,
+)
+from tests.test_anthropic_stage_timings import (
+    _build_request as _build_anthropic_request,
+)
+from tests.test_anthropic_stage_timings import (
+    _DummyAnthropicHandler,
+    _ResponseStub,
 )
 
 ISSUE_2440_ERROR = "API Error: 400 Tool reference 'headroom_retrieve' not found in available tools"
@@ -67,6 +75,50 @@ def test_sessionless_history_redeclares_ccr_tool(session_id: str | None) -> None
     assert was_injected is True
     assert response["status"] == 200
     assert response["declared_tools"] == {CCR_TOOL_NAME}
+
+
+def test_anthropic_handler_redeclares_frozen_tracked_history() -> None:
+    handler = _DummyAnthropicHandler()
+    handler.config.ccr_inject_tool = True
+    handler.session_tracker_store.compute_session_id = lambda *args, **kwargs: (
+        "handler-session-empty"
+    )
+    handler.session_tracker_store.resolve_tracker = lambda *args, **kwargs: type(
+        "FrozenTracker",
+        (),
+        {
+            "get_frozen_message_count": lambda self: 3,
+            "get_last_original_messages": lambda self: [],
+            "get_last_forwarded_messages": lambda self: [],
+            "record_request": lambda self, *args, **kwargs: None,
+        },
+    )()
+
+    async def strict_retry(method, url, headers, body, **kwargs):
+        assert body.get("tools", [])
+        assert [tool["name"] for tool in body["tools"]] == [CCR_TOOL_NAME]
+        handler.captured = (method, url, headers, body)
+        return _ResponseStub()
+
+    handler._retry_request = strict_retry
+    request = _build_anthropic_request(
+        {
+            "model": "claude-3-5-sonnet-latest",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "name": CCR_TOOL_NAME}],
+                }
+            ],
+        },
+        {"authorization": "Bearer sk-ant-api-test"},
+    )
+
+    import anyio
+
+    anyio.run(handler.handle_anthropic_messages, request)
+
+    assert get_session_ccr_tracker().has_done_ccr("anthropic", "handler-session-empty")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue_2440_sessionless_ccr_history.py
+++ b/tests/test_issue_2440_sessionless_ccr_history.py
@@ -56,24 +56,34 @@ def _reset_tracker():
 
 @pytest.mark.parametrize("session_id", [None, "anthropic-session-without-tracker"])
 def test_sessionless_history_redeclares_ccr_tool(session_id: str | None) -> None:
-    body = _issue_body([{"type": "tool_use", "name": CCR_TOOL_NAME}])
-
-    with pytest.raises(RuntimeError, match="400 Tool reference") as error:
-        _strict_upstream(body)
-    assert str(error.value) == ISSUE_2440_ERROR
+    base_body = _issue_body([{"type": "tool_use", "name": CCR_TOOL_NAME}])
+    head_body = _issue_body([{"type": "tool_use", "name": CCR_TOOL_NAME}])
 
     injector = CCRToolInjector(provider="anthropic")
-    injector.scan_for_markers(body["messages"])
-    body["tools"], was_injected = apply_session_sticky_ccr_tool(
+    injector.scan_for_markers(head_body["messages"])
+    base_body["tools"], base_injected = apply_session_sticky_ccr_tool(
+        provider="anthropic",
+        session_id=session_id,
+        request_id="issue-2440-base-shape",
+        existing_tools=base_body["tools"],
+        has_compressed_content_this_turn=False,
+        has_ccr_tool_use_history=False,
+    )
+    with pytest.raises(RuntimeError, match="400 Tool reference") as error:
+        _strict_upstream(base_body)
+    assert base_injected is False
+    assert str(error.value) == ISSUE_2440_ERROR
+
+    head_body["tools"], was_injected = apply_session_sticky_ccr_tool(
         provider="anthropic",
         session_id=session_id,
         request_id="issue-2440",
-        existing_tools=body["tools"],
+        existing_tools=head_body["tools"],
         has_compressed_content_this_turn=False,
         has_ccr_tool_use_history=injector.has_anthropic_ccr_tool_use_history,
     )
 
-    response = _strict_upstream(body)
+    response = _strict_upstream(head_body)
 
     assert was_injected is True
     assert response["status"] == 200
@@ -129,6 +139,66 @@ def test_anthropic_handler_redeclares_history_added_by_pre_send() -> None:
     anyio.run(handler.handle_anthropic_messages, request)
 
     assert get_session_ccr_tracker().has_done_ccr("anthropic", "handler-session-empty")
+
+
+@pytest.mark.parametrize(
+    ("ccr_enabled", "bypass_header"),
+    [
+        (False, None),
+        (True, "true"),
+    ],
+)
+def test_anthropic_handler_final_rescan_respects_disabled_and_bypass(
+    ccr_enabled: bool,
+    bypass_header: str | None,
+) -> None:
+    handler = _DummyAnthropicHandler()
+    handler.config.ccr_inject_tool = ccr_enabled
+    handler.session_tracker_store.compute_session_id = lambda *args, **kwargs: (
+        "handler-session-disabled"
+    )
+    handler.session_tracker_store.resolve_tracker = lambda *args, **kwargs: type(
+        "FrozenTracker",
+        (),
+        {
+            "get_frozen_message_count": lambda self: 3,
+            "get_last_original_messages": lambda self: [],
+            "get_last_forwarded_messages": lambda self: [],
+            "record_request": lambda self, *args, **kwargs: None,
+        },
+    )()
+
+    def emit(stage, **kwargs):
+        if stage is PipelineStage.PRE_SEND:
+            kwargs["messages"] = [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "name": CCR_TOOL_NAME}],
+                }
+            ]
+        return SimpleNamespace(**kwargs)
+
+    handler.pipeline_extensions = SimpleNamespace(emit=emit)
+
+    async def strict_retry(method, url, headers, body, **kwargs):
+        assert body.get("tools", []) == []
+        return _ResponseStub()
+
+    handler._retry_request = strict_retry
+    headers = {"authorization": "Bearer sk-ant-api-test"}
+    if bypass_header is not None:
+        headers["x-headroom-bypass"] = bypass_header
+    request = _build_anthropic_request(
+        {
+            "model": "claude-3-5-sonnet-latest",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        headers,
+    )
+
+    import anyio
+
+    anyio.run(handler.handle_anthropic_messages, request)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue_2440_sessionless_ccr_history.py
+++ b/tests/test_issue_2440_sessionless_ccr_history.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from headroom.ccr.tool_injection import CCR_TOOL_NAME, CCRToolInjector
+from headroom.pipeline import PipelineStage
 from headroom.proxy.helpers import (
     _reset_session_ccr_tracker_for_test,
     apply_session_sticky_ccr_tool,
@@ -77,7 +80,7 @@ def test_sessionless_history_redeclares_ccr_tool(session_id: str | None) -> None
     assert response["declared_tools"] == {CCR_TOOL_NAME}
 
 
-def test_anthropic_handler_redeclares_frozen_tracked_history() -> None:
+def test_anthropic_handler_redeclares_history_added_by_pre_send() -> None:
     handler = _DummyAnthropicHandler()
     handler.config.ccr_inject_tool = True
     handler.session_tracker_store.compute_session_id = lambda *args, **kwargs: (
@@ -94,6 +97,18 @@ def test_anthropic_handler_redeclares_frozen_tracked_history() -> None:
         },
     )()
 
+    def emit(stage, **kwargs):
+        if stage is PipelineStage.PRE_SEND:
+            kwargs["messages"] = [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "name": CCR_TOOL_NAME}],
+                }
+            ]
+        return SimpleNamespace(**kwargs)
+
+    handler.pipeline_extensions = SimpleNamespace(emit=emit)
+
     async def strict_retry(method, url, headers, body, **kwargs):
         assert body.get("tools", [])
         assert [tool["name"] for tool in body["tools"]] == [CCR_TOOL_NAME]
@@ -104,12 +119,7 @@ def test_anthropic_handler_redeclares_frozen_tracked_history() -> None:
     request = _build_anthropic_request(
         {
             "model": "claude-3-5-sonnet-latest",
-            "messages": [
-                {
-                    "role": "assistant",
-                    "content": [{"type": "tool_use", "name": CCR_TOOL_NAME}],
-                }
-            ],
+            "messages": [{"role": "user", "content": "hello"}],
         },
         {"authorization": "Bearer sk-ant-api-test"},
     )

--- a/tests/test_issue_2440_sessionless_ccr_history.py
+++ b/tests/test_issue_2440_sessionless_ccr_history.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import pytest
 
 from headroom.ccr.tool_injection import CCR_TOOL_NAME, CCRToolInjector
-from headroom.proxy.helpers import apply_session_sticky_ccr_tool
+from headroom.proxy.helpers import (
+    _reset_session_ccr_tracker_for_test,
+    apply_session_sticky_ccr_tool,
+)
 
 ISSUE_2440_ERROR = "API Error: 400 Tool reference 'headroom_retrieve' not found in available tools"
 
@@ -33,7 +36,15 @@ def _issue_body(content: list[dict], tools: list[dict] | None = None) -> dict:
     }
 
 
-def test_sessionless_history_redeclares_ccr_tool() -> None:
+@pytest.fixture(autouse=True)
+def _reset_tracker():
+    _reset_session_ccr_tracker_for_test()
+    yield
+    _reset_session_ccr_tracker_for_test()
+
+
+@pytest.mark.parametrize("session_id", [None, "anthropic-session-without-tracker"])
+def test_sessionless_history_redeclares_ccr_tool(session_id: str | None) -> None:
     body = _issue_body([{"type": "tool_use", "name": CCR_TOOL_NAME}])
 
     with pytest.raises(RuntimeError, match="400 Tool reference") as error:
@@ -44,7 +55,7 @@ def test_sessionless_history_redeclares_ccr_tool() -> None:
     injector.scan_for_markers(body["messages"])
     body["tools"], was_injected = apply_session_sticky_ccr_tool(
         provider="anthropic",
-        session_id=None,
+        session_id=session_id,
         request_id="issue-2440",
         existing_tools=body["tools"],
         has_compressed_content_this_turn=False,

--- a/tests/test_issue_2440_sessionless_ccr_history.py
+++ b/tests/test_issue_2440_sessionless_ccr_history.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from headroom.ccr.tool_injection import CCR_TOOL_NAME, CCRToolInjector
+from headroom.proxy.helpers import apply_session_sticky_ccr_tool
+
+ISSUE_2440_ERROR = "API Error: 400 Tool reference 'headroom_retrieve' not found in available tools"
+
+
+def _strict_upstream(body: dict) -> dict:
+    history_has_ccr_tool = any(
+        message.get("role") == "assistant"
+        and isinstance(message.get("content"), list)
+        and any(
+            isinstance(block, dict)
+            and block.get("type") == "tool_use"
+            and block.get("name") == CCR_TOOL_NAME
+            for block in message["content"]
+        )
+        for message in body["messages"]
+    )
+    declared_names = {tool.get("name") for tool in body.get("tools", [])}
+    if history_has_ccr_tool and CCR_TOOL_NAME not in declared_names:
+        raise RuntimeError(ISSUE_2440_ERROR)
+    return {"status": 200, "declared_tools": declared_names}
+
+
+def _issue_body(content: list[dict], tools: list[dict] | None = None) -> dict:
+    return {
+        "messages": [{"role": "assistant", "content": content}],
+        "tools": tools or [],
+    }
+
+
+def test_sessionless_history_redeclares_ccr_tool() -> None:
+    body = _issue_body([{"type": "tool_use", "name": CCR_TOOL_NAME}])
+
+    with pytest.raises(RuntimeError, match="400 Tool reference") as error:
+        _strict_upstream(body)
+    assert str(error.value) == ISSUE_2440_ERROR
+
+    injector = CCRToolInjector(provider="anthropic")
+    injector.scan_for_markers(body["messages"])
+    body["tools"], was_injected = apply_session_sticky_ccr_tool(
+        provider="anthropic",
+        session_id=None,
+        request_id="issue-2440",
+        existing_tools=body["tools"],
+        has_compressed_content_this_turn=False,
+        has_ccr_tool_use_history=injector.has_anthropic_ccr_tool_use_history,
+    )
+
+    response = _strict_upstream(body)
+
+    assert was_injected is True
+    assert response["status"] == 200
+    assert response["declared_tools"] == {CCR_TOOL_NAME}
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        [{"type": "text", "text": CCR_TOOL_NAME}],
+        [{"type": "tool_use", "name": "other_tool"}],
+        [{"name": CCR_TOOL_NAME}],
+    ],
+)
+def test_sessionless_history_requires_structured_ccr_event(content: list[dict]) -> None:
+    body = _issue_body(content)
+    injector = CCRToolInjector(provider="anthropic")
+    injector.scan_for_markers(body["messages"])
+
+    body["tools"], was_injected = apply_session_sticky_ccr_tool(
+        provider="anthropic",
+        session_id=None,
+        request_id="negative-space",
+        existing_tools=body["tools"],
+        has_compressed_content_this_turn=False,
+        has_ccr_tool_use_history=injector.has_anthropic_ccr_tool_use_history,
+    )
+
+    assert was_injected is False
+    assert body["tools"] == []


### PR DESCRIPTION
## Description

The CCR proxy can return a fatal `API Error: 400 Tool reference 'headroom_retrieve' not found in available tools` when outbound history already contains a prior Anthropic `headroom_retrieve` `tool_use` block, the current turn emits no fresh CCR marker, and tracker state is unavailable. The helper previously keyed fresh tracked sessions only on the current-turn compression flag, so it dropped the tool declaration even though outbound history still referenced it.

This PR teaches the Anthropic path to honor the authoritative prior `tool_use` event already present in outbound history, including a computed session id whose tracker has no CCR record and a late PRE_SEND mutation that adds the retrieval call after the earlier guard ran. It extends the existing CCR marker scan with a read-only history discriminator, threads that signal through the frozen-prefix guard and both sticky-helper state branches, re-scans the final outbound Anthropic messages before forwarding, and keeps that final rescan behind the same CCR-enabled and bypass gates as the initial injection path. Tracked-session replay, client-supplied tool definitions, and non-Anthropic paths stay unchanged.

Closes #2440

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Extend the Anthropic CCR scan with a structured-history signal that recognizes assistant `tool_use` blocks named `headroom_retrieve`.
- Thread that signal through `should_inject_ccr_tool()` and `apply_session_sticky_ccr_tool()` so sessionless and empty-tracker tracked paths can re-declare the retrieval tool when history already references it.
- Re-scan the final outbound Anthropic messages after remembered, PRE_SEND, and request-context mutators so a late-added `headroom_retrieve` call still gets its declaration before forwarding.
- Keep that final rescan gated by `ccr_inject_tool` and bypass handling so disabled and passthrough requests still forward unchanged.
- Keep the helper signature backward-compatible and preserve tracked-session replay, client-supplied tool definitions, and disabled or bypassed requests.
- Add focused regression and boundary coverage for the exact issue shape, the computed-session empty-tracker path, the post-PRE_SEND mutation seam, disabled and bypassed requests, the discriminator, the sessionless helper path, and the negative-space cases.
- Leave `CHANGELOG.md` untouched because Headroom generates changelog entries from conventional commits.

## Testing

- [x] Unit tests pass (`uv run pytest tests/test_issue_2440_sessionless_ccr_history.py tests/test_ccr_tool_injection.py tests/test_ccr_marker_policy.py tests/test_ccr_tool_always_on.py -v`, `78 passed in 0.58s`)
- [x] Linting passes (`uv run ruff check headroom/ccr/tool_injection.py headroom/proxy/ccr_marker_policy.py headroom/proxy/helpers.py headroom/proxy/handlers/anthropic.py tests/test_ccr_tool_injection.py tests/test_ccr_marker_policy.py tests/test_ccr_tool_always_on.py tests/test_issue_2440_sessionless_ccr_history.py`)
- [ ] Type checking passes (`uv run mypy headroom`)
- [x] New tests added for new functionality when applicable
- [ ] Manual testing performed

### Test Output

```text
78 passed in 0.58s
All checks passed!
8 files already formatted
```

## Real Behavior Proof

- Environment: Windows, `uv` development environment, strict local upstream stub, no live provider call
- Exact command / steps: run the issue-shaped Anthropic regression with both `session_id=None` and a computed non-None session id whose tracker is empty, then run the real handler regression with a non-None empty tracker and `frozen_message_count=3` where PRE_SEND mutates the outbound messages to add the assistant `headroom_retrieve` `tool_use`; each request reaches a strict upstream that rejects a missing declaration; then run the focused CCR test set
- Observed result: the strict local harness and handler-level strict upstream both reject a missing declaration and pass after one `headroom_retrieve` tool is forwarded even when PRE_SEND adds the tool-use block late, while disabled and bypassed requests still forward with `tools == []`; the focused suite completed with `78 passed in 0.58s`.
- Not tested: live Anthropic provider call

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

- Scope stays on the reported Anthropic history path. The helper signature remains backward-compatible, and non-Anthropic callers stay unchanged until separate evidence requires them.
- Keep the final `Real Behavior Proof` claim scoped to the reporter's captured 400 plus the local strict-upstream reproduction unless owner-reaching Anthropic proof is available during implementation.
- `CHANGELOG.md` remains untouched because Headroom's release process generates changelog entries from conventional commits.