### PR TITLE
fix(tool-schema): preserve $defs/definitions subschemas named like annotations

### DIFF
--- a/headroom/proxy/tool_schema_compaction.py
+++ b/headroom/proxy/tool_schema_compaction.py
@@ -56,6 +56,22 @@ TOOL_SCHEMA_DROP_KEYS: frozenset[str] = frozenset(
     }
 )
 
+# JSON Schema keywords whose direct children are *names* (property names,
+# reusable-subschema names, dependency triggers), NOT schema annotations. A
+# child key under one of these must never be dropped even when it happens to
+# equal a name in TOOL_SCHEMA_DROP_KEYS: e.g. a `$defs` entry named "title" is a
+# reusable subschema (referenced by `$ref: #/$defs/title`), and dropping it
+# leaves a dangling reference that breaks the tool schema.
+TOOL_SCHEMA_NAME_CONTAINERS: frozenset[str] = frozenset(
+    {
+        "properties",
+        "$defs",
+        "definitions",
+        "patternProperties",
+        "dependentSchemas",
+    }
+)
+
 # Parameter names that are self-explanatory.  When ``description``
 # matches the name (case-insensitive prefix), it can be stripped.
 _SEMANTIC_PARAM_NAMES: frozenset[str] = frozenset(
@@ -212,9 +228,10 @@ def compact_tool_schema_value(
 ) -> Any:
     """Recursively compact a tool-schema structure.
 
-    - Drops annotation keys (``TOOL_SCHEMA_DROP_KEYS``) unless they appear
-      as property *names* inside a ``properties`` object (e.g. a field
-      literally named ``"title"`` must survive).
+    - Drops annotation keys (``TOOL_SCHEMA_DROP_KEYS``) unless they appear as
+      *names* inside a name-container keyword (``TOOL_SCHEMA_NAME_CONTAINERS``,
+      e.g. ``properties`` or ``$defs``). A field literally named ``"title"`` or
+      a ``$defs`` subschema named ``"title"`` must survive.
     - Normalises ``description`` strings by collapsing whitespace.
     """
     if isinstance(value, list):
@@ -225,9 +242,11 @@ def compact_tool_schema_value(
 
     compacted: dict[str, Any] = {}
     for key, child in value.items():
-        # Don't drop keys that are property *names* inside a JSON Schema
-        # `properties` object — only drop them when they are schema annotations.
-        if _parent_key != "properties" and key in TOOL_SCHEMA_DROP_KEYS:
+        # Don't drop keys that are *names* inside a JSON Schema name container
+        # (`properties`, `$defs`, `definitions`, ...) — a `$defs` entry named
+        # "title" is a reusable subschema referenced by `$ref`, not an
+        # annotation. Only drop these keys when they are schema annotations.
+        if _parent_key not in TOOL_SCHEMA_NAME_CONTAINERS and key in TOOL_SCHEMA_DROP_KEYS:
             continue
 
         if key == "description" and isinstance(child, str):

--- a/tests/test_tool_schema_compaction.py
+++ b/tests/test_tool_schema_compaction.py
@@ -52,6 +52,39 @@ class TestCompactToolSchemaValue:
         assert "title" in props, "property named 'title' must survive"
         assert "code" in props
 
+    def test_preserves_defs_subschema_named_like_annotation(self) -> None:
+        """A `$defs` entry named 'title' is a reusable subschema (referenced by
+        `$ref`), not an annotation, so it must survive — dropping it would leave
+        a dangling reference that breaks the schema. Annotations *inside* the
+        subschema are still dropped."""
+        schema = {
+            "type": "object",
+            "properties": {"field": {"$ref": "#/$defs/title"}},
+            "$defs": {
+                "title": {
+                    "type": "string",
+                    "title": "annotation-should-drop",
+                    "enum": ["a", "b"],
+                },
+            },
+        }
+        result = compact_tool_schema_value(schema)
+        defs = result["$defs"]
+        assert "title" in defs, "$defs subschema named 'title' must survive (ref target)"
+        # The annotation *inside* the subschema is still dropped.
+        assert "title" not in defs["title"], "annotation inside the subschema should drop"
+        assert defs["title"]["enum"] == ["a", "b"], "real constraints inside must survive"
+
+    def test_preserves_definitions_subschema_named_like_annotation(self) -> None:
+        """Same protection for the draft-07 `definitions` keyword."""
+        schema = {
+            "type": "object",
+            "properties": {"field": {"$ref": "#/definitions/example"}},
+            "definitions": {"example": {"type": "integer"}},
+        }
+        result = compact_tool_schema_value(schema)
+        assert "example" in result["definitions"], "definitions entry must survive"
+
     def test_normalises_description_whitespace(self) -> None:
         schema = {
             "name": "my_tool",


### PR DESCRIPTION
## Description

`compact_tool_schema_value` (the Layer 1 tool-schema compactor, run as a turn hook on outgoing tool definitions) drops JSON Schema annotation keys such as `title`, `example`, `deprecated`, `readOnly`. To avoid deleting a real field that happens to be *named* like an annotation, it guards on the parent key:

```python
if _parent_key != "properties" and key in TOOL_SCHEMA_DROP_KEYS:
    continue
```

The guard only protects names inside a `properties` object. But `properties` is not the only JSON Schema keyword whose children are names rather than annotations. Reusable subschemas live under `$defs` (2020-12) and `definitions` (draft-07), and are referenced by `$ref`. So a subschema named `title` (i.e. `$defs.title`, referenced by `$ref: "#/$defs/title"`) is dropped as if it were an annotation, which leaves a **dangling `$ref`** and corrupts the tool schema. Strict providers reject a schema with an unresolvable `$ref` with a 400.

Reproduced directly against the module:

```python
schema = {
    "type": "object",
    "properties": {"field": {"$ref": "#/$defs/title"}},
    "$defs": {"title": {"type": "string", "enum": ["a", "b"]}},
}
compact_tool_schema_value(schema)["$defs"]   # -> {}  (the $ref now dangles)
```

## Fix

Introduce `TOOL_SCHEMA_NAME_CONTAINERS` (`properties`, `$defs`, `definitions`, `patternProperties`, `dependentSchemas`) and protect drop-key names under any of them, not just `properties`:

```python
if _parent_key not in TOOL_SCHEMA_NAME_CONTAINERS and key in TOOL_SCHEMA_DROP_KEYS:
    continue
```

This only ever preserves keys that were previously dropped, so it cannot over-compress or change any schema that already worked. Annotations *inside* each subschema are still dropped (e.g. a `title` annotation on the `$defs.title` subschema is removed; its `enum` and `type` are kept), so real compression is unaffected.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- `headroom/proxy/tool_schema_compaction.py`: add `TOOL_SCHEMA_NAME_CONTAINERS`; `compact_tool_schema_value` protects drop-key names under any name container, not only `properties`.
- `tests/test_tool_schema_compaction.py`: add `test_preserves_defs_subschema_named_like_annotation` and `test_preserves_definitions_subschema_named_like_annotation`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check` / `ruff format --check`)
- [x] Type checking passes (`mypy`)
- [x] New tests added for the fix
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_tool_schema_compaction.py -q
29 passed

# with the fix reverted, the two new tests fail (the $defs/definitions
# subschema is dropped, leaving a dangling $ref):
$ git stash push headroom/proxy/tool_schema_compaction.py && \
    python -m pytest tests/test_tool_schema_compaction.py -k named_like_annotation -q
2 failed

$ uvx ruff@0.15.17 check headroom/proxy/tool_schema_compaction.py tests/test_tool_schema_compaction.py
All checks passed!
$ uvx mypy@1.20.2 --ignore-missing-imports headroom/proxy/tool_schema_compaction.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12, project venv (`uv sync --extra proxy`), `uvx ruff@0.15.17` / `uvx mypy@1.20.2`, pytest in the venv.
- Exact command / steps: called `compact_tool_schema_value` on a schema whose `properties.field` is `{"$ref": "#/$defs/title"}` with a matching `$defs.title` subschema (that also carried a `title` annotation and an `enum`); then reverted the source and re-ran the two new tests.
- Observed result: with the fix the `$defs.title` subschema is preserved (so the `$ref` resolves), the inner `title` annotation is dropped, and `enum`/`type` are kept; a field literally named `deprecated` under `properties` still survives; with the fix reverted the whole `$defs.title` subschema is dropped (`$defs` becomes `{}`) and the `$ref` dangles. Ran against the actual module.
- Not tested: a live request to a provider that 400s on an unresolvable `$ref` (the corruption is verified at the transform boundary instead).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
