### PR TITLE
fix(mcp): pin mcp dependency to <2.0.0 to prevent server startup crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ proxy = [
     "orjson>=3.9.14; platform_python_implementation != 'PyPy'",
     "httpx[http2]>=0.24.0",
     "openai>=2.14.0",             # OpenAI API format support
-    "mcp>=1.28.1",                 # MCP server (headroom_compress, retrieve, stats)
+    "mcp>=1.28.1,<2.0.0",         # MCP server (headroom_compress, retrieve, stats)
     "magika>=0.6.0",              # ML content detection for ContentRouter
     "zstandard>=0.20.0",          # Decompress zstd request bodies (Codex, etc.)
     "websockets>=13.0",           # WebSocket proxy for /v1/responses (Codex gpt-5.4+)
@@ -225,7 +225,7 @@ autogen = [
 ]
 # MCP server for Claude Code integration
 mcp = [
-    "mcp>=1.28.1",
+    "mcp>=1.28.1,<2.0.0",
     "httpx>=0.24.0",
     "starlette>=0.27.0",
     "uvicorn>=0.23.0,<1.0",


### PR DESCRIPTION
## Description

The MCP Python SDK recently released version `2.0.0`, which introduced breaking changes to the high-level server interface (removing `.list_tools()` and `.call_tool()` decorators on `mcp.server.Server`). Because `headroom-ai` specified `mcp>=1.28.1` without an upper bound, installing or upgrading `headroom-ai` pulled in `mcp 2.0.0`. When `headroom mcp serve` was started by an MCP client (such as OpenCode or Claude Code), the server crashed immediately on startup with `AttributeError: 'Server' object has no attribute 'list_tools'`, resulting in the connection closing error (`headroom MCP error -32000: Connection closed`).

This PR pins the `mcp` dependency to `<2.0.0` (`mcp>=1.28.1,<2.0.0`) in `pyproject.toml` so compatible 1.x SDK releases (e.g. `1.29.0`) are used.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Pinned `mcp` dependency to `"mcp>=1.28.1,<2.0.0"` under both `proxy` dependencies and the `mcp` extra in `pyproject.toml`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ ruff check pyproject.toml headroom/ccr/mcp_server.py
All checks passed!

$ pytest tests/test_ccr_mcp_server.py tests/test_cli/test_mcp.py tests/test_cli/test_mcp_status.py
============================== 45 passed in 1.03s ==============================
```

## Real Behavior Proof
- Environment: macOS (Darwin arm64), Python 3.14.5, uv
- Exact command / steps: Executed uv sync --all-extras and sent stdio JSON-RPC initialize and tools/list requests to .venv/bin/headroom mcp serve.
- Observed result: Server initializes cleanly and returns JSON-RPC response {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"experimental":{},"tools":{"listChanged":false}},"serverInfo":{"name":"headroom","version":"1.29.0"}}} with no startup AttributeError or closed pipe errors.
- Not tested: N/A

## Review Readiness
- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit CHANGELOG.md — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)
N/A

## Additional Notes
Capping mcp<2.0.0 ensures stability with current headroom releases while a future update can adopt MCP SDK 2.x interface changes if desired.