### PR TITLE
fix(proxy/memory): harden _extract_tool_calls against malformed choices and blocks

### DIFF
--- a/headroom/proxy/memory_handler.py
+++ b/headroom/proxy/memory_handler.py
@@ -1077,7 +1077,12 @@ your responses, not to drive new actions."""
             if isinstance(first, dict):
                 message = first.get("message")
                 if isinstance(message, dict):
-                    tc_list = list(message.get("tool_calls", []) or [])
+                    # Filter to dict entries: a null / string element inside
+                    # tool_calls (which downstream immediately calls `.get` on)
+                    # would otherwise still crash detection.
+                    tc_list = [
+                        tc for tc in (message.get("tool_calls") or []) if isinstance(tc, dict)
+                    ]
                     if tc_list:
                         return tc_list
 

--- a/headroom/proxy/memory_handler.py
+++ b/headroom/proxy/memory_handler.py
@@ -1056,17 +1056,30 @@ your responses, not to drive new actions."""
         if provider == "anthropic":
             content = response.get("content", [])
             if isinstance(content, list):
-                return [block for block in content if block.get("type") == "tool_use"]
+                return [
+                    block
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "tool_use"
+                ]
             return []
 
         elif provider == "openai":
-            # Chat Completions format: choices[0].message.tool_calls
-            choices = response.get("choices", [])
-            if choices:
-                message = choices[0].get("message", {})
-                tc_list = list(message.get("tool_calls", []) or [])
-                if tc_list:
-                    return tc_list
+            # Chat Completions format: choices[0].message.tool_calls. Guard the
+            # first choice for dict-ness the way the sibling
+            # CCRResponseHandler._extract_assistant_message already does: an
+            # OpenAI-compatible gateway can send `choices: [null]` on a
+            # content-filtered / usage-only response, and this runs from
+            # has_memory_tool_calls, which is called outside the try that wraps
+            # the rest of memory handling — so an unguarded `choices[0].get` here
+            # would surface AttributeError to the request handler.
+            choices = response.get("choices")
+            first = choices[0] if isinstance(choices, list) and choices else None
+            if isinstance(first, dict):
+                message = first.get("message")
+                if isinstance(message, dict):
+                    tc_list = list(message.get("tool_calls", []) or [])
+                    if tc_list:
+                        return tc_list
 
             # Responses API format: output[] with type=function_call
             output = response.get("output", [])

--- a/tests/test_memory_handler_null_function.py
+++ b/tests/test_memory_handler_null_function.py
@@ -63,3 +63,25 @@ def test_extract_tool_calls_survives_non_dict_anthropic_block():
     response = {"content": [None, {"type": "tool_use", "id": "t1", "name": "memory_save"}]}
     calls = _handler._extract_tool_calls(response, "anthropic")
     assert [c["id"] for c in calls] == ["t1"]
+
+
+def test_extract_tool_calls_skips_non_dict_openai_tool_call_elements():
+    # A null / string element inside message.tool_calls is passed straight to
+    # `.get` downstream (has_memory_tool_calls / handle_memory_tool_calls), so a
+    # malformed element must be dropped while a valid tool call is still seen.
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "tool_calls": [
+                        None,
+                        "oops",
+                        {"id": "c1", "type": "function", "function": {"name": "memory_save"}},
+                    ]
+                }
+            }
+        ]
+    }
+    calls = _handler._extract_tool_calls(response, "openai")
+    assert [c["id"] for c in calls] == ["c1"]
+    assert _handler.has_memory_tool_calls(response, "openai") is True

--- a/tests/test_memory_handler_null_function.py
+++ b/tests/test_memory_handler_null_function.py
@@ -34,3 +34,32 @@ def test_has_memory_tool_calls_survives_null_function():
 def test_has_memory_tool_calls_all_null_functions_is_false():
     response = _openai_response([{"id": "c1", "type": "function", "function": None}])
     assert _handler.has_memory_tool_calls(response, "openai") is False
+
+
+def test_extract_tool_calls_survives_null_choice_element():
+    # An OpenAI-compatible gateway can send `choices: [null]` on a
+    # content-filtered / usage-only response. `choices[0].get(...)` on the null
+    # element would raise AttributeError; detection must treat it as no tool
+    # calls, matching the sibling guard in CCRResponseHandler.
+    for choices in ([None], ["not-a-dict"], [{"message": None}]):
+        response = {"choices": choices}
+        assert _handler._extract_tool_calls(response, "openai") == []
+        assert _handler.has_memory_tool_calls(response, "openai") is False
+
+
+def test_extract_tool_calls_falls_through_to_responses_output():
+    # A null first choice must not shadow a Responses-API `output[]` payload in
+    # the same response; the function_call there is still detected.
+    response = {
+        "choices": [None],
+        "output": [{"type": "function_call", "name": "memory_save", "arguments": "{}"}],
+    }
+    assert _handler.has_memory_tool_calls(response, "openai") is True
+
+
+def test_extract_tool_calls_survives_non_dict_anthropic_block():
+    # A reconstructed Anthropic response may carry a null content block; the
+    # `block.get("type")` filter must skip it instead of raising.
+    response = {"content": [None, {"type": "tool_use", "id": "t1", "name": "memory_save"}]}
+    calls = _handler._extract_tool_calls(response, "anthropic")
+    assert [c["id"] for c in calls] == ["t1"]


### PR DESCRIPTION
## Description

`MemoryHandler._extract_tool_calls` reads tool calls from an upstream response. The OpenAI Chat Completions branch only truthiness-checked `choices` before indexing:

```python
choices = response.get("choices", [])
if choices:
    message = choices[0].get("message", {})
    ...
```

An OpenAI-compatible gateway can send `choices: [null]` on a content-filtered or usage-only response (the same shape the sibling `CCRResponseHandler._extract_assistant_message` was explicitly hardened for, see its comment: "a present-but-empty `choices: []` (or `[null]`) which OpenAI-compatible gateways can send"). With `[null]`, `choices` is truthy, so `choices[0].get("message", {})` runs on `None` and raises `AttributeError`. A non-dict first element (`choices: ["..."]`) breaks the same way.

This is not caught locally: `_extract_tool_calls` runs from `has_memory_tool_calls`, which the OpenAI handler calls in the `if (...)` condition **before** the `try` that wraps the rest of memory handling, so the `AttributeError` surfaces to the request handler rather than being swallowed and logged.

The Anthropic branch had a smaller version of the same gap: `[block for block in content if block.get("type") == "tool_use"]` guards `content` for list-ness but not each block, so a null element in a reconstructed response crashes `block.get`.

## Fix

Guard the first choice and its `message` for dict-ness before calling `.get`, mirroring `_extract_assistant_message`. A malformed choice now yields no tool calls and correctly falls through to the Responses-API `output[]` check. Skip non-dict blocks in the Anthropic branch. Well-formed responses are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/memory_handler.py`: dict-guard the first choice and its `message` in the OpenAI branch of `_extract_tool_calls`; skip non-dict content blocks in the Anthropic branch.
- `tests/test_memory_handler_null_function.py`: regressions for `choices: [null]` / non-dict choice / null message, fall-through to a Responses `output[]` function_call, and a non-dict Anthropic content block.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_memory_handler_null_function.py -q
5 passed

# with the fix reverted, the three new tests fail with
# AttributeError: 'NoneType' object has no attribute 'get'

$ uvx ruff@0.15.17 check headroom/proxy/memory_handler.py tests/test_memory_handler_null_function.py
All checks passed!
$ uvx mypy@1.20.2 --ignore-missing-imports headroom/proxy/memory_handler.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12, project venv (`uv sync --extra proxy`), `uvx ruff@0.15.17` / `uvx mypy@1.20.2`, pytest in the venv.
- Exact command / steps: called `_extract_tool_calls` / `has_memory_tool_calls` on a bare `MemoryHandler` (via `object.__new__`) with `choices: [null]`, `choices: ["x"]`, `choices: [{"message": null}]`, a `[null]`-choices response that also carries a Responses `output[]` function_call, and an Anthropic response whose content list starts with a null block; then reverted `memory_handler.py` and re-ran.
- Observed result: with the fix the malformed choices return `[]` / `False`, the `output[]` fall-through is still detected as `True`, and the valid Anthropic tool_use block is returned; with the fix reverted the `choices: [null]` and non-dict-block cases raise `AttributeError: 'NoneType' object has no attribute 'get'`. Ran against the actual module via `tests/test_memory_handler_null_function.py`.
- Not tested: a live OpenAI-compatible gateway emitting `choices: [null]` on a memory-enabled request, end to end.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
