### PR TITLE
docs(readme): describe CacheAligner as detector-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Headroom compresses everything your AI agent reads — tool outputs, logs, RAG c
 
 - **ContentRouter** — detects content type, selects the right compressor
 - **SmartCrusher / CodeCompressor / Kompress-v2-base** — compress JSON, AST, or prose
-- **CacheAligner** — stabilizes prefixes so provider KV caches actually hit
+- **CacheAligner** - detects and warns about volatile content that can bust provider KV cache prefixes; never rewrites prompts
 - **CCR** — stores originals locally; LLM calls `headroom_retrieve` if it needs them
 
 → [Architecture](https://headroom-docs.vercel.app/docs/architecture) · [CCR reversible compression](https://headroom-docs.vercel.app/docs/ccr) · [Kompress-v2-base model card](https://huggingface.co/chopratejas/kompress-v2-base)
@@ -319,7 +319,7 @@ Platform support note: macOS auth reuse via Copilot CLI Keychain storage has bee
 - **CodeCompressor** — AST-aware for Python, JS/TS, Go, Rust, Java, C/C++, Perl.
 - **Kompress-v2-base** — our HuggingFace model, trained on agentic traces.
 - **Image compression** — 40–90% reduction via trained ML router.
-- **CacheAligner** — stabilizes prefixes so Anthropic/OpenAI KV caches actually hit.
+- **CacheAligner** - detects and warns about volatile content that can bust provider KV cache prefixes; never rewrites prompts.
 - **Live-zone compression** — compresses only new bytes (fresh tool output, latest turn); frozen prefix stays byte-identical so provider cache is not busted. History is never dropped.
 - **CCR** — reversible compression; LLM retrieves originals on demand.
 - **Cross-agent memory** — shared store, agent provenance, auto-dedup.


### PR DESCRIPTION
## Description

README still described CacheAligner as a component that stabilizes prefixes for provider KV cache hits. On current main, CacheAligner is detector-only: it warns about volatile content and does not rewrite prompts. Prefix stability is already covered by live-zone compression.

Closes #2592

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Updated the How it works CacheAligner bullet to detector-only detect/warn wording
- Updated the What's inside CacheAligner bullet the same way
- Left the architecture diagram stage name and live-zone compression description unchanged

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ rg -n "CacheAligner" README.md
69:    │  CacheAligner  →  ContentRouter  →  CCR            │
83:- **CacheAligner** - detects and warns about volatile content that can bust provider KV cache prefixes; never rewrites prompts
322:- **CacheAligner** - detects and warns about volatile content that can bust provider KV cache prefixes; never rewrites prompts.
338:- **Transforms** do the work: CacheAligner → ContentRouter → SmartCrusher / CodeCompressor / Kompress-base (live-zone only; IntelligentContext and RollingWindow were retired in PR-B1).

$ rg -n "CacheAligner.*stabilizes prefixes" README.md || echo OLD_CLAIM_ABSENT
OLD_CLAIM_ABSENT

$ git diff --stat
 README.md | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

## Real Behavior Proof

- Environment: Linux VPS, Python 3.11.15, sparse checkout of headroomlabs-ai/headroom main at f74d874, branch fix/readme-cache-aligner-detector-only-2592
- Exact command / steps: `rg -n "CacheAligner" README.md`; `rg -n "CacheAligner.*stabilizes prefixes" README.md || echo OLD_CLAIM_ABSENT`; `git diff --stat`
- Observed result: both README CacheAligner bullets use detector-only wording; old "stabilizes prefixes" claim for CacheAligner is absent; diff is README.md only (+2/-2)
- Not tested: docs-site marketing.tsx and wiki/index.md still carry older CacheAligner marketing copy (out of scope for this README issue); no runtime proxy/pytest path (docs-only)

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A

## Additional Notes

- Scope is README only for #2592. Marketing site / wiki wording can be a follow-up if maintainers want the same detector-only language there.
