### PR TITLE
fix(install/windows): back persistent-service with an always-on task (#1866)

### DIFF
--- a/headroom/install/supervisors.py
+++ b/headroom/install/supervisors.py
@@ -502,8 +502,13 @@ def start_supervisor(manifest: DeploymentManifest) -> None:
         _bootstrap_with_retry(domain, plist_path, action="start")
         return
     if _is_windows():
-        # Both SERVICE and TASK are task-backed on Windows (#1866); run the
-        # startup task to (re)launch the proxy now.
+        # Both SERVICE and TASK are task-backed on Windows (#1866). Re-enable the
+        # health watchdog (stop disables it, see stop_supervisor) before running
+        # the startup task to (re)launch the proxy now.
+        subprocess.run(
+            ["schtasks", "/Change", "/TN", f"{manifest.service_name}-health", "/ENABLE"],
+            check=True,
+        )
         subprocess.run(["schtasks", "/Run", "/TN", f"{manifest.service_name}-startup"], check=True)
 
 
@@ -542,7 +547,14 @@ def stop_supervisor(manifest: DeploymentManifest) -> None:
         return
     if _is_windows():
         # Task-backed on Windows (#1866); ending the startup task stops the proxy.
+        # Also disable the 5-minute health watchdog — otherwise `ensure` would
+        # restart the deployment on the next interval, making `stop` non-durable.
+        # start/restart re-enable it (see start_supervisor).
         subprocess.run(["schtasks", "/End", "/TN", f"{manifest.service_name}-startup"], check=True)
+        subprocess.run(
+            ["schtasks", "/Change", "/TN", f"{manifest.service_name}-health", "/DISABLE"],
+            check=True,
+        )
 
 
 def remove_supervisor(manifest: DeploymentManifest) -> None:

--- a/headroom/install/supervisors.py
+++ b/headroom/install/supervisors.py
@@ -546,15 +546,19 @@ def stop_supervisor(manifest: DeploymentManifest) -> None:
             )
         return
     if _is_windows():
-        # Task-backed on Windows (#1866); ending the startup task stops the proxy.
-        # Also disable the 5-minute health watchdog — otherwise `ensure` would
-        # restart the deployment on the next interval, making `stop` non-durable.
-        # start/restart re-enable it (see start_supervisor).
+        # Task-backed on Windows (#1866). Order matters so `stop` is durable:
+        #   1. DISABLE the health watchdog — no future 5-minute triggers.
+        #   2. End any *already running* health task — /Change only blocks future
+        #      triggers, so an in-flight `ensure` could otherwise re-enable health
+        #      and restart the proxy after we stop it (best effort: usually not
+        #      running).
+        #   3. End the startup task LAST, so a proxy a racing `ensure` just
+        #      started is still torn down.
+        # start/restart re-enable health (see start_supervisor).
+        health = f"{manifest.service_name}-health"
+        subprocess.run(["schtasks", "/Change", "/TN", health, "/DISABLE"], check=True)
+        subprocess.run(["schtasks", "/End", "/TN", health], check=False)
         subprocess.run(["schtasks", "/End", "/TN", f"{manifest.service_name}-startup"], check=True)
-        subprocess.run(
-            ["schtasks", "/Change", "/TN", f"{manifest.service_name}-health", "/DISABLE"],
-            check=True,
-        )
 
 
 def remove_supervisor(manifest: DeploymentManifest) -> None:

--- a/headroom/install/supervisors.py
+++ b/headroom/install/supervisors.py
@@ -418,31 +418,24 @@ def install_supervisor(manifest: DeploymentManifest) -> list[ArtifactRecord]:
         records.append(ArtifactRecord(kind="plist", path=str(plist_path)))
         return records
 
-    if _is_windows() and manifest.supervisor_kind == SupervisorKind.SERVICE.value:
-        # sc.exe's binPath= value embeds its own quotes (cmd.exe /c "<path>").
-        # Passing this as an argv list lets subprocess.list2cmdline re-quote the
-        # token and sc.exe mis-tokenizes it (issue #1654), so build the exact
-        # command line ourselves and hand subprocess a string.
-        run_cmd = windows_run_cmd_path(manifest.profile)
-        create_cmd = (
-            f"sc.exe create {manifest.service_name} "
-            f'binPath= "cmd.exe /c \\"{run_cmd}\\"" start= auto'
-        )
-        subprocess.run(create_cmd, check=True)
-        subprocess.run(
-            ["sc.exe", "failure", manifest.service_name, "reset= 0", "actions= restart/5000"],
-            check=True,
-        )
-        records.append(ArtifactRecord(kind="windows-service", path=manifest.service_name))
-        return records
-
-    if _is_windows() and manifest.supervisor_kind == SupervisorKind.TASK.value:
+    if _is_windows() and manifest.supervisor_kind in (
+        SupervisorKind.SERVICE.value,
+        SupervisorKind.TASK.value,
+    ):
+        # A plain console process (cmd.exe /c run-headroom.cmd) cannot speak the
+        # SCM protocol, so registering it with `sc.exe create` always failed at
+        # start with 1053 (issue #1866). Both SERVICE and TASK are backed by
+        # scheduled tasks instead. SERVICE launches the foreground proxy
+        # (run-headroom) at boot so it stays always-on; TASK re-ensures the proxy
+        # on boot. Both add a 5-minute health task as a watchdog. All tasks are
+        # registered from S4U/hidden XML so they never flash a console (#2453).
+        if manifest.supervisor_kind == SupervisorKind.SERVICE.value:
+            startup_cmd = str(windows_run_cmd_path(manifest.profile))
+        else:
+            startup_cmd = str(windows_ensure_cmd_path(manifest.profile))
+        health_cmd = str(windows_ensure_cmd_path(manifest.profile))
         startup_name = f"{manifest.service_name}-startup"
         health_name = f"{manifest.service_name}-health"
-        startup_cmd = str(windows_ensure_cmd_path(manifest.profile))
-        # Register from task XML (not schtasks flags) so the principal is S4U /
-        # hidden — flag-created tasks use an interactive token and flash a
-        # focus-stealing console on every run (issue #2453).
         _register_windows_task(
             startup_name,
             _windows_task_xml(
@@ -452,7 +445,7 @@ def install_supervisor(manifest: DeploymentManifest) -> list[ArtifactRecord]:
         _register_windows_task(
             health_name,
             _windows_task_xml(
-                startup_cmd, trigger_xml=_windows_health_trigger(), scope=manifest.scope
+                health_cmd, trigger_xml=_windows_health_trigger(), scope=manifest.scope
             ),
         )
         records.extend(
@@ -508,8 +501,10 @@ def start_supervisor(manifest: DeploymentManifest) -> None:
         plist_path = plist_dir / f"{label}.plist"
         _bootstrap_with_retry(domain, plist_path, action="start")
         return
-    if _is_windows() and manifest.supervisor_kind == SupervisorKind.SERVICE.value:
-        subprocess.run(["sc.exe", "start", manifest.service_name], check=True)
+    if _is_windows():
+        # Both SERVICE and TASK are task-backed on Windows (#1866); run the
+        # startup task to (re)launch the proxy now.
+        subprocess.run(["schtasks", "/Run", "/TN", f"{manifest.service_name}-startup"], check=True)
 
 
 def stop_supervisor(manifest: DeploymentManifest) -> None:
@@ -545,8 +540,9 @@ def stop_supervisor(manifest: DeploymentManifest) -> None:
                 f"launchctl bootout failed for {domain}/{label}: {detail or 'unknown error'}"
             )
         return
-    if _is_windows() and manifest.supervisor_kind == SupervisorKind.SERVICE.value:
-        subprocess.run(["sc.exe", "stop", manifest.service_name], check=True)
+    if _is_windows():
+        # Task-backed on Windows (#1866); ending the startup task stops the proxy.
+        subprocess.run(["schtasks", "/End", "/TN", f"{manifest.service_name}-startup"], check=True)
 
 
 def remove_supervisor(manifest: DeploymentManifest) -> None:
@@ -620,18 +616,11 @@ def remove_supervisor(manifest: DeploymentManifest) -> None:
         return
 
     if _is_windows():
-        if manifest.supervisor_kind == SupervisorKind.SERVICE.value:
-            run(
-                ["sc.exe", "stop", manifest.service_name],
-                capture_output=True,
-                text=True,
-            )
-            run(
-                ["sc.exe", "delete", manifest.service_name],
-                capture_output=True,
-                text=True,
-            )
-            return
+        # Both SERVICE and TASK are task-backed on Windows (#1866). Best-effort
+        # delete a legacy `sc.exe`-created service too, in case this profile was
+        # applied by an older build.
+        run(["sc.exe", "stop", manifest.service_name], capture_output=True, text=True)
+        run(["sc.exe", "delete", manifest.service_name], capture_output=True, text=True)
         run(
             ["schtasks", "/Delete", "/TN", f"{manifest.service_name}-startup", "/F"],
             capture_output=True,

--- a/tests/test_install/test_supervisors.py
+++ b/tests/test_install/test_supervisors.py
@@ -524,13 +524,15 @@ def test_start_and_stop_supervisor_darwin_windows_and_none(monkeypatch) -> None:
     start_supervisor(_manifest(supervisor=SupervisorKind.SERVICE.value))
     stop_supervisor(_manifest(supervisor=SupervisorKind.SERVICE.value))
     # #1866: Windows service is task-backed. start re-enables the health
-    # watchdog then runs the startup task; stop ends the startup task then
-    # disables the watchdog so `ensure` cannot restart it minutes later.
+    # watchdog then runs the startup task. stop disables the watchdog, ends any
+    # in-flight health task, then ends the startup task last — so no running
+    # `ensure` can re-enable or restart the service after `stop` completes.
     assert calls == [
         ["schtasks", "/Change", "/TN", "headroom-default-health", "/ENABLE"],
         ["schtasks", "/Run", "/TN", "headroom-default-startup"],
-        ["schtasks", "/End", "/TN", "headroom-default-startup"],
         ["schtasks", "/Change", "/TN", "headroom-default-health", "/DISABLE"],
+        ["schtasks", "/End", "/TN", "headroom-default-health"],
+        ["schtasks", "/End", "/TN", "headroom-default-startup"],
     ]
 
 

--- a/tests/test_install/test_supervisors.py
+++ b/tests/test_install/test_supervisors.py
@@ -396,15 +396,12 @@ def test_install_supervisor_darwin_windows_and_unsupported(monkeypatch, tmp_path
     )
     win_service = install_supervisor(_manifest(supervisor=SupervisorKind.SERVICE.value))
     win_task = install_supervisor(_manifest(supervisor=SupervisorKind.TASK.value))
-    assert win_service[-1].kind == "windows-service"
+    # #1866: a console process can't be an SCM service, so SERVICE is task-backed
+    # too — no more `sc.exe create`. Both presets emit startup + health tasks.
+    assert win_service[-1].kind == "windows-task"
+    assert win_service[-2].path.endswith("-startup")
     assert win_task[-2].path.endswith("-startup")
-    # Regression for #1654: the create command must be a single pre-quoted
-    # string (bypassing list2cmdline) with the inner quotes backslash-escaped
-    # and `start= auto` as a separate trailing token.
-    assert (
-        "sc.exe create headroom-default "
-        'binPath= "cmd.exe /c \\"C:\\tmp\\default\\run-headroom.cmd\\"" start= auto'
-    ) in calls
+    assert not any(isinstance(c, str) and c.startswith("sc.exe create") for c in calls)
     # #2453: tasks are registered from S4U/hidden XML via `schtasks /XML`, not
     # interactive-token flag creation. Assert the startup and health tasks are
     # each created from an XML file (the temp path varies).
@@ -526,9 +523,10 @@ def test_start_and_stop_supervisor_darwin_windows_and_none(monkeypatch) -> None:
     monkeypatch.setattr("headroom.install.supervisors.sys.platform", "win32")
     start_supervisor(_manifest(supervisor=SupervisorKind.SERVICE.value))
     stop_supervisor(_manifest(supervisor=SupervisorKind.SERVICE.value))
+    # #1866: Windows service is task-backed — start/stop drive the startup task.
     assert calls == [
-        ["sc.exe", "start", "headroom-default"],
-        ["sc.exe", "stop", "headroom-default"],
+        ["schtasks", "/Run", "/TN", "headroom-default-startup"],
+        ["schtasks", "/End", "/TN", "headroom-default-startup"],
     ]
 
 
@@ -730,9 +728,12 @@ def test_remove_supervisor_darwin_and_windows(monkeypatch, tmp_path: Path) -> No
     monkeypatch.setattr("headroom.install.supervisors.sys.platform", "win32")
     remove_supervisor(_manifest(supervisor=SupervisorKind.SERVICE.value))
     remove_supervisor(_manifest(supervisor=SupervisorKind.TASK.value))
-    assert calls == [
+    # #1866: both presets are task-backed, so removal deletes the two tasks. A
+    # best-effort `sc.exe` delete stays to clean up any legacy service.
+    windows_cleanup = [
         ["sc.exe", "stop", "headroom-default"],
         ["sc.exe", "delete", "headroom-default"],
         ["schtasks", "/Delete", "/TN", "headroom-default-startup", "/F"],
         ["schtasks", "/Delete", "/TN", "headroom-default-health", "/F"],
     ]
+    assert calls == windows_cleanup + windows_cleanup

--- a/tests/test_install/test_supervisors.py
+++ b/tests/test_install/test_supervisors.py
@@ -523,10 +523,14 @@ def test_start_and_stop_supervisor_darwin_windows_and_none(monkeypatch) -> None:
     monkeypatch.setattr("headroom.install.supervisors.sys.platform", "win32")
     start_supervisor(_manifest(supervisor=SupervisorKind.SERVICE.value))
     stop_supervisor(_manifest(supervisor=SupervisorKind.SERVICE.value))
-    # #1866: Windows service is task-backed — start/stop drive the startup task.
+    # #1866: Windows service is task-backed. start re-enables the health
+    # watchdog then runs the startup task; stop ends the startup task then
+    # disables the watchdog so `ensure` cannot restart it minutes later.
     assert calls == [
+        ["schtasks", "/Change", "/TN", "headroom-default-health", "/ENABLE"],
         ["schtasks", "/Run", "/TN", "headroom-default-startup"],
         ["schtasks", "/End", "/TN", "headroom-default-startup"],
+        ["schtasks", "/Change", "/TN", "headroom-default-health", "/DISABLE"],
     ]
 
 


### PR DESCRIPTION
## Description

`headroom install apply --preset persistent-service` failed on Windows. It registered `cmd.exe /c run-headroom.cmd` as a service via `sc.exe create`, but a plain console process never performs the SCM `StartServiceCtrlDispatcher` handshake, so Windows killed it after the 30s start timeout (`StartService FAILED 1053`) and left an empty `deploy/default` profile. Fixes #1866.

Rather than add a service-wrapper dependency, the Windows service is now backed by scheduled tasks: a `BootTrigger` task launches the foreground proxy (`run-headroom`) at boot so it stays always-on, plus a 5-minute health task as a watchdog. Both are registered from the same S4U/hidden task XML introduced for #2453, so no console window ever flashes.

> Stacked on #2459 (the #2453 S4U/hidden XML machinery). Until that merges, this PR's diff includes its commit; it collapses automatically once #2459 lands.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `headroom/install/supervisors.py`: collapse the Windows SERVICE/TASK branches of `install_supervisor` — SERVICE registers a boot task running `run-headroom.cmd` (always-on) plus a 5-minute `ensure-headroom.cmd` health task; TASK re-ensures on boot. Both use `_windows_task_xml` (S4U/hidden). `start_supervisor`/`stop_supervisor` now `schtasks /Run` / `/End` the startup task; `remove_supervisor` deletes both tasks and best-effort deletes any legacy `sc.exe` service.
- `tests/test_install/test_supervisors.py`: assert SERVICE now emits `windows-task` records (no `sc.exe create`), and that Windows start/stop/remove drive the tasks.

## Testing

- [x] Unit tests pass

```
$ python -m pytest tests/test_install/test_supervisors.py -q
collected 29 items
tests\test_install\test_supervisors.py .............................     [100%]
============================= 29 passed in 0.35s ==============================
```

## Real Behavior Proof

- Environment: Windows 11 Pro 10.0.26200, Python 3.13.11
- Exact command / steps: python -m pytest tests/test_install/test_supervisors.py -q; ruff check + ruff format --check; mypy headroom/install/supervisors.py --ignore-missing-imports
- Observed result: 29 passed; ruff clean; mypy exit 0. SERVICE install now returns windows-task records and issues no sc.exe create.
- Not tested: live `headroom install apply --preset persistent-service` on a physical Windows host confirming the proxy answers /readyz after reboot with no 1053 (no interactive Windows host in CI).

## Runtime Rollout Safety

- Rollout-managed feature(s): none. The install/supervisor path is not in the `headroom.rollout` feature registry
- Minimum rollout channel: n/a
- Stable/default behavior changed: yes, for Windows `--preset persistent-service` installs only. It registers a boot-triggered scheduled task plus a 5-minute health task instead of an `sc.exe` service; other presets and other platforms are unchanged
- Kill switch / disable path: none needed as a flag. `headroom install remove` deletes both tasks and best-effort removes any legacy `sc.exe` service, returning the host to no supervisor; this change replaces a path that never worked (`StartService FAILED 1053`), not a working default
- Unsafe override required: no
- Qualification impact: none. Install/supervisor logic only, no routing/caching/backend-selection change
- Rollback path: revert this commit. `remove_supervisor` cleans up both new tasks before rollback, so no orphaned scheduled tasks remain

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

