### PR TITLE
fix(doctor): don't crash on a valid-but-non-object settings.json

### DIFF
--- a/headroom/cli/doctor.py
+++ b/headroom/cli/doctor.py
@@ -157,6 +157,17 @@ def check_claude_routing(settings_path: Path, port: int) -> CheckResult:
             status=WARN,
             summary=f"could not parse {settings_path}: {exc}",
         )
+    # `json.loads` succeeds on valid non-object JSON (e.g. `[]`, `null`, `42`),
+    # which a hand-edited or reset settings file can contain. `.get` on a
+    # non-dict raises AttributeError, and it is not one of the caught parse
+    # errors above, so it would crash the very command run to diagnose the
+    # broken config. Treat a non-object like an unparseable file.
+    if not isinstance(payload, dict):
+        return CheckResult(
+            name=name,
+            status=WARN,
+            summary=f"could not parse {settings_path}: not a JSON object",
+        )
     base_url = ""
     env_block = payload.get("env")
     if isinstance(env_block, dict):
@@ -199,7 +210,10 @@ def check_claude_remote_control_gate(
     if settings_path.exists():
         try:
             payload = json.loads(settings_path.read_text(encoding="utf-8"))
-            env_block = payload.get("env")
+            # Valid non-object JSON (`[]`, `null`, ...) parses fine but has no
+            # `.get`, and AttributeError is not caught below; guard for dict-ness
+            # so a malformed settings file can't crash the gate check.
+            env_block = payload.get("env") if isinstance(payload, dict) else None
             if isinstance(env_block, dict):
                 settings_env = env_block
                 settings_base_url = str(env_block.get("ANTHROPIC_BASE_URL", "") or "")

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -108,6 +108,16 @@ class TestClaudeRouting:
         path.write_text("{not json", encoding="utf-8")
         assert check_claude_routing(path, 8787).status == WARN
 
+    @pytest.mark.parametrize("body", ["[]", "null", "42", '"a string"'])
+    def test_non_object_json_warns(self, tmp_path, body):
+        # Valid JSON that isn't an object parses cleanly, so it slips past the
+        # JSONDecodeError guard; the later payload.get("env") must not crash the
+        # diagnostic command that is being run precisely because the config is
+        # suspect.
+        path = tmp_path / "settings.json"
+        path.write_text(body, encoding="utf-8")
+        assert check_claude_routing(path, 8787).status == WARN
+
     def test_no_env_key_warns(self, tmp_path):
         path = tmp_path / "settings.json"
         path.write_text(json.dumps({"env": {}}), encoding="utf-8")
@@ -171,6 +181,19 @@ class TestClaudeRemoteControlGate:
             encoding="utf-8",
         )
         assert check_claude_remote_control_gate(path, {}) is None
+
+    @pytest.mark.parametrize("body", ["[]", "null", "42"])
+    def test_non_object_settings_does_not_crash(self, tmp_path, body):
+        # A valid-but-non-object settings file parses past the JSONDecodeError
+        # guard; payload.get("env") must not raise AttributeError. The shell env
+        # still drives the gate, so a custom base there still warns.
+        path = tmp_path / "settings.json"
+        path.write_text(body, encoding="utf-8")
+        result = check_claude_remote_control_gate(
+            path, {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"}
+        )
+        assert result is not None
+        assert result.status == WARN
 
     def test_api_key_auth_suppresses_warning(self, tmp_path):
         # Issue #1779: a PAYG / API-key session never had Remote Control, so the


### PR DESCRIPTION
## Description

`headroom doctor` parses `~/.claude/settings.json` in two checks:

```python
try:
    payload = json.loads(settings_path.read_text(encoding="utf-8"))
except (OSError, ValueError) as exc:
    return CheckResult(... WARN "could not parse" ...)
...
env_block = payload.get("env")
```

`json.loads` returns a non-dict for any valid JSON that is not an object: `[]`, `null`, `42`, `"a string"`. None of those raise `JSONDecodeError`, so they slip past the `except (OSError, ValueError)` guard, and the following `payload.get("env")` raises `AttributeError`. `AttributeError` is not in the caught tuple, so it escapes and crashes `doctor` with a traceback. That is the worst moment for it: `doctor` is the command a user runs precisely because their config is suspect, and a hand-edited or reset `settings.json` holding `[]` or `null` is exactly the kind of file it should report on, not fall over on.

Two functions have this shape: `check_claude_routing` (the `.get` is after the `try` returns) and `check_claude_remote_control_gate` (the `.get` is inside a `try` whose `except` is also `(OSError, ValueError)`).

## Fix

Guard `payload` for dict-ness in both checks. `check_claude_routing` now returns the same WARN it already returns for unparseable files, with a "not a JSON object" summary; `check_claude_remote_control_gate` treats a non-object as having no `env` block, so the shell environment still drives the gate. Well-formed object settings behave exactly as before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cli/doctor.py`: guard `payload` for dict-ness in `check_claude_routing` and `check_claude_remote_control_gate` before calling `.get`.
- `tests/test_cli_doctor.py`: parametrized regressions feeding `[]`, `null`, `42`, and a bare string to both checks.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_cli_doctor.py -q
68 passed

# with the fix reverted, the new tests fail with
# AttributeError: 'list' object has no attribute 'get'

$ uvx ruff@0.15.17 check headroom/cli/doctor.py tests/test_cli_doctor.py
All checks passed!
$ uvx mypy@1.20.2 --ignore-missing-imports headroom/cli/doctor.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12, project venv (`uv sync --extra proxy`), `uvx ruff@0.15.17` / `uvx mypy@1.20.2`, pytest in the venv.
- Exact command / steps: wrote a `settings.json` containing `[]` (and `null`, `42`, `"a string"`) into a tmp path and called `check_claude_routing(path, 8787)` and `check_claude_remote_control_gate(path, {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8787"})`; then reverted `doctor.py` and re-ran.
- Observed result: with the fix both checks return a WARN result instead of raising; with the fix reverted both raise `AttributeError: 'list' object has no attribute 'get'` (and the analogous message for `null`/`42`/string). Ran against the actual module via `tests/test_cli_doctor.py`.
- Not tested: the full `headroom doctor` CLI end to end against a real `~/.claude/settings.json`.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
