### PR TITLE
fix(docs): point GHCR image pulls at the headroomlabs-ai org path

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Everything in this repo stays open source (Apache 2.0). The managed offering is 
 uv tool install --python 3.13 "headroom-ai[all]"  # CLI, isolated app env
 pip install "headroom-ai[all]"                    # Python, everything — includes the `headroom` CLI
 npm install headroom-ai                           # TypeScript SDK (library only — no `headroom` CLI)
-docker pull ghcr.io/chopratejas/headroom:latest
+docker pull ghcr.io/headroomlabs-ai/headroom:latest
 ```
 
 Granular extras: `[proxy]`, `[mcp]`, `[ml]` (Kompress-v2-base), `[code]`, `[memory]`, `[vector]` (optional HNSW backend — needs a C++ toolchain, not in `[all]`), `[relevance]`, `[image]`, `[agno]`, `[langchain]`, `[evals]`, `[pytorch-mps]` (Apple-GPU memory-embedder offload — set `HEADROOM_EMBEDDER_RUNTIME=pytorch_mps`). Requires **Python 3.10+**.

--- a/TESTING-copilot-subscription.md
+++ b/TESTING-copilot-subscription.md
@@ -107,7 +107,7 @@ There is **no native Windows wheel yet**, so pick one:
 
 **A. Mechanism test (easiest — Docker Desktop or WSL2):**
 ```powershell
-$env:HEADROOM_DOCKER_IMAGE = "ghcr.io/chopratejas/headroom:<branch-tag>"   # ask the maintainer for the tag
+$env:HEADROOM_DOCKER_IMAGE = "ghcr.io/headroomlabs-ai/headroom:<branch-tag>"   # ask the maintainer for the tag
 # run the Docker-native installer (scripts/install.ps1), then:
 $env:GITHUB_COPILOT_TOKEN = "<your-token>"
 headroom wrap copilot --subscription -- --model gpt-4o -p "Reply with: HEADROOM_OK"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@
 #   3. point your LLM client at http://localhost:8787  (proxy)
 #
 # Just want the proxy without the memory features? You can run the proxy image
-# on its own (`docker run -p 8787:8787 ghcr.io/chopratejas/headroom`); the two
+# on its own (`docker run -p 8787:8787 ghcr.io/headroomlabs-ai/headroom`); the two
 # database services below are only required for the memory/relevance features.
 #
 # Ports exposed on the host:

--- a/docs/content/docs/docker-install.mdx
+++ b/docs/content/docs/docker-install.mdx
@@ -30,7 +30,7 @@ irm https://raw.githubusercontent.com/chopratejas/headroom/main/scripts/install.
 ## What the installer does
 
 1. Verifies Docker is installed and available.
-2. Pulls `ghcr.io/chopratejas/headroom:latest` by default, or reuses / pulls `HEADROOM_DOCKER_IMAGE` when you set a custom image override.
+2. Pulls `ghcr.io/headroomlabs-ai/headroom:latest` by default, or reuses / pulls `HEADROOM_DOCKER_IMAGE` when you set a custom image override.
 3. Installs a `headroom` wrapper into `~/.local/bin` or `~/bin`.
 4. Updates shell startup files so the wrapper directory is on `PATH`.
 
@@ -44,7 +44,7 @@ The wrapper keeps Headroom inside Docker and mounts host state back into the con
 
 Port `8787` stays the default, so `http://localhost:8787` works the same way as a native install.
 
-Published releases also push versioned GHCR tags such as `ghcr.io/chopratejas/headroom:0.5.26`, and those images are built with the same synced package version used for the matching PyPI and npm release.
+Published releases also push versioned GHCR tags such as `ghcr.io/headroomlabs-ai/headroom:0.5.26`, and those images are built with the same synced package version used for the matching PyPI and npm release.
 
 ## How the wrapper behaves
 
@@ -66,7 +66,7 @@ docker run --rm -it \
   -p 8787:8787 \
   -v "$PWD:/workspace" \
   -w /workspace \
-  ghcr.io/chopratejas/headroom:latest \
+  ghcr.io/headroomlabs-ai/headroom:latest \
   headroom proxy --host 0.0.0.0 --port 8787
 ```
 

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -218,8 +218,8 @@ node -e "const h = require('headroom-ai'); console.log('headroom-ai loaded')"
 Pre-built images are published to GitHub Container Registry on every release.
 
 ```bash
-docker pull ghcr.io/chopratejas/headroom:latest
-docker run -p 8787:8787 ghcr.io/chopratejas/headroom:latest
+docker pull ghcr.io/headroomlabs-ai/headroom:latest
+docker run -p 8787:8787 ghcr.io/headroomlabs-ai/headroom:latest
 ```
 
 <Callout type="info" title="Running Headroom without installing Python or Node?">

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,7 @@ The canonical, always-current documentation index lives at the docs site below. 
 
 - Python: `pip install headroom-ai` (add `[all]` for every optional extra)
 - TypeScript / Node: `npm install headroom-ai` (or `pnpm add headroom-ai`, `bun add headroom-ai`)
-- Docker: `docker run -p 8787:8787 ghcr.io/chopratejas/headroom:latest`
+- Docker: `docker run -p 8787:8787 ghcr.io/headroomlabs-ai/headroom:latest`
 - Run the proxy: `headroom proxy --port 8787` then point any client at `http://127.0.0.1:8787`
 - Wrap an agent in one command: `headroom wrap claude` (also: `codex`, `copilot`, `cursor`, `aider`, `opencode`, `cline`, `continue`, `goose`, `openhands`, `openclaw`, `vibe`, `omp`)
 

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -637,7 +637,7 @@ Options:
                                   (already the default).
   --image TEXT                    Docker image to use when runtime=docker or
                                   preset=persistent-docker.  [default:
-                                  ghcr.io/chopratejas/headroom:latest]
+                                  ghcr.io/headroomlabs-ai/headroom:latest]
   -?, --help                      Show this message and exit.
 ```
 
@@ -665,7 +665,7 @@ headroom install apply --preset persistent-docker --scope user
 | `--memory` | off | Enable persistent memory in the managed runtime |
 | `--telemetry` | off | Opt in to anonymous telemetry (off by default) |
 | `--no-telemetry` | off | Force anonymous telemetry off (already the default) |
-| `--image` | `ghcr.io/chopratejas/headroom:latest` | Docker image for Docker-backed installs |
+| `--image` | `ghcr.io/headroomlabs-ai/headroom:latest` | Docker image for Docker-backed installs |
 
 `apply` stores a manifest under
 `${HEADROOM_WORKSPACE_DIR}/deploy/<profile>/manifest.json` (default

--- a/wiki/docker-install.md
+++ b/wiki/docker-install.md
@@ -27,7 +27,7 @@ irm https://raw.githubusercontent.com/chopratejas/headroom/main/scripts/install.
 ## What the installer does
 
 1. Verifies Docker is installed and available.
-2. Pulls `ghcr.io/chopratejas/headroom:latest` by default, or reuses / pulls `HEADROOM_DOCKER_IMAGE` when you set a custom image override.
+2. Pulls `ghcr.io/headroomlabs-ai/headroom:latest` by default, or reuses / pulls `HEADROOM_DOCKER_IMAGE` when you set a custom image override.
 3. Installs a `headroom` wrapper into `~/.local/bin` or `~/bin`.
 4. Updates shell startup files so the wrapper directory is on `PATH`.
 
@@ -41,7 +41,7 @@ The wrapper keeps Headroom inside Docker and mounts host state back into the con
 
 Port `8787` stays the default, so `http://localhost:8787` works the same way as a native install.
 
-Published releases also push versioned GHCR tags such as `ghcr.io/chopratejas/headroom:0.5.26`, and those images are built with the same synced package version used for the matching PyPI and npm release.
+Published releases also push versioned GHCR tags such as `ghcr.io/headroomlabs-ai/headroom:0.5.26`, and those images are built with the same synced package version used for the matching PyPI and npm release.
 
 ## How the wrapper behaves
 
@@ -63,7 +63,7 @@ docker run --rm -it \
   -p 8787:8787 \
   -v "$PWD:/workspace" \
   -w /workspace \
-  ghcr.io/chopratejas/headroom:latest \
+  ghcr.io/headroomlabs-ai/headroom:latest \
   headroom proxy --host 0.0.0.0 --port 8787
 ```
 


### PR DESCRIPTION
## Description

After the repo moved from the personal `chopratejas` account to the `headroomlabs-ai` org, the docs still tell users to pull `ghcr.io/chopratejas/headroom`. GitHub redirects `github.com` and `raw.githubusercontent.com` URLs after a transfer, **but GHCR does not redirect the old package** — so that path is frozen at the last release before the move (v0.27.0, built 2026-06-22), while every release since v0.28.0 publishes to `ghcr.io/headroomlabs-ai/headroom` (`:latest` is currently v0.32.0).

Anyone following the README / install docs today therefore pulls an image ~5 minor versions stale. CI itself is healthy — the fix is purely documentation repointing at the live registry path.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Repointed `ghcr.io/chopratejas/headroom` → `ghcr.io/headroomlabs-ai/headroom` image references in user-facing docs: `README.md`, `docs/content/docs/installation.mdx`, `docs/content/docs/docker-install.mdx`, `wiki/cli.md`, `wiki/docker-install.md`, `llms.txt`, `docker-compose.yml`, and `TESTING-copilot-subscription.md` (14 lines across 8 files).
- **Intentionally left unchanged** — `headroom/install/state.py` and `tests/test_install/*`: the deprecated `chopratejas` string there is the *match target* for the runtime manifest migration added in #2426, not a stale reference.
- **Intentionally left unchanged** — `github.com` / `raw.githubusercontent.com` URLs: these redirect after the transfer and still resolve (verified below), so they are not broken.
- Did **not** touch `CHANGELOG.md` — it is generated by release-please from the Conventional Commit title.

## Testing

<!-- Check what you actually ran, then paste the real command output below. -->

- [ ] Unit tests pass (`pytest`) — N/A, docs-only change, no code paths modified
- [ ] Linting passes (`ruff check .`) — N/A, no Python changed
- [ ] Type checking passes (`mypy headroom`) — N/A, no Python changed
- [ ] New tests added for new functionality — N/A, no functional change
- [x] Manual testing performed — verified the new GHCR path resolves and the old one is stale (see below)

### Test Output

```text
$ for tag in latest 0.32.0; do
    new=$(curl -s -o /dev/null -w "%{http_code}" \
      "https://ghcr.io/v2/headroomlabs-ai/headroom/manifests/$tag" \
      -H "Authorization: Bearer $TOKEN_NEW" -H "Accept: application/vnd.oci.image.index.v1+json")
    old=$(curl -s -o /dev/null -w "%{http_code}" \
      "https://ghcr.io/v2/chopratejas/headroom/manifests/$tag" \
      -H "Authorization: Bearer $TOKEN_OLD" -H "Accept: application/vnd.oci.image.index.v1+json")
    printf 'tag %-8s  headroomlabs-ai=%s  chopratejas=%s\n' "$tag" "$new" "$old"
  done
tag latest    headroomlabs-ai=200  chopratejas=200
tag 0.32.0    headroomlabs-ai=200  chopratejas=404

# chopratejas:latest still returns 200 but resolves to a frozen image:
#   org.opencontainers.image.version = v0.27.0, created 2026-06-22
# chopratejas:0.32.0 (and 0.28.0-0.31.0) => 404: never published to the old path.
# headroomlabs-ai:latest => v0.32.0, promoted 2026-07-17.
```

## Real Behavior Proof

- **Environment:** anonymous GHCR pull tokens against `ghcr.io/v2/...` manifest API; upstream `main` at the time of writing.
- **Exact command / steps:** `curl` the manifest endpoint for both registry paths (see Test Output); additionally fetched the `:latest` image config blob on each path and read `org.opencontainers.image.version`.
- **Observed result:** old path `chopratejas` — `:latest` = v0.27.0 (frozen 2026-06-22), version tags `0.28.0`–`0.32.0` all 404. New path `headroomlabs-ai` — `:latest` = v0.32.0 (promoted 2026-07-17), `0.28.0`–`0.32.0` all present. `github.com/chopratejas/headroom` returns 301 → `headroomlabs-ai`, and `raw.githubusercontent.com/chopratejas/.../install.sh` still serves 200, confirming those URLs are not broken and were correctly left untouched.
- **Not tested:** did not run a full `docker pull` of each variant image (registry manifest resolution is sufficient to prove the tag exists); no application/unit tests run since no code changed.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, docs-only, no code behavior changed
- [x] New and existing unit tests pass locally with my changes — no code changed; not re-run
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — text/registry-path change only.

## Additional Notes

- The follow-up cleanup of the (still-working, redirecting) `github.com` / `raw.githubusercontent.com/chopratejas` URLs is deliberately out of scope here to keep this PR to the confirmed-broken references only.
- Root cause context: CI is publishing every release correctly; the only defect was the docs pointing at the pre-transfer GHCR package that GitHub does not redirect.