### PR TITLE
docs: add troubleshooting entry for uv build cache errors

### DIFF
--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -396,6 +396,35 @@ Threat: Trojan:Win64/Lazy!MTB
 
 4. **Report the false positive to Microsoft** so a corrected signature ships for everyone: submit `sg.exe` at the [Microsoft Security Intelligence sample submission](https://www.microsoft.com/en-us/wdsi/filesubmission) page.
 
+### uv build errors: "src does not appear to be a Python project"
+
+**Symptom**: `uv tool install "headroom-ai[all]"` fails to build a dependency (commonly `litellm` or `cryptography`) with:
+
+```text
+error: Failed to build: <package>==<version>
+Caused by: `src does not appear to be a Python project, as neither `pyproject.toml`
+nor `setup.py` are present`
+```
+
+or a wheel install fails with `Unknown wheel data type: .DS_Store`.
+
+**Cause**: Corrupted or stale entries in uv's local build/wheel cache, not a Headroom dependency-pin problem. Headroom does not pin exact versions of `litellm` or `cryptography` that would trigger this.
+
+**Fix**: clear uv's cache and reinstall:
+
+```bash
+uv cache clean
+uv tool install "headroom-ai[all]"
+```
+
+To clear the cache for just one package instead:
+
+```bash
+uv cache clean litellm
+```
+
+If the failure is specifically for `ast-grep-cli==0.44.1`, that release is already excluded by Headroom's dependency pin (`ast-grep-cli>=0.30.0,!=0.44.1`) due to a compromised supply-chain build ([ast-grep/ast-grep#2799](https://github.com/ast-grep/ast-grep/issues/2799)) — `uv cache clean` and a plain reinstall should pick up a safe version automatically.
+
 ## Provider-Specific Issues
 
 ### OpenAI: Invalid API key


### PR DESCRIPTION
## Description

Adds a troubleshooting section for a uv build error macOS users hit installing headroom-ai via uv: `src does not appear to be a Python project` (typically surfacing on `litellm` or `cryptography`) or `Unknown wheel data type: .DS_Store`. Root cause is uv build/wheel cache corruption on the user's machine, not a Headroom dependency pin. Also cross-references the existing `ast-grep-cli>=0.30.0,!=0.44.1` pin, which already excludes the compromised 0.44.1 build reported in the same issue.

Closes #2476

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Added "uv build errors: 'src does not appear to be a Python project'" subsection under Installation Issues in `docs/content/docs/troubleshooting.mdx`, with symptom, cause, and `uv cache clean` fix.
- Cross-referenced the already-shipped `ast-grep-cli` version pin for the 0.44.1 supply-chain issue.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
N/A — docs-only change, no code paths touched. No pytest/ruff/mypy relevant.
```

## Real Behavior Proof

- Environment: N/A — markdown documentation edit only, no runtime behavior changed.
- Exact command / steps: Read the modified `docs/content/docs/troubleshooting.mdx` section against the rendered structure of adjacent entries (Windows Defender / ast-grep-cli section) to confirm heading level, code fences, and link formatting match.
- Observed result: New subsection renders consistently with surrounding Installation Issues entries (same `###` heading depth, Symptom/Cause/Fix structure, fenced code blocks).
- Not tested: Live docs site build/preview (`cd docs && npm run dev`) was not run in this environment.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas — N/A, prose docs
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, docs-only
- [ ] New and existing unit tests pass locally with my changes — N/A, docs-only
- [x] I did **not** edit `CHANGELOG.md`

## Screenshots (if applicable)

N/A

## Additional Notes

Docs-only change; no source code touched. `docs && npm run dev` not run locally in this environment — flagging for maintainer to preview if desired before merge.