### PR TITLE
feat(lossless): factor a shared directory across rg --heading file headers

### DIFF
--- a/headroom/transforms/lossless_compaction.py
+++ b/headroom/transforms/lossless_compaction.py
@@ -27,6 +27,8 @@ __all__ = [
     "search_unheading",
     "search_dir_heading",
     "search_dir_unheading",
+    "search_file_heading_dir",
+    "search_file_heading_undir",
     "diff_strip_index",
     "compact_lossless",
 ]
@@ -353,6 +355,116 @@ def search_dir_unheading(text: str) -> str:
     return _join(out, had_trailing)
 
 
+def search_file_heading_dir(text: str) -> str:
+    """Factor a shared parent directory across consecutive rg --heading headings.
+
+    ripgrep's default output (and :func:`search_heading`'s output) groups matches
+    under a bare file-path *header* line followed by ``line:content`` data rows::
+
+        src/auth/login.py
+        12:def login()
+        src/auth/session.py
+        8:def session()
+
+    Consecutive headers that share a parent directory repeat it on every header.
+    Factor it to a directory line (ending in ``/``) once, leaving the basenames::
+
+        src/auth/
+        login.py
+        12:def login()
+        session.py
+        8:def session()
+
+    A *header* is a non-data line immediately followed by a ``line:content`` data
+    row (the same notion :func:`search_heading` / :func:`search_unheading` use);
+    data rows keep the active directory so grouped files under one dir all fold.
+    Complements :func:`search_dir_heading` (which factors a directory across
+    ``path:line:content`` grep rows); this factors it across heading-form file
+    headers. Reversed exactly by :func:`search_file_heading_undir`;
+    ``compact_lossless`` verifies the round-trip.
+    """
+    lines, had_trailing = _split_keep_trailing(text)
+    if not lines:
+        return text
+    out: list[str] = []
+    current_dir: str | None = None
+    n = len(lines)
+    for i, line in enumerate(lines):
+        is_data = bool(_HEADING_ROW_RE.match(line))
+        next_is_data = i + 1 < n and bool(_HEADING_ROW_RE.match(lines[i + 1]))
+        if not is_data and next_is_data and "/" in line and not line.endswith("/"):
+            cut = line.rindex("/") + 1
+            dir_part, base = line[:cut], line[cut:]
+            if base:
+                if dir_part != current_dir:
+                    out.append(dir_part)
+                    current_dir = dir_part
+                out.append(base)
+                continue
+        # Data rows and blank separators belong to the group and keep the active
+        # dir (rg separates file groups under one dir with a blank line); any
+        # other line (a header with no dir, or passthrough content) ends it.
+        if not is_data and line != "":
+            current_dir = None
+        out.append(line)
+    return _join(out, had_trailing)
+
+
+def search_file_heading_undir(text: str) -> str:
+    """Exact inverse of :func:`search_file_heading_dir`.
+
+    A produced *directory header* is a line ending in ``/`` (not a data row)
+    whose next line is a basename header (no ``/``, not a data row, itself
+    followed by a data row); it is consumed and re-prefixed onto the basename
+    headers beneath it until a non-data, non-basename line clears the grouping.
+    """
+    lines, had_trailing = _split_keep_trailing(text)
+    if not lines:
+        return text
+    out: list[str] = []
+    current_dir: str | None = None
+    n = len(lines)
+    i = 0
+    while i < n:
+        line = lines[i]
+        is_data = bool(_HEADING_ROW_RE.match(line))
+        next_line = lines[i + 1] if i + 1 < n else None
+        next_is_data = next_line is not None and bool(_HEADING_ROW_RE.match(next_line))
+        # A basename header under an active dir: re-prefix it (keep the dir so
+        # sibling files under the same directory all get it).
+        if (
+            current_dir is not None
+            and not is_data
+            and line != ""
+            and "/" not in line
+            and next_is_data
+        ):
+            out.append(current_dir + line)
+            i += 1
+            continue
+        # A directory header we produced: ``dir/`` immediately above a basename
+        # header (non-data, no '/', itself followed by a data row). Consume it.
+        if (
+            line.endswith("/")
+            and not is_data
+            and next_line is not None
+            and next_line != ""
+            and "/" not in next_line
+            and not _HEADING_ROW_RE.match(next_line)
+            and i + 2 < n
+            and _HEADING_ROW_RE.match(lines[i + 2])
+        ):
+            current_dir = line
+            i += 1
+            continue
+        # Data rows and blank separators keep the active dir; anything else clears it.
+        if not is_data and line != "":
+            current_dir = None
+        out.append(line)
+        i += 1
+    return _join(out, had_trailing)
+
+
 def diff_strip_index(text: str) -> str:
     """Drop ``index <sha>..<sha>`` lines from a unified diff (still applies)."""
     lines, had_trailing = _split_keep_trailing(text)
@@ -457,14 +569,17 @@ def compact_lossless(content: str, kind: str) -> str:
             return candidate if _smaller(candidate, content) else content
 
         if kind == "search":
-            # Two independent folds; keep the smaller that round-trips exactly.
-            # search_heading factors a repeated FILE (many matches in one file);
-            # search_dir_heading factors a repeated DIRECTORY (one match each
-            # across many files in a dir — the grep -rn case the file fold misses).
+            # Independent folds; keep the smallest that round-trips exactly.
+            #  * search_heading factors a repeated FILE (many matches in one file).
+            #  * search_dir_heading factors a repeated DIRECTORY across
+            #    ``path:line:content`` grep rows (the grep -rn case).
+            #  * search_file_heading_dir factors a repeated DIRECTORY across
+            #    rg --heading FILE headers (already grouped file:line:content).
             best = content
             for candidate, inverse in (
                 (search_heading(content), search_unheading),
                 (search_dir_heading(content), search_dir_unheading),
+                (search_file_heading_dir(content), search_file_heading_undir),
             ):
                 if inverse(candidate) == content and _smaller(candidate, best):
                     best = candidate

--- a/tests/test_bash_search_lossless_fold.py
+++ b/tests/test_bash_search_lossless_fold.py
@@ -263,3 +263,59 @@ def test_search_file_fold_still_wins_for_many_matches_one_file() -> None:
     out = compact_lossless(grep, "search")
     assert len(out) < len(grep)
     assert search_unheading(out) == grep
+
+
+# --- rg --heading directory fold: factor a shared dir across FILE headers ---
+from headroom.transforms.lossless_compaction import (  # noqa: E402
+    search_file_heading_dir,
+    search_file_heading_undir,
+)
+
+
+def test_heading_dir_fold_factors_directory_across_rg_headings() -> None:
+    # rg --heading output: each file is a bare path header followed by
+    # ``line:content`` rows. Files under one directory repeat the dir on every
+    # header; the fold factors it to a single ``dir/`` line, losslessly.
+    rg = (
+        "src/auth/login.py\n12:def login()\n15:    return token\n"
+        "src/auth/session.py\n8:def session()\n"
+        "src/auth/logout.py\n3:def logout()\n"
+    )
+    folded = search_file_heading_dir(rg)
+    assert len(folded) < len(rg)
+    assert folded.startswith("src/auth/\n")  # dir factored to a header line
+    assert "src/auth/login.py" not in folded  # basenames left bare beneath it
+    assert search_file_heading_undir(folded) == rg  # exact byte round-trip
+    # And through the self-verifying dispatcher:
+    assert compact_lossless(rg, "search") == folded
+
+
+def test_heading_dir_fold_survives_blank_group_separators() -> None:
+    # ripgrep separates file groups with a blank line; the dir must persist
+    # across the blank so all files under one directory still fold.
+    rg = "a/b/one.rs\n1:x\n\na/b/two.rs\n2:y\n\na/b/three.rs\n3:z\n"
+    folded = search_file_heading_dir(rg)
+    assert len(folded) < len(rg)
+    assert search_file_heading_undir(folded) == rg
+
+
+def test_heading_dir_fold_is_lossless_or_passes_through_messy_input() -> None:
+    # A mix of dir'd and top-level (no-dir) headers is ambiguous to reverse, so
+    # compact_lossless must fall back to a candidate that round-trips exactly
+    # (never corrupt). Losslessness is the invariant, not that it always folds.
+    messy = "src/a/x.py\n1:hit\ntop_level.py\n2:hit\nsrc/a/y.py\n3:hit\n"
+    out = compact_lossless(messy, "search")
+    assert len(out) <= len(messy)
+    assert (
+        search_file_heading_undir(out) == messy
+        or search_dir_unheading(out) == messy
+        or search_unheading(out) == messy
+        or out == messy
+    )
+
+
+def test_grep_row_input_is_untouched_by_heading_dir_fold() -> None:
+    # grep path:line:content rows are NOT rg --heading form, so the heading-dir
+    # fold leaves them for search_heading / search_dir_heading (no interference).
+    grep = "src/a/f1.py:1:x\nsrc/a/f2.py:2:y\n"
+    assert search_file_heading_dir(grep) == grep


### PR DESCRIPTION
## Description

Complements #2547 (which factored a shared directory across grep `path:line:content` rows). This adds the same directory factoring for **ripgrep `--heading`** output, where each file is a bare path *header* line followed by `line:content` rows:

```
src/auth/login.py
12:def login()
15:    return token
src/auth/session.py
8:def session()
```

Consecutive file headers under one directory repeat it on every header. `search_file_heading_dir` factors it to a single directory line (ending in `/`) once, leaving the basenames beneath — byte-losslessly:

```
src/auth/
login.py
12:def login()
15:    return token
session.py
8:def session()
```

It persists the active directory across the blank lines ripgrep inserts between file groups, so all files under one directory tree fold. A *header* is a non-data line immediately followed by a `line:content` data row — the same notion `search_heading` / `search_unheading` already use.

Added to the `kind="search"` candidate list. `compact_lossless` runs each candidate's registered inverse and only keeps a fold whose round-trip reproduces the input exactly, so:

- grep `path:line:content` output is left for `search_heading` / `search_dir_heading` (the heading-dir fold detects no headers there and is a no-op — a test pins this);
- ambiguous mixed input (top-level files interleaved with directory-grouped ones) falls back to the original — never corrupted.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/transforms/lossless_compaction.py`: add `search_file_heading_dir` / `search_file_heading_undir`, export them, and register the fold in the `kind="search"` dispatch.
- `tests/test_bash_search_lossless_fold.py`: fold + exact round-trip on rg-heading output, survival across blank group separators, losslessness (or safe passthrough) on ambiguous mixed input, and a guard that grep-row output is untouched.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_bash_search_lossless_fold.py tests/test_lossless_first_dispatch.py tests/test_lossless_mode.py tests/test_lossless_excluded_compaction.py tests/test_lossless_then_lossy.py tests/test_transforms/test_content_router.py tests/test_openai_responses_compression_units.py -q
174 passed

$ uvx ruff@0.15.17 check headroom/transforms/lossless_compaction.py tests/test_bash_search_lossless_fold.py
All checks passed!
$ uvx mypy@1.20.2 --ignore-missing-imports headroom/transforms/lossless_compaction.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12, project venv (`uv sync --extra proxy`), `uvx ruff@0.15.17` / `uvx mypy@1.20.2`, pytest in the venv.
- Exact command / steps: folded real rg-heading samples (shared dir, and with blank group separators) and asserted `search_file_heading_undir(fold(x)) == x` and `compact_lossless(x, "search") == fold`; then fuzzed 40,000 random grep-row and rg-heading inputs asserting `compact_lossless(x, "search")` never grows, never raises, and never corrupts.
- Observed result: the fold shrinks rg-heading output under a shared directory and round-trips byte-exactly (including across blank separators); the fuzz reported 0 anomalies (never grew, corrupted, or crashed) — losslessness is enforced by the dispatcher's per-candidate round-trip check. grep `path:line:content` inputs are left unchanged by the new fold. Ran against the actual module.
- Not tested: a live agent session measuring the token reduction on real `rg --heading` tool output (the fold is deterministic and verified byte-exact here).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
