### PR TITLE
fix(proxy/cost): dedupe pricing-lookup warning per unresolvable model

### DIFF
--- a/headroom/proxy/cost.py
+++ b/headroom/proxy/cost.py
@@ -44,6 +44,10 @@ def _get_litellm_module() -> Any | None:
 
 logger = logging.getLogger("headroom.proxy")
 
+# Models we've already warned about missing pricing data, to avoid log spam
+# from repeated warnings for the same unresolvable model.
+_pricing_warned_models: set[str] = set()
+
 # Provider-specific cache discount multipliers (what fraction of input price)
 # Used to calculate dollar savings from prefix caching
 _CACHE_ECONOMICS = {
@@ -728,7 +732,9 @@ class CostTracker:
             return float(total_cost) if total_cost > 0 else None
 
         except Exception as e:
-            logger.warning(f"Failed to get pricing for model {model}: {e}")
+            if model not in _pricing_warned_models:
+                _pricing_warned_models.add(model)
+                logger.warning(f"Failed to get pricing for model {model}: {e}")
             return None
 
     def _prune_old_costs(self):

--- a/tests/test_pricing_warning_dedup.py
+++ b/tests/test_pricing_warning_dedup.py
@@ -1,0 +1,42 @@
+"""Regression test: unresolvable model pricing warnings are logged once, not per-call.
+
+See https://github.com/headroomlabs-ai/headroom/issues/2504 — a custom/unknown
+model routed through litellm floods proxy.log with an identical WARNING on
+every request.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from tests._dotenv import (
+    autouse_apply_env,
+    importorskip_no_env_leak,
+    load_env_overrides,
+)
+
+_env_overrides = load_env_overrides()
+apply_dotenv = autouse_apply_env(_env_overrides)
+
+importorskip_no_env_leak("litellm")
+
+
+def test_pricing_warning_logged_once_per_model(caplog):
+    from headroom.proxy import cost as cost_module
+    from headroom.proxy.server import CostTracker
+
+    cost_module._pricing_warned_models.clear()
+
+    ct = CostTracker()
+    unknown_model = "totally-unknown-model-xyz"
+
+    with caplog.at_level(logging.WARNING, logger="headroom.proxy"):
+        for _ in range(5):
+            ct.estimate_cost(unknown_model, input_tokens=100, output_tokens=50)
+
+    warnings = [
+        r
+        for r in caplog.records
+        if "Failed to get pricing" in r.message and unknown_model in r.message
+    ]
+    assert len(warnings) == 1


### PR DESCRIPTION
## Description

Custom/unknown models routed through the proxy (e.g. `glm-5.2` via an OpenAI-compatible backend) fail litellm pricing resolution on every single request. This logs an identical `WARNING - Failed to get pricing for model X: ...` line per API call, flooding `proxy.log` in long-running sessions.

## Type of Change

- [x] Bug fix

## Changes Made

- Added module-level `_pricing_warned_models: set[str]` in `headroom/proxy/cost.py`.
- The pricing-lookup exception handler now warns once per unique model name per process lifetime instead of on every call.
- Added regression test `tests/test_pricing_warning_dedup.py` asserting a single warning is emitted across 5 repeated `estimate_cost` calls for the same unresolvable model.

## Testing

- [x] Added/updated tests
- [x] Ran full test suite locally

```
tests/test_pricing_warning_dedup.py::test_pricing_warning_logged_once_per_model PASSED [100%]
1 passed in 7.72s
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.13.11, headroom repo at `G:\Programmi Aggiuntivi\headroom`, branch `fix/dedupe-pricing-warning` off `upstream/main`
- Exact command / steps: `python -m pytest tests/test_pricing_warning_dedup.py -v`
- Observed result: 1 passed — 5 calls to `CostTracker.estimate_cost()` for an unresolvable model produced exactly 1 `WARNING` log line instead of 5
- Not tested: live proxy session against a real OpenAI-compatible backend with a custom model (covered instead by a targeted unit test on the pricing warning path)

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

Fixes #2504