### PR TITLE
parity: promote log_compressor from stub to a real comparator

### DIFF
--- a/crates/headroom-parity/src/lib.rs
+++ b/crates/headroom-parity/src/lib.rs
@@ -1,9 +1,10 @@
 //! Parity harness: load JSON fixtures recorded from the Python implementation,
 //! run the Rust port, and compare outputs.
 //!
-//! Phase 0: the per-transform comparators are stubs (`todo!()`), but the
-//! harness wiring (fixture loading, dispatch, diff reporting) is real and
-//! covered by a negative test.
+//! Six of the eight comparators are real: `log_compressor`, `diff_compressor`,
+//! `tokenizer`, `smart_crusher`, `content_detector`, `text_crusher`. Two remain
+//! stubs and report `Skipped` — see the `stub_comparator!` block below for what
+//! each is waiting on.
 
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -147,9 +148,15 @@ pub fn run_comparator(dir: &Path, comparator: &dyn TransformComparator) -> Resul
 
 // --- Built-in comparator stubs ---------------------------------------------
 //
-// Phase 1 will replace `todo!()` bodies with real Rust ports. Until then they
-// return `Err`, causing the harness to mark fixtures as `Skipped` instead of
-// panicking. The parity-run binary wires them up so the CLI works today.
+// These return `Err`, which the harness turns into `Skipped` rather than a
+// panic or a diff — so a stubbed comparator cannot fail the parity gate. Both
+// are blocked on missing Rust surface, not on wiring:
+//
+// * `cache_aligner` — needs the volatile-content detector, which lives in
+//   `headroom-proxy` while this crate depends only on `headroom-core`. Either
+//   add the dependency or move the detector down into core.
+// * `ccr` — the fixtures compare `ccr_retrieve` tool-definition injection
+//   (`headroom/ccr/tool_injection.py`), which has no Rust port at all.
 
 macro_rules! stub_comparator {
     ($ty:ident, $name:literal) => {
@@ -169,9 +176,105 @@ macro_rules! stub_comparator {
     };
 }
 
-stub_comparator!(LogCompressorComparator, "log_compressor");
 stub_comparator!(CacheAlignerComparator, "cache_aligner");
 stub_comparator!(CcrComparator, "ccr");
+
+/// Real comparator for the `log_compressor` transform.
+///
+/// Two wrinkles beyond the usual adapter shape:
+///
+/// * **bias.** Python's signature is `compress(content, context="", bias=1.0)`
+///   and the recorder captured only `content`, so every fixture was produced at
+///   the default `bias = 1.0`. Rust takes `bias` positionally — pass 1.0.
+/// * **CCR store.** The Python compressor owns its store internally, while Rust
+///   mints a `cache_key` only when one is handed to `compress_with_store`.
+///   Without a store the CCR branch bails out with `"no store provided"` and
+///   `cache_key` comes back `None`, which would diff against any fixture that
+///   recorded a key. A throwaway `InMemoryCcrStore` is enough: the key is
+///   `md5(content)[:24]` on both sides and does not depend on the backend.
+pub struct LogCompressorComparator;
+
+impl TransformComparator for LogCompressorComparator {
+    fn name(&self) -> &str {
+        "log_compressor"
+    }
+
+    fn run(
+        &self,
+        input: &serde_json::Value,
+        config: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        use headroom_core::ccr::InMemoryCcrStore;
+        use headroom_core::transforms::{LogCompressor, LogCompressorConfig};
+
+        let content = input
+            .as_str()
+            .context("log_compressor fixture input must be a JSON string")?;
+
+        let usize_or = |key: &str, default: usize| -> usize {
+            config
+                .get(key)
+                .and_then(|v| v.as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(default)
+        };
+        let bool_or = |key: &str, default: bool| -> bool {
+            config.get(key).and_then(|v| v.as_bool()).unwrap_or(default)
+        };
+
+        let cfg = LogCompressorConfig {
+            // The twelve fields the Python dataclass carries, all recorded.
+            max_errors: usize_or("max_errors", 10),
+            error_context_lines: usize_or("error_context_lines", 3),
+            keep_first_error: bool_or("keep_first_error", true),
+            keep_last_error: bool_or("keep_last_error", true),
+            max_stack_traces: usize_or("max_stack_traces", 3),
+            stack_trace_max_lines: usize_or("stack_trace_max_lines", 20),
+            max_warnings: usize_or("max_warnings", 5),
+            dedupe_warnings: bool_or("dedupe_warnings", true),
+            keep_summary_lines: bool_or("keep_summary_lines", true),
+            max_total_lines: usize_or("max_total_lines", 100),
+            enable_ccr: bool_or("enable_ccr", true),
+            min_lines_for_ccr: usize_or("min_lines_for_ccr", 50),
+
+            // Rust-only knobs, absent from the fixtures. Each falls back to the
+            // Rust default rather than to a Python-equivalent value, so the
+            // comparator exercises the code as it actually ships.
+            //
+            // Python applies the same 0.5 ratio gate inline.
+            min_compression_ratio_for_ccr: config
+                .get("min_compression_ratio_for_ccr")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.5),
+            // Rust's `true` collapses runtime frames where Python truncates the
+            // tail — a deliberate upgrade, and the one place these two
+            // implementations are known to disagree. Kept at the Rust default
+            // anyway: measured both ways, all 20 fixtures match either setting,
+            // because every recorded traceback is 3 lines and the collapse path
+            // only opens above `stack_trace_max_lines` (20). Leaving it `true`
+            // means a future fixture with a deep traceback will surface the
+            // divergence instead of having it configured away here.
+            collapse_runtime_frames: bool_or("collapse_runtime_frames", true),
+            trace_head_frames: usize_or("trace_head_frames", 3),
+            trace_app_frames: usize_or("trace_app_frames", 5),
+        };
+
+        let store = InMemoryCcrStore::new();
+        let (result, _sidecar) =
+            LogCompressor::new(cfg).compress_with_store(content, 1.0, Some(&store));
+
+        Ok(serde_json::json!({
+            "cache_key": result.cache_key,
+            "compressed": result.compressed,
+            "compressed_line_count": result.compressed_line_count,
+            "compression_ratio": result.compression_ratio,
+            "format_detected": result.format_detected.as_str(),
+            "original": result.original,
+            "original_line_count": result.original_line_count,
+            "stats": result.stats,
+        }))
+    }
+}
 
 /// Real comparator for the `diff_compressor` transform. Drives the Rust port
 /// over the recorded fixture inputs and emits the Python-shaped JSON output
@@ -619,14 +722,17 @@ mod tests {
 
     #[test]
     fn stub_comparators_skip_rather_than_panic() {
+        // Uses `cache_aligner` because `log_compressor` is a real comparator
+        // now. Any remaining `stub_comparator!` works here — the point is that
+        // an unimplemented comparator reports Skipped instead of panicking.
         let tmp = tempdir();
         write_fixture(
             tmp.path(),
-            "log_compressor",
+            "cache_aligner",
             "case1",
             serde_json::json!({"compressed": "x"}),
         );
-        let report = run_comparator(tmp.path(), &LogCompressorComparator).unwrap();
+        let report = run_comparator(tmp.path(), &CacheAlignerComparator).unwrap();
         assert_eq!(report.skipped.len(), 1);
         assert_eq!(report.matched, 0);
     }


### PR DESCRIPTION
## Description

Promotes `log_compressor` from a Phase-0 stub to a real comparator, un-blinding
the 20 recorded fixtures that have been reporting `Skipped` since the harness
landed. **All 20 match on the first run** — the Rust port is already
byte-identical to the recorded Python output, CCR path included.

> **Stacked on #2567.** Base that first; this branch contains its three commits.
> Review only `8c41e92d`.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- **`LogCompressorComparator`** replaces the `stub_comparator!` entry. Two things
  the adapter has to get right, neither obvious from the fixture shape:
  - **bias.** Python's signature is `compress(content, context="", bias=1.0)` and
    the recorder captured only `content`, so every fixture was produced at the
    default `bias = 1.0`. Rust takes it positionally.
  - **CCR store.** Python's compressor owns its store internally; Rust mints a
    `cache_key` only when one is handed to `compress_with_store`. Without it the
    CCR branch bails with `"no store provided"` and returns `cache_key: None`,
    which would diff against any fixture that recorded a key. A throwaway
    `InMemoryCcrStore` is enough — the key is `md5(content)[:24]` on both sides
    and does not depend on the backend.
- **Rust-only config knobs fall back to the Rust defaults**, not to
  Python-equivalent values, so the comparator drives the code as it ships. See
  Additional Notes for the one knob where that choice is load-bearing.
- **Repointed `stub_comparators_skip_rather_than_panic`** at
  `CacheAlignerComparator`. It asserted `LogCompressorComparator` skips, which
  stops being true here; its `write_fixture` helper supplies `input: "hello"`, so
  the now-real comparator would have run and **diffed** rather than skipped.
- **Corrected two stale comments** that claimed every comparator is a `todo!()`
  stub (already wrong before this PR — four were real), and recorded what the two
  remaining stubs are actually blocked on.

## Testing

- [ ] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

No Python source changed, so `pytest`/`mypy` are N/A for this diff.

### Test Output

```text
$ cargo fmt --all -- --check
fmt OK

$ cargo clippy -p headroom-parity --all-targets -- -D warnings
(no warnings)

$ cargo test -p headroom-parity
test tests::missing_transform_dir_yields_empty_report ... ok
test tests::harness_reports_match_for_agreeing_comparator ... ok
test tests::harness_reports_diff_for_divergent_comparator ... ok
test tests::stub_comparators_skip_rather_than_panic ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ make test-parity
[log_compressor  ] total=20 matched=20 skipped=0  diffed=0     <-- was 0/20/0
[diff_compressor ] total=27 matched=27 skipped=0  diffed=0
[cache_aligner   ] total=20 matched=0  skipped=20 diffed=0
[tokenizer       ] total=40 matched=40 skipped=0  diffed=0
[ccr             ] total=25 matched=0  skipped=25 diffed=0
[smart_crusher   ] total=17 matched=17 skipped=0  diffed=0
[content_detector] total=21 matched=21 skipped=0  diffed=0
[text_crusher    ] total=6  matched=6  skipped=0  diffed=0

TOTALS total=176 matched=131 skipped=45 diffed=0   → exit 0
```

Harness coverage goes from 111/176 to 131/176 compared; skipped drops 65 → 45.

## Real Behavior Proof

- **Environment:** macOS 25.4.0 (darwin arm64), rustc 1.95.0.
- **Exact command / steps:** `make test-parity`, plus two deliberate negative
  controls to prove the comparator is not passing vacuously:
  1. **Is the CCR store load-bearing?** Swapped `Some(&store)` for `None` and
     re-ran.
  2. **Does `collapse_runtime_frames` matter here?** Ran the full fixture set at
     both `true` (Rust default) and `false` (Python-equivalent).
- **Observed result:**
  1. With `None`: `total=20 matched=19 skipped=0 diffed=1`, and the single diff is
     `tests/parity/fixtures/log_compressor/3bc015edc0a36387.json` — precisely the
     one fixture that recorded a `cache_key`. So the store is real and the
     comparator genuinely exercises the md5 key and the retrieval marker, not
     just the passthrough branch.
  2. `20/20` at **both** settings. Independently confirmed why: 19 of the 20
     fixtures are under `min_lines_for_ccr = 50` and return verbatim, and the one
     large fixture (305 → 8 lines) has a 3-line traceback, far below the
     `stack_trace_max_lines = 20` threshold that opens the collapse path.
  3. Separately verified the key algorithm agrees:
     `hashlib.md5(content).hexdigest()[:24]` equals the recorded
     `80a6e711dbe62fc84e7b2b56`.
- **Not tested:** `cargo test --workspace` was not run to completion locally
  (disk pressure on this box); `headroom-parity` is a leaf crate with no
  `[dependencies]` entry anywhere, so no other crate's tests can observe this
  diff, and CI runs the full suite here. The `cache_aligner` and `ccr` stubs are
  untouched and still Skipped. Rust's trace-collapsing path remains uncovered by
  fixtures — see Additional Notes.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — harness output only.

## Additional Notes

**The one judgement call worth reviewing.** `LogCompressorConfig` carries four
knobs the Python dataclass does not. `collapse_runtime_frames` defaults to `true`
in Rust, which collapses runtime frames where Python truncates the tail — per its
own doc comment, the one place these implementations knowingly disagree.

I set the comparator to the **Rust** default rather than the Python-equivalent
`false`, which is the opposite of the precedent in `DiffCompressorComparator`
(whose comment says its `0.8` default "reproduces Python's hardcoded 20%-savings
gate"). Reasoning: measured both ways it makes no difference to these 20
fixtures, so choosing `true` costs nothing today and means a future fixture with
a deep traceback will *surface* the divergence rather than have it configured
away in the harness. If you'd rather the harness always neutralise deliberate
Rust improvements for consistency with `diff_compressor`, flipping it is a
one-word change and the fixtures stay green.

Caveat that follows from this: no recorded fixture exercises trace collapsing at
all. Covering it needs a new fixture with a >20-line traceback, which has to be
recorded against Python first — worth doing, but it belongs with the recorder,
not here.

**Documentation checkbox unchecked:** `REALIGNMENT/11-phase-I-test-infra.md` still
describes these comparators as Phase-1 work. I fixed the misleading in-file
comments but left the phase doc alone rather than rewriting planning history in a
harness PR.

Remaining uncovered after this lands: `cache_aligner` (20), `ccr` (25),
`codex_openai_contracts` (1, no comparator registered).
