### PR TITLE
style(cli): format proxy URL leak warning to satisfy ruff 0.15.17

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -5286,9 +5286,7 @@ def _warn_if_proxy_env_leaked(port: int) -> None:
             leaked.append((name, value))
     if not leaked:
         return
-    click.echo(
-        "  ⚠ Headroom's proxy URL is still exported in this shell's environment:"
-    )
+    click.echo("  ⚠ Headroom's proxy URL is still exported in this shell's environment:")
     for name, value in leaked:
         click.echo(f"      {name}={value}")
     click.echo(


### PR DESCRIPTION
## Description

`main` is currently red on the `lint` job, which also fails every open PR that branches from it.

PR #2571 (commit `904bc675`) added a `click.echo(...)` call in `_warn_if_proxy_env_leaked` written across three lines:

```python
click.echo(
    "  ⚠ Headroom's proxy URL is still exported in this shell's environment:"
)
```

The pinned formatter `ruff==0.15.17` (resolved by `scripts/verify-ruff-version.py`, the same version CI installs) collapses that call onto a single line because it fits within the line-length limit. Since the merged code kept it multi-line, `ruff format --check` reports `Would reformat: headroom/cli/wrap.py` and exits non-zero. The previous main commit `fd6abac8` was green; `904bc675` is the first red one.

## Fix

Run the pinned formatter on the one drifted call so the whole tree is formatted again:

```python
click.echo("  ⚠ Headroom's proxy URL is still exported in this shell's environment:")
```

No behavior change: identical output, identical control flow. This only restores `ruff format --check` to green on `main`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- `headroom/cli/wrap.py`: reformat the `_warn_if_proxy_env_leaked` warning `click.echo` call onto one line, per `ruff==0.15.17`.

## Testing

- [x] Linting passes (`ruff format --check`)
- [ ] Manual testing performed

### Test Output

```text
$ python scripts/verify-ruff-version.py --print-version
0.15.17

# before (on main / this file unchanged):
$ uvx ruff@0.15.17 format --check .
Would reformat: headroom/cli/wrap.py
1 file would be reformatted, 1339 files already formatted

# after this change:
$ uvx ruff@0.15.17 format --check .
1340 files already formatted
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12, `uvx ruff@0.15.17` (the version `scripts/verify-ruff-version.py --print-version` reports, matching CI's `pip install ruff==...`).
- Exact command / steps: confirmed `upstream/main` at `904bc675` fails `uvx ruff@0.15.17 format --check .` on `headroom/cli/wrap.py` and that its check-run `lint` is `failure` (while `fd6abac8` before it was green); ran `uvx ruff@0.15.17 format headroom/cli/wrap.py`; re-ran `format --check .`.
- Observed result: before, one file would reformat and the check exits non-zero; after, all 1340 files are already formatted and the check exits zero. The reformat is idempotent (`format --check` on the changed file passes) and touches only the single `click.echo` call.
- Not tested: runtime behavior of the warning path (unchanged by a pure formatting edit).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
