### PR TITLE
fix(dashboard): restore lifetime cache-reads tile and per-project setup hints

### DIFF
--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -468,8 +468,8 @@
                     </div>
                 </div>
 
-                <!-- Prefix Cache Impact: current process only -->
-                <template x-if="cacheSessionActive">
+                <!-- Prefix Cache Impact: current process plus durable cache reads after restart -->
+                <template x-if="cacheCardAvailable">
                     <div class="bg-surface rounded-lg p-4 border border-border mb-6">
                         <div class="flex justify-between items-center mb-3">
                             <div class="text-sm font-medium text-gray-300">Prefix Cache Impact</div>
@@ -479,6 +479,15 @@
                             <div class="text-xs text-gray-500 font-mono"
                                  x-show="!cacheSessionActive">no activity since restart</div>
                         </div>
+                        <template x-if="!cacheSessionActive && lifetimeCacheReadTokens > 0">
+                            <div class="mb-4 rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3">
+                                <div class="text-xs text-gray-500 uppercase tracking-wide mb-1">Cache Reads (lifetime)</div>
+                                <div class="text-2xl font-light tabular-nums text-cyan-400"
+                                     x-text="formatNumber(lifetimeCacheReadTokens)"></div>
+                                <div class="text-xs text-cyan-400/70"
+                                     x-text="'$' + formatCurrency(lifetimeCacheSavingsUsd) + ' saved'"></div>
+                            </div>
+                        </template>
                         <!-- Totals row -->
                         <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
                             <div>
@@ -783,7 +792,9 @@
 
                         <template x-if="agentRows.length === 0">
                             <div class="rounded-lg border border-dashed border-border p-6 text-center text-sm text-gray-500">
-                                Agent usage appears after Cursor, Claude, Codex, or another client sends traffic through this proxy.
+                                <div>Agent usage appears after Cursor, Claude, Codex, or another client sends traffic through this proxy.</div>
+                                <div class="mt-2 font-mono text-xs text-accent"
+                                     x-text="'ANTHROPIC_BASE_URL: ' + window.location.origin + '/p/&lt;project-name&gt;'"></div>
                             </div>
                         </template>
                     </div>
@@ -1323,8 +1334,7 @@
                         <div class="px-4 py-8 text-center">
                             <div class="text-xs text-gray-500 mb-3">No per-project data yet.</div>
                             <div class="text-xs text-gray-600 font-mono leading-relaxed">
-                                Route project traffic through
-                                <span class="text-accent" x-text="window.location.origin + '/p/&lt;project-name&gt;'"></span>
+                                <span class="text-accent" x-text="'ANTHROPIC_BASE_URL: ' + window.location.origin + '/p/&lt;project-name&gt;'"></span>
                             </div>
                         </div>
                     </template>
@@ -2476,6 +2486,18 @@
 
                 get cacheSessionActive() {
                     return (this.stats.prefix_cache?.totals?.requests || 0) > 0;
+                },
+
+                get lifetimeCacheReadTokens() {
+                    return this.stats.persistent_savings?.lifetime?.cache_read_tokens || 0;
+                },
+
+                get lifetimeCacheSavingsUsd() {
+                    return this.stats.persistent_savings?.lifetime?.cache_savings_usd || 0;
+                },
+
+                get cacheCardAvailable() {
+                    return this.cacheSessionActive || this.lifetimeCacheReadTokens > 0 || this.lifetimeCacheSavingsUsd > 0;
                 },
 
                 get cacheSavingsPercent() {


### PR DESCRIPTION
## Description

Restores the lifetime Cache Reads tile and the per-project setup hints on the dashboard, fixing the two `test-dashboard-ui` failures currently red on `main`.

The dashboard has been silently dropping durable cache savings on every proxy restart since 2026-07-16. The backend still collects the data — `savings_tracker.py:1172-1173` populates `lifetime.cache_read_tokens` and `lifetime.cache_savings_usd`, and `/stats` emits it via `stats_preview()` (`server.py:3749`) — but the template stopped rendering it. This is a real user-facing regression, not just a red test.

Commit is cherry-picked from `c87a0ec2` to preserve @JerrettDavis's authorship. The fix currently exists only inside #873 ("feat: add architectural guardrails", +843/−22 across 19 files, `mergeable: UNKNOWN`), where it is an unrelated drive-by. Lifting it into a focused PR so it can land on its own.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

One file, `headroom/dashboard/templates/dashboard.html`, +27/−5:

- **Card gate.** `<template x-if="cacheSessionActive">` → `x-if="cacheCardAvailable"`, plus three new getters:
  - `lifetimeCacheReadTokens` → `stats.persistent_savings?.lifetime?.cache_read_tokens || 0`
  - `lifetimeCacheSavingsUsd` → `stats.persistent_savings?.lifetime?.cache_savings_usd || 0`
  - `cacheCardAvailable` → `cacheSessionActive || lifetimeCacheReadTokens > 0 || lifetimeCacheSavingsUsd > 0`
- **New "Cache Reads (lifetime)" tile**, shown only when `!cacheSessionActive && lifetimeCacheReadTokens > 0` — so it appears after a zero-traffic restart and stays out of the way once session traffic resumes.
- **Setup hints.** Both empty states now render the copy-pasteable `ANTHROPIC_BASE_URL: <origin>/p/<project-name>`, derived from `window.location.origin`: the agent-usage empty state (inside `viewMode === 'session'`) and the per-project empty state (inside `viewMode === 'lifetime'`).

## Root cause

1. **#1665** (`908997ef`, 2026-07-08) added the lifetime tile *and* the tests that pin it.
2. **#2198** (`0537cbfd`, 2026-07-16, branch `migration/c365c7ff-dashboard-metrics`) rewrote that region of `dashboard.html` and reverted the gate to session-only — reintroducing the `<!-- Prefix Cache Impact: current process only -->` comment — while leaving #1665's tests in place. #1665 is a verified ancestor of #2198, so this was a bad conflict resolution, not a missing rebase.
3. **#2198 merged with 4 check-runs total: `label` and `template`.** The `CI` workflow never ran on its head sha (`92387e65`), so the tests that would have caught this never executed.
4. Nothing since has run them. `test-dashboard-ui` is gated on `needs.changes.outputs.dashboard == 'true'` (`ci.yml:389`), and the main pytest shards skip these files via `importorskip` because playwright is not installed there (`ci.yml:417-418`). Across the last 30 `ci.yml` runs the job reached a real conclusion exactly once — on #2567, which is what surfaced this.

## Testing

- [x] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

No Python source changed — `ruff`/`mypy` are N/A. No new tests: #1665's existing tests already specify this behaviour exactly and were failing; this makes them pass.

### Test Output

Before, on unmodified `main`:

```text
$ pytest tests/test_dashboard_cache_lifetime_playwright.py tests/test_dashboard_cache_ttl_playwright.py -q
FAILED tests/test_dashboard_cache_lifetime_playwright.py::test_card_renders_lifetime_cache_reads_after_zero_traffic_restart
FAILED tests/test_dashboard_cache_ttl_playwright.py::test_dashboard_per_project_setup_url_uses_current_origin
========================= 2 failed, 2 passed in 19.89s =========================
```

After, same command:

```text
========================= 4 passed in 4.67s =========================
```

Full suite as CI invokes it (`ci.yml:419`):

```text
$ pytest tests/test_dashboard_*_playwright.py -q
tests/test_dashboard_cache_lifetime_playwright.py ..                     [ 18%]
tests/test_dashboard_cache_net_playwright.py ...                         [ 45%]
tests/test_dashboard_cache_ttl_playwright.py ..                          [ 63%]
tests/test_dashboard_context_tool_availability_playwright.py ....        [100%]
========================= 11 passed in 11.47s =========================
```

Was 2 failed / 9 passed on `main`; now 11 passed.

## Real Behavior Proof

- **Environment:** macOS 25.4.0 (darwin arm64), Python 3.12 in `.venv`, playwright 1.61.0, Chrome Headless Shell 149.0.7827.55.
- **Exact command / steps:**
  1. Checked out `upstream/main`'s `dashboard.html` alone and ran the two tests → reproduced the exact CI failures locally (`Locator expected to be visible`, `get_by_text("Prefix Cache Impact", exact=True)` and `get_by_text("ANTHROPIC_BASE_URL: http://127.0.0.1:8788/p/<project-name>", exact=True)`).
  2. Restored the fix and re-ran the same two tests → 4 passed.
  3. Ran the full `tests/test_dashboard_*_playwright.py` set → 11 passed.
- **Observed result:** the failures are template-only and this diff resolves both. Independently confirmed the data was already present end-to-end, so the tile has something real to show: `_default_state()` carries `cache_read_tokens` / `cache_savings_usd` (`savings_tracker.py:1172-1173`), and `stats_preview()` forwards `lifetime` into the `/stats` payload consumed by the dashboard.
- **Checked for a strict-mode hazard:** the setup-hint string is now emitted in two places, which would break `get_by_text(..., exact=True).to_be_visible()` if both could render at once. They cannot — the agent-usage empty state is inside `x-if="viewMode === 'session'"` (line 192) and the per-project one inside `x-if="viewMode === 'lifetime'"` (line 1274), and `viewMode` defaults to `'session'` (line 1827). Exactly one matches. Verified empirically by the passing run.
- **Not tested:** no live proxy was driven — these tests fully mock `/stats`, `/stats-history`, and `/health`, and `tests/test_dashboard/test_live_feed.py` (which needs a real proxy on `:8787`) stays excluded from this job as before. I did not verify the tile against a genuinely restarted proxy with persisted state on disk.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

Not captured. The assertions are on exact text (`Cache Reads (lifetime)`, `629.5M`, `$7.20 saved`, `ANTHROPIC_BASE_URL: …`), which the passing run covers more precisely than a screenshot would. `HEADROOM_PLAYWRIGHT_ARTIFACT_DIR` artifacts upload from CI if wanted.

## Additional Notes

**Overlap with #873.** If #873 lands first this becomes an empty cherry-pick and can be closed. Given #873 is 19 files with `mergeable: UNKNOWN` and this is a one-file regression fix, landing this first seems better; @JerrettDavis may want to drop the `dashboard.html` hunk from #873 to avoid a conflict.

**The structural problem is not fixed here, and it is the more important half.** Two independent gaps let a shipped feature regress for 10 days:

1. **#2198 merged with no CI.** Only `label` and `template` ran. Worth understanding why — if `migration/*` branches or fork PRs routinely merge with workflows sitting at `action_required`, no test suite protects `main`. Several open PRs are in that state right now (#1153, #1154, #1155, #2258).
2. **`test-dashboard-ui` almost never runs.** Filter-gated, and skipped in the main shards because playwright is not installed there. Options: install playwright in one shard, or drop the filter for this job. Either makes these 11 tests real.

I have deliberately kept both out of this PR so the regression fix can land quickly. Happy to file an issue for them, or to send the CI change as a follow-up.
