### PR TITLE
fix(proxy/hooks): only run stream-safe turn hooks on the OpenAI Responses path (#2549)

### DIFF
--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -2384,7 +2384,14 @@ class OpenAIHandlerMixin:
                 tools=working.get("tools"),
                 config=getattr(self, "config", None),
             )
-            run_request_hooks(_req_ctx)
+            # The Responses path (HTTP /v1/responses, WS, and passthrough) never
+            # runs on_response hooks — only handle_openai_chat does. So a
+            # buffered-only hook that re-drives the model in on_response (defer a
+            # tool, reload it when asked) would have its on_request applied here
+            # but its on_response never fire, leaving the turn half-transformed.
+            # Restrict to stream-safe (fold-only) hooks, whose on_request stands
+            # alone — the same guard the streamed chat path uses (#2549).
+            run_request_hooks(_req_ctx, stream_safe_only=True)
             if _req_ctx.tools is not working.get("tools"):
                 working["tools"] = _req_ctx.tools
             # A hook may also fold the messages (replace or in-place). Write back a

--- a/tests/test_openai_responses_compression_units.py
+++ b/tests/test_openai_responses_compression_units.py
@@ -27,6 +27,46 @@ def _handler_with_router(router: ContentRouter) -> OpenAIHandlerMixin:
     return handler
 
 
+def test_responses_payload_runs_only_stream_safe_hooks_on_request():
+    """The Responses path never runs on_response hooks, so a buffered-only
+    (re-drive) hook must not have its on_request applied there — it would leave
+    the turn half-transformed. Only fold-only (stream_safe) hooks run, matching
+    the streamed chat path (#2549)."""
+    from headroom.proxy.turn_hooks import clear_turn_hooks, register_turn_hook
+
+    class Fold:
+        name = "fold"
+        stream_safe = True  # opts in — safe without an on_response
+
+        def on_request(self, ctx):  # noqa: ANN001, ANN201
+            ctx.tools = list(ctx.tools or []) + [{"name": "fold_ran"}]
+
+    class Redrive:
+        name = "redrive"  # no stream_safe attr → buffered-only
+
+        def on_request(self, ctx):  # noqa: ANN001, ANN201
+            ctx.tools = list(ctx.tools or []) + [{"name": "redrive_ran"}]
+
+    clear_turn_hooks()
+    register_turn_hook(Fold())
+    register_turn_hook(Redrive())
+    try:
+        handler = _handler_with_router(ContentRouter())
+        payload = {
+            "model": "gpt-5",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+            "tools": [{"name": "existing"}],
+        }
+        new_payload = handler._compress_openai_responses_payload(
+            payload, model="gpt-5", request_id="req_test"
+        )[0]
+        names = {t.get("name") for t in new_payload.get("tools", [])}
+        assert "fold_ran" in names  # stream-safe hook's on_request applied
+        assert "redrive_ran" not in names  # buffered-only hook skipped on Responses
+    finally:
+        clear_turn_hooks()
+
+
 def test_openai_responses_unit_parallelism_env_defaults_and_clamps(monkeypatch):
     monkeypatch.delenv("HEADROOM_TOOL_OUTPUT_COMPRESSION_PARALLELISM", raising=False)
     assert openai_handler._openai_responses_unit_parallelism() == 4


### PR DESCRIPTION
## Description

Follow-up to #2549, which closed the turn-hook gap on the streamed OpenAI **chat** path. The same seam is still open on the OpenAI **Responses** path.

All three Responses entry points — `handle_openai_responses` (HTTP `/v1/responses`), `handle_openai_responses_ws` (the WS transport), and `_maybe_compress_passthrough_responses` — run turn hooks through `_compress_openai_responses_payload`, which called:

```python
run_request_hooks(_req_ctx)   # unfiltered: every hook's on_request runs
```

But **none** of the Responses paths ever call `run_response_hooks` — only `handle_openai_chat` does. So a buffered-only hook (one that re-drives the model in `on_response`: defer a tool, then reload it when the model asks for it) had its `on_request` applied on the Responses path with **no `on_response` to follow**, leaving the turn half-transformed (e.g. a tool deferred and never restored). This is the same class of bug #2549 fixed for streamed chat, where an on_request without a possible on_response is unsafe.

## Fix

Restrict the Responses `on_request` to stream-safe (fold-only) hooks — those whose `on_request` stands alone with no `on_response` re-drive:

```python
run_request_hooks(_req_ctx, stream_safe_only=True)
```

This is exactly the guard #2549 added for the streamed chat path (`stream_safe_only=stream`); the Responses path uses `True` unconditionally because it never runs `on_response` at all. Fold-only hooks (e.g. the lossless-guard fold) declare `stream_safe = True` and are unaffected; only a re-drive hook is now correctly skipped on Responses instead of being half-applied. No behavior change until a non-stream-safe hook is registered.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/handlers/openai.py`: pass `stream_safe_only=True` to `run_request_hooks` in `_compress_openai_responses_payload`, with a comment explaining the Responses path never runs `on_response`.
- `tests/test_openai_responses_compression_units.py`: register a stream-safe fold hook and a buffered-only re-drive hook, run the Responses payload compressor, and assert only the fold hook's `on_request` was applied.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_openai_responses_compression_units.py -q
38 passed

# with the fix reverted, the new test fails: the buffered-only hook's
# on_request ("redrive_ran") is applied on the Responses path

$ uvx ruff@0.15.17 check headroom/proxy/handlers/openai.py tests/test_openai_responses_compression_units.py
All checks passed!
$ uvx mypy@1.20.2 --ignore-missing-imports headroom/proxy/handlers/openai.py
Success: no issues found in 1 source file
```

Note: `tests/test_turn_hooks.py` has 6 `@pytest.mark.asyncio` `on_response` tests that fail locally because pytest-asyncio isn't configured in this environment; they fail identically on clean `main` and are unrelated to this change (it doesn't touch `turn_hooks.py`).

## Real Behavior Proof

- Environment: Windows 11, Python 3.12, project venv (`uv sync --extra proxy`), `uvx ruff@0.15.17` / `uvx mypy@1.20.2`, pytest in the venv.
- Exact command / steps: registered a `stream_safe=True` fold hook and a default (buffered-only) re-drive hook, both mutating `ctx.tools` in `on_request`; called `_compress_openai_responses_payload` on a Responses payload; then reverted the source and re-ran.
- Observed result: with the fix the returned payload's tools contain the fold hook's marker but not the re-drive hook's; with the fix reverted both markers appear (the re-drive hook is half-applied, since the Responses path never runs its `on_response`). Ran against the actual handler.
- Not tested: a live `/v1/responses` request end to end with a registered re-drive hook.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
