### PR TITLE
ci(rust): gate jobs with `if:` instead of a workflow-level paths filter

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,25 +1,18 @@
 name: rust
 
+# Path gating lives in the `rust-changes` job below, NOT in a workflow-level
+# `paths:` filter. The distinction matters for branch protection: a workflow
+# skipped by `paths:` never creates its check runs at all, so a required status
+# check from it sits pending forever on any PR that misses those paths, and the
+# PR can never merge. A job skipped by `if:` still creates a check run, reports
+# `skipped`, and GitHub counts skipped as success for a required check.
+#
+# Same coverage as the old filter — the path list moved verbatim into
+# `rust-changes` — but `parity` is now safe to mark required on `main`.
 on:
   push:
     branches: [ main, rust-rewrite ]
-    paths:
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
-      - 'tests/parity/**'
-      - 'Makefile'
-      - '.github/workflows/rust.yml'
   pull_request:
-    paths:
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
-      - 'tests/parity/**'
-      - 'Makefile'
-      - '.github/workflows/rust.yml'
   schedule:
     # Nightly parity run at 07:17 UTC (weekdays only). Redundant with the
     # per-PR gate below, but catches drift from toolchain/dependency updates
@@ -38,8 +31,43 @@ permissions:
   contents: read
 
 jobs:
+  # Carries the path list the workflow-level `paths:` filter used to hold. Named
+  # `rust-changes` rather than `changes` so it does not collide with ci.yml's
+  # `changes` check.
+  rust-changes:
+    name: rust-changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      rust: ${{ steps.decide.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        with:
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'tests/parity/**'
+              - 'Makefile'
+              - '.github/workflows/rust.yml'
+      - id: decide
+        # `schedule` and `workflow_dispatch` have no diff to filter against, so
+        # they run the full suite — that is the point of the nightly job.
+        run: |
+          case "${{ github.event_name }}" in
+            pull_request|push) echo "rust=${{ steps.filter.outputs.rust }}" >> "$GITHUB_OUTPUT" ;;
+            *)                 echo "rust=true" >> "$GITHUB_OUTPUT" ;;
+          esac
+
   test:
     name: test (ubuntu)
+    needs: rust-changes
+    if: needs.rust-changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -78,6 +106,8 @@ jobs:
 
   simulator-e2e:
     name: simulator e2e (${{ matrix.os }})
+    needs: rust-changes
+    if: needs.rust-changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -97,6 +127,8 @@ jobs:
 
   wheels:
     name: wheels (${{ matrix.target }})
+    needs: rust-changes
+    if: needs.rust-changes.outputs.rust == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -137,6 +169,8 @@ jobs:
 
   audit:
     name: audit
+    needs: rust-changes
+    if: needs.rust-changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -168,6 +202,8 @@ jobs:
   # drifting away from the fixtures; that needs re-recording, not this job.
   parity:
     name: parity
+    needs: rust-changes
+    if: needs.rust-changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Description

Moves `rust.yml`'s path gating out of the workflow-level `paths:` filter and into a job-level `if:`. This is the prerequisite for making `parity` a **required** status check on `main` — without it, requiring `parity` would deadlock every PR that doesn't touch Rust.

Phase 1 of branch protection is already enabled on `main` (require a PR, plus the four checks that always run). This PR is Phase 2: making the checks that actually matter safe to require.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## The problem

A workflow skipped by a top-level `paths:` filter **never creates its check runs at all**. GitHub cannot distinguish "not applicable" from "not finished yet", so a required check sourced from that workflow sits pending forever on any PR that misses those paths — and the PR can never merge.

A job skipped by `if:` behaves differently: the check run *is* created, reports `skipped`, and GitHub counts skipped as success for branch protection. Same coverage, and requireable.

`rust.yml` had the first shape. That is why `parity` could not simply be added to the required-checks list after #2567 made it blocking.

## Changes Made

- New `rust-changes` job holding the **same seven path patterns** the `on:` block used to carry, verbatim, via `dorny/paths-filter@v4`.
- All five existing jobs (`test`, `simulator-e2e`, `wheels`, `audit`, `parity`) gain `needs: rust-changes` and `if: needs.rust-changes.outputs.rust == 'true'`.
- `paths:` removed from both the `push` and `pull_request` triggers.
- Named `rust-changes`, not `changes`, so it does not collide with ci.yml's existing `changes` check.
- Job `name:` fields are untouched — no check names change, so nothing already referencing them breaks.
- `schedule` / `workflow_dispatch` have no diff to filter against, so the `decide` step forces `rust=true`, preserving today's behaviour where the nightly cron runs the full suite.

**CI spend is unchanged.** The same jobs run on the same PRs; the only addition is a ~15s `rust-changes` job on PRs that previously skipped the workflow outright.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

CI-config only — no Python or Rust source touched, so pytest/ruff/mypy are N/A.

### Test Output

```text
$ actionlint .github/workflows/rust.yml
$ echo $?
0

$ python3 -c "yaml.safe_load(...)"
triggers: {'push': ['branches'], 'pull_request': None, 'schedule': [{'cron': '17 7 * * 1-5'}]}
jobs: ['rust-changes', 'test', 'simulator-e2e', 'wheels', 'audit', 'parity']
  rust-changes:  needs=None            if=None
  test:          needs=rust-changes    if=needs.rust-changes.outputs.rust == 'true'
  simulator-e2e: needs=rust-changes    if=needs.rust-changes.outputs.rust == 'true'
  wheels:        needs=rust-changes    if=needs.rust-changes.outputs.rust == 'true'
  audit:         needs=rust-changes    if=needs.rust-changes.outputs.rust == 'true'
  parity:        needs=rust-changes    if=needs.rust-changes.outputs.rust == 'true'
rust-changes outputs: {'rust': '${{ steps.decide.outputs.rust }}'}
```

## Real Behavior Proof

- **Environment:** macOS 25.4.0 (darwin arm64); actionlint downloaded to a temp dir, not installed system-wide.
- **Exact command / steps:** `actionlint .github/workflows/rust.yml` (exit 0); YAML parse asserting every job carries the gate and `rust-changes` exports `rust`; confirmed the seven path patterns are character-for-character the ones removed from `on:`.
- **Observed result:** clean. **This PR edits `.github/workflows/rust.yml`, which is itself in the path list — so it exercises the `rust=true` branch on itself.** If the `rust` workflow's five jobs run and pass on this PR, the run-path is proven end-to-end by the PR that introduces it.
- **Not tested — and this is the important gap:** the **skip** path. Proving it needs a PR that touches *no* Rust paths, which this PR by construction cannot be. Until that is observed, `parity` should **not** be added to the required-checks list. Concretely: after this merges, the next Python-only or docs-only PR should show `parity = skipped` rather than absent. I will confirm on the first such PR and follow up.
- `scripts/validate-workflows.sh` was not run locally — it requires `act`, which is not installed here. CI's `workflow-validation` job runs both `actionlint` and `act`.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

No tests added: this is workflow configuration, and the mechanism it relies on (skipped-job-counts-as-success) is GitHub platform behaviour, observable only in CI. The "not tested" note above says exactly what remains unverified.

## Screenshots (if applicable)

N/A.

## Additional Notes

**Sequencing.** Merge this, confirm `parity = skipped` on the next non-Rust PR, *then* add `parity` to the required-checks list. Adding it before that confirmation risks deadlocking every non-Rust PR — precisely the failure this PR exists to prevent.

**`ci.yml` has the mirror-image problem and is not addressed here.** Its trigger carries `paths-ignore: docs/**, wiki/**, **/*.md`, so a docs-only PR skips the whole workflow and never produces `lint`, `test (1-4)`, or `build-wheel`. Requiring any of those today would deadlock docs PRs. Its *jobs* already use the `changes` + `if:` pattern correctly — only the workflow-level `paths-ignore` needs removing. Deliberately left for a separate PR so this one stays reviewable and each can be reverted independently.

**Why this matters beyond tidiness.** `main` had no branch protection at all until today, which is how #2198 merged with only `label` and `template` green and silently reverted the dashboard's lifetime cache tile for 10 days (fixed in #2573). Making the real gates requireable is what closes that hole; #2567 only made them fail loudly.
