### PR TITLE
ci: THROWAWAY diagnostic — baseline test-dashboard-ui on main (do not merge)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,10 @@ concurrency:
   group: rust-${{ github.ref }}
   cancel-in-progress: true
 
+# THROWAWAY DIAGNOSTIC — do not merge. This comment exists only to make the
+# `dashboard` paths-filter in ci.yml match (it includes '.github/workflows/**'),
+# so `test-dashboard-ui` runs against unmodified main content. See #2567.
+
 # Default permissions: read-only. Individual jobs override only what they need.
 # Mitigates CodeQL/CWE-275 (missing-workflow-permissions): the GITHUB_TOKEN
 # defaults to whatever the repo policy is, which can be read-write. Pinning


### PR DESCRIPTION
**Draft, throwaway, do not merge. Will be closed as soon as `test-dashboard-ui` reports.**

## Purpose

#2567 turned `test-dashboard-ui` red. That job is normally `SKIPPED` — it fires on `needs.changes.outputs.dashboard == 'true'`, and the filter is `headroom/dashboard/**` **plus** `.github/workflows/**` (`ci.yml:85-86`). #2567 edits `.github/workflows/rust.yml`, so it ran there for the first time in a long while.

Across the last 30 `ci.yml` runs, `test-dashboard-ui` reached a real conclusion exactly once: #2567. So there is no baseline to compare against, and no way to tell from CI history alone whether #2567 caused the failure or merely exposed it.

This PR is that baseline. It is a **comment-only** edit to `rust.yml`, carrying none of #2567's content, whose only effect is to make the same paths-filter match.

## Control properties

- The diff is three comment lines. `yaml.safe_load` of the result is **equal** to `yaml.safe_load` of `upstream/main:.github/workflows/rust.yml` — a verified semantic no-op.
- Branched directly off `b121223e` (current main), so every other file is unmodified main content.

## How to read the result

- `test-dashboard-ui` **fails here** → the failures are pre-existing rot on main, exposed rather than caused by #2567. #2567 and #2568 are clear to merge, and the two assertions want their own fix.
- `test-dashboard-ui` **passes here** → something in #2567 is genuinely implicated and I need to look again.

Closing this immediately once it reports.