### PR TITLE
ci: require ONNX Runtime >= 1.24 in the workflows that feed the Rust core

### DIFF
--- a/.github/workflows/network-diff-capture.yml
+++ b/.github/workflows/network-diff-capture.yml
@@ -43,7 +43,7 @@ jobs:
             'magika>=0.6.0' \
             'zstandard>=0.20.0' \
             'websockets>=13.0' \
-            'onnxruntime>=1.16.0' \
+            'onnxruntime>=1.24' \
             'transformers>=4.30.0' \
             'watchdog>=4.0.0' \
             'sqlite-vec>=0.1.6' \
@@ -107,7 +107,7 @@ jobs:
             'magika>=0.6.0' \
             'zstandard>=0.20.0' \
             'websockets>=13.0' \
-            'onnxruntime>=1.16.0' \
+            'onnxruntime>=1.24' \
             'transformers>=4.30.0' \
             'watchdog>=4.0.0' \
             'sqlite-vec>=0.1.6'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,12 +68,48 @@ jobs:
         # users via the pip `onnxruntime` package.
         run: |
           # >= 1.24, not 1.16: `ort`'s ORT_API_VERSION resolves to 24 because
-          # `fastembed` enables its `api-24` feature. An older runtime does not
-          # fail this job — `ort` deadlocks building the version-mismatch error
-          # (it re-enters the `Once` it is already inside), so the job would
-          # hang silently until the 30-minute timeout.
+          # `fastembed` enables its `api-24` feature.
           pip install 'onnxruntime>=1.24'
-          echo "ORT_DYLIB_PATH=$(python -c "import onnxruntime, pathlib; p = pathlib.Path(onnxruntime.__file__).parent / 'capi'; print(next(iter(sorted(p.glob('libonnxruntime.so*')))))")" >> "$GITHUB_ENV"
+          # Pre-flight, not just a pin. `ort` deadlocks rather than errors on
+          # ANY failure inside `load_dylib_from_path` — a version mismatch and
+          # a library that cannot be resolved at all both re-enter the `Once`
+          # that `setup_api()` is initialising, and `std::sync::Once` blocks
+          # forever on re-entry. Either way the job burns its full 30-minute
+          # timeout at 0% CPU with nothing in the log. Assert both conditions
+          # here so a bad runner fails in seconds with a readable message.
+          python - <<'PY' >> "$GITHUB_ENV"
+          import pathlib, sys
+
+          def die(msg: str) -> None:
+              print(f"::error::{msg}", file=sys.stderr)
+              raise SystemExit(1)
+
+          try:
+              import onnxruntime
+          except Exception as exc:  # noqa: BLE001 - any import failure is fatal here
+              die(f"onnxruntime is not importable: {exc}")
+
+          version = onnxruntime.__version__
+          try:
+              major, minor = (int(part) for part in version.split(".")[:2])
+          except ValueError:
+              die(f"cannot parse onnxruntime version {version!r}")
+          if (major, minor) < (1, 24):
+              die(
+                  f"onnxruntime {version} is too old: ort requires >= 1.24 "
+                  "(ORT_API_VERSION=24, set by fastembed's api-24 feature). "
+                  "ort DEADLOCKS instead of erroring below this, so the tests "
+                  "would hang rather than fail."
+              )
+
+          capi = pathlib.Path(onnxruntime.__file__).parent / "capi"
+          libs = sorted(capi.glob("libonnxruntime.so*")) or sorted(capi.glob("libonnxruntime*.dylib"))
+          if not libs:
+              die(f"no libonnxruntime shared library under {capi}")
+
+          print(f"ORT_DYLIB_PATH={libs[0]}")
+          print(f"onnxruntime {version} -> {libs[0]}", file=sys.stderr)
+          PY
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
       - name: cargo clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,12 @@ jobs:
         # at it — same contract `headroom/_ort.py` fulfills for Python
         # users via the pip `onnxruntime` package.
         run: |
-          pip install 'onnxruntime>=1.16.0'
+          # >= 1.24, not 1.16: `ort`'s ORT_API_VERSION resolves to 24 because
+          # `fastembed` enables its `api-24` feature. An older runtime does not
+          # fail this job — `ort` deadlocks building the version-mismatch error
+          # (it re-enters the `Once` it is already inside), so the job would
+          # hang silently until the 30-minute timeout.
+          pip install 'onnxruntime>=1.24'
           echo "ORT_DYLIB_PATH=$(python -c "import onnxruntime, pathlib; p = pathlib.Path(onnxruntime.__file__).parent / 'capi'; print(next(iter(sorted(p.glob('libonnxruntime.so*')))))")" >> "$GITHUB_ENV"
       - name: cargo fmt --check
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Description

Every onnxruntime floor in the repo was `>=1.16.0` (and `>=1.7` in the image extra). The Rust core actually requires **1.24**, and below that `ort` **deadlocks instead of erroring** — the process hangs at 0% CPU with no message.

This is not a CI-only concern. `headroom/_ort.py` exports `ORT_DYLIB_PATH` pointing at whichever pip `onnxruntime` is installed, so a user who resolves 1.16–1.23 hands the Rust core an incompatible runtime.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Why 1.24

`ort-sys` computes `ORT_API_VERSION = 17 + one per enabled api-N feature`, and Cargo features are additive across the whole graph:

```
$ cargo tree -p headroom-core -e features -i ort-sys
ort feature "api-17" -> "api-18" -> ... -> "api-24" -> fastembed v5.17.3
```

`fastembed 5.17.3` enables `api-24`, so the constant resolves to **24** and `ort` rejects any runtime with a lower minor version.

## Why the failure mode is a hang, not an error

On rejection, `ort` calls `Error::new(...)` from inside `load_dylib_from_path`, which is itself running inside the `Once` that `setup_api()` is initialising. Constructing the error re-enters that same `Once`, and `std::sync::Once` blocks forever on re-entry:

```
Session::builder() -> setup_api() -> OnceLock::get_or_try_init      <- outer Once
  -> load_dylib_from_path() -> OnceLock::get_or_try_init            <- inner Once
    -> version check fails -> ort::error::Error::new -> ...         <- blocks here
```

That is an upstream `ort` bug (rc.12), but the trigger is our version floor, and raising the floor removes it.

## Changes Made

| Site | Before | After |
|---|---|---|
| `pyproject.toml` `[proxy]` | `onnxruntime>=1.16.0` | `>=1.24` |
| `pyproject.toml` `[voice]` | `onnxruntime>=1.16.0` | `>=1.24` |
| `pyproject.toml` `[image]` | `onnxruntime>=1.7,<2` (py3.13+) | `>=1.24,<2` |
| `.github/workflows/rust.yml` | `onnxruntime>=1.16.0` | `>=1.24` |
| `.github/workflows/network-diff-capture.yml` (×2) | `onnxruntime>=1.16.0` | `>=1.24` |

Each carries a comment explaining the derivation, so the number can be re-checked when `fastembed` moves.

## Testing

- [ ] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

Dependency-metadata and CI-config only; no Python or Rust source changed.

### Test Output

```text
$ python -c "tomllib.load(...)"
  [proxy]: ['onnxruntime>=1.24']
  [image]: ["onnxruntime>=1.24,<2; python_version>='3.13'"]
  [voice]: ['onnxruntime>=1.24']
TOML OK

$ python -c "yaml.safe_load(...)"
  .github/workflows/rust.yml ok
  .github/workflows/network-diff-capture.yml ok

$ ruff check .
All checks passed!

$ grep -rn "onnxruntime>=1.16.0" .github/ pyproject.toml
  none
```

## Real Behavior Proof

- **Environment:** macOS 25.4.0 (darwin arm64), rustc 1.95.0, `ort 2.0.0-rc.12`.
- **Exact command / steps:** built a standalone probe calling `ort::session::Session::builder()` and `commit_from_file()` with nothing else in the process, and ran it against two runtimes.
- **Observed result:**
  - onnxruntime **1.21.1** → `builder()` never returns. Killed after >1 hour at **0.0% CPU / 528 KB RSS**. `sample(1)` shows the stack parked in `ort::error::Error::new` inside the nested `Once`. Setting `ORT_DYLIB_PATH` correctly makes **no** difference — I verified this specifically, because it is the obvious first guess.
  - onnxruntime **1.24.4** → `builder()` ok in **1.18s**, `commit_from_file()` ok in **0.93s**.
- **Downstream confirmation:** with 1.24.4 the parity harness completes and the previously-unrunnable kompress fixtures pass — `[kompress] total=21 matched=21 skipped=0 diffed=0`, whole run exit 0.
- **Not tested:** I did not run a full resolver pass for the `[image]` extra on Python 3.13 to confirm `rapidocr 3.x` accepts `onnxruntime>=1.24,<2`. It is the only floor here I raised across a third-party constraint; CI's image/e2e jobs will exercise it, and if the resolver objects, that one line can be reverted independently of the rest.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

No test added: the regression is a dependency floor, and the only faithful test would be installing an old runtime and asserting a hang — which is precisely the unbounded behaviour being removed.

## Screenshots (if applicable)

N/A.

## Additional Notes

**Why this is worth landing ahead of the Rust compressor stack.** #1155 adds a `kompress-parity` job that deliberately warms the ONNX model into the HF cache — the exact condition that triggers this. With the old floor, a runner resolving anything below 1.24 would not fail that job; it would hang until the 30-minute timeout, with no error to diagnose. #1153 and #1154 are unaffected in CI today only because the model is absent there, so the comparator errors out before reaching `Session::builder()`.

**It works today by luck.** `>=1.16.0` lets pip pick the newest wheel, which is currently ≥1.24. Any constraint, cache, or platform that pins lower reintroduces the hang.

**Touches `rust.yml`, as does #2580.** Different regions (that PR edits the `on:` block and job gates; this one edits a step inside `test`), so they should merge cleanly in either order.

**Worth reporting upstream to `pyke-io/ort`** — "version-mismatch error path deadlocks instead of returning `Err`" is a genuine bug, and rc.12 is what we pin. I have not filed it.
