### PR TITLE
fix(proxy/memory): harden MemoryToolAdapter._extract_tool_calls against malformed responses

### DIFF
--- a/headroom/proxy/memory_tool_adapter.py
+++ b/headroom/proxy/memory_tool_adapter.py
@@ -798,7 +798,10 @@ class MemoryToolAdapter:
         first = choices[0] if isinstance(choices, list) and choices else None
         message = first.get("message") if isinstance(first, dict) else None
         if isinstance(message, dict):
-            return list(message.get("tool_calls", []) or [])
+            # Filter to dict entries: downstream (_get_tool_name /
+            # _get_tool_input) calls `.get` on each element, so a null / string
+            # element inside tool_calls would still crash the same path.
+            return [tc for tc in (message.get("tool_calls") or []) if isinstance(tc, dict)]
         return []
 
     def _get_tool_name(self, tool_call: dict[str, Any], provider: Provider) -> str:

--- a/headroom/proxy/memory_tool_adapter.py
+++ b/headroom/proxy/memory_tool_adapter.py
@@ -747,44 +747,59 @@ class MemoryToolAdapter:
         response: dict[str, Any],
         provider: Provider,
     ) -> list[dict[str, Any]]:
-        """Extract tool calls from response based on provider format."""
+        """Extract tool calls from response based on provider format.
+
+        Every branch reads from the untrusted upstream response, so it guards
+        the shapes an OpenAI-compatible gateway can send on a content-filtered /
+        usage-only turn: a null element inside ``choices`` / ``candidates`` /
+        ``content`` (`[null]`), or a present-but-null nested object. Without the
+        guards, ``choices[0].get`` / ``block.get`` raises AttributeError, the
+        same class the sibling ``MemoryHandler._extract_tool_calls`` and this
+        adapter's own ``_get_tool_*`` helpers already defend against.
+        """
         if provider == "anthropic":
-            content = response.get("content", [])
-            if isinstance(content, list):
-                return [block for block in content if block.get("type") == "tool_use"]
-            return []
+            return self._extract_anthropic_tool_uses(response)
 
         elif provider == "openai":
-            choices = response.get("choices", [])
-            if choices:
-                message = choices[0].get("message", {})
-                return list(message.get("tool_calls", []) or [])
-            return []
+            return self._extract_openai_tool_calls(response)
 
         elif provider == "gemini":
             # Gemini format: candidates[0].content.parts[*].functionCall
-            candidates = response.get("candidates", [])
-            if candidates:
-                content = candidates[0].get("content", {})
-                parts = content.get("parts", [])
-                return [p for p in parts if "functionCall" in p]
+            candidates = response.get("candidates")
+            first = candidates[0] if isinstance(candidates, list) and candidates else None
+            content = first.get("content") if isinstance(first, dict) else None
+            parts = content.get("parts") if isinstance(content, dict) else None
+            if isinstance(parts, list):
+                return [p for p in parts if isinstance(p, dict) and "functionCall" in p]
             return []
 
         # Generic fallback - try both formats
-        tool_calls = []
-
-        # Try Anthropic format
-        content = response.get("content", [])
-        if isinstance(content, list):
-            tool_calls.extend([block for block in content if block.get("type") == "tool_use"])
-
-        # Try OpenAI format
-        choices = response.get("choices", [])
-        if choices:
-            message = choices[0].get("message", {})
-            tool_calls.extend(list(message.get("tool_calls", []) or []))
+        tool_calls = self._extract_anthropic_tool_uses(response)
+        tool_calls.extend(self._extract_openai_tool_calls(response))
 
         return tool_calls
+
+    @staticmethod
+    def _extract_anthropic_tool_uses(response: dict[str, Any]) -> list[dict[str, Any]]:
+        """Anthropic ``content[]`` tool_use blocks, skipping non-dict elements."""
+        content = response.get("content", [])
+        if isinstance(content, list):
+            return [
+                block
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "tool_use"
+            ]
+        return []
+
+    @staticmethod
+    def _extract_openai_tool_calls(response: dict[str, Any]) -> list[dict[str, Any]]:
+        """OpenAI ``choices[0].message.tool_calls``, guarding a null/non-dict choice."""
+        choices = response.get("choices")
+        first = choices[0] if isinstance(choices, list) and choices else None
+        message = first.get("message") if isinstance(first, dict) else None
+        if isinstance(message, dict):
+            return list(message.get("tool_calls", []) or [])
+        return []
 
     def _get_tool_name(self, tool_call: dict[str, Any], provider: Provider) -> str:
         """Get the tool name from a tool call."""

--- a/tests/test_memory_tool_adapter_null_fields.py
+++ b/tests/test_memory_tool_adapter_null_fields.py
@@ -33,3 +33,42 @@ def test_get_tool_helpers_still_parse_real_calls():
     tc = {"function": {"name": "memory_save", "arguments": '{"content": "hi"}'}}
     assert _adapter._get_tool_name(tc, "openai") == "memory_save"
     assert _adapter._get_tool_input(tc, "openai") == {"content": "hi"}
+
+
+def test_extract_tool_calls_survives_malformed_openai_choices():
+    # `choices: [null]` (a content-filtered / usage-only turn from an
+    # OpenAI-compatible gateway) once crashed choices[0].get. It must yield no
+    # tool calls, across the explicit openai branch and the generic fallback.
+    for choices in ([None], ["str"], [{"message": None}]):
+        response = {"choices": choices}
+        assert _adapter._extract_tool_calls(response, "openai") == []
+        assert _adapter._extract_tool_calls(response, "other") == []
+
+
+def test_extract_tool_calls_survives_malformed_gemini_candidates():
+    # A null candidate / null content / null parts must not crash the Gemini
+    # branch's chained .get calls.
+    for response in (
+        {"candidates": [None]},
+        {"candidates": [{"content": None}]},
+        {"candidates": [{"content": {"parts": None}}]},
+    ):
+        assert _adapter._extract_tool_calls(response, "gemini") == []
+
+    # A real functionCall part is still returned; a non-dict part is skipped.
+    response = {
+        "candidates": [{"content": {"parts": [None, {"functionCall": {"name": "memory_save"}}]}}]
+    }
+    calls = _adapter._extract_tool_calls(response, "gemini")
+    assert calls == [{"functionCall": {"name": "memory_save"}}]
+
+
+def test_extract_tool_calls_survives_non_dict_anthropic_block():
+    response = {"content": [None, {"type": "tool_use", "id": "t1", "name": "memory_save"}]}
+    calls = _adapter._extract_tool_calls(response, "anthropic")
+    assert [c["id"] for c in calls] == ["t1"]
+
+
+def test_extract_tool_calls_still_parses_real_openai_call():
+    response = {"choices": [{"message": {"tool_calls": [{"id": "c1"}]}}]}
+    assert _adapter._extract_tool_calls(response, "openai") == [{"id": "c1"}]

--- a/tests/test_memory_tool_adapter_null_fields.py
+++ b/tests/test_memory_tool_adapter_null_fields.py
@@ -72,3 +72,25 @@ def test_extract_tool_calls_survives_non_dict_anthropic_block():
 def test_extract_tool_calls_still_parses_real_openai_call():
     response = {"choices": [{"message": {"tool_calls": [{"id": "c1"}]}}]}
     assert _adapter._extract_tool_calls(response, "openai") == [{"id": "c1"}]
+
+
+def test_extract_tool_calls_skips_non_dict_openai_tool_call_elements():
+    # A null / string element inside message.tool_calls is passed straight to
+    # `.get` downstream (_get_tool_name / _get_tool_input), so a malformed
+    # element must be dropped while a valid tool call is still returned.
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "tool_calls": [
+                        None,
+                        "oops",
+                        {"id": "c1", "type": "function", "function": {"name": "memory_save"}},
+                    ]
+                }
+            }
+        ]
+    }
+    calls = _adapter._extract_tool_calls(response, "openai")
+    assert [c["id"] for c in calls] == ["c1"]
+    assert _adapter.has_memory_tool_calls(response, "openai") is True


### PR DESCRIPTION
## Description

`MemoryToolAdapter._extract_tool_calls` reads tool calls out of an upstream response for each provider format. Its own `_get_tool_name` / `_get_tool_input` helpers were already hardened against malformed upstream data (see `test_memory_tool_adapter_null_fields.py`: "reachable from the untrusted upstream response"), but `_extract_tool_calls` itself indexed and chained `.get` with no guards:

```python
# openai
choices = response.get("choices", [])
if choices:
    message = choices[0].get("message", {})   # choices: [null] -> AttributeError
    ...
# gemini
content = candidates[0].get("content", {})    # candidates: [null] -> AttributeError
parts = content.get("parts", [])              # content: null -> AttributeError
# anthropic
[block for block in content if block.get("type") == "tool_use"]  # null block -> AttributeError
```

An OpenAI-compatible gateway can send `choices: [null]` on a content-filtered / usage-only turn (the same shape the sibling `MemoryHandler._extract_tool_calls` was hardened for — see PR #2483). The truthiness check on `choices` lets `[null]` through, and `choices[0].get` then raises `AttributeError`. The Gemini branch has the same gap on a null candidate / null `content`, and the Anthropic branch (and the generic fallback) crash on a non-dict content block.

## Fix

Guard the first choice/candidate and the nested `message` / `content` / `parts` for type before calling `.get`, and skip non-dict elements — mirroring `MemoryHandler._extract_tool_calls` and this adapter's already-hardened `_get_tool_*` helpers. The OpenAI and Anthropic extraction is factored into two small helpers so the explicit branches and the generic fallback stay in lockstep. Well-formed responses are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/memory_tool_adapter.py`: type-guard the OpenAI, Gemini, and Anthropic branches (and the generic fallback) of `_extract_tool_calls`; add `_extract_anthropic_tool_uses` / `_extract_openai_tool_calls` helpers shared by the explicit branches and the fallback.
- `tests/test_memory_tool_adapter_null_fields.py`: regressions for malformed OpenAI choices, malformed Gemini candidates/content/parts (plus a null part skipped), a non-dict Anthropic block, and a valid OpenAI call still parsed.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_memory_tool_adapter_null_fields.py -q
7 passed

# with the fix reverted, the three new malformed-shape tests fail with
# AttributeError: 'NoneType' object has no attribute 'get'

$ uvx ruff@0.15.17 check headroom/proxy/memory_tool_adapter.py tests/test_memory_tool_adapter_null_fields.py
All checks passed!
$ uvx mypy@1.20.2 --ignore-missing-imports headroom/proxy/memory_tool_adapter.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12, project venv (`uv sync --extra proxy`), `uvx ruff@0.15.17` / `uvx mypy@1.20.2`, pytest in the venv.
- Exact command / steps: called `_extract_tool_calls` on a bare `MemoryToolAdapter` (via `object.__new__`) with `choices: [null]` / `[str]` / `[{"message": null}]` (openai and generic), `candidates: [null]` / null content / null parts (gemini), and a null Anthropic content block; then reverted `memory_tool_adapter.py` and re-ran.
- Observed result: with the fix the malformed shapes return `[]`, a real Gemini `functionCall` part is still returned (null part skipped), and a valid OpenAI tool call still parses; with the fix reverted the openai `[null]`, gemini null-content, and non-dict-block cases raise `AttributeError: 'NoneType' object has no attribute 'get'`. Ran against the actual module via `tests/test_memory_tool_adapter_null_fields.py`.
- Not tested: a live OpenAI-compatible gateway emitting `choices: [null]` routed through the adapter end to end.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
