### PR TITLE
fix(learn): harden analyzer JSON parsing against malformed LLM output

### DIFF
--- a/headroom/learn/analyzer.py
+++ b/headroom/learn/analyzer.py
@@ -514,7 +514,12 @@ def _strip_fenced_json(raw: str) -> dict:
 
     # Nothing parsed as an object: re-raise the natural error on the raw text
     # so callers see a JSONDecodeError, preserving the documented contract.
-    result: dict = json.loads(text)
+    # json.loads raises for invalid JSON, but valid JSON that is not an object
+    # (e.g. a bare array the model emitted) would otherwise be returned as a
+    # non-dict and crash callers that do `.get(...)`, so reject it explicitly.
+    result = json.loads(text)
+    if not isinstance(result, dict):
+        raise json.JSONDecodeError("Expected a JSON object", text, 0)
     return result
 
 

--- a/headroom/learn/analyzer.py
+++ b/headroom/learn/analyzer.py
@@ -825,11 +825,15 @@ def _parse_llm_response(raw: dict) -> list[Recommendation]:
     """Convert LLM structured output into Recommendation objects."""
     recommendations: list[Recommendation] = []
 
-    for rule in raw.get("context_file_rules", []):
+    # `.get(key, [])` / `.get(key, "")` only fall back when the key is absent;
+    # the model controls this JSON, so a present-but-null `*_file_rules` list or
+    # a null `section`/`content` would return None and crash the iteration /
+    # `.strip()`. Coerce with `or` so a null is treated like an absent value.
+    for rule in raw.get("context_file_rules") or []:
         if not isinstance(rule, dict):
             continue
-        section = rule.get("section", "").strip()
-        content = rule.get("content", "").strip()
+        section = (rule.get("section") or "").strip()
+        content = (rule.get("content") or "").strip()
         if not section or not content:
             continue
         recommendations.append(
@@ -843,11 +847,11 @@ def _parse_llm_response(raw: dict) -> list[Recommendation]:
             )
         )
 
-    for rule in raw.get("memory_file_rules", []):
+    for rule in raw.get("memory_file_rules") or []:
         if not isinstance(rule, dict):
             continue
-        section = rule.get("section", "").strip()
-        content = rule.get("content", "").strip()
+        section = (rule.get("section") or "").strip()
+        content = (rule.get("content") or "").strip()
         if not section or not content:
             continue
         recommendations.append(

--- a/headroom/learn/analyzer.py
+++ b/headroom/learn/analyzer.py
@@ -827,13 +827,14 @@ def _parse_llm_response(raw: dict) -> list[Recommendation]:
 
     # `.get(key, [])` / `.get(key, "")` only fall back when the key is absent;
     # the model controls this JSON, so a present-but-null `*_file_rules` list or
-    # a null `section`/`content` would return None and crash the iteration /
-    # `.strip()`. Coerce with `or` so a null is treated like an absent value.
+    # a non-string `section`/`content` would crash the iteration / `.strip()`.
+    # `_as_str` coerces any non-string (null, number, list, object) to "" so a
+    # malformed field is treated like an absent one instead of raising.
     for rule in raw.get("context_file_rules") or []:
         if not isinstance(rule, dict):
             continue
-        section = (rule.get("section") or "").strip()
-        content = (rule.get("content") or "").strip()
+        section = _as_str(rule.get("section")).strip()
+        content = _as_str(rule.get("content")).strip()
         if not section or not content:
             continue
         recommendations.append(
@@ -850,8 +851,8 @@ def _parse_llm_response(raw: dict) -> list[Recommendation]:
     for rule in raw.get("memory_file_rules") or []:
         if not isinstance(rule, dict):
             continue
-        section = (rule.get("section") or "").strip()
-        content = (rule.get("content") or "").strip()
+        section = _as_str(rule.get("section")).strip()
+        content = _as_str(rule.get("content")).strip()
         if not section or not content:
             continue
         recommendations.append(
@@ -869,6 +870,17 @@ def _parse_llm_response(raw: dict) -> list[Recommendation]:
     recommendations.sort(key=lambda r: r.estimated_tokens_saved, reverse=True)
 
     return recommendations
+
+
+def _as_str(val: object) -> str:
+    """Return ``val`` if it is a string, else ``""``.
+
+    Fields like ``section``/``content`` come straight from model-controlled JSON,
+    where a number/list/object is as possible as a string. Coercing a non-string
+    to empty keeps ``.strip()`` from raising and lets the caller's emptiness check
+    drop the malformed rule.
+    """
+    return val if isinstance(val, str) else ""
 
 
 def _safe_int(val: object) -> int:

--- a/tests/test_learn/test_analyzer.py
+++ b/tests/test_learn/test_analyzer.py
@@ -361,6 +361,28 @@ class TestLLMResponseParser:
         recs = _parse_llm_response(raw)
         assert recs == []
 
+    def test_handles_null_rule_lists_and_fields(self):
+        # The model controls this JSON. A present-but-null rules list or a null
+        # section/content must be treated like an absent value, not crash the
+        # iteration / `.strip()`.
+        assert _parse_llm_response({"context_file_rules": None, "memory_file_rules": None}) == []
+        assert (
+            _parse_llm_response({"context_file_rules": [{"section": None, "content": "x"}]}) == []
+        )
+        assert _parse_llm_response({"memory_file_rules": [{"section": "s", "content": None}]}) == []
+
+        # A valid rule alongside the null shapes is still parsed.
+        recs = _parse_llm_response(
+            {
+                "context_file_rules": [
+                    None,
+                    {"section": "Large Files", "content": "use offset", "evidence_count": 3},
+                ]
+            }
+        )
+        assert [r.section for r in recs] == ["Large Files"]
+        assert recs[0].evidence_count == 3
+
 
 # =============================================================================
 # Full Analyzer Integration Tests (mocked LLM)

--- a/tests/test_learn/test_analyzer.py
+++ b/tests/test_learn/test_analyzer.py
@@ -371,6 +371,18 @@ class TestLLMResponseParser:
         )
         assert _parse_llm_response({"memory_file_rules": [{"section": "s", "content": None}]}) == []
 
+        # A truthy non-string section/content (number, list, object) is also
+        # model-controlled and must not crash `.strip()`; it is dropped like null.
+        assert _parse_llm_response({"context_file_rules": [{"section": 123, "content": "x"}]}) == []
+        assert _parse_llm_response({"context_file_rules": [{"section": "s", "content": 123}]}) == []
+        assert (
+            _parse_llm_response({"memory_file_rules": [{"section": ["s"], "content": "x"}]}) == []
+        )
+        assert (
+            _parse_llm_response({"memory_file_rules": [{"section": "s", "content": {"a": 1}}]})
+            == []
+        )
+
         # A valid rule alongside the null shapes is still parsed.
         recs = _parse_llm_response(
             {

--- a/tests/test_learn/test_analyzer.py
+++ b/tests/test_learn/test_analyzer.py
@@ -592,6 +592,19 @@ class TestStripFencedJson:
         with pytest.raises(json.JSONDecodeError):
             _strip_fenced_json("not json at all")
 
+    def test_non_object_json_raises(self):
+        # A model may return valid JSON that is not an object (a bare array,
+        # string, number, ...). The contract is to raise JSONDecodeError so
+        # callers do not receive a non-dict and crash on `.get`.
+        for raw in ("[1, 2, 3]", '["a", "b"]', '[{"a": 1}, {"b": 2}]', '"a string"', "42", "true"):
+            with pytest.raises(json.JSONDecodeError):
+                _strip_fenced_json(raw)
+
+    def test_array_wrapping_a_single_object_is_extracted(self):
+        # The lenient first-{ .. last-} slice still recovers a single object a
+        # model wrapped in an array; only genuinely object-less JSON raises.
+        assert _strip_fenced_json('[{"key": "value"}]') == {"key": "value"}
+
     def test_prose_preamble_before_fence(self):
         # Models sometimes add a preamble before the fence despite being told
         # to return JSON only (e.g. "Here it is:\n\n```json ...").


### PR DESCRIPTION
## Description

Two spots in the `learn` analyzer crash on JSON a model can realistically emit. Both parse fully model-controlled output.

**1. `_strip_fenced_json` returns a non-object instead of raising.** It is documented to return a dict and to raise `json.JSONDecodeError` when no candidate is an object, but its final fallback was `result: dict = json.loads(text); return result`. `json.loads` raises for invalid JSON, but for valid JSON that is not an object (a bare array, string, or number) it returns a non-dict. The `-> dict`-annotated value is then a list/str, and all three callers do `.get(...)` on it, raising `AttributeError` instead of the clean `JSONDecodeError` they already handle.

**2. `_parse_llm_response` crashes on null rule lists/fields.** It read `raw.get("context_file_rules", [])` / `raw.get("memory_file_rules", [])` and `rule.get("section", "").strip()` / `rule.get("content", "").strip()`. `.get(key, default)` only falls back when the key is absent, so a present-but-null `"context_file_rules": null` made `for rule in None` raise `TypeError`, and a null `section`/`content` made `None.strip()` raise `AttributeError`.

## Fix

- `_strip_fenced_json`: reject a non-dict fallback result explicitly (`raise json.JSONDecodeError(...)`), restoring the documented contract. The lenient first-brace..last-brace slice still recovers a single object a model wrapped in an array; only genuinely object-less JSON raises.
- `_parse_llm_response`: coerce the rule lists and the `section`/`content` fields with `or` so a null is treated like an absent value. Valid rules parse unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/learn/analyzer.py`: raise `JSONDecodeError` when `_strip_fenced_json`'s fallback parse yields a non-dict; `or`-coerce null rule lists and null `section`/`content` in `_parse_llm_response`.
- `tests/test_learn/test_analyzer.py`: regressions for non-object JSON raising (and array-wrapped-object still extracted), and for null rule lists / null fields being tolerated with valid rules still parsed.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_learn/test_analyzer.py::TestStripFencedJson tests/test_learn/test_analyzer.py::TestLLMResponseParser -q
# all pass; each new test fails with the corresponding fix reverted
# (JSONDecodeError contract / 'NoneType' object is not iterable / has no attribute 'strip')

$ uvx ruff@0.15.17 check headroom/learn/analyzer.py tests/test_learn/test_analyzer.py
All checks passed!
$ uvx mypy@1.20.2 --ignore-missing-imports headroom/learn/analyzer.py
Success: no issues found in 1 source file
```

Note: one unrelated digest-builder test (`TestDigestBuilder::test_includes_project_info`) fails in my local Windows venv because it hardcodes a `/tmp/...` path; it fails identically on a clean `main` and is not touched by this change.

## Real Behavior Proof

- Environment: Windows 11, Python 3.12, project venv (`uv sync --extra proxy`), `uvx ruff@0.15.17` / `uvx mypy@1.20.2`, pytest in the venv.
- Exact command / steps: called the real `_strip_fenced_json` with object-less JSON (`[1,2,3]`, `"str"`, `42`, ...) and valid/extractable objects, and the real `_parse_llm_response` with `{"context_file_rules": null}`, a rule with `section: null`, and a valid rule; then reverted each fix and re-ran.
- Observed result: with the fixes the object-less inputs raise `JSONDecodeError`, the null shapes yield an empty recommendation list, and valid inputs parse as before; with each fix reverted the respective input raises (`AttributeError: 'list' object has no attribute 'get'`, `TypeError: 'NoneType' object is not iterable`, `AttributeError: 'NoneType' object has no attribute 'strip'`). Ran against the actual module.
- Not tested: a live `headroom learn` run where the backing model returns these shapes.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
