### PR TITLE
fix(proxy/cost): stop double-charging OpenAI non-cached input in stats

### DIFF
--- a/headroom/proxy/cost.py
+++ b/headroom/proxy/cost.py
@@ -907,8 +907,24 @@ class CostTracker:
             uncached = info.get("input_cost_per_token")
             if not uncached:
                 return None
-            cache_read = info.get("cache_read_input_token_cost", uncached)
-            cache_write = info.get("cache_creation_input_token_cost", uncached)
+            cc_cost = info.get("cache_creation_input_token_cost")
+            cr_cost = info.get("cache_read_input_token_cost")
+            cache_read = cr_cost if cr_cost is not None else uncached
+            # Cache-write price. A provider that prices cache READS but not cache
+            # CREATION (OpenAI-family) uses a read-discount model with NO write
+            # premium: the written tokens are already billed once as uncached
+            # input, and the OpenAI handler reports cache_write == uncached for
+            # them, so pricing a separate cache_write at the full input rate
+            # double-charges the non-cached input (~2x for a low-hit request).
+            # Treat writes as free there. Anthropic prices cache_creation
+            # explicitly (Sonnet/Opus), so it is unaffected; a model with no
+            # cache pricing at all (e.g. Haiku here) keeps the full-price default.
+            if cc_cost is not None:
+                cache_write = cc_cost
+            elif cr_cost is not None:
+                cache_write = 0.0
+            else:
+                cache_write = uncached
             return (cache_read, cache_write, uncached)
         except Exception:
             return None

--- a/tests/test_cost_tracker_counterfactual.py
+++ b/tests/test_cost_tracker_counterfactual.py
@@ -49,6 +49,45 @@ def test_savings_at_list_price():
     assert abs(stats["savings_usd"] - expected) < 0.001
 
 
+def test_openai_cache_write_not_double_charged():
+    """OpenAI has no cache-write premium, so cache_write tokens (which equal the
+    uncached tokens for OpenAI: input - cache_read) must not be billed a second
+    time on top of uncached input. Regression for the ~2x cost over-report in
+    stats() where _get_cache_prices defaulted the write price to the full input
+    rate for a read-discount provider.
+    """
+    import litellm
+
+    from headroom.pricing.litellm_pricing import resolve_litellm_model
+    from headroom.proxy.server import CostTracker
+
+    model = "gpt-4o"
+    info = litellm.model_cost.get(resolve_litellm_model(model), {})
+    uncached_price = info.get("input_cost_per_token")
+    cache_read_price = info.get("cache_read_input_token_cost", uncached_price)
+    # The exact shape that triggered the bug: cache reads priced, creation not.
+    assert info.get("cache_creation_input_token_cost") is None
+
+    ct = CostTracker()
+    input_tokens, cache_read = 100_000, 20_000
+    non_cached = input_tokens - cache_read  # what the OpenAI handler reports for BOTH
+    ct.record_tokens(
+        model,
+        tokens_saved=0,
+        tokens_sent=input_tokens,
+        cache_read_tokens=cache_read,
+        cache_write_tokens=non_cached,
+        uncached_tokens=non_cached,
+    )
+    stats = ct.stats()
+
+    # Correct: cached at the read discount + uncached at full, NO write charge.
+    expected = cache_read * cache_read_price + non_cached * uncached_price
+    doubled = expected + non_cached * uncached_price  # the buggy figure
+    assert abs(stats["cost_with_headroom_usd"] - expected) < 0.001
+    assert stats["cost_with_headroom_usd"] < doubled - 0.001
+
+
 def test_savings_monotonic():
     """Adding more saved tokens always increases savings_usd."""
     from headroom.proxy.server import CostTracker


### PR DESCRIPTION
## Description

`CostTracker.stats()` computes each model's input cost as:

```python
model_cost = cr * cr_price + cw * cw_price + uncached * uncached_price
```

where `cr`/`cw`/`uncached` are the accumulated cache-read, cache-write, and uncached token counts, and the per-token prices come from `_get_cache_prices()`. This assumes the three token buckets are disjoint (the Anthropic model: `input_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens` are separate counts). For OpenAI that assumption breaks.

OpenAI has no separate cache-creation charge, so the handler reports the same value for both cache-write and uncached tokens:

```python
# headroom/proxy/handlers/openai.py
cache_write_tokens = _infer_openai_cache_write_tokens(total_input_tokens, cache_read_tokens)  # input - cache_read
...
uncached_input_tokens = max(0, total_input_tokens - cache_read_tokens)                        # input - cache_read  (same)
```

Both then reach `record_tokens`. Meanwhile `_get_cache_prices()` defaulted the cache-write price to the full input rate whenever litellm had no `cache_creation_input_token_cost`, which is exactly the case for OpenAI models (they only carry `cache_read_input_token_cost`). So the non-cached input is billed twice: once as `cache_write` at the full rate, once as `uncached` at the full rate.

Measured on gpt-4o with 100k input / 20k cached:

```
stats() reported: $0.4250
correct:          $0.2250   (89% over-report)
```

The budget path (`estimate_cost` -> `litellm.cost_per_token`) is not affected because litellm prices OpenAI cache creation at zero; only the `stats()` dollar figure (dashboard `cost_with_headroom_usd` / `/stats`) was inflated.

## Fix

Price cache writes as free when a model prices cache READS but not cache CREATION (the read-discount shape OpenAI uses). Anthropic Sonnet/Opus price `cache_creation_input_token_cost` explicitly, so they are unchanged; a model with no cache pricing at all keeps the prior full-price default. The check is robust to a key that is present-but-null.

```python
cc_cost = info.get("cache_creation_input_token_cost")
cr_cost = info.get("cache_read_input_token_cost")
if cc_cost is not None:
    cache_write = cc_cost          # Anthropic: real creation price
elif cr_cost is not None:
    cache_write = 0.0              # OpenAI: read discount, no write premium
else:
    cache_write = uncached         # no cache pricing data: prior default
```

This matches the dashboard's own economics table, which already models OpenAI with `write_multiplier = 1.0` (no premium).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- `headroom/proxy/cost.py`: `_get_cache_prices()` prices cache writes as free for read-discount providers (cache-read priced, cache-creation absent); Anthropic and no-cache-data models are unchanged.
- `tests/test_cost_tracker_counterfactual.py`: `test_openai_cache_write_not_double_charged` drives a gpt-4o turn and asserts the stats cost equals cached-at-discount plus uncached-at-full, not the doubled figure.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check` / `ruff format --check`)
- [x] Type checking passes (`mypy`)
- [x] New test added for the fix
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_cost_tracker_counterfactual.py -q
9 passed

# with the fix reverted, the new test fails (cost is the doubled figure):
$ git stash push headroom/proxy/cost.py && \
    python -m pytest tests/test_cost_tracker_counterfactual.py -k double_charged -q
1 failed

$ uvx ruff@0.15.17 check headroom/proxy/cost.py tests/test_cost_tracker_counterfactual.py
All checks passed!
$ uvx mypy@1.20.2 --ignore-missing-imports headroom/proxy/cost.py
Success: no issues found in 1 source file
```

The pre-existing failures in `tests/test_proxy_streaming_resilience.py` (11) and the `fsyncs_parent_directory` test are `@pytest.mark.asyncio` / Windows-fsync environment issues that fail identically on clean `main`; this change adds no new failures.

## Real Behavior Proof

- Environment: Windows 11, Python 3.12, project venv (`uv sync --extra proxy`), `uvx ruff@0.15.17` / `uvx mypy@1.20.2`, pytest in the venv, litellm from the extras.
- Exact command / steps: called `CostTracker._get_cache_prices` for gpt-4o / gpt-5.5 / claude-sonnet-4 / claude-3-5-haiku, then recorded a gpt-4o turn (100k input, 20k cache-read, cache_write == uncached == 80k) and read `stats()["cost_with_headroom_usd"]`; then reverted the source and re-ran.
- Observed result: gpt-4o and gpt-5.5 now price cache writes at 0; Sonnet keeps its real creation price; Haiku (no cache data) is unchanged. The recorded gpt-4o turn costs $0.2250 with the fix versus $0.4250 before it. Ran against the actual module and litellm data.
- Not tested: a live OpenAI request end to end (the accounting is verified directly against the cost tracker and litellm pricing).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable
