### PR TITLE
fix(cli): attach unwrap-claude decorators to the command, not the helper

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -5262,13 +5262,6 @@ def claude(
 # =============================================================================
 
 
-@unwrap.command("claude")
-@click.option(
-    "--port", "-p", default=8787, type=click.IntRange(1, 65535), help="Proxy port (default: 8787)"
-)
-@click.option("--no-stop-proxy", is_flag=True, help="Do not stop the local Headroom proxy")
-@click.option("--keep-mcp", is_flag=True, help="Keep Headroom MCP registrations")
-@click.option("--keep-rtk", is_flag=True, help="Keep rtk Claude hooks")
 def _warn_if_proxy_env_leaked(port: int) -> None:
     """Issue #2238: surface a proxy URL that survived unwrap in the live shell.
 
@@ -5286,9 +5279,7 @@ def _warn_if_proxy_env_leaked(port: int) -> None:
             leaked.append((name, value))
     if not leaked:
         return
-    click.echo(
-        "  ⚠ Headroom's proxy URL is still exported in this shell's environment:"
-    )
+    click.echo("  ⚠ Headroom's proxy URL is still exported in this shell's environment:")
     for name, value in leaked:
         click.echo(f"      {name}={value}")
     click.echo(
@@ -5303,6 +5294,13 @@ def _warn_if_proxy_env_leaked(port: int) -> None:
     )
 
 
+@unwrap.command("claude")
+@click.option(
+    "--port", "-p", default=8787, type=click.IntRange(1, 65535), help="Proxy port (default: 8787)"
+)
+@click.option("--no-stop-proxy", is_flag=True, help="Do not stop the local Headroom proxy")
+@click.option("--keep-mcp", is_flag=True, help="Keep Headroom MCP registrations")
+@click.option("--keep-rtk", is_flag=True, help="Keep rtk Claude hooks")
 def unwrap_claude(
     port: int,
     no_stop_proxy: bool,


### PR DESCRIPTION
## Description

**`main` is currently red.** CI has failed `lint` and `test (1)` since #2571 landed as `904bc675`. This restores it.

#2571 added `_warn_if_proxy_env_leaked()` directly above `unwrap_claude()`, and the `@unwrap.command("claude")` decorator stack ended up on the **new helper** instead of the command. Click therefore registered the helper as the `unwrap claude` callback and invoked it with all four options:

```
TypeError: _warn_if_proxy_env_leaked() got an unexpected keyword argument 'no_stop_proxy'
TypeError: _warn_if_proxy_env_leaked() got an unexpected keyword argument 'keep_mcp'
```

Meanwhile the real `unwrap_claude` was left undecorated and unreachable.

This is a **live user-facing break**, not just a failing test — `headroom unwrap claude` exits non-zero for anyone on this build.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

Two failures, one file (`headroom/cli/wrap.py`), +8/−10:

- **`test (1)`** — moved the decorator stack (unchanged, character for character) off `_warn_if_proxy_env_leaked` and back onto `unwrap_claude`, leaving the helper a plain function as intended.
- **`lint`** — ran `ruff format` on the file. #2571 also landed one over-length `click.echo(...)` unformatted, which is the separate `ruff format --check` failure.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

No new tests: #2571's own tests already covered this and were failing. They pass now.

### Test Output

```text
$ pytest tests/test_cli/test_unwrap_claude.py -q
tests/test_cli/test_unwrap_claude.py ..............                      [100%]
============================== 14 passed in 0.55s ==============================

$ ruff check .
All checks passed!

$ ruff format --check .
1340 files already formatted

$ mypy headroom
Success: no issues found in 509 source files
```

On `main` the same test file fails 6 of 14 with the `TypeError` above, and `ruff format --check` reports `Would reformat: headroom/cli/wrap.py`.

## Real Behavior Proof

- **Environment:** macOS 25.4.0 (darwin arm64), Python 3.12 in `.venv`.
- **Exact command / steps:** reproduced both failures on unmodified `upstream/main`, applied the fix, re-ran. Then asserted the Click registration directly:
  ```
  >>> from headroom.cli.wrap import unwrap
  >>> unwrap.commands['claude'].callback.__name__
  'unwrap_claude'
  >>> [p.name for p in unwrap.commands['claude'].params]
  ['port', 'no_stop_proxy', 'keep_mcp', 'keep_rtk']
  ```
  On `main` that callback is `_warn_if_proxy_env_leaked`.
- **Observed result:** the command resolves to the right callback with all four options; 14/14 tests pass; all three lint/type gates clean.
- **Not tested:** I did not execute `headroom unwrap claude` against a real wrapped Claude install — the CLI sandbox here can't run mutating `wrap`/`unwrap` commands. Coverage is the existing CliRunner tests plus the registration assertion above. The behaviour #2571 intended (warning on a leaked `ANTHROPIC_BASE_URL`) is untouched by this change — only *where* the decorators sit moved.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A.

## Additional Notes

**Please merge ahead of other open PRs** — every PR branched off `904bc675` or later inherits a red `lint` and `test (1)`, which makes it hard to tell real failures from this one.

**How this reached `main`.** #2571's own CI would have caught it. Branch protection was only enabled on `main` earlier today and does **not** yet require `lint` or `test (1)` — those come from `ci.yml`, which is workflow-level `paths-ignore`-filtered, so requiring them today would deadlock docs-only PRs. #2580 fixes that class of problem for `rust.yml`; `ci.yml` needs the same treatment before `lint` and `test` can be required. Until then a red CI on `main` can still merge.
