### PR TITLE
fix(read-lifecycle): don't mark a Read stale on a failed edit

### DIFF
--- a/headroom/transforms/read_lifecycle.py
+++ b/headroom/transforms/read_lifecycle.py
@@ -131,7 +131,12 @@ class ReadLifecycleManager:
 
         # Phase 1: Build tool metadata and file operation index
         tool_metadata = self._build_tool_metadata(messages)
-        file_ops = self._build_file_operation_index(messages, tool_metadata)
+        # A tool call whose result reported an error did not actually run: a
+        # failed Edit/Write left the file unchanged (so it must not mark a prior
+        # Read stale), and a failed Read produced no content (so it can't
+        # supersede an earlier one). Drop those ops before classifying.
+        failed_ids = self._failed_tool_call_ids(messages)
+        file_ops = self._build_file_operation_index(messages, tool_metadata, failed_ids)
 
         # Phase 2: Classify each Read
         classifications = self._classify_reads(file_ops)
@@ -222,19 +227,52 @@ class ReadLifecycleManager:
 
         return metadata
 
+    @staticmethod
+    def _failed_tool_call_ids(messages: list[dict[str, Any]]) -> set[str]:
+        """Tool-call IDs whose result reported an error.
+
+        Uses the Anthropic ``tool_result.is_error`` flag, which Claude Code sets
+        on failed tool calls (e.g. an Edit whose ``old_string`` was not found).
+        A failed call did not change the file, so it must not drive Read
+        lifecycle decisions. OpenAI-format tool results carry no structured
+        error flag, so they are left untouched here (no behavior change there).
+        """
+        failed: set[str] = set()
+        for msg in messages:
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if (
+                    isinstance(block, dict)
+                    and block.get("type") == "tool_result"
+                    and block.get("is_error") is True
+                ):
+                    tc_id = block.get("tool_use_id", "")
+                    if tc_id:
+                        failed.add(tc_id)
+        return failed
+
     def _build_file_operation_index(
         self,
         messages: list[dict[str, Any]],
         tool_metadata: dict[str, tuple[str, str | None, int | None, int | None]],
+        failed_ids: set[str] | None = None,
     ) -> dict[str, list[FileOperation]]:
         """Build file_path → [FileOperation] index in a single pass.
 
         Groups all Read/Edit/Write operations by file_path for lifecycle analysis.
+        Tool calls in ``failed_ids`` (their result reported an error) are skipped:
+        a failed edit did not change the file and a failed read produced no
+        content, so neither should affect a Read's classification.
         """
         file_ops: dict[str, list[FileOperation]] = defaultdict(list)
+        failed_ids = failed_ids or set()
 
         for tc_id, (name, file_path, offset, limit) in tool_metadata.items():
             if not file_path:
+                continue
+            if tc_id in failed_ids:
                 continue
 
             if name in _READ_TOOL_NAMES:

--- a/tests/test_transforms/test_read_lifecycle.py
+++ b/tests/test_transforms/test_read_lifecycle.py
@@ -126,17 +126,18 @@ def make_anthropic_edit(tool_call_id: str, file_path: str) -> dict:
     }
 
 
-def make_anthropic_tool_result(tool_call_id: str, content: str) -> dict:
+def make_anthropic_tool_result(tool_call_id: str, content: str, is_error: bool = False) -> dict:
     """Create an Anthropic-format user message with a tool_result block."""
+    block: dict = {
+        "type": "tool_result",
+        "tool_use_id": tool_call_id,
+        "content": content,
+    }
+    if is_error:
+        block["is_error"] = True
     return {
         "role": "user",
-        "content": [
-            {
-                "type": "tool_result",
-                "tool_use_id": tool_call_id,
-                "content": content,
-            }
-        ],
+        "content": [block],
     }
 
 
@@ -197,6 +198,47 @@ class TestStaleDetection:
         assert "stale" in tool_result["content"].lower()
         assert "/src/app.py" in tool_result["content"]
         assert "hash=" in tool_result["content"]
+
+    def test_failed_edit_does_not_make_read_stale(self):
+        """Read(A) → Edit(A) that FAILED (is_error): file unchanged, Read stays fresh.
+
+        A failed Edit (e.g. old_string not found) does not modify the file, so
+        the earlier Read is still accurate and must not be marked stale.
+        """
+        config = ReadLifecycleConfig(enabled=True)
+        mgr = ReadLifecycleManager(config)
+
+        messages = [
+            make_anthropic_read("r1", "/src/app.py"),
+            make_anthropic_tool_result("r1", LARGE_CONTENT),
+            make_anthropic_edit("e1", "/src/app.py"),
+            make_anthropic_tool_result(
+                "e1", "Error: String to replace not found in file.", is_error=True
+            ),
+        ]
+
+        result = mgr.apply(messages)
+        assert result.reads_stale == 0
+        assert result.reads_fresh == 1
+        assert result.transforms_applied == []
+
+    def test_failed_then_successful_edit_still_makes_read_stale(self):
+        """A later SUCCESSFUL edit still marks the Read stale even if an earlier edit failed."""
+        config = ReadLifecycleConfig(enabled=True)
+        mgr = ReadLifecycleManager(config)
+
+        messages = [
+            make_anthropic_read("r1", "/src/app.py"),
+            make_anthropic_tool_result("r1", LARGE_CONTENT),
+            make_anthropic_edit("e1", "/src/app.py"),
+            make_anthropic_tool_result("e1", "Error: not found", is_error=True),
+            make_anthropic_edit("e2", "/src/app.py"),
+            make_anthropic_tool_result("e2", "edit success"),
+        ]
+
+        result = mgr.apply(messages)
+        assert result.reads_stale == 1
+        assert result.reads_fresh == 0
 
     def test_write_makes_read_stale(self):
         """Read(A) → Write(A): Read becomes stale."""


### PR DESCRIPTION
## Description

`ReadLifecycleManager` marks a Read output STALE when a later Edit/Write targets the same file. The staleness check looks only at tool *calls*, never at whether the edit actually succeeded:

```python
is_stale = self.config.compress_stale and any(
    e.msg_index > read_op.msg_index for e in edits
)
```

`edits` is built purely from assistant tool-use blocks (`_build_file_operation_index` never consults the tool result). So a **failed** Edit still counts. Failed edits are common in agentic coding: Claude Code frequently gets `String to replace not found in file` when an `old_string` no longer matches, and the tool result comes back with `is_error: true`. The file is unchanged, so the earlier Read is still accurate, yet it gets replaced with a stale marker plus a CCR hash. That both misleads the model (the marker says the file was edited when it was not) and forces an unnecessary retrieval to get content that was correct all along.

`compress_stale` and `enabled` are both on by default (`ReadLifecycleConfig`), so this happens in normal Claude Code sessions.

## Fix

Before building the file-operation index, collect the tool-call IDs whose Anthropic tool_result carries `is_error: true`, and skip those operations. A failed edit no longer triggers staleness, and a failed read (no real content) can no longer supersede an earlier read. A later *successful* edit still marks the Read stale.

The Anthropic `is_error` flag is the reliable signal (it is what Claude Code sets). OpenAI-format tool results carry no structured error flag, so they are left exactly as today (no behavior change on that path).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- `headroom/transforms/read_lifecycle.py`: add `_failed_tool_call_ids()` (scans tool_result blocks for `is_error: true`); `_build_file_operation_index()` takes a `failed_ids` set and skips those tool calls; `apply()` threads it through.
- `tests/test_transforms/test_read_lifecycle.py`: `make_anthropic_tool_result` gains an `is_error` flag; add `test_failed_edit_does_not_make_read_stale` and `test_failed_then_successful_edit_still_makes_read_stale`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check` / `ruff format --check`)
- [x] Type checking passes (`mypy`)
- [x] New tests added for the fix
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_transforms/test_read_lifecycle.py -q
25 passed

$ uvx ruff@0.15.17 check headroom/transforms/read_lifecycle.py tests/test_transforms/test_read_lifecycle.py
All checks passed!
$ uvx ruff@0.15.17 format --check headroom/transforms/read_lifecycle.py tests/test_transforms/test_read_lifecycle.py
2 files already formatted
$ uvx mypy@1.20.2 --ignore-missing-imports headroom/transforms/read_lifecycle.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12, project venv (`uv sync --extra proxy`), `uvx ruff@0.15.17` / `uvx mypy@1.20.2`, pytest in the venv.
- Exact command / steps: built a `ReadLifecycleManager(ReadLifecycleConfig(enabled=True, compress_stale=True))` and drove `apply()` on an Anthropic message list of Read(/src/app.py) then Edit(/src/app.py) whose tool_result was `is_error=True`; then repeated with a success result and with a failed-then-successful edit.
- Observed result: before the fix the read was classified STALE (`reads_stale=1`, transform `read_lifecycle:stale:/src/app.py` emitted) even though the edit failed; after the fix the same failed-edit case leaves it FRESH (`reads_stale=0`, `reads_fresh=1`, no transform), a successful edit still yields STALE, and a failed-then-successful edit still yields STALE. Ran against the actual module.
- Not tested: a live end-to-end Claude Code session (the classifier is exercised directly instead).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
