### PR TITLE
fix(kompress): match all ONNX backends with startswith, not exact "onnx"

### DIFF
--- a/headroom/transforms/kompress_compressor.py
+++ b/headroom/transforms/kompress_compressor.py
@@ -1150,7 +1150,7 @@ class KompressCompressor(Transform):
     def _timed_canary(self, model: Any, tokenizer: Any, backend: str) -> float:
         """Run one small inference and return its wall-clock seconds."""
         words = _canary_words()
-        is_onnx = backend == "onnx"
+        is_onnx = backend.startswith("onnx")
         encoding = tokenizer(
             words,
             is_split_into_words=True,
@@ -1251,7 +1251,7 @@ class KompressCompressor(Transform):
             model, tokenizer, backend = _load_kompress(
                 self.config.model_id, self.config.device, allow_download=allow_download
             )
-            is_onnx = backend == "onnx"
+            is_onnx = backend.startswith("onnx")
             device_type = _model_device_type(model, backend)
 
             if self._should_batch_single_content(model, backend):
@@ -1604,7 +1604,7 @@ class KompressCompressor(Transform):
                     results[i] = self._passthrough(contents[i], len(word_lists[i]))
             return [r for r in results if r is not None]
 
-        is_onnx = backend == "onnx"
+        is_onnx = backend.startswith("onnx")
         device_type = _model_device_type(model, backend)
         kept_ids_per_text: dict[int, set[int]] = {i: set() for i in range(n) if results[i] is None}
         inference_ms = 0.0
@@ -1830,8 +1830,8 @@ class KompressCompressor(Transform):
 
         model, _tokenizer, backend = _kompress_cache[model_id]
 
-        if backend == "onnx":
-            return True  # ONNX CPU provider doesn't parallelize batch dim
+        if backend.startswith("onnx"):
+            return True  # ONNX EPs don't parallelize the batch dim
         if backend == "pytorch":
             try:
                 import torch

--- a/tests/test_transforms/test_kompress_compressor.py
+++ b/tests/test_transforms/test_kompress_compressor.py
@@ -485,3 +485,57 @@ class TestUnloadKompressModel:
 
         # Should return False when no model is loaded
         assert unload_kompress_model() is False
+
+
+# ── onnx_coreml backend gating (issue #2442) ────────────────────────────
+
+
+class TestOnnxBackendPrefixGating:
+    """Non-CPU ONNX backends (onnx_coreml, onnx_cpu) must take the ONNX path.
+
+    The bug: sites gated on the exact string ``backend == "onnx"`` misclassified
+    ``onnx_coreml`` as PyTorch and called ``next(model.parameters())`` on the
+    ``_OnnxModel`` wrapper, which has no ``.parameters()`` — crashing every call
+    and silently disabling Kompress. The fix uses ``backend.startswith("onnx")``.
+    """
+
+    class _FakeOnnxModel:
+        """Mimics the ONNX wrapper: has get_keep_mask but no .parameters()."""
+
+        def get_keep_mask(self, input_ids, attention_mask):  # noqa: ANN001, ANN201
+            return [[True]]
+
+    @staticmethod
+    def _fake_tokenizer(words, **kwargs):  # noqa: ANN001, ANN205
+        # ONNX path must request numpy tensors, never torch.
+        assert kwargs.get("return_tensors") == "np"
+        return {"input_ids": [[1, 2]], "attention_mask": [[1, 1]]}
+
+    def test_timed_canary_onnx_coreml_skips_pytorch_device_dispatch(self) -> None:
+        from headroom.transforms.kompress_compressor import KompressCompressor
+
+        compressor = KompressCompressor()
+        model = self._FakeOnnxModel()  # no .parameters()
+
+        # Must not raise AttributeError: '_OnnxModel' object has no attribute
+        # 'parameters'; returns a float wall-clock duration.
+        elapsed = compressor._timed_canary(model, self._fake_tokenizer, "onnx_coreml")
+        assert isinstance(elapsed, float)
+
+    def test_timed_canary_pytorch_still_dispatches_to_device(self) -> None:
+        # Negative control: the PyTorch branch DOES touch .parameters(), so the
+        # paramless fake model raises there — proving the test above is only
+        # green because onnx_coreml correctly skips that branch.
+        import pytest
+
+        from headroom.transforms.kompress_compressor import KompressCompressor
+
+        compressor = KompressCompressor()
+        model = self._FakeOnnxModel()
+
+        def pt_tokenizer(words, **kwargs):  # noqa: ANN001, ANN202
+            assert kwargs.get("return_tensors") == "pt"
+            return {"input_ids": [[1, 2]], "attention_mask": [[1, 1]]}
+
+        with pytest.raises(AttributeError):
+            compressor._timed_canary(model, pt_tokenizer, "pytorch")


### PR DESCRIPTION
## Description

With `HEADROOM_KOMPRESS_BACKEND=onnx_coreml`, every Kompress compression call and the startup canary crash with `'_OnnxModel' object has no attribute 'parameters'`, so Kompress silently degrades to passthrough and `/health` reports `kompress: unhealthy, backend: null`.

Root cause: `headroom/transforms/kompress_compressor.py` gated the ONNX-vs-PyTorch branch with an exact string match `backend == "onnx"`. But `_load_kompress_onnx` returns `onnx_coreml` (CoreML) or `onnx_cpu` — never the bare string `onnx`. So under `onnx_coreml` the code built PyTorch tensors and dispatched to a device via `next(model.parameters())`, which the `_OnnxModel` wrapper doesn't implement. This is the accelerated backend Apple Silicon users reach for, so the fast path is exactly the broken one.

Fixes #2442

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Change the four exact-match `backend == "onnx"` sites in `headroom/transforms/kompress_compressor.py` to `backend.startswith("onnx")`, matching the convention already used by `_model_device_type`: `_timed_canary`, `compress`, `compress_batch`, and the batch-parallelism guard in `_should_use_sequential_fallback`.
- Update the guard comment ("ONNX CPU provider" → "ONNX EPs") since it now covers all ONNX execution providers.
- Add regression tests exercising `_timed_canary` on `onnx_coreml` (must take the numpy path and never touch `.parameters()`) with a negative control proving the PyTorch branch still dispatches to a device.
- Leave `CHANGELOG.md` untouched — release-please generates it from conventional commits.
- Out of scope: the secondary `/health` under-reporting the issue flags as informational (deferred-preload warmup object never flips to `loaded`).

## Testing

- [x] Unit tests pass (`python -m pytest tests/test_transforms/test_kompress_compressor.py::TestOnnxBackendPrefixGating -q`)
- [x] Linting passes (`ruff check`, `ruff format --check` on the two changed files)
- [x] Type checking passes (`mypy headroom/transforms/kompress_compressor.py --ignore-missing-imports`)
- [x] New tests added for new functionality

### Test Output

```text
$ python -m pytest tests/test_transforms/test_kompress_compressor.py::TestOnnxBackendPrefixGating -q
collected 2 items
tests\test_transforms\test_kompress_compressor.py ..                     [100%]
2 passed in 2.20s

$ ruff check headroom/transforms/kompress_compressor.py tests/test_transforms/test_kompress_compressor.py
All checks passed!
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.13, local dev checkout on a branch off upstream/main (no Apple Silicon / CoreML hardware available)
- Exact command / steps: Ran the new `TestOnnxBackendPrefixGating` regression; then temporarily reverted one site back to `backend == "onnx"` and re-ran to confirm the test discriminates.
- Observed result: With the fix, `_timed_canary(model, tokenizer, "onnx_coreml")` returns a float and never touches `.parameters()`. Reverting one site makes the onnx_coreml test fail (it takes the `pt` tensor path and hits the paramless model), proving the test catches the exact bug. The issue reporter separately verified the fix on real Apple Silicon hardware (onnxruntime 1.27.0, CoreMLExecutionProvider): zero occurrences of the error afterward and compression completing on the CoreML session.
- Not tested: End-to-end run on real CoreML hardware from this environment — reproduced via the unit-level device-dispatch seam instead; hardware confirmation is in the issue.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review