### PR TITLE
fix(docker): adds mount for the litellm config dir

### DIFF
--- a/headroom/install/runtime.py
+++ b/headroom/install/runtime.py
@@ -83,7 +83,14 @@ def _runtime_env(manifest: DeploymentManifest) -> dict[str, str]:
 
 
 def _ensure_host_dirs() -> None:
-    for subdir in (".headroom", ".claude", ".codex", ".gemini", ".config/opencode"):
+    for subdir in (
+        ".headroom",
+        ".claude",
+        ".codex",
+        ".gemini",
+        ".config/opencode",
+        ".config/litellm",
+    ):
         (Path.home() / subdir).mkdir(parents=True, exist_ok=True)
 
 
@@ -131,6 +138,8 @@ def build_runtime_command(manifest: DeploymentManifest) -> list[str]:
         f"{_mount_source(home, '.gemini')}:{container_home}/.gemini",
         "--volume",
         f"{_mount_source(home, '.config/opencode')}:{container_home}/.config/opencode",
+        "--volume",
+        f"{_mount_source(home, '.config/litellm')}:{container_home}/.config/litellm",
     ]
     docker_gpus = manifest.base_env.get("HEADROOM_DOCKER_GPUS", "").strip()
     if docker_gpus:

--- a/tests/test_install/test_runtime.py
+++ b/tests/test_install/test_runtime.py
@@ -61,6 +61,10 @@ def test_build_runtime_command_for_docker_includes_deployment_env(
     # the container.
     assert "HEADROOM_WORKSPACE_DIR=/tmp/headroom-home/.headroom" in command
     assert "HEADROOM_CONFIG_DIR=/tmp/headroom-home/.headroom/config" in command
+    assert (
+        f"{_mount_source(str(tmp_path), '.config/litellm')}:/tmp/headroom-home/.config/litellm"
+        in joined
+    )
 
 
 def test_build_runtime_command_for_docker_includes_gpu_passthrough(
@@ -158,6 +162,7 @@ def test_build_runtime_command_for_docker_matches_wrapper_parity(
     assert (tmp_path / ".claude").is_dir()
     assert (tmp_path / ".codex").is_dir()
     assert (tmp_path / ".gemini").is_dir()
+    assert (tmp_path / ".config" / "litellm").is_dir()
     assert "--env" in command
     joined = " ".join(command)
     assert "ANTHROPIC_API_KEY" in joined


### PR DESCRIPTION
litellm expects access token in its config dir for github copilot

## Description

<!-- Briefly explain the change and why it is needed. -->
I could not authenticate github copilot via litellm when using persistent install via docker without mounting litellm's config dir

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- adds mount for litellm's config dir to the proxy container

## Testing

<!-- Check what you actually ran, then paste the real command output below. -->

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
ruff check .
All checks passed!

mypy headroom/install/runtime.py
Success: no issues found in 1 source file

pytest tests/test_install/test_runtime.py
====================================================================================================== test session starts =======================================================================================================
platform darwin -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /Users/derrik.fleming/repos/headroom/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/derrik.fleming/repos/headroom
configfile: pyproject.toml
plugins: anyio-4.12.1, langsmith-0.9.3, asyncio-1.3.0, respx-0.23.1, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 25 items

tests/test_install/test_runtime.py::test_build_runtime_command_for_docker_includes_deployment_env PASSED                                                                                                                   [  4%]
tests/test_install/test_runtime.py::test_build_runtime_command_for_docker_includes_gpu_passthrough PASSED                                                                                                                  [  8%]
tests/test_install/test_runtime.py::test_build_runtime_command_docker_manifest_env_beats_host_passthrough PASSED                                                                                                           [ 12%]
tests/test_install/test_runtime.py::test_build_runtime_command_for_docker_matches_wrapper_parity PASSED                                                                                                                    [ 16%]
tests/test_install/test_runtime.py::test_build_runtime_command_for_docker_does_not_duplicate_entrypoint PASSED                                                                                                             [ 20%]
tests/test_install/test_runtime.py::test_resolve_headroom_command_prefers_headroom_binary PASSED                                                                                                                           [ 24%]
tests/test_install/test_runtime.py::test_resolve_headroom_command_falls_back_to_python_module PASSED                                                                                                                       [ 28%]
tests/test_install/test_runtime.py::test_runtime_env_and_mount_source PASSED                                                                                                                                               [ 32%]
tests/test_install/test_runtime.py::test_build_runtime_command_python_and_docker_user PASSED                                                                                                                               [ 36%]
tests/test_install/test_runtime.py::test_read_pid_handles_invalid_content PASSED                                                                                                                                           [ 40%]
tests/test_install/test_runtime.py::test_write_read_and_clear_pid PASSED                                                                                                                                                   [ 44%]
tests/test_install/test_runtime.py::test_runtime_start_lock_is_nonblocking PASSED                                                                                                                                          [ 48%]
tests/test_install/test_runtime.py::test_runtime_start_lock_blocks_another_process PASSED                                                                                                                                  [ 52%]
tests/test_install/test_runtime.py::test_run_foreground_and_detached_helpers PASSED                                                                                                                                        [ 56%]
tests/test_install/test_runtime.py::test_start_detached_agent_closes_parent_log_fd PASSED                                                                                                                                  [ 60%]
tests/test_install/test_runtime.py::test_start_detached_agent_closes_log_fd_when_popen_raises PASSED                                                                                                                       [ 64%]
tests/test_install/test_runtime.py::test_start_stop_wait_and_runtime_status_branches PASSED                                                                                                                                [ 68%]
tests/test_install/test_runtime.py::test_stop_runtime_for_docker_stops_and_removes_container PASSED                                                                                                                        [ 72%]
tests/test_install/test_runtime.py::test_runtime_status_reads_container_and_pid_state PASSED                                                                                                                               [ 76%]
tests/test_install/test_runtime.py::test_runtime_status_reports_live_pid_without_terminating PASSED                                                                                                                        [ 80%]
tests/test_install/test_runtime.py::test_runtime_status_survives_winerror87_systemerror PASSED                                                                                                                             [ 84%]
tests/test_install/test_runtime.py::TestRestartCurrentDeployment::test_foreground_when_no_deployment_env PASSED                                                                                                            [ 88%]
tests/test_install/test_runtime.py::TestRestartCurrentDeployment::test_docker_returns_host_command_without_restarting PASSED                                                                                               [ 92%]
tests/test_install/test_runtime.py::TestRestartCurrentDeployment::test_task_mode_detected_and_not_restarted PASSED                                                                                                         [ 96%]
tests/test_install/test_runtime.py::TestRestartCurrentDeployment::test_service_spawns_detached_restart PASSED                                                                                                              [100%]

======================================================================================================= 25 passed in 0.35s =======================================================================================================
```

## Real Behavior Proof

- Environment: Docker / MacOS
- Exact command / steps:  My steps included:
    - `headroom install apply --image headroom:local --preset persistent-docker --scope provider --providers manual --backend github_copilot`
    - send prompt through supported proxy to supported model
- Observed result: litellm cannot authenticate to provider
- Not tested: I didn't test all models from provider, the problem was apparent. I did not test other providers through litellm. 

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Maintainer note: existing runtime command tests cover the Docker command-building path touched here; this PR does not add new test files or test cases.
