### PR TITLE
fix(backends): forward the standard service_tier param (litellm + anyllm)

### DIFF
--- a/headroom/backends/anyllm.py
+++ b/headroom/backends/anyllm.py
@@ -230,6 +230,8 @@ class AnyLLMBackend(Backend):
                 kwargs["tools"] = body["tools"]
             if "tool_choice" in body:
                 kwargs["tool_choice"] = body["tool_choice"]
+            if "service_tier" in body:
+                kwargs["service_tier"] = body["service_tier"]
 
             logger.debug(f"any-llm request: provider={self.provider}, model={original_model}")
 
@@ -280,6 +282,8 @@ class AnyLLMBackend(Backend):
                 kwargs["tools"] = body["tools"]
             if "tool_choice" in body:
                 kwargs["tool_choice"] = body["tool_choice"]
+            if "service_tier" in body:
+                kwargs["service_tier"] = body["service_tier"]
 
             msg_id = f"msg_{uuid.uuid4().hex[:24]}"
 
@@ -376,6 +380,7 @@ class AnyLLMBackend(Backend):
                 "response_format",
                 "seed",
                 "n",
+                "service_tier",
             ]:
                 if param in body:
                     kwargs[param] = body[param]
@@ -494,6 +499,7 @@ class AnyLLMBackend(Backend):
                 "response_format",
                 "seed",
                 "n",
+                "service_tier",
             ]:
                 if param in body:
                     kwargs[param] = body[param]

--- a/headroom/backends/litellm.py
+++ b/headroom/backends/litellm.py
@@ -878,6 +878,9 @@ class LiteLLMBackend(Backend):
                 kwargs["tools"] = [_convert_anthropic_tool(t) for t in tools_in]
             if "tool_choice" in body:
                 kwargs["tool_choice"] = _convert_tool_choice(body["tool_choice"])
+            # Standard provider param — forward it instead of silently dropping.
+            if "service_tier" in body:
+                kwargs["service_tier"] = body["service_tier"]
 
             # System prompt (Anthropic puts it in body, OpenAI in messages)
             if "system" in body:

--- a/tests/test_backend_anyllm.py
+++ b/tests/test_backend_anyllm.py
@@ -452,3 +452,23 @@ async def test_close_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     backend, _instance = make_backend(monkeypatch)
     assert await backend.close() is None
     assert isinstance(StreamEvent(event_type="message_start", data={}), StreamEvent)
+
+
+@pytest.mark.asyncio
+async def test_send_message_forwards_service_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    """service_tier is a standard provider param — forward it, don't drop it."""
+    backend, instance = make_backend(monkeypatch)
+    instance.response = make_response(
+        make_choice("done", "stop"),
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+    await backend.send_message(
+        {
+            "model": "claude-3-7-sonnet",
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            "max_tokens": 16,
+            "service_tier": "standard_only",
+        },
+        {},
+    )
+    assert instance.calls[0]["service_tier"] == "standard_only"


### PR DESCRIPTION
## Description

`service_tier` is a standard provider request field (OpenAI `flex`/`default`/`priority`, Anthropic `auto`/`standard_only`), but the SDK-translation backends rebuilt the upstream request from a fixed field whitelist and **silently dropped** it — so a client that set `service_tier` had it discarded on `--backend litellm`/`anyllm`. The direct passthrough already forwards it; this makes the translation backends do the same, alongside `temperature`/`top_p`/`tools`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `backends/litellm.py` (Anthropic path): forward `service_tier` when present (the OpenAI path already forwards unconsumed fields via `_build_openai_extra_body`).
- `backends/anyllm.py`: add `service_tier` to the forwarded params (both the Anthropic whitelist and the OpenAI param list).

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] New test added

### Test Output

```text
$ python -m pytest tests/test_backend_anyllm.py -q
16 passed in 2.51s

$ ruff check headroom/backends/litellm.py headroom/backends/anyllm.py
All checks passed!

$ mypy headroom/backends/anyllm.py headroom/backends/litellm.py   # 0 new errors
```

## Real Behavior Proof

- Environment: local, FakeAnyLLM instance capturing `acompletion` kwargs.
- Steps: `send_message({..., "service_tier": "standard_only"})`.
- Observed: `instance.calls[0]["service_tier"] == "standard_only"` — the param reaches the SDK call (previously absent).
- Not tested: live provider round-trip (no keys in CI); relies on the SDK forwarding standard params.

## Checklist

- [x] Self-reviewed
- [x] Tests added and passing
- [x] I did **not** edit `CHANGELOG.md`