### PR TITLE
feat(wrap): extend reduce-at-source quiet defaults to telemetry/nag banners

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -317,7 +317,10 @@ _TOOL_SEARCH_FALSY = {"false", "0", "no", "off"}
 # Opt out entirely with HEADROOM_WRAP_QUIET=0 (or false/no/off).
 _QUIET_CLI_ENV = "HEADROOM_WRAP_QUIET"
 _QUIET_CLI_FALSY = {"0", "false", "no", "off"}
-# name -> value, injected only when the user has not already set it.
+# name -> value, injected only when the user has not already set it. Every entry
+# here suppresses ONLY zero-signal chatter — telemetry pings, version nags,
+# funding/first-run banners, progress bars, pager framing — never diffs, errors,
+# summaries, or search results.
 _QUIET_CLI_DEFAULTS: dict[str, str] = {
     "GIT_PAGER": "cat",  # never page (keeps full content, drops pager framing)
     "PIP_QUIET": "1",  # drop "Requirement already satisfied"/download chatter
@@ -325,6 +328,20 @@ _QUIET_CLI_DEFAULTS: dict[str, str] = {
     "npm_config_fund": "false",  # drop the funding banner
     "npm_config_audit": "false",  # drop the audit summary (not a security scan here)
     "npm_config_progress": "false",  # drop the install progress bar
+    "npm_config_update_notifier": "false",  # drop the boxed "update available" notice
+    # Cross-tool telemetry opt-out standard (consoledonottrack.com), honored by
+    # turbo, netlify, gatsby, and many others to drop telemetry pings/banners.
+    "DO_NOT_TRACK": "1",
+    # .NET SDK: telemetry ping + the "Welcome to .NET" logo/copyright banner.
+    "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+    "DOTNET_NOLOGO": "1",
+    # JS framework telemetry banners printed on build/dev.
+    "NEXT_TELEMETRY_DISABLED": "1",
+    "GATSBY_TELEMETRY_DISABLED": "1",
+    "ASTRO_TELEMETRY_DISABLED": "1",
+    "NG_CLI_ANALYTICS": "false",  # Angular CLI analytics ping + first-run prompt
+    # Homebrew's "==> ... hints" chatter (not warnings/errors).
+    "HOMEBREW_NO_ENV_HINTS": "1",
 }
 
 

--- a/tests/test_wrap_quiet_cli.py
+++ b/tests/test_wrap_quiet_cli.py
@@ -21,6 +21,28 @@ def test_defaults_injected_into_empty_env(monkeypatch) -> None:
     assert "GIT_PAGER" in written and "PYTEST_ADDOPTS" in written
 
 
+def test_telemetry_and_nag_suppressors_injected(monkeypatch) -> None:
+    # Telemetry pings, version nags, and first-run/logo banners are zero-signal
+    # tokens; the SAFE reduce-at-source set suppresses them across common tools.
+    monkeypatch.delenv("HEADROOM_WRAP_QUIET", raising=False)
+    env: dict[str, str] = {}
+    written = _configure_quiet_cli_env(env)
+    expected = {
+        "npm_config_update_notifier": "false",
+        "DO_NOT_TRACK": "1",
+        "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+        "DOTNET_NOLOGO": "1",
+        "NEXT_TELEMETRY_DISABLED": "1",
+        "GATSBY_TELEMETRY_DISABLED": "1",
+        "ASTRO_TELEMETRY_DISABLED": "1",
+        "NG_CLI_ANALYTICS": "false",
+        "HOMEBREW_NO_ENV_HINTS": "1",
+    }
+    for name, value in expected.items():
+        assert env[name] == value
+        assert name in written
+
+
 def test_user_value_always_wins(monkeypatch) -> None:
     monkeypatch.delenv("HEADROOM_WRAP_QUIET", raising=False)
     env = {"GIT_PAGER": "less -R", "PIP_QUIET": "0"}


### PR DESCRIPTION
## Description

Extends the reduce-at-source quiet-CLI env defaults added in #2548. That set covered git/pip/npm chatter (pager framing, progress bars, funding/audit banners, version nags). But coding agents constantly shell out to other common tools that print **zero-signal** telemetry pings, version nags, and first-run / logo banners into `tool_result` output — tokens the agent never acts on and the proxy then has to carry.

This adds SAFE defaults for those, following the exact criterion in #2548's comment: only knobs that suppress chatter, never anything that could hide diffs, errors, summaries, or search results.

New entries:

- `npm_config_update_notifier=false` — npm's boxed "update available" notice
- `DO_NOT_TRACK=1` — the cross-tool telemetry opt-out standard (consoledonottrack.com), honored by turbo, netlify, gatsby, and many others
- `DOTNET_CLI_TELEMETRY_OPTOUT=1`, `DOTNET_NOLOGO=1` — .NET SDK telemetry ping + the "Welcome to .NET" logo/copyright banner
- `NEXT_TELEMETRY_DISABLED=1`, `GATSBY_TELEMETRY_DISABLED=1`, `ASTRO_TELEMETRY_DISABLED=1` — JS framework build/dev telemetry banners
- `NG_CLI_ANALYTICS=false` — Angular CLI analytics ping + first-run prompt
- `HOMEBREW_NO_ENV_HINTS=1` — Homebrew's `==> ... hints` chatter (not warnings/errors)

Each is the canonical, widely-documented "disable telemetry / nag" variable for its tool. As with the existing set, a value the user already set always wins (defaults fill only when absent), and the whole feature is opt-out via `HEADROOM_WRAP_QUIET=0`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cli/wrap.py`: add the telemetry/nag/banner env defaults to `_QUIET_CLI_DEFAULTS`.
- `tests/test_wrap_quiet_cli.py`: assert the new suppressors are injected into an empty env (and, via the existing tests, still respect user overrides and the opt-out switch).

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_wrap_quiet_cli.py -q
6 passed

# with the new defaults reverted, the telemetry-suppressor test fails
# (the keys are absent from the injected env)

$ uvx ruff@0.15.17 check headroom/cli/wrap.py tests/test_wrap_quiet_cli.py
All checks passed!
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12, project venv (`uv sync --extra proxy`), `uvx ruff@0.15.17`, pytest in the venv.
- Exact command / steps: called `_configure_quiet_cli_env({})` with `HEADROOM_WRAP_QUIET` unset and inspected the resulting env; also exercised the existing user-override and opt-out tests; then reverted the source and re-ran.
- Observed result: with the change the new keys (`DO_NOT_TRACK`, `DOTNET_CLI_TELEMETRY_OPTOUT`, `DOTNET_NOLOGO`, `NEXT_/GATSBY_/ASTRO_TELEMETRY_DISABLED`, `NG_CLI_ANALYTICS`, `HOMEBREW_NO_ENV_HINTS`, `npm_config_update_notifier`) are present with their documented values and reported in the written list; a user-set value is left untouched; and with `HEADROOM_WRAP_QUIET=0` nothing is injected. With the change reverted the new keys are absent. Ran against the actual module.
- Not tested: launching each real CLI to observe the reduced output (the env variables are each tool's own documented telemetry/nag switch).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

cc @chopratejas 
