### PR TITLE
fix(install): surface per-protocol target overrides in install status

### DIFF
--- a/headroom/cli/install.py
+++ b/headroom/cli/install.py
@@ -741,7 +741,31 @@ def install_status(profile: str) -> None:
         config = payload.get("config")
         if not isinstance(config, dict):
             config = {}
-        click.echo(f"Backend:    {config.get('backend', manifest.backend)}")
+        # Per-protocol target overrides (#2615): `backend` is the nominal
+        # default route, but OPENAI_TARGET_API_URL-style overrides route that
+        # protocol's traffic elsewhere. When any override exists, qualify the
+        # Backend line and surface which routes are overridden so an
+        # OpenAI-only deployment doesn't read as "using Anthropic". The URL
+        # values themselves are deliberately not echoed — status output is
+        # routinely pasted into issues/chat. Without overrides the output is
+        # byte-identical to the previous format.
+        backend_value = config.get("backend", manifest.backend)
+        target_fields = (
+            ("Anthropic target:", "anthropic_api_url"),
+            ("OpenAI target:   ", "openai_api_url"),
+            ("Gemini target:   ", "gemini_api_url"),
+            ("Cloud Code target:", "cloudcode_api_url"),
+            ("Vertex target:   ", "vertex_api_url"),
+        )
+        if any(config.get(key) for _, key in target_fields):
+            click.echo(f"Backend:    {backend_value} (default for non-overridden routes)")
+            for label, key in target_fields:
+                if config.get(key):
+                    click.echo(f"{label} configured")
+                elif key in ("anthropic_api_url", "openai_api_url"):
+                    click.echo(f"{label} default")
+        else:
+            click.echo(f"Backend:    {backend_value}")
 
 
 @install.command("start")

--- a/tests/test_cli/test_install_cli.py
+++ b/tests/test_cli/test_install_cli.py
@@ -209,6 +209,78 @@ def test_install_status_includes_backend_from_health_probe(monkeypatch) -> None:
     assert "Backend:    anthropic" in result.output
 
 
+def test_install_status_surfaces_per_protocol_target_overrides(monkeypatch) -> None:
+    """An OpenAI-only deployment (OPENAI_TARGET_API_URL set, no Anthropic
+    override) must not present the default `anthropic` backend as the
+    effective route for its OpenAI traffic (#2615)."""
+    runner = CliRunner()
+
+    class Manifest:
+        profile = "default"
+        preset = "persistent-service"
+        runtime_kind = "python"
+        supervisor_kind = "service"
+        scope = "user"
+        port = 8787
+        backend = "anthropic"
+        health_url = "http://127.0.0.1:8787/readyz"
+
+    monkeypatch.setattr("headroom.cli.install.load_manifest", lambda profile: Manifest())
+    monkeypatch.setattr("headroom.cli.install.runtime_status", lambda manifest: "running")
+    monkeypatch.setattr("headroom.cli.install.probe_ready", lambda url: True)
+    monkeypatch.setattr(
+        "headroom.cli.install.probe_json",
+        lambda url: {
+            "config": {
+                "backend": "anthropic",
+                "anthropic_api_url": None,
+                "openai_api_url": "https://openai-compatible.example/v1",
+            }
+        },
+    )
+
+    result = runner.invoke(main, ["install", "status"])
+
+    assert result.exit_code == 0, result.output
+    # The Backend line is qualified so the default value cannot be read as
+    # the effective route for the overridden protocol's traffic.
+    assert "Backend:    anthropic (default for non-overridden routes)" in result.output
+    assert "OpenAI target:    configured" in result.output
+    assert "Anthropic target: default" in result.output
+    # The target URL value must not be echoed — status output is shareable.
+    assert "openai-compatible.example" not in result.output
+
+
+def test_install_status_omits_target_lines_without_overrides(monkeypatch) -> None:
+    """With no per-protocol target overrides the status output keeps its
+    original shape — no target lines are added."""
+    runner = CliRunner()
+
+    class Manifest:
+        profile = "default"
+        preset = "persistent-service"
+        runtime_kind = "python"
+        supervisor_kind = "service"
+        scope = "user"
+        port = 8787
+        backend = "anthropic"
+        health_url = "http://127.0.0.1:8787/readyz"
+
+    monkeypatch.setattr("headroom.cli.install.load_manifest", lambda profile: Manifest())
+    monkeypatch.setattr("headroom.cli.install.runtime_status", lambda manifest: "running")
+    monkeypatch.setattr("headroom.cli.install.probe_ready", lambda url: True)
+    monkeypatch.setattr(
+        "headroom.cli.install.probe_json",
+        lambda url: {"config": {"backend": "anthropic", "openai_api_url": None}},
+    )
+
+    result = runner.invoke(main, ["install", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "Backend:    anthropic" in result.output
+    assert "target:" not in result.output
+
+
 def test_install_status_survives_non_dict_config(monkeypatch) -> None:
     """A health payload whose `config` is a non-dict (e.g. a different service
     answering on the port returns config: null) must not crash the command."""


### PR DESCRIPTION
## Description

`headroom install status` printed a single `Backend:` line taken from `/health.config.backend`, which is `ProxyConfig.backend` — a value that stays at its default `anthropic` even when the deployment's only configured route is an `OPENAI_TARGET_API_URL` override. For an OpenAI-only persistent service the status read as `Backend: anthropic`, implying the observed OpenAI Responses traffic was handled by Anthropic.

`install_status()` now derives per-protocol route state from the target URL fields the loopback `/health` `config` block already exposes (`anthropic_api_url`, `openai_api_url`, `gemini_api_url`, `cloudcode_api_url`, `vertex_api_url`). When at least one override is present, the `Backend:` line is qualified and the per-protocol routes are listed:

```
Backend:    anthropic (default for non-overridden routes)
Anthropic target: default
OpenAI target:    configured
```

Design choices:

- **URL values are never echoed** — status output is routinely pasted into issues/chat, matching the issue's own sanitized report.
- **No overrides → output byte-identical to today**, so anything reading the current format is unaffected.
- The `Backend:` key is kept (still greppable) but qualified whenever an override exists, so the default value cannot be read as the effective route for overridden traffic.

Closes #2615

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cli/install.py::install_status()`: qualify the `Backend:` line and print per-protocol target lines (`configured` / `default`) when any target override is reported by `/health`; unchanged output otherwise.
- `tests/test_cli/test_install_cli.py`: two new tests — one asserting the qualified line + target lines for an OpenAI-only config (and that the URL value is not echoed), one locking the unchanged no-override output shape.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/test_cli/ -q
1 failed, 719 passed in 171.04s
# The one failure is tests/test_cli/test_recover_codex.py::test_recovery_records_sockets_and_secures_both_backups
# ("OSError: AF_UNIX path too long") — pre-existing macOS environment failure tracked in #2394, unrelated to this change.

$ ruff check headroom/cli/install.py tests/test_cli/test_install_cli.py
All checks passed!

$ mypy headroom/cli/install.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: macOS 26.5 (arm64), Python 3.12 via `uv`, headroom from source (editable install). Isolated state via `HEADROOM_WORKSPACE_DIR`; real proxy started with `OPENAI_TARGET_API_URL=https://openai-compatible.example/v1 headroom proxy --port 8791`; a `persistent-service` manifest for that port written under the workspace's `deploy/default/`.
- Exact command / steps: `headroom install status --profile default` against the live proxy, after the patch.
- Observed result: the OpenAI override is surfaced as `OpenAI target: configured`, the Backend default is explicitly scoped as `(default for non-overridden routes)`, and the URL value is not echoed anywhere in the output. Full captures below.

  Live `/health` config (loopback), confirming the issue's premise:

  ```json
  {
    "backend": "anthropic",
    "anthropic_api_url": null,
    "openai_api_url": "https://openai-compatible.example/v1"
  }
  ```

  Status output:

  ```
  Profile:    default
  Preset:     persistent-service
  Runtime:    python
  Supervisor: service
  Scope:      user
  Port:       8791
  Status:     stopped
  Healthy:    yes
  Health URL: http://127.0.0.1:8791/health
  Backend:    anthropic (default for non-overridden routes)
  Anthropic target: default
  OpenAI target:    configured
  ```

- Not tested: a real `install apply --preset persistent-service` end-to-end install (the manifest was hand-written against a manually started proxy, so `Status: stopped` reflects the absent launchd service — the health probe and `/health`-driven backend/target readout, which are what this fix touches, ran against the live proxy); Windows/Linux supervisors.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

- Documentation checklist item is N/A: no doc page shows the `install status` output block (verified by grep across `docs/`).
- Downstream review: nothing in the repo parses `install status` output (`doctor` only references the command in a hint string), and the docs reference the command without showing its output. Version skew is safe — probing an older proxy whose `/health` lacks the target URL keys yields no new lines and today's exact output.
