### PR TITLE
feat(install): persist memory learning settings

### DIFF
--- a/headroom/cli/install.py
+++ b/headroom/cli/install.py
@@ -344,8 +344,12 @@ def _build_deployment_manifest(
     backend: str,
     anyllm_provider: str | None,
     region: str | None,
-    proxy_mode: str,
+    proxy_mode: str | None,
     memory: bool,
+    learn_enabled: bool | None,
+    memory_storage_mode: str,
+    traffic_learning_min_evidence: int,
+    memory_project_root: str,
     telemetry: bool,
     no_telemetry: bool,
     image: str,
@@ -370,9 +374,13 @@ def _build_deployment_manifest(
         anyllm_provider=anyllm_provider,
         region=region,
         proxy_mode=proxy_mode,
-        memory_enabled=memory,
+        memory_enabled=memory or learn_enabled is True,
         telemetry_enabled=telemetry and not no_telemetry,
         image=image,
+        learn_enabled=learn_enabled,
+        memory_storage_mode=memory_storage_mode,
+        traffic_learning_min_evidence=traffic_learning_min_evidence,
+        memory_project_root=memory_project_root,
         no_http2=no_http2,
         code_aware=code_aware,
         intercept_tool_results=intercept_tool_results,
@@ -525,11 +533,38 @@ def _echo_installed(manifest: DeploymentManifest, *, prefix: str = "Installed pe
 @click.option(
     "--mode",
     "proxy_mode",
-    default="cache",
-    show_default=True,
-    help="Proxy optimization mode. cache = delta-only compression at ~0 prefix-cache busts.",
+    default=None,
+    help="Proxy optimization mode. Omit to use runtime/settings defaults.",
 )
 @click.option("--memory", is_flag=True, help="Enable persistent memory in the proxy runtime.")
+@click.option(
+    "--learn/--no-learn",
+    "learn_enabled",
+    default=None,
+    help="Explicitly enable or disable traffic learning.",
+)
+@click.option(
+    "--memory-storage",
+    "memory_storage_mode",
+    type=click.Choice(["project", "user", "global"], case_sensitive=False),
+    default="project",
+    show_default=True,
+    help="Persistent memory storage scope.",
+)
+@click.option(
+    "--min-evidence",
+    "traffic_learning_min_evidence",
+    type=click.IntRange(min=1),
+    default=5,
+    show_default=True,
+    help="Evidence count required before learning persists a pattern.",
+)
+@click.option(
+    "--memory-project-root",
+    type=click.Path(path_type=str),
+    default="",
+    help="Override the project root used by project memory storage.",
+)
 @click.option(
     "--telemetry",
     is_flag=True,
@@ -607,8 +642,12 @@ def install_apply(
     backend: str,
     anyllm_provider: str | None,
     region: str | None,
-    proxy_mode: str,
+    proxy_mode: str | None,
     memory: bool,
+    learn_enabled: bool | None,
+    memory_storage_mode: str,
+    traffic_learning_min_evidence: int,
+    memory_project_root: str,
     telemetry: bool,
     no_telemetry: bool,
     image: str,
@@ -655,6 +694,10 @@ def install_apply(
         region=region,
         proxy_mode=proxy_mode,
         memory=memory,
+        learn_enabled=learn_enabled,
+        memory_storage_mode=memory_storage_mode,
+        traffic_learning_min_evidence=traffic_learning_min_evidence,
+        memory_project_root=memory_project_root,
         telemetry=telemetry,
         no_telemetry=no_telemetry,
         image=image,
@@ -706,9 +749,8 @@ def install_apply(
 @click.option(
     "--mode",
     "proxy_mode",
-    default="cache",
-    show_default=True,
-    help="Proxy optimization mode. cache = delta-only compression at ~0 prefix-cache busts.",
+    default=None,
+    help="Proxy optimization mode. Omit to use runtime/settings defaults.",
 )
 @click.option(
     "--scope",
@@ -733,6 +775,34 @@ def install_apply(
     help="Tool target to configure when --providers manual is used.",
 )
 @click.option("--memory", is_flag=True, help="Enable persistent memory in the proxy runtime.")
+@click.option(
+    "--learn/--no-learn",
+    "learn_enabled",
+    default=None,
+    help="Explicitly enable or disable traffic learning.",
+)
+@click.option(
+    "--memory-storage",
+    "memory_storage_mode",
+    type=click.Choice(["project", "user", "global"], case_sensitive=False),
+    default="project",
+    show_default=True,
+    help="Persistent memory storage scope.",
+)
+@click.option(
+    "--min-evidence",
+    "traffic_learning_min_evidence",
+    type=click.IntRange(min=1),
+    default=5,
+    show_default=True,
+    help="Evidence count required before learning persists a pattern.",
+)
+@click.option(
+    "--memory-project-root",
+    type=click.Path(path_type=str),
+    default="",
+    help="Override the project root used by project memory storage.",
+)
 @click.option(
     "--telemetry",
     is_flag=True,
@@ -765,11 +835,15 @@ def deploy(
     backend: str,
     anyllm_provider: str | None,
     region: str | None,
-    proxy_mode: str,
+    proxy_mode: str | None,
     scope: str,
     provider_mode: str,
     targets: tuple[str, ...],
     memory: bool,
+    learn_enabled: bool | None,
+    memory_storage_mode: str,
+    traffic_learning_min_evidence: int,
+    memory_project_root: str,
     telemetry: bool,
     no_telemetry: bool,
     image: str,
@@ -793,6 +867,10 @@ def deploy(
         region=region,
         proxy_mode=proxy_mode,
         memory=memory,
+        learn_enabled=learn_enabled,
+        memory_storage_mode=memory_storage_mode,
+        traffic_learning_min_evidence=traffic_learning_min_evidence,
+        memory_project_root=memory_project_root,
         telemetry=telemetry,
         no_telemetry=no_telemetry,
         image=image,
@@ -816,6 +894,18 @@ def install_status(profile: str) -> None:
     click.echo(f"Runtime:    {manifest.runtime_kind}")
     click.echo(f"Supervisor: {manifest.supervisor_kind}")
     click.echo(f"Scope:      {manifest.scope}")
+    click.echo(f"Mode:       {getattr(manifest, 'proxy_mode', None) or 'runtime default'}")
+    click.echo(
+        f"Memory:     {'enabled' if getattr(manifest, 'memory_enabled', False) else 'disabled'}"
+    )
+    learn_enabled = getattr(manifest, "learn_enabled", None)
+    learning = (
+        "runtime default" if learn_enabled is None else ("enabled" if learn_enabled else "disabled")
+    )
+    click.echo(f"Learning:   {learning}")
+    click.echo(f"Storage:    {getattr(manifest, 'memory_storage_mode', 'project')}")
+    click.echo(f"Min evidence: {getattr(manifest, 'traffic_learning_min_evidence', 5)}")
+    click.echo(f"Project root: {getattr(manifest, 'memory_project_root', '') or 'runtime default'}")
     click.echo(f"Port:       {manifest.port}")
     click.echo(f"Status:     {runtime_status(manifest)}")
     click.echo(f"Healthy:    {'yes' if probe_ready(manifest.health_url) else 'no'}")

--- a/headroom/install/models.py
+++ b/headroom/install/models.py
@@ -102,9 +102,13 @@ class DeploymentManifest:
     backend: str
     anyllm_provider: str | None = None
     region: str | None = None
-    proxy_mode: str = "cache"
+    proxy_mode: str | None = None
     memory_enabled: bool = False
     memory_db_path: str = ""
+    learn_enabled: bool | None = None
+    memory_storage_mode: str = "project"
+    traffic_learning_min_evidence: int = 5
+    memory_project_root: str = ""
     telemetry_enabled: bool = True
     image: str = "ghcr.io/headroomlabs-ai/headroom:latest"
     service_name: str = "headroom"

--- a/headroom/install/planner.py
+++ b/headroom/install/planner.py
@@ -129,10 +129,14 @@ def build_manifest(
     backend: str,
     anyllm_provider: str | None,
     region: str | None,
-    proxy_mode: str,
+    proxy_mode: str | None,
     memory_enabled: bool,
     telemetry_enabled: bool,
     image: str,
+    learn_enabled: bool | None = None,
+    memory_storage_mode: str = "project",
+    traffic_learning_min_evidence: int = 5,
+    memory_project_root: str = "",
     no_http2: bool = False,
     code_aware: bool | None = None,
     intercept_tool_results: bool = False,
@@ -166,7 +170,6 @@ def build_manifest(
     base_env = {
         "HEADROOM_PORT": str(port),
         "HEADROOM_HOST": "127.0.0.1",
-        "HEADROOM_MODE": proxy_mode,
         "HEADROOM_BACKEND": backend,
     }
     if anyllm_provider:
@@ -221,11 +224,11 @@ def build_manifest(
         "127.0.0.1",
         "--port",
         str(port),
-        "--mode",
-        proxy_mode,
         "--backend",
         backend,
     ]
+    if proxy_mode is not None:
+        proxy_args.extend(["--mode", proxy_mode])
     proxy_args.append("--telemetry" if telemetry_enabled else "--no-telemetry")
     if memory_enabled:
         proxy_args.append("--memory")
@@ -241,6 +244,13 @@ def build_manifest(
         # runtime the resolved host path is correct, so keep passing it.
         if runtime_kind != RuntimeKind.DOCKER.value:
             proxy_args.extend(["--memory-db-path", str(_paths.memory_db_path())])
+    if learn_enabled is not None:
+        proxy_args.append("--learn" if learn_enabled else "--no-learn")
+    proxy_args.extend(["--memory-storage", memory_storage_mode])
+    if "HEADROOM_MIN_EVIDENCE" not in base_env:
+        proxy_args.extend(["--min-evidence", str(traffic_learning_min_evidence)])
+    if memory_project_root:
+        proxy_args.extend(["--memory-project-root", memory_project_root])
     if anyllm_provider:
         proxy_args.extend(["--anyllm-provider", anyllm_provider])
     if region:
@@ -276,6 +286,10 @@ def build_manifest(
         proxy_mode=proxy_mode,
         memory_enabled=memory_enabled,
         memory_db_path=str(_paths.memory_db_path()),
+        learn_enabled=learn_enabled,
+        memory_storage_mode=memory_storage_mode,
+        traffic_learning_min_evidence=traffic_learning_min_evidence,
+        memory_project_root=memory_project_root,
         telemetry_enabled=telemetry_enabled,
         image=image,
         service_name=f"headroom-{normalized_profile}",

--- a/headroom/install/state.py
+++ b/headroom/install/state.py
@@ -78,6 +78,26 @@ def _migrate_deprecated_image(image: Any) -> Any:
     return image
 
 
+def _migrate_manifest_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Apply safe in-memory migrations for older deployment manifests."""
+
+    if "image" in payload:
+        payload["image"] = _migrate_deprecated_image(payload["image"])
+    # Mode is represented by the proxy argument generated from ``proxy_mode``.
+    # Older manifests also exported it through the supervisor environment,
+    # creating two competing runtime inputs. Remove only the matching derived
+    # copy; a different or mode-less environment value remains an explicit input.
+    base_env = payload.get("base_env")
+    proxy_mode = payload.get("proxy_mode")
+    if (
+        isinstance(base_env, dict)
+        and proxy_mode is not None
+        and base_env.get("HEADROOM_MODE") == proxy_mode
+    ):
+        base_env.pop("HEADROOM_MODE", None)
+    return payload
+
+
 def load_manifest(profile: str = "default") -> DeploymentManifest | None:
     """Load a deployment manifest when present."""
 
@@ -92,9 +112,7 @@ def load_manifest(profile: str = "default") -> DeploymentManifest | None:
         payload = json.loads(path.read_text(encoding="utf-8"))
         payload["mutations"] = [ManagedMutation(**item) for item in payload.get("mutations", [])]
         payload["artifacts"] = [ArtifactRecord(**item) for item in payload.get("artifacts", [])]
-        if "image" in payload:
-            payload["image"] = _migrate_deprecated_image(payload["image"])
-        return DeploymentManifest(**payload)
+        return DeploymentManifest(**_migrate_manifest_payload(payload))
     except (json.JSONDecodeError, ValueError, TypeError, OSError) as e:
         raise ManifestError(f"deployment profile '{profile}' is corrupt ({path}): {e}") from e
 
@@ -114,9 +132,7 @@ def list_manifests() -> list[DeploymentManifest]:
                 ManagedMutation(**item) for item in payload.get("mutations", [])
             ]
             payload["artifacts"] = [ArtifactRecord(**item) for item in payload.get("artifacts", [])]
-            if "image" in payload:
-                payload["image"] = _migrate_deprecated_image(payload["image"])
-            manifests.append(DeploymentManifest(**payload))
+            manifests.append(DeploymentManifest(**_migrate_manifest_payload(payload)))
         except (OSError, ValueError, TypeError):
             continue
     return manifests

--- a/tests/test_cli/test_install_cli.py
+++ b/tests/test_cli/test_install_cli.py
@@ -485,6 +485,41 @@ def test_install_status_survives_non_dict_config(monkeypatch) -> None:
     assert "Backend:    anthropic" in result.output
 
 
+def test_install_status_reports_effective_memory_options(monkeypatch) -> None:
+    runner = CliRunner()
+
+    class Manifest:
+        profile = "default"
+        preset = "persistent-service"
+        runtime_kind = "python"
+        supervisor_kind = "service"
+        scope = "user"
+        port = 8787
+        backend = "anthropic"
+        health_url = "http://127.0.0.1:8787/readyz"
+        proxy_mode = None
+        memory_enabled = True
+        learn_enabled = False
+        memory_storage_mode = "global"
+        traffic_learning_min_evidence = 7
+        memory_project_root = "/tmp/scratch-project"
+
+    monkeypatch.setattr("headroom.cli.install.load_manifest", lambda profile: Manifest())
+    monkeypatch.setattr("headroom.cli.install.runtime_status", lambda manifest: "running")
+    monkeypatch.setattr("headroom.cli.install.probe_ready", lambda url: True)
+    monkeypatch.setattr("headroom.cli.install.probe_json", lambda url: {"config": {}})
+
+    result = runner.invoke(main, ["install", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "Mode:       runtime default" in result.output
+    assert "Memory:     enabled" in result.output
+    assert "Learning:   disabled" in result.output
+    assert "Storage:    global" in result.output
+    assert "Min evidence: 7" in result.output
+    assert "Project root: /tmp/scratch-project" in result.output
+
+
 def test_install_restart_uses_internal_helpers(monkeypatch) -> None:
     runner = CliRunner()
     calls: list[str] = []

--- a/tests/test_install/test_memory_options.py
+++ b/tests/test_install/test_memory_options.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+from headroom.install.planner import build_manifest
+from headroom.install.runtime import build_runtime_command
+from headroom.install.state import load_manifest, save_manifest
+
+
+def test_learning_project_storage_round_trips_into_runtime(monkeypatch, tmp_path: Path) -> None:
+    """A persistent profile must carry learning/project storage without patches."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    manifest = build_manifest(
+        profile="memory-project",
+        preset="persistent-service",
+        runtime_kind="python",
+        scope="user",
+        provider_mode="manual",
+        targets=["claude"],
+        port=8787,
+        backend="anthropic",
+        anyllm_provider=None,
+        region=None,
+        proxy_mode=None,
+        memory_enabled=True,
+        learn_enabled=True,
+        memory_storage_mode="project",
+        traffic_learning_min_evidence=7,
+        memory_project_root="/tmp/scratch-project",
+        telemetry_enabled=False,
+        image="ghcr.io/headroomlabs-ai/headroom:latest",
+    )
+    save_manifest(manifest)
+
+    loaded = load_manifest("memory-project")
+
+    assert loaded is not None
+    assert loaded.learn_enabled is True
+    assert loaded.memory_storage_mode == "project"
+    assert loaded.traffic_learning_min_evidence == 7
+    assert loaded.memory_project_root == "/tmp/scratch-project"
+    assert build_runtime_command(loaded)[4:] == [
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8787",
+        "--backend",
+        "anthropic",
+        "--no-telemetry",
+        "--memory",
+        "--memory-db-path",
+        str(tmp_path / ".headroom" / "memory.db"),
+        "--learn",
+        "--memory-storage",
+        "project",
+        "--min-evidence",
+        "7",
+        "--memory-project-root",
+        "/tmp/scratch-project",
+    ]
+
+
+def test_install_apply_persists_explicit_memory_options(monkeypatch) -> None:
+    captured = []
+    monkeypatch.setattr("headroom.cli.install._apply_manifest", captured.append)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "install",
+            "apply",
+            "--learn",
+            "--memory-storage",
+            "user",
+            "--min-evidence",
+            "7",
+            "--memory-project-root",
+            "/tmp/scratch-project",
+            "--mode",
+            "cache",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    manifest = captured[0]
+    assert manifest.memory_enabled is True
+    assert manifest.learn_enabled is True
+    assert manifest.memory_storage_mode == "user"
+    assert manifest.traffic_learning_min_evidence == 7
+    assert manifest.memory_project_root == "/tmp/scratch-project"
+    assert manifest.proxy_args.count("--mode") == 1
+    assert "HEADROOM_MODE" not in manifest.base_env
+
+
+def test_install_apply_no_learn_is_persistent_override(monkeypatch) -> None:
+    captured = []
+    monkeypatch.setattr("headroom.cli.install._apply_manifest", captured.append)
+
+    result = CliRunner().invoke(main, ["install", "apply", "--memory", "--no-learn"])
+
+    assert result.exit_code == 0, result.output
+    manifest = captured[0]
+    assert manifest.memory_enabled is True
+    assert manifest.learn_enabled is False
+    assert "--no-learn" in manifest.proxy_args
+
+
+def test_explicit_min_evidence_env_wins_over_cli_default() -> None:
+    manifest = build_manifest(
+        profile="memory-env-precedence",
+        preset="persistent-service",
+        runtime_kind="python",
+        scope="user",
+        provider_mode="manual",
+        targets=["claude"],
+        port=8787,
+        backend="anthropic",
+        anyllm_provider=None,
+        region=None,
+        proxy_mode=None,
+        memory_enabled=True,
+        learn_enabled=True,
+        memory_storage_mode="project",
+        traffic_learning_min_evidence=7,
+        memory_project_root="",
+        telemetry_enabled=False,
+        image="ghcr.io/headroomlabs-ai/headroom:latest",
+        extra_env={"HEADROOM_MIN_EVIDENCE": "11"},
+    )
+
+    assert manifest.base_env["HEADROOM_MIN_EVIDENCE"] == "11"
+    assert "--min-evidence" not in manifest.proxy_args
+
+
+def test_docker_learning_options_omit_host_memory_path() -> None:
+    manifest = build_manifest(
+        profile="memory-docker",
+        preset="persistent-docker",
+        runtime_kind="docker",
+        scope="user",
+        provider_mode="manual",
+        targets=["claude"],
+        port=8787,
+        backend="anthropic",
+        anyllm_provider=None,
+        region=None,
+        proxy_mode=None,
+        memory_enabled=True,
+        learn_enabled=True,
+        memory_storage_mode="project",
+        traffic_learning_min_evidence=7,
+        memory_project_root="/tmp/scratch-project",
+        telemetry_enabled=False,
+        image="ghcr.io/headroomlabs-ai/headroom:latest",
+    )
+
+    assert "--memory" in manifest.proxy_args
+    assert "--memory-db-path" not in manifest.proxy_args
+    assert "--learn" in manifest.proxy_args
+    assert manifest.proxy_args[-6:] == [
+        "--memory-storage",
+        "project",
+        "--min-evidence",
+        "7",
+        "--memory-project-root",
+        "/tmp/scratch-project",
+    ]

--- a/tests/test_install/test_proxy_mode_default.py
+++ b/tests/test_install/test_proxy_mode_default.py
@@ -1,58 +1,40 @@
-"""`headroom install` must default to cache mode, like `headroom proxy` does.
-
-#1893 shipped the coding/cache posture as Headroom's out-of-box default, but it
-only touched `cli/proxy.py` and `proxy/server.py` — the install path kept the
-older `token` default from #1404. Since `planner.py` writes `HEADROOM_MODE` into
-the install env, an installed Headroom actively *overrode* the good server default
-with the cache-busting one.
-
-Cache mode freezes prior turns and compresses only the newest delta ("~0
-prefix-cache busts"); token mode rewrites frozen history, which moves the cached
-prefix bytes and forces a full cold re-write. These tests pin the agreement so the
-two entry points cannot drift apart again.
-"""
+"""`headroom install` must leave mode ownership with the proxy runtime."""
 
 from __future__ import annotations
 
 from headroom.install.models import DeploymentManifest
-from headroom.proxy.proxy_mode_policy import PROXY_MODE_CACHE
 
 
-def _mode_option_default(command) -> str:
+def _mode_option_default(command) -> object:
     """The declared default of a command's ``--mode`` option."""
     for param in command.params:
         if param.name == "proxy_mode":
-            return str(param.default)
+            return param.default
     raise AssertionError(f"{command.name} has no --mode/proxy_mode option")
 
 
-def test_install_apply_defaults_to_cache_mode() -> None:
+def test_install_apply_omits_mode_by_default() -> None:
     from headroom.cli.install import install_apply
 
-    assert _mode_option_default(install_apply) == PROXY_MODE_CACHE
+    assert _mode_option_default(install_apply) is None
 
 
-def test_deploy_defaults_to_cache_mode() -> None:
+def test_deploy_omits_mode_by_default() -> None:
     from headroom.cli.install import deploy
 
-    assert _mode_option_default(deploy) == PROXY_MODE_CACHE
+    assert _mode_option_default(deploy) is None
 
 
-def test_manifest_default_is_cache_mode() -> None:
-    """A manifest that omits proxy_mode must not fall back to token."""
-    assert DeploymentManifest.__dataclass_fields__["proxy_mode"].default == PROXY_MODE_CACHE
+def test_manifest_default_leaves_mode_to_runtime() -> None:
+    assert DeploymentManifest.__dataclass_fields__["proxy_mode"].default is None
 
 
-def test_install_and_proxy_agree_on_the_default() -> None:
-    """The whole point: both entry points land on the same posture.
-
-    `headroom proxy` resolves `mode or HEADROOM_MODE or PROXY_MODE_CACHE`, so its
-    default is PROXY_MODE_CACHE. Install must match, or installing Headroom
-    silently changes the compression posture versus running it directly.
-    """
+def test_install_entry_points_leave_mode_to_runtime() -> None:
+    """An install must not pin a mode through its CLI or supervisor env."""
     from headroom.cli.install import deploy, install_apply
 
-    assert _mode_option_default(install_apply) == _mode_option_default(deploy) == PROXY_MODE_CACHE
+    assert _mode_option_default(install_apply) is None
+    assert _mode_option_default(deploy) is None
 
 
 def test_token_mode_is_still_reachable() -> None:

--- a/tests/test_install/test_state.py
+++ b/tests/test_install/test_state.py
@@ -35,6 +35,7 @@ def _manifest() -> DeploymentManifest:
 def test_save_and_load_manifest_round_trip(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     manifest = _manifest()
+    manifest.base_env["HEADROOM_MODE"] = "token"
 
     save_manifest(manifest)
     loaded = load_manifest("default")
@@ -43,6 +44,8 @@ def test_save_and_load_manifest_round_trip(monkeypatch, tmp_path: Path) -> None:
     assert loaded.profile == "default"
     assert loaded.mutations[0].kind == "shell-block"
     assert loaded.artifacts[0].kind == "script"
+    assert loaded.proxy_mode is None
+    assert loaded.base_env["HEADROOM_MODE"] == "token"
 
 
 def test_load_manifest_raises_manifest_error_on_corrupt_payload(
@@ -154,3 +157,40 @@ def test_delete_manifest_removes_profile_root(monkeypatch, tmp_path: Path) -> No
 
     assert load_manifest("default") is None
     assert not extra_file.parent.exists()
+
+
+def test_load_old_manifest_uses_memory_defaults_and_one_mode_authority(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    profile_dir = tmp_path / ".headroom" / "deploy" / "old"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "profile": "old",
+                "preset": "persistent-service",
+                "runtime_kind": "python",
+                "supervisor_kind": "service",
+                "scope": "user",
+                "provider_mode": "manual",
+                "targets": ["claude"],
+                "port": 8787,
+                "host": "127.0.0.1",
+                "backend": "anthropic",
+                "proxy_mode": "cache",
+                "base_env": {"HEADROOM_MODE": "cache"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_manifest("old")
+
+    assert loaded is not None
+    assert loaded.learn_enabled is None
+    assert loaded.memory_storage_mode == "project"
+    assert loaded.traffic_learning_min_evidence == 5
+    assert loaded.memory_project_root == ""
+    assert loaded.proxy_mode == "cache"
+    assert "HEADROOM_MODE" not in loaded.base_env


### PR DESCRIPTION
## Description

Headroom already supports memory and traffic-learning controls at runtime, but persistent install manifests did not retain the learning toggle, storage mode, minimum evidence, or project-root override.

This PR persists those settings through the existing manifest, planner, state, and generated supervisor command. It also removes the duplicate legacy `HEADROOM_MODE` input.

This complements merged #2563 and overlaps #2346.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add persistent `--learn/--no-learn`, `--memory-storage`, `--min-evidence`, and `--memory-project-root` options.
- Save and restore those values through `DeploymentManifest`.
- Regenerate matching runtime arguments during apply and restart.
- Leave optimization mode unset when the operator does not select one.
- Show persisted memory and learning settings in install status.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
176 passed, 2 skipped
All checks passed!
Success: no issues found in 509 source files
```

## Real Behavior Proof

- Environment: macOS; temporary install homes and manifests plus the combined local deployment.
- Exact command / steps: Exercised learning on/off, all storage modes, custom evidence thresholds, project-root overrides, legacy manifests, restart regeneration, generated runtime arguments, and install status.
- Observed result: Settings survived manifest round-trips and produced one consistent supervisor command; omitted values retained runtime defaults.
- Not tested: Linux, Windows, VMs, or GitHub CI.

## Runtime Rollout Safety

- Rollout-managed feature(s): None.
- Minimum rollout channel: N/A; this change uses stable/default behavior.
- Stable/default behavior changed: Install profiles retain learning, memory-storage, minimum-evidence, and project-root settings across apply and restart.
- Kill switch / disable path: Use `--no-learn` and omit `--memory` to disable both learning and persistent memory.
- Unsafe override required: No.
- Qualification impact: Installer manifest round-trips and generated runtime arguments for memory and learning settings.
- Rollback path: Revert this PR and regenerate affected profiles before using an older Headroom version.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation changes are not required for this installer parity change
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Older manifests load with backward-compatible defaults. New manifests add four optional fields; older Headroom versions may require regenerating the profile before reuse.