### PR TITLE
fix(kompress): treat onnx_coreml as an ONNX backend (#2442)

### DIFF
--- a/headroom/transforms/kompress_compressor.py
+++ b/headroom/transforms/kompress_compressor.py
@@ -1150,7 +1150,7 @@ class KompressCompressor(Transform):
     def _timed_canary(self, model: Any, tokenizer: Any, backend: str) -> float:
         """Run one small inference and return its wall-clock seconds."""
         words = _canary_words()
-        is_onnx = backend == "onnx"
+        is_onnx = backend.startswith("onnx")
         encoding = tokenizer(
             words,
             is_split_into_words=True,
@@ -1251,7 +1251,7 @@ class KompressCompressor(Transform):
             model, tokenizer, backend = _load_kompress(
                 self.config.model_id, self.config.device, allow_download=allow_download
             )
-            is_onnx = backend == "onnx"
+            is_onnx = backend.startswith("onnx")
             device_type = _model_device_type(model, backend)
 
             if self._should_batch_single_content(model, backend):
@@ -1604,7 +1604,7 @@ class KompressCompressor(Transform):
                     results[i] = self._passthrough(contents[i], len(word_lists[i]))
             return [r for r in results if r is not None]
 
-        is_onnx = backend == "onnx"
+        is_onnx = backend.startswith("onnx")
         device_type = _model_device_type(model, backend)
         kept_ids_per_text: dict[int, set[int]] = {i: set() for i in range(n) if results[i] is None}
         inference_ms = 0.0
@@ -1830,7 +1830,7 @@ class KompressCompressor(Transform):
 
         model, _tokenizer, backend = _kompress_cache[model_id]
 
-        if backend == "onnx":
+        if backend.startswith("onnx"):
             return True  # ONNX CPU provider doesn't parallelize batch dim
         if backend == "pytorch":
             try:

--- a/tests/test_transforms/test_kompress_compressor.py
+++ b/tests/test_transforms/test_kompress_compressor.py
@@ -485,3 +485,28 @@ class TestUnloadKompressModel:
 
         # Should return False when no model is loaded
         assert unload_kompress_model() is False
+
+
+def test_timed_canary_treats_onnx_coreml_as_onnx() -> None:
+    """onnx_coreml must take the ONNX path (NumPy tensors, no torch .parameters()).
+
+    Regression for #2442: an exact-match ``backend == "onnx"`` skipped
+    ``onnx_coreml`` and fell into the PyTorch branch, calling
+    ``next(model.parameters())`` on an ``_OnnxModel`` that has no
+    ``parameters`` attribute → AttributeError.
+    """
+    from headroom.transforms import kompress_compressor as kmod
+
+    class _StubOnnxModel:
+        # Mirrors _OnnxModel: has get_keep_mask, but NO .parameters().
+        def get_keep_mask(self, input_ids, attention_mask):
+            return "mask"
+
+    def _stub_tokenizer(words, **kwargs):
+        return {"input_ids": [[1, 2, 3]], "attention_mask": [[1, 1, 1]]}
+
+    compressor = kmod.KompressCompressor()
+
+    elapsed = compressor._timed_canary(_StubOnnxModel(), _stub_tokenizer, "onnx_coreml")
+
+    assert isinstance(elapsed, float)


### PR DESCRIPTION
## Description

The Kompress `onnx_coreml` backend crashes with `AttributeError: _OnnxModel has no attribute parameters`.

Root cause: four code paths in `headroom/transforms/kompress_compressor.py` test the backend with an exact-match `backend == "onnx"`, which misses the `onnx_coreml` backend value. `onnx_coreml` is a first-class backend (`KompressBackend` Literal, line 114; emitted by `_load_kompress_onnx(..., use_coreml=True)` at line 665). Because the exact-match returns `False` for `onnx_coreml`, the model wrongly takes the PyTorch branch and calls `next(model.parameters())` — but `_OnnxModel` (an ONNX-session wrapper) has no `.parameters()`, so it crashes.

The file already uses the correct predicate for the same "is this an ONNX backend?" question elsewhere: `backend.startswith("onnx")` at lines 343 (`_onnx_session_options`) and 358 (`_model_device_type`). This change brings the four stragglers in line with that convention.

Closes #2442

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/transforms/kompress_compressor.py`: change four `backend == "onnx"` checks to `backend.startswith("onnx")`:
  - line 1153 (`_timed_canary`), line 1254 (`compress`), line 1607 (`compress_batch`) — these set `is_onnx`, which selects NumPy vs PyTorch tensors and guards the `next(model.parameters())` call, so they are the sites that actually crash for `onnx_coreml`.
  - line 1833 (`_should_use_sequential_fallback`) — behavior-neutral (see below), changed for consistency so all four identical checks are uniform.
- `tests/test_transforms/test_kompress_compressor.py`: add `test_timed_canary_treats_onnx_coreml_as_onnx`, a regression test that drives `_timed_canary` with a stub ONNX model (mirrors `_OnnxModel`: has `get_keep_mask`, no `.parameters()`) and backend `"onnx_coreml"`, asserting it does not raise.

Sites deliberately left exact (verified): line 823 (`backend == "onnx_coreml"`, coreml-specific) and the `"pytorch"` / `"pytorch_mps"` checks (360, 827, 1835). `startswith("onnx")` matches every ONNX variant (`onnx`, `onnx_cpu`, `onnx_coreml`) and never matches the pytorch backends.

**Site 1833 is behavior-neutral**: `_should_use_sequential_fallback` ends with `return True  # Conservative default: sequential`, so `onnx_coreml` already returned `True` by falling through. After the change it returns `True` at line 1833 explicitly — same result, clearer intent, and the inline comment now applies accurately.

No new abstraction (kept the inline idiom the file already uses), no dependency change, no CHANGELOG edit (the repo runs a `no-manual-changelog` check; release-please owns `CHANGELOG.md`).

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
# Before the fix (test added, code reverted) — reproduces the exact crash:
$ uv run pytest tests/test_transforms/test_kompress_compressor.py -k test_timed_canary_treats_onnx_coreml_as_onnx -v
FAILED ... test_timed_canary_treats_onnx_coreml_as_onnx
E   AttributeError: '_StubOnnxModel' object has no attribute 'parameters'
    (headroom/transforms/kompress_compressor.py:1165: device = next(model.parameters()).device)

# After the fix:
$ uv run pytest tests/test_transforms/test_kompress_compressor.py -k test_timed_canary_treats_onnx_coreml_as_onnx -q
1 passed, 28 deselected

$ grep -n '== "onnx"' headroom/transforms/kompress_compressor.py   # (none remaining)
$ grep -c 'backend.startswith("onnx")' headroom/transforms/kompress_compressor.py
6    # the original 2 (lines 343/358) + the 4 fixed

$ uv run ruff check headroom/transforms/kompress_compressor.py tests/test_transforms/test_kompress_compressor.py
All checks passed!
```

Full module: `28 passed, 1 failed`. The single failure is `TestKompressBackendSelection::test_onnx_session_options_read_thread_caps` (asserts `enable_cpu_mem_arena is False`), which is **pre-existing and unrelated** — it fails identically on clean `main` and touches `_onnx_session_options` (line 343 region), a function this diff does not modify.

## Real Behavior Proof

- **Environment:** Windows 11, Python 3.13.5, headroom installed from this branch (editable, via `uv`).
- **Exact command / steps:** The crash is a pure string-branch bug, reproducible without CoreML hardware. The regression test drives the real `_timed_canary` with backend `"onnx_coreml"` and a stub that faithfully mirrors `_OnnxModel` (no `.parameters()`).
- **Observed result:** On unmodified code the test raises `AttributeError: ... object has no attribute 'parameters'` at `kompress_compressor.py:1165` — the same crash as the field report (`_OnnxModel has no attribute parameters`). After changing the four predicates to `backend.startswith("onnx")`, `onnx_coreml` takes the ONNX (NumPy) path and the test passes.
- **Not tested:** An end-to-end run on real Apple-Silicon CoreML hardware (no macOS/CoreML runtime available here). The unit test exercises the identical string-branch that causes the crash, so the fix is validated without that hardware.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

- Documentation and CHANGELOG checklist items are N/A — behavioral bug fix with no docs surface, and the repo's `no-manual-changelog` check means release-please generates the changelog from the commit message.
- `mypy` left unchecked — not run as part of this verification; the change is a predicate swap with no type-level surface.
- I considered extracting a shared `_is_onnx_backend()` helper to centralize the six `startswith("onnx")` sites, but kept the inline idiom to match the file's existing style and keep the diff minimal — happy to extract one if maintainers prefer.
