### PR TITLE
ci(parity): make the parity harness a real per-PR gate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,18 +164,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.95.0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
       - uses: Swatinem/rust-cache@v2
-      - name: Install deps
-        run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install --upgrade pip
-          pip install maturin
-          pip install -e .
+      # No Python toolchain: headroom-parity links headroom-core directly and
+      # never crosses into the interpreter, so the venv + maturin + `pip
+      # install -e .` setup this job used to do was pure overhead.
       - name: Run parity harness
-        run: |
-          source .venv/bin/activate
-          make test-parity
+        run: make test-parity

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,9 @@ on:
       - 'Makefile'
       - '.github/workflows/rust.yml'
   schedule:
-    # Nightly parity run at 07:17 UTC (weekdays only). Phase 0 allows failure.
+    # Nightly parity run at 07:17 UTC (weekdays only). Redundant with the
+    # per-PR gate below, but catches drift from toolchain/dependency updates
+    # that land without touching any filtered path.
     - cron: '17 7 * * 1-5'
 
 concurrency:
@@ -154,11 +156,19 @@ jobs:
         continue-on-error: true
         run: cargo deny check licenses
 
-  parity-nightly:
-    name: parity (nightly, allowed to fail during Phase 0)
-    if: github.event_name == 'schedule'
+  # Blocking on every PR that touches Rust. Safe to harden now because the
+  # harness fails only on a Diff — `parity-run` sets `any_diffs` inside the
+  # diffed loop alone, so the 65 fixtures still served by `stub_comparator!`
+  # report as Skipped and cannot turn this red. Measured on main today:
+  # 111 matched / 65 skipped / 0 diffed.
+  #
+  # What it protects: the recorded fixtures are frozen Python output, so this
+  # gate catches the Rust side drifting away from that snapshot — exactly the
+  # failure mode the ongoing port produces. It cannot detect the Python side
+  # drifting away from the fixtures; that needs re-recording, not this job.
+  parity:
+    name: parity
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ FIXTURES ?= tests/parity/fixtures
 help:
 	@echo "Headroom Rust targets:"
 	@echo "  make test               - cargo test --workspace"
-	@echo "  make test-parity        - maturin develop + parity-run against fixtures"
+	@echo "  make test-parity        - parity-run against recorded fixtures"
 	@echo "  make bench              - cargo bench --workspace"
 	@echo "  make build-proxy        - release build + strip headroom-proxy, print size"
 	@echo "  make build-wheel        - release wheel for headroom-py"
@@ -36,12 +36,12 @@ help:
 test:
 	$(CARGO) test --workspace
 
+# headroom-parity has no pyo3 dependency — its comparators call headroom-core
+# directly, so this target needs neither a venv nor a built extension module.
+# (See crates/headroom-parity/Cargo.toml: "Phase 0 does not invoke Python from
+# Rust.") Dropping the `maturin develop` step keeps the harness runnable from a
+# bare checkout and takes the Python toolchain off the CI parity job.
 test-parity:
-	@if [ -z "$$VIRTUAL_ENV" ]; then \
-		echo "error: activate a venv first (e.g. source .venv/bin/activate)"; \
-		exit 1; \
-	fi
-	$(MATURIN) develop -m crates/headroom-py/Cargo.toml
 	$(CARGO) run -p headroom-parity -- run --fixtures $(FIXTURES)
 
 bench:

--- a/crates/headroom-parity/src/lib.rs
+++ b/crates/headroom-parity/src/lib.rs
@@ -466,6 +466,51 @@ impl TransformComparator for ContentDetectorComparator {
     }
 }
 
+/// Real comparator for the `text_crusher` transform. The fixture `input` is an
+/// object rather than a bare string, mirroring the recorder's three arguments
+/// (`tests/parity/record_text_crusher.py`), and `config` is always `null` — the
+/// recorder drove the Python default config, so the Rust side uses
+/// `TextCrusherConfig::default()` to match.
+pub struct TextCrusherComparator;
+
+impl TransformComparator for TextCrusherComparator {
+    fn name(&self) -> &str {
+        "text_crusher"
+    }
+
+    fn run(
+        &self,
+        input: &serde_json::Value,
+        _config: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        use headroom_core::transforms::{TextCrusher, TextCrusherConfig};
+
+        let content = input
+            .get("content")
+            .and_then(|v| v.as_str())
+            .context("text_crusher fixture input needs a string `content`")?;
+        let context = input
+            .get("context")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        // Null in the `short_passthrough` fixture, where the recorder passed no
+        // ratio at all — `Option<f64>` carries that through to the same default
+        // the Python call used.
+        let target_ratio = input.get("target_ratio").and_then(|v| v.as_f64());
+
+        let result =
+            TextCrusher::new(TextCrusherConfig::default()).compress(content, context, target_ratio);
+        Ok(serde_json::json!({
+            "compressed": result.compressed,
+            "original_tokens": result.original_tokens,
+            "compressed_tokens": result.compressed_tokens,
+            "compression_ratio": result.compression_ratio,
+            "kept_segments": result.kept_segments,
+            "total_segments": result.total_segments,
+        }))
+    }
+}
+
 /// Every built-in comparator, in a stable order.
 pub fn builtin_comparators() -> Vec<Box<dyn TransformComparator>> {
     vec![
@@ -476,6 +521,7 @@ pub fn builtin_comparators() -> Vec<Box<dyn TransformComparator>> {
         Box::new(CcrComparator),
         Box::new(SmartCrusherComparator),
         Box::new(ContentDetectorComparator),
+        Box::new(TextCrusherComparator),
     ]
 }
 


### PR DESCRIPTION
## Description

Three independent hardening steps on the Rust-vs-Python parity harness, ordered
smallest-blast-radius first. Together they make `make test-parity` a real gate
instead of a nightly advisory, and un-blind 6 fixtures that were being silently
ignored.

Context: the Rust port relies on the parity harness as its safety net, but the
harness was running once a night with `continue-on-error: true`, so a Rust
comparator that started diverging would not have failed anything.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- **`ef00772e` — drop the dead maturin/venv step.** `headroom-parity` has no
  `pyo3` dependency; its comparators link `headroom-core` directly and never
  cross into the interpreter (the crate manifest says as much: *"Phase 0 does not
  invoke Python from Rust"*). Yet `make test-parity` refused to run without an
  activated venv and rebuilt `headroom._core` via `maturin develop` first, and
  the CI job additionally provisioned Python 3.11 + pip + maturin +
  `pip install -e .`. All removed. `MATURIN` stays defined — `build-wheel` uses it.
- **`d9cf8ddb` — register a `text_crusher` comparator.** 6 fixtures have sat in
  `tests/parity/fixtures/text_crusher/` since the recorder landed, but
  `text_crusher` was never added to `builtin_comparators()`. `parity-run` only
  walks directories it has a comparator for, so those fixtures were not
  skipped — they were invisible, and nothing reported them missing. The API maps
  1:1, so the comparator is a straight adapter.
- **`6a1c6ab4` — promote parity to a blocking per-PR gate.** Drops
  `if: github.event_name == 'schedule'` and `continue-on-error: true`. The
  existing `paths` filter is already the right trigger set. The nightly cron
  stays as a backstop for toolchain/dependency drift that lands without touching
  a filtered path.

Deliberately **not** widening the path filter to Python paths: the fixtures are
frozen recordings of Python output and the harness never invokes Python, so it
measures Rust-vs-snapshot. A Python-side edit cannot move the result, so running
the job on Python paths would spend CI on a check that is structurally blind to
the diff. Detecting fixture staleness needs re-recording — a different mechanism,
and its own change.

## Testing

- [ ] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

No Python source changed, so `pytest`/`mypy` are N/A for this diff. Rust gates
below are the relevant ones.

### Test Output

```text
$ cargo fmt --all -- --check
fmt OK

$ cargo clippy --workspace -- -D warnings
(no warnings, rc=0)

$ cargo test -p headroom-parity
test tests::harness_reports_diff_for_divergent_comparator ... ok
test tests::stub_comparators_skip_rather_than_panic ... ok
test tests::missing_transform_dir_yields_empty_report ... ok
test tests::harness_reports_match_for_agreeing_comparator ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ make test-parity
[log_compressor  ] total=20 matched=0  skipped=20 diffed=0
[diff_compressor ] total=27 matched=27 skipped=0  diffed=0
[cache_aligner   ] total=20 matched=0  skipped=20 diffed=0
[tokenizer       ] total=40 matched=40 skipped=0  diffed=0
[ccr             ] total=25 matched=0  skipped=25 diffed=0
[smart_crusher   ] total=17 matched=17 skipped=0  diffed=0
[content_detector] total=21 matched=21 skipped=0  diffed=0
[text_crusher    ] total=6  matched=6  skipped=0  diffed=0

total=176 matched=111 skipped=65 diffed=0   → exit 0
```

## Real Behavior Proof

- **Environment:** macOS 25.4.0 (darwin arm64), rustc 1.95.0, no venv activated.
- **Exact command / steps:**
  1. `env -u VIRTUAL_ENV make test-parity` — proves the harness runs from a bare
     checkout with no Python toolchain and no built extension module.
  2. `make test-parity` — full fixture sweep.
  3. `python3 -c "yaml.safe_load(open('.github/workflows/rust.yml'))"` — confirms
     the `parity` job has neither an `if` key nor `continue-on-error`, and that
     `push`/`pull_request`/`schedule` triggers all survive.
  4. `grep -rn parity-nightly . --exclude-dir=target --exclude-dir=.git` — empty,
     so the job rename leaves no dangling reference; no job uses `needs:`.
- **Observed result:** identical report before and after removing the maturin
  step (105 matched / 65 skipped / 0 diffed), plus 6 newly-visible
  `text_crusher` fixtures matching on the first run — so the Rust `TextCrusher`
  is already byte-identical to the recorded Python output, including the
  `unicode` fixture (CJK context, which routes through the separate CJK BM25
  branch) and `redundant` (Python's dedup fires, taking a requested 0.9 ratio
  down to an actual 0.44). Harness exit code 0.
- **Not tested:** `cargo test --workspace` was not run to completion locally
  (disk pressure on this box). It is unaffected by design — `headroom-parity` is
  a leaf crate that appears only in workspace `members`, with no `[dependencies]`
  entry anywhere, so no other crate's tests can observe this diff. CI runs the
  full workspace suite on this PR. The `cache_aligner` and `ccr` stubs are
  untouched and still report Skipped.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — CI and harness output only.

## Additional Notes

**This gate blocks merges only once `parity` is added to the branch-protection
required-checks list for `main`.** Until then a failure shows red on the PR but
does not prevent merging. That is a repo-settings change, not a code change.

**Why it is safe to harden now rather than after the stubs are filled in:**
`parity-run` sets `any_diffs` only inside the diffed loop and exits non-zero
solely on that flag, so the 65 fixtures still served by `stub_comparator!`
(`log_compressor`, `cache_aligner`, `ccr`) report as `Skipped` and cannot turn
the job red. Measured on this branch: 111 matched / 65 skipped / 0 diffed.

**Documentation checkbox left unchecked:** `REALIGNMENT/11-phase-I-test-infra.md`
describes PR-I6 as blocked on I5. The exit-code logic above shows it was not.
I left the phase doc alone rather than editing planning history in a CI PR;
happy to follow up if you'd prefer it corrected.

Follow-ups, not in this PR:
- `log_compressor` comparator (20 fixtures) — in progress on a branch.
- `codex_openai_contracts/` (1 fixture) is still uncovered; it needs a real
  comparator, not just registration.
- `cache_aligner` needs `volatile_detector.rs`, which lives in `headroom-proxy`
  while `headroom-parity` depends only on `headroom-core`. `ccr` fixtures compare
  `ccr_retrieve` tool-definition injection, which has no Rust port at all.
