### PR TITLE
docs(benchmarks): remove unreproducible savings claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,7 @@ args = ["mcp", "serve"]
 
 ## Proof
 
-**Savings on real agent workloads:**
-
-| Workload                      | Before | After  | Savings |
-|-------------------------------|-------:|-------:|--------:|
-| Code search (100 results)     | 17,765 |  1,408 | **92%** |
-| SRE incident debugging        | 65,694 |  5,118 | **92%** |
-| GitHub issue triage           | 54,174 | 14,761 | **73%** |
-| Codebase exploration          | 78,502 | 41,254 | **47%** |
+See the [benchmark methodology and reproduction instructions](https://headroom-docs.vercel.app/docs/benchmarks), including Compression Performance.
 
 **Accuracy preserved on standard benchmarks:**
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -72,12 +72,7 @@ Headroom works as a **transparent proxy** (zero code changes), a **Python functi
 
 87.6% fewer tokens. Same answer. The FATAL error was automatically preserved -- not by keyword matching, but by statistical analysis of field variance.
 
-| Scenario | Before | After | Savings |
-|---|---|---|---|
-| Code search (100 results) | 17,765 | 1,408 | **92%** |
-| SRE incident debugging | 65,694 | 5,118 | **92%** |
-| Codebase exploration | 78,502 | 41,254 | **47%** |
-| GitHub issue triage | 54,174 | 14,761 | **73%** |
+See the [benchmark methodology and reproduction instructions](/docs/benchmarks).
 
 ## Key Features
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -288,15 +288,6 @@ Context management is handled automatically inside the pipeline (live-zone-only 
 
 **87.6% fewer tokens. Same answer.** The FATAL error was automatically preserved — not by keyword matching, but by statistical analysis of field variance.
 
-### Real Workloads
-
-| Scenario | Before | After | Savings |
-|----------|--------|-------|---------|
-| Code search (100 results) | 17,765 | 1,408 | **92%** |
-| SRE incident debugging | 65,694 | 5,118 | **92%** |
-| Codebase exploration | 78,502 | 41,254 | **47%** |
-| GitHub issue triage | 54,174 | 14,761 | **73%** |
-
 ### Accuracy Benchmarks
 
 | Benchmark | Category | N | Accuracy | Compression |


### PR DESCRIPTION
## Description

The README, docs homepage, and wiki publish four exact real-agent savings rows that the repository cannot reproduce. The current benchmark runner defines only three of the four named scenarios, generates inputs with unseeded randomness, and obtains token usage from a live OpenAI response without a checked-in result artifact.

This change removes those unsupported exact figures from all three publication surfaces and directs readers to the repository's existing benchmark methodology and reproduction instructions. Runtime and benchmark behavior stay unchanged. The related report in [issue #1890](https://github.com/headroomlabs-ai/headroom/issues/1890) raised the same savings-table gap among broader benchmark questions.

Closes #2593

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Remove the unsupported four-row real-agent savings table from `README.md` and link to the benchmark methodology.
- Remove the matching table from `docs/content/docs/index.mdx` and route readers to `/docs/benchmarks`.
- Remove the matching table from `wiki/index.md` while retaining its benchmark methodology link.
- Leave the benchmark runner and every unrelated benchmark table unchanged.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [x] Type checking passes (`npm --prefix docs run types:check`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
base: README savings table present; head: README savings table removed
base: 2 mirrored savings tables present; head: 0 mirrored savings tables present
benchmark links: checked-in methodology targets exist and all 3 publication surfaces link to them
boundary GSM8K: unrelated benchmark sections preserved
npm --prefix docs run types:check: clean exit
git diff --check: clean exit
```

## Real Behavior Proof

- Environment: Windows, Python environment synchronized with `uv sync --extra dev`, Node 20 or newer, no provider credentials.
- Exact command / steps: compared `origin/main` and the edited worktree with focused content assertions, validated all benchmark links, ran the docs MDX/type-generation command, and inspected the zero-context diff.
- Observed result: the unsupported savings table is absent from the README, docs homepage, and wiki; all three surfaces retain a route to the benchmark methodology; unrelated benchmark content is unchanged.
- Not tested: live OpenAI benchmark regeneration

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

Not applicable; this is a text-only documentation correction.

## Additional Notes

Python unit tests, Ruff, and mypy are not applicable because the patch changes only Markdown and MDX. The focused base/head assertions validate the reported claim, its mirrors, the checked-in benchmark link targets, and the rendered documentation source. A seeded, versioned live-provider benchmark artifact remains separate follow-up work.
