### PR TITLE
docs: add guide for using Headroom with OpenCode + DeepSeek

### DIFF
--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -38,6 +38,7 @@
     "claude-code-vertex",
     "claude-code-azure-foundry",
     "opencode",
+    "opencode-deepseek",
     "grok-build",
     "mcp",
     "---Configuration---",

--- a/docs/content/docs/opencode-deepseek.mdx
+++ b/docs/content/docs/opencode-deepseek.mdx
@@ -1,4 +1,7 @@
-# Using Headroom with OpenCode + DeepSeek
+---
+title: OpenCode + DeepSeek
+description: Configure OpenCode to route DeepSeek traffic through the Headroom proxy for compression, output shaping, and savings visibility.
+---
 
 Save 20-60% on DeepSeek API costs with Headroom's context compression proxy.
 
@@ -166,7 +169,7 @@ Or open the dashboard at [http://127.0.0.1:8787/dashboard](http://127.0.0.1:8787
 
 ## Thinking mode (reasoning)
 
-Both models support thinking mode natively — no extra config needed.
+Both models support thinking mode natively, and DeepSeek enables it by default.
 This replaces the deprecated `deepseek-reasoner` (R1) model.
 See [DeepSeek's thinking mode docs](https://api-docs.deepseek.com/guides/thinking_mode)
 for details on switching between thinking and non-thinking modes.

--- a/docs/open-code-deepseek.md
+++ b/docs/open-code-deepseek.md
@@ -1,0 +1,199 @@
+# Using Headroom with OpenCode + DeepSeek
+
+Save 20-60% on DeepSeek API costs with Headroom's context compression proxy.
+
+## How it works
+
+```
+OpenCode → Headroom Proxy (:8787) → DeepSeek API
+              ↑ compresses input
+              + shapes output
+```
+
+The proxy sits between OpenCode and DeepSeek. It compresses tool outputs, logs,
+and search results before they reach the model, then shapes responses to be
+concise. DeepSeek's API is OpenAI-compatible — one flag and you're running.
+
+---
+
+## 1. Install Headroom
+
+```bash
+pip install headroom-ai
+# or via uv:
+uv tool install headroom-ai
+```
+
+You get SmartCrusher (structural compression), the proxy, output shaping, and
+the MCP server — everything you need.
+
+---
+
+## 2. Get your DeepSeek API key
+
+Sign up at [platform.deepseek.com](https://platform.deepseek.com) and generate
+an API key.
+
+Store it somewhere safe:
+```bash
+export DEEPSEEK_API_KEY="sk-your-deepseek-key-here"
+```
+
+---
+
+## 3. Start the proxy
+
+```bash
+headroom proxy \
+  --port 8787 \
+  --openai-api-url https://api.deepseek.com/v1
+```
+
+The proxy auto-detects `api.deepseek.com` and labels itself "DeepSeek" on the
+dashboard. Verify it's running:
+
+```bash
+curl http://127.0.0.1:8787/health
+# → "status": "healthy"
+```
+
+### With output shaping (optional)
+
+Output shaping makes the model's responses shorter — fewer tokens, lower cost:
+
+```bash
+HEADROOM_OUTPUT_SHAPER=1 HEADROOM_VERBOSITY_LEVEL=2 \
+headroom proxy --port 8787 --openai-api-url https://api.deepseek.com/v1
+```
+
+Verbosity levels:
+
+| Level | Behavior |
+|---|---|
+| `1` | Skip preambles/postambles |
+| `2` | + Don't restate code/file content already in context (**recommended**) |
+| `3` | + Omit rationale unless asked |
+| `4` | Maximum — fragments, zero fluff |
+
+---
+
+## 4. Configure OpenCode
+
+Edit `~/.config/opencode/opencode.jsonc`:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "headroom/deepseek-v4-pro",
+  "provider": {
+    "headroom": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Headroom Proxy",
+      "options": {
+        "baseURL": "http://127.0.0.1:8787/v1",
+        "apiKey": "sk-your-deepseek-key"
+      },
+      "models": {
+        "deepseek-v4-pro": {
+          "name": "DeepSeek V4 Pro",
+          "limit": { "context": 200000, "output": 16384 }
+        },
+        "deepseek-v4-flash": {
+          "name": "DeepSeek V4 Flash (Free)",
+          "limit": { "context": 200000, "output": 16384 }
+        },
+        "deepseek-reasoner": {
+          "name": "DeepSeek R1",
+          "limit": { "context": 128000, "output": 8192 }
+        }
+      }
+    }
+  },
+  "mcp": {
+    "headroom": {
+      "type": "local",
+      "command": ["headroom", "mcp", "serve"],
+      "enabled": true
+    }
+  }
+}
+```
+
+### Model comparison
+
+| Model | Cost | Context | Best for |
+|---|---|---|---|
+| `deepseek-v4-pro` | Paid ($0.435/$0.87) | 200K | Complex coding, architecture, debugging |
+| `deepseek-v4-flash` | Free | 200K | Daily tasks, quick edits, exploration |
+| `deepseek-reasoner` (R1) | Paid | 128K | Math, logic, multi-step reasoning |
+
+Switch models at any time with `/model` in OpenCode.
+
+---
+
+## 5. Start OpenCode
+
+```bash
+opencode
+```
+
+Run `/models` to confirm all three DeepSeek models appear. Select one with
+`/model deepseek-v4-pro`.
+
+---
+
+## 6. Check savings
+
+```bash
+curl http://127.0.0.1:8787/stats | python3 -m json.tool | grep -A5 compression
+```
+
+Or open the dashboard at [http://127.0.0.1:8787/dashboard](http://127.0.0.1:8787/dashboard).
+
+---
+
+## Common issues
+
+### "Authentication Fails" / Unauthorized
+
+The `apiKey` in OpenCode's config is missing or wrong. OpenCode must send the
+API key to the proxy, and the proxy forwards it to DeepSeek. Make sure
+`"apiKey": "sk-..."` is set under `options` in `opencode.jsonc`.
+
+### Models appear but requests fail
+
+You ran `headroom wrap opencode`. That command replaces your config with Claude
+and GPT models. **Do not use `headroom wrap`.** Configure OpenCode manually as
+shown above, and launch OpenCode directly with `opencode`.
+
+### "headroom" command not found
+
+`uv tool install` puts binaries in `~/.local/bin/`. Add it to your PATH:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+### Output shaping shows no savings
+
+Output savings are measured against a learned baseline (it compares "what the
+model actually emitted" vs "what it would have emitted unshaped"). After a few
+sessions, run:
+
+```bash
+headroom learn --verbosity --apply
+```
+
+This builds the baseline, and `/stats` will show output savings numbers. The
+shaper is active immediately — the numbers just need calibration.
+
+---
+
+## What's NOT in this guide
+
+- **Claude or GPT models** — this setup uses DeepSeek exclusively
+- **`headroom wrap`** — do not use it; it overrides the config
+- **Kompress (ML compression)** — requires extra dependencies; SmartCrusher
+  handles the majority of use cases
+- **Any code changes** — headroom ships full DeepSeek support natively
+  (model tables, pricing, tokenizers, domain detection)

--- a/docs/open-code-deepseek.md
+++ b/docs/open-code-deepseek.md
@@ -127,7 +127,8 @@ Edit `~/.config/opencode/opencode.json`:
 
 **Important:** Only include model IDs that appear in the proxy's `/v1/models`
 response. OpenCode validates config models against the proxy's model list.
-If you need DeepSeek R1 (reasoner), see the note at the end of the guide.
+The current DeepSeek model names are `deepseek-v4-pro` and `deepseek-v4-flash`.
+`deepseek-chat` and `deepseek-reasoner` are deprecated compatibility aliases.
 
 ### Model comparison
 
@@ -135,6 +136,8 @@ If you need DeepSeek R1 (reasoner), see the note at the end of the guide.
 |---|---|---|---|
 | `deepseek-v4-pro` | Paid ($0.435/$0.87) | 200K | Complex coding, architecture, debugging |
 | `deepseek-v4-flash` | Free | 200K | Daily tasks, quick edits, exploration |
+
+Both models support **thinking mode** for step-by-step reasoning (see below).
 
 Switch models at any time with `/model` in OpenCode.
 
@@ -146,7 +149,7 @@ Switch models at any time with `/model` in OpenCode.
 opencode
 ```
 
-Run `/models` to confirm the DeepSeek models appear under "Headroom Proxy".
+Run `/models` to confirm both DeepSeek models appear under "Headroom Proxy".
 Select one with `/model deepseek-v4-flash` or `/model deepseek-v4-pro`.
 
 ---
@@ -158,6 +161,35 @@ curl http://127.0.0.1:8787/stats | python3 -m json.tool | grep -A5 compression
 ```
 
 Or open the dashboard at [http://127.0.0.1:8787/dashboard](http://127.0.0.1:8787/dashboard).
+
+---
+
+## Thinking mode (reasoning)
+
+Both `deepseek-v4-pro` and `deepseek-v4-flash` support **thinking mode** — the
+model works through problems step-by-step before answering. This replaces the
+deprecated `deepseek-reasoner` (R1) model.
+
+To enable thinking mode, pass `thinking` in the request body:
+
+```json
+{
+  "model": "deepseek-v4-pro",
+  "messages": [{"role": "user", "content": "Your question"}],
+  "thinking": {"type": "enabled"},
+  "reasoning_effort": "high"
+}
+```
+
+OpenCode sends requests through the headroom proxy, which forwards them to
+DeepSeek. If you need thinking mode for specific tasks, you can:
+
+- **Set it in your provider options** — add `headers` or request body defaults
+  via the AI SDK's provider configuration if supported
+- **Use `/model deepseek-v4-flash`** for free-tier reasoning (thinking mode on
+  flash gives similar behavior to the old R1 model)
+- **Check DeepSeek's API docs** for the latest thinking mode parameters:
+  [api-docs.deepseek.com](https://api-docs.deepseek.com)
 
 ---
 
@@ -175,7 +207,6 @@ API key to the proxy, and the proxy forwards it to DeepSeek. Make sure
 2. Check which models the proxy exposes: `curl -s http://127.0.0.1:8787/v1/models -H "Authorization: Bearer sk-your-key"`
 3. Make sure your config model IDs match **exactly** what the proxy returns
 4. Don't use both `opencode.json` and `opencode.jsonc` in the same config directory — use one file
-5. Models like `deepseek-reasoner` and `deepseek-chat` are not exposed by the proxy; use `deepseek-v4-pro` or `deepseek-v4-flash` instead
 
 ### Models appear but requests fail
 
@@ -206,27 +237,13 @@ shaper is active immediately — the numbers just need calibration.
 
 ---
 
-## Using DeepSeek R1 (reasoner)
-
-The proxy's `/v1/models` endpoint currently only exposes `deepseek-v4-pro` and
-`deepseek-v4-flash`. However, the proxy can still route requests to R1 — you
-just can't select it from OpenCode's `/models` picker.
-
-If you need R1 for math/logic tasks, switch your default model:
-
-```bash
-/model deepseek-reasoner
-```
-
-Or set it directly in an OpenCode session config. R1 has 128K context and
-excels at reasoning-heavy workloads.
-
----
-
 ## What's NOT in this guide
 
 - **Claude or GPT models** — this setup uses DeepSeek exclusively
 - **`headroom wrap`** — do not use it; it overrides the config
+- **Deprecated model names** — `deepseek-chat` and `deepseek-reasoner` are
+  compatibility aliases that will be deprecated on 2026-07-24; use
+  `deepseek-v4-pro` and `deepseek-v4-flash` instead
 - **Kompress (ML compression)** — requires extra dependencies; SmartCrusher
   handles the majority of use cases
 - **Any code changes** — headroom ships full DeepSeek support natively

--- a/docs/open-code-deepseek.md
+++ b/docs/open-code-deepseek.md
@@ -57,6 +57,12 @@ curl http://127.0.0.1:8787/health
 # → "status": "healthy"
 ```
 
+To see which models the proxy exposes:
+```bash
+curl -s http://127.0.0.1:8787/v1/models \
+  -H "Authorization: Bearer sk-your-key" | jq '.data[].id'
+```
+
 ### With output shaping (optional)
 
 Output shaping makes the model's responses shorter — fewer tokens, lower cost:
@@ -79,7 +85,11 @@ Verbosity levels:
 
 ## 4. Configure OpenCode
 
-Edit `~/.config/opencode/opencode.jsonc`:
+**Note:** If you have an existing `~/.config/opencode/opencode.json` (for MCP
+servers, etc.), merge the provider section into that file. Having both `.json`
+and `.jsonc` in the same directory can cause conflicts.
+
+Edit `~/.config/opencode/opencode.json`:
 
 ```jsonc
 {
@@ -101,10 +111,6 @@ Edit `~/.config/opencode/opencode.jsonc`:
         "deepseek-v4-flash": {
           "name": "DeepSeek V4 Flash (Free)",
           "limit": { "context": 200000, "output": 16384 }
-        },
-        "deepseek-reasoner": {
-          "name": "DeepSeek R1",
-          "limit": { "context": 128000, "output": 8192 }
         }
       }
     }
@@ -119,13 +125,16 @@ Edit `~/.config/opencode/opencode.jsonc`:
 }
 ```
 
+**Important:** Only include model IDs that appear in the proxy's `/v1/models`
+response. OpenCode validates config models against the proxy's model list.
+If you need DeepSeek R1 (reasoner), see the note at the end of the guide.
+
 ### Model comparison
 
 | Model | Cost | Context | Best for |
 |---|---|---|---|
 | `deepseek-v4-pro` | Paid ($0.435/$0.87) | 200K | Complex coding, architecture, debugging |
 | `deepseek-v4-flash` | Free | 200K | Daily tasks, quick edits, exploration |
-| `deepseek-reasoner` (R1) | Paid | 128K | Math, logic, multi-step reasoning |
 
 Switch models at any time with `/model` in OpenCode.
 
@@ -137,8 +146,8 @@ Switch models at any time with `/model` in OpenCode.
 opencode
 ```
 
-Run `/models` to confirm all three DeepSeek models appear. Select one with
-`/model deepseek-v4-pro`.
+Run `/models` to confirm the DeepSeek models appear under "Headroom Proxy".
+Select one with `/model deepseek-v4-flash` or `/model deepseek-v4-pro`.
 
 ---
 
@@ -158,7 +167,15 @@ Or open the dashboard at [http://127.0.0.1:8787/dashboard](http://127.0.0.1:8787
 
 The `apiKey` in OpenCode's config is missing or wrong. OpenCode must send the
 API key to the proxy, and the proxy forwards it to DeepSeek. Make sure
-`"apiKey": "sk-..."` is set under `options` in `opencode.jsonc`.
+`"apiKey": "sk-..."` is set under `options`.
+
+### Models don't appear under "Headroom Proxy"
+
+1. Verify the proxy is running: `curl http://127.0.0.1:8787/health`
+2. Check which models the proxy exposes: `curl -s http://127.0.0.1:8787/v1/models -H "Authorization: Bearer sk-your-key"`
+3. Make sure your config model IDs match **exactly** what the proxy returns
+4. Don't use both `opencode.json` and `opencode.jsonc` in the same config directory — use one file
+5. Models like `deepseek-reasoner` and `deepseek-chat` are not exposed by the proxy; use `deepseek-v4-pro` or `deepseek-v4-flash` instead
 
 ### Models appear but requests fail
 
@@ -186,6 +203,23 @@ headroom learn --verbosity --apply
 
 This builds the baseline, and `/stats` will show output savings numbers. The
 shaper is active immediately — the numbers just need calibration.
+
+---
+
+## Using DeepSeek R1 (reasoner)
+
+The proxy's `/v1/models` endpoint currently only exposes `deepseek-v4-pro` and
+`deepseek-v4-flash`. However, the proxy can still route requests to R1 — you
+just can't select it from OpenCode's `/models` picker.
+
+If you need R1 for math/logic tasks, switch your default model:
+
+```bash
+/model deepseek-reasoner
+```
+
+Or set it directly in an OpenCode session config. R1 has 128K context and
+excels at reasoning-heavy workloads.
 
 ---
 

--- a/docs/open-code-deepseek.md
+++ b/docs/open-code-deepseek.md
@@ -106,11 +106,11 @@ Edit `~/.config/opencode/opencode.json`:
       "models": {
         "deepseek-v4-pro": {
           "name": "DeepSeek V4 Pro",
-          "limit": { "context": 200000, "output": 16384 }
+          "limit": { "context": 1000000, "output": 384000 }
         },
         "deepseek-v4-flash": {
-          "name": "DeepSeek V4 Flash (Free)",
-          "limit": { "context": 200000, "output": 16384 }
+          "name": "DeepSeek V4 Flash",
+          "limit": { "context": 1000000, "output": 384000 }
         }
       }
     }
@@ -132,10 +132,10 @@ The current DeepSeek model names are `deepseek-v4-pro` and `deepseek-v4-flash`.
 
 ### Model comparison
 
-| Model | Cost | Context | Best for |
+| Model | Input / Output (per 1M) | Context | Max Output |
 |---|---|---|---|
-| `deepseek-v4-pro` | Paid ($0.435/$0.87) | 200K | Complex coding, architecture, debugging |
-| `deepseek-v4-flash` | Free | 200K | Daily tasks, quick edits, exploration |
+| `deepseek-v4-pro` | $0.435 / $0.87 | 1M | 384K |
+| `deepseek-v4-flash` | $0.14 / $0.28 | 1M | 384K |
 
 Both models support **thinking mode** for step-by-step reasoning (see below).
 
@@ -166,30 +166,10 @@ Or open the dashboard at [http://127.0.0.1:8787/dashboard](http://127.0.0.1:8787
 
 ## Thinking mode (reasoning)
 
-Both `deepseek-v4-pro` and `deepseek-v4-flash` support **thinking mode** — the
-model works through problems step-by-step before answering. This replaces the
-deprecated `deepseek-reasoner` (R1) model.
-
-To enable thinking mode, pass `thinking` in the request body:
-
-```json
-{
-  "model": "deepseek-v4-pro",
-  "messages": [{"role": "user", "content": "Your question"}],
-  "thinking": {"type": "enabled"},
-  "reasoning_effort": "high"
-}
-```
-
-OpenCode sends requests through the headroom proxy, which forwards them to
-DeepSeek. If you need thinking mode for specific tasks, you can:
-
-- **Set it in your provider options** — add `headers` or request body defaults
-  via the AI SDK's provider configuration if supported
-- **Use `/model deepseek-v4-flash`** for free-tier reasoning (thinking mode on
-  flash gives similar behavior to the old R1 model)
-- **Check DeepSeek's API docs** for the latest thinking mode parameters:
-  [api-docs.deepseek.com](https://api-docs.deepseek.com)
+Both models support thinking mode natively — no extra config needed.
+This replaces the deprecated `deepseek-reasoner` (R1) model.
+See [DeepSeek's thinking mode docs](https://api-docs.deepseek.com/guides/thinking_mode)
+for details on switching between thinking and non-thinking modes.
 
 ---
 


### PR DESCRIPTION
Documents how to configure Headroom proxy with DeepSeek for OpenCode users.

- No `headroom wrap` needed -- manual config avoids Claude/GPT model overwrites
- Covers proxy setup, OpenCode provider config, output shaping, model comparison, and troubleshooting
- Includes current DeepSeek V4 Pro and V4 Flash models, with deprecated alias guidance for `deepseek-chat` / `deepseek-reasoner`
- Adds the guide to the published docs tree and navigation
- All API keys use placeholders

## Description

Adds documentation (`docs/content/docs/opencode-deepseek.mdx`) showing OpenCode users how to route through Headroom proxy with DeepSeek. Addresses the gap described in #78 (OpenCode integration docs) and provides the manual config workaround documented in #1679 (wrap broken with Go CLI).

## Type of Change

- [x] Documentation update

## Changes Made

- New docs page: `docs/content/docs/opencode-deepseek.mdx` -- step-by-step setup guide covering proxy launch, OpenCode provider config, output shaping, model comparison, thinking-mode notes, and troubleshooting
- Updated `docs/content/docs/meta.json` so the guide appears under Integrations

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed
- [x] `git diff --check`
- [x] `npm ci` in `docs/`
- [ ] `npm run types:check` in `docs/` -- pre-existing failure in generated docs plumbing

### Test Output

```text
git diff --check: passed (no trailing whitespace, no conflict markers)
npm ci: installed in docs/ successfully
npm run types:check: pre-existing failure in lib/source.ts(2,22) -- not introduced by this PR
```

## Real Behavior Proof

- Environment: Ubuntu, Python 3.13, headroom-ai 0.32.1, OpenCode (Go CLI)
- Exact command / steps: Ran `headroom proxy --port 8787 --openai-api-url https://api.deepseek.com/v1`, configured OpenCode with `@ai-sdk/openai-compatible` pointing at `http://127.0.0.1:8787/v1`, sent chat completions through the proxy, verified compression on dashboard.
- Observed result: proxy routes chat completions to DeepSeek, input compression active (SmartCrusher), output shaping (level 2) reduces response tokens by ~11%. Dashboard at http://127.0.0.1:8787/stats shows compressed requests and token savings (1075994 tokens saved across 675 requests).
- Not tested: did not verify `docs/` static site build with `npm run build` in this environment (CI types:check failure exists on main before this PR).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review