### PR TITLE
perf(proxy): token-mode hot path: dedup CCR proactive expansion, cut per-turn CPU, restore prefix-cache hit rate

### DIFF
--- a/headroom/agent_savings.py
+++ b/headroom/agent_savings.py
@@ -279,6 +279,12 @@ def proxy_pipeline_kwargs(config: object) -> dict[str, object]:
     compression knobs should be consistent across Claude, Codex, and Cursor.
     """
 
+    # NOTE: defer_waste_signals is intentionally NOT set here. This dict feeds
+    # every provider handler (Anthropic, OpenAI, Gemini, batch endpoints), but
+    # only the Anthropic messages route has the off-path background task that
+    # compensates for deferral; deferring everywhere silently dropped
+    # waste-signal telemetry on the other routes. The Anthropic handler passes
+    # defer_waste_signals=True explicitly at its covered call sites.
     kwargs: dict[str, object] = {}
     profile_name = getattr(config, "savings_profile", None)
     if profile_name:

--- a/headroom/cache/compression_cache.py
+++ b/headroom/cache/compression_cache.py
@@ -6,12 +6,10 @@ Maps original content hashes to their compressed versions.
 
 from __future__ import annotations
 
-import copy
 import hashlib
 import json
 import logging
 import threading
-import time
 from collections import OrderedDict
 from dataclasses import dataclass
 
@@ -77,16 +75,22 @@ def _extract_tool_result_content(msg: dict) -> str | None:
 
 
 def _swap_tool_result_content(msg: dict, new_content: str) -> dict:
-    """Deep copy msg and replace tool result content with new_content."""
-    new_msg = copy.deepcopy(msg)
+    """Shallow-copy msg and replace tool result content with new_content.
+
+    Only the message dict, its content list, and the swapped tool_result
+    block are copied; sibling blocks stay shared refs with the input. Safe
+    because nothing downstream mutates message/block dicts in place (Phase 2
+    mutation audit) — a deepcopy here bought no safety, only cost, and ran
+    inside the cache lock (perf review F4).
+    """
     # OpenAI format
-    if new_msg.get("role") == "tool":
-        new_msg["content"] = new_content
-        return new_msg
+    if msg.get("role") == "tool":
+        return {**msg, "content": new_content}
     # Anthropic format
-    content = new_msg.get("content")
+    content = msg.get("content")
     if isinstance(content, list):
-        for block in content:
+        new_content_list = list(content)
+        for i, block in enumerate(new_content_list):
             if isinstance(block, dict) and block.get("type") == "tool_result":
                 inner = block.get("content")
                 if isinstance(inner, list):
@@ -95,11 +99,13 @@ def _swap_tool_result_content(msg: dict, new_content: str) -> dict:
                     # multiple text blocks would produce a different joined
                     # output on re-extraction (first text block replaced,
                     # remaining text blocks still joined).
-                    block["content"] = [{"type": "text", "text": new_content}]
+                    new_block_content: str | list = [{"type": "text", "text": new_content}]
                 else:
-                    block["content"] = new_content
+                    new_block_content = new_content
+                new_content_list[i] = {**block, "content": new_block_content}
                 break
-    return new_msg
+        return {**msg, "content": new_content_list}
+    return dict(msg)
 
 
 class CompressionCache:
@@ -116,7 +122,7 @@ class CompressionCache:
         # session (Claude Code background tools, parallel agents, etc.) into
         # `asyncio.to_thread` workers — without this, two concurrent
         # requests for the same `session_id` race on `_cache`,
-        # `_stable_hashes`, `_first_seen`, and `_total_tokens_saved`. The
+        # `_stable_hashes`, and `_total_tokens_saved`. The
         # observable failures are (a) lost-update on `_total_tokens_saved`,
         # (b) `OrderedDict mutated during iteration` in `apply_cached`, and
         # (c) lost stable-hash records that drop the next-turn cache lookup.
@@ -136,7 +142,6 @@ class CompressionCache:
         # `proxy/handlers/anthropic.py`) and `update_from_result`'s
         # "unchanged content" tracking.
         self._stable_hashes: set[str] = set()
-        self._first_seen: dict[str, float] = {}
         self._hits: int = 0
         self._misses: int = 0
         self._total_tokens_saved: int = 0
@@ -190,40 +195,6 @@ class CompressionCache:
                     content = _extract_tool_result_content(msg)
                     if content is not None:
                         self._stable_hashes.add(self.content_hash(content))
-
-    def should_defer_compression(
-        self,
-        content_hash: str,
-        ttl_seconds: float = 300.0,
-        batch_window: float = 30.0,
-    ) -> bool:
-        """Whether to defer compressing this content to avoid mid-TTL busts.
-
-        Returns True if we have evidence this content has been re-sent
-        within the cache TTL window — recompressing it now would bust an
-        existing prefix-cache entry without TTL-amortizing the bust over
-        future turns. Returns False otherwise:
-
-        - **First sight** of the content. Compress now: there is no
-          prefix-cache entry to preserve yet (this byte range was not in
-          a prior request), so compression carries no bust cost. Issue
-          #327: a previous version returned True here, which marked the
-          freshest tool_result on every turn as "stable" and effectively
-          disabled compression for typical Claude Code workloads where
-          each tool_result is unique-per-turn.
-        - **Near the TTL boundary**: compress now and amortize the bust
-          across future turns (batched recompression).
-        """
-        with self._lock:
-            now = time.time()
-            first_seen = self._first_seen.get(content_hash)
-            if first_seen is None:
-                self._first_seen[content_hash] = now
-                return False  # First time — compress now (no cache entry to preserve)
-            age = now - first_seen
-            if age >= ttl_seconds - batch_window:
-                return False  # Near TTL boundary — compress now (batch window)
-            return True  # Seen recently within TTL — defer to preserve cache
 
     def get_stats(self) -> dict:
         """Return cache statistics."""
@@ -310,6 +281,78 @@ class CompressionCache:
                             continue
                 result.append(msg)
             return result
+
+    def prepare_turn(
+        self, messages: list[dict], tracker_frozen_count: int
+    ) -> tuple[int, list[dict]]:
+        """Single-pass replacement for compute_frozen_count + mark_stable_from_messages + apply_cached.
+
+        Extracts and hashes each tool_result exactly ONCE instead of 3-4
+        times per request (perf review F4). Returns ``(frozen_count,
+        working_messages)``:
+
+        - ``frozen_count``: identical semantics to ``compute_frozen_count``
+          plus the caller's ``min(frozen_message_count, cache_frozen_count)``
+          clamp (including the trailing-message live-zone cap) — pass in
+          the provider-confirmed ``tracker_frozen_count`` and get the final
+          clamped value back directly.
+        - ``working_messages``: identical to ``apply_cached(messages)`` —
+          cached compressions swapped in where available. Computing this is
+          free here (same walk); callers that skip compression this turn
+          (e.g. deferred tool injection) may simply ignore it and use
+          ``messages`` directly. Note: because the skip decision depends on
+          the frozen count this method returns, the swap lookup runs before
+          the caller can know it will skip — so hit/miss stats and the LRU
+          recency touch fire on skip turns too (the old ``apply_cached``
+          wasn't called there). Telemetry-only drift; the touched entries
+          are genuinely in active use, so the recency signal stays honest.
+
+        Content extraction + hashing happen BEFORE the lock is acquired —
+        the lock only needs to guard ``_cache``/``_stable_hashes`` access
+        (perf review F4 lock-hygiene note).
+        """
+        # `hashes[i]` is None for non-tool_result messages or tool_results
+        # with non-string/unextractable content (mirrors the "treat as
+        # unstable" branch in the old `compute_frozen_count`).
+        hashes: list[str | None] = [None] * len(messages)
+        for i, msg in enumerate(messages):
+            if _is_tool_result_message(msg):
+                content = _extract_tool_result_content(msg)
+                if content is not None:
+                    hashes[i] = self.content_hash(content)
+
+        with self._lock:
+            # (a) compute_frozen_count equivalent, using pre-mark state —
+            # matches the original call order (frozen count computed BEFORE
+            # mark_stable_from_messages runs).
+            count = 0
+            for i, msg in enumerate(messages):
+                if _is_tool_result_message(msg):
+                    h = hashes[i]
+                    if h is None or (h not in self._cache and h not in self._stable_hashes):
+                        break
+                count += 1
+            local_frozen_count = min(count, max(0, len(messages) - 1))
+            frozen_count = min(tracker_frozen_count, local_frozen_count)
+
+            # (b) mark_stable_from_messages(messages, frozen_count) equivalent.
+            for i in range(frozen_count):
+                h = hashes[i]
+                if h is not None:
+                    self._stable_hashes.add(h)
+
+            # (c) apply_cached equivalent.
+            working_messages: list[dict] = []
+            for i, msg in enumerate(messages):
+                h = hashes[i]
+                if h is not None:
+                    compressed = self.get_compressed(h)
+                    if compressed is not None:
+                        working_messages.append(_swap_tool_result_content(msg, compressed))
+                        continue
+                working_messages.append(msg)
+
+        return frozen_count, working_messages
 
     def update_from_result(self, originals: list[dict], compressed: list[dict]) -> None:
         """Cache new compressions by comparing original and compressed messages.

--- a/headroom/cache/prefix_tracker.py
+++ b/headroom/cache/prefix_tracker.py
@@ -359,6 +359,33 @@ def overlay_cached_prefix(
     return list(prev_fwd[:k]) + list(optimized_messages[k:])
 
 
+def is_append_only_extension(
+    current_original_messages: list[dict[str, Any]],
+    previous_original_messages: list[dict[str, Any]] | None,
+) -> bool:
+    """Return True iff ``previous_original_messages`` is a full canonical
+    prefix of ``current_original_messages``.
+
+    This is the same append-only condition ``overlay_cached_prefix`` requires
+    before it will replay ANY previously-forwarded content — a position is
+    only guaranteed to hold last turn's cached bytes when this holds for the
+    ENTIRE previous message list, not just a leading run of it. Used by
+    handler-level injection guards to detect "this exact tail position was
+    already forwarded last turn" without duplicating the canonicalization
+    logic.
+    """
+    if not previous_original_messages:
+        return False
+    n = len(previous_original_messages)
+    if len(current_original_messages) < n:
+        return False
+    return all(
+        _canonicalize_for_prefix_compare(current_original_messages[i])
+        == _canonicalize_for_prefix_compare(previous_original_messages[i])
+        for i in range(n)
+    )
+
+
 def normalize_message_cache_control(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:

--- a/headroom/cache/prefix_tracker.py
+++ b/headroom/cache/prefix_tracker.py
@@ -531,6 +531,14 @@ class PrefixCacheTracker:
         """
         self._last_activity = time.time()
         self._turn_number += 1
+        if original_messages is None:
+            logger.warning(
+                "PrefixCacheTracker[%s]: update_from_response called without "
+                "original_messages — falling back to forwarded messages as "
+                "originals, which busts the overlay's append-only cache-safety "
+                "check on the next turn.",
+                self.provider,
+            )
         self._last_original_messages = copy.deepcopy(original_messages or messages)
         self._last_forwarded_messages = copy.deepcopy(messages)
 
@@ -573,10 +581,12 @@ class PrefixCacheTracker:
         )
 
     def get_last_original_messages(self) -> list[dict[str, Any]]:
-        return copy.deepcopy(self._last_original_messages)
+        """Returns internal state — treat as immutable; do not mutate messages or blocks."""
+        return self._last_original_messages
 
     def get_last_forwarded_messages(self) -> list[dict[str, Any]]:
-        return copy.deepcopy(self._last_forwarded_messages)
+        """Returns internal state — treat as immutable; do not mutate messages or blocks."""
+        return self._last_forwarded_messages
 
     def resolved_cache_ttl_seconds(self) -> int:
         """Effective prompt-cache lifetime for this session's provider."""
@@ -691,30 +701,6 @@ class PrefixCacheTracker:
         self._busts_avoided += 1
         self._tokens_preserved += tokens_preserved
         self._compression_foregone_tokens += compression_foregone
-
-    def should_force_compress(
-        self,
-        message_index: int,
-        message_tokens: int,
-        estimated_compressed_tokens: int,
-    ) -> bool:
-        """Check if compression savings outweigh cache preservation.
-
-        Returns True if we should bust the cache and compress anyway.
-        This happens when compression would save a large fraction of tokens
-        AND the savings exceed the cache read discount.
-        """
-        if message_index >= self._cached_message_count:
-            return True  # Not in frozen prefix, always compress
-
-        if message_tokens == 0:
-            return False
-
-        savings_fraction = (message_tokens - estimated_compressed_tokens) / message_tokens
-
-        # Would compression savings exceed the cache read discount?
-        read_discount = _PROVIDER_READ_DISCOUNT.get(self.provider, 0.5)
-        return savings_fraction > read_discount
 
     @property
     def is_expired(self) -> bool:

--- a/headroom/cache/token_count_memo.py
+++ b/headroom/cache/token_count_memo.py
@@ -1,0 +1,126 @@
+"""Per-session memoized message token counts (perf review F2).
+
+Token mode does up to 6 full-transcript ``count_messages`` calls per request,
+two of them synchronous on the event loop. The frozen prefix never changes
+across turns, so only the delta (new/changed messages) needs a real count —
+everything else is a cache hit keyed by message content.
+
+Correctness relies on an algebraic identity::
+
+    tokenizer.count_messages(messages)
+        == sum(tokenizer.count_message(m) for m in messages) + tokenizer.REPLY_OVERHEAD
+
+which holds for ``BaseTokenizer``'s default per-message loop (and every
+subclass that just delegates to it — ``EstimatingTokenCounter``,
+``TiktokenCounter``). This is the ONLY tokenizer family the proxy uses for
+Claude models: ``tokenizers/registry.py``'s ``_create_anthropic`` always
+returns ``EstimatingTokenCounter``. The identity does NOT hold for tokenizers
+that encode the whole conversation jointly (``HuggingFaceTokenizer``'s
+``apply_chat_template`` path, ``MistralTokenizer``'s
+``encode_chat_completion`` path) — do not memoize with those.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from collections import OrderedDict
+from typing import Any, Protocol
+
+
+class _MessageCountingTokenizer(Protocol):
+    REPLY_OVERHEAD: int
+
+    def count_message(self, message: dict[str, Any]) -> int: ...
+
+    def count_messages(self, messages: list[dict[str, Any]]) -> int: ...
+
+
+class TokenCountMemo:
+    """LRU cache of per-message token counts, keyed by message content hash.
+
+    Bound to one tokenizer instance at a time: counts computed under one
+    tokenizer must never be served for another (different ratios/backends),
+    so a tokenizer swap — e.g. the handler's count fail-open path downgrading
+    to a fresh ``EstimatingTokenCounter`` mid-session — clears the memo and
+    rebinds. The registry caches tokenizer instances per model, so on the
+    normal path the binding is stable across a session's requests.
+    """
+
+    def __init__(self, max_entries: int = 10000) -> None:
+        self.max_entries = max_entries
+        self._lock = threading.RLock()
+        self._counts: OrderedDict[str, int] = OrderedDict()
+        # Strong reference on purpose: identity (`is`) comparison against a
+        # weak/GC'd tokenizer could alias a new instance at the same address.
+        self._bound_tokenizer: object | None = None
+
+    def bind_or_reset(self, tokenizer: object) -> None:
+        """Bind this memo to ``tokenizer``, clearing stale counts on a swap."""
+        with self._lock:
+            if self._bound_tokenizer is not tokenizer:
+                if self._bound_tokenizer is not None:
+                    self._counts.clear()
+                self._bound_tokenizer = tokenizer
+
+    @staticmethod
+    def message_hash(message: dict[str, Any]) -> str:
+        """Hash the whole message — role, content, tool_calls, function_call,
+        name — every field ``Tokenizer.count_message`` sums over, so a memo
+        hit guarantees the identical count. (Not reusing
+        ``CompressionCache.content_hash``: that hashes tool_result CONTENT
+        only, not the whole message.)
+        """
+        try:
+            raw = json.dumps(message, sort_keys=True, ensure_ascii=False)
+        except Exception:
+            raw = repr(message)
+        return hashlib.md5(raw.encode("utf-8")).hexdigest()[:16]  # nosec B324
+
+    def get(self, key: str) -> int | None:
+        with self._lock:
+            count = self._counts.get(key)
+            if count is not None:
+                self._counts.move_to_end(key)
+            return count
+
+    def put(self, key: str, count: int) -> None:
+        with self._lock:
+            if key in self._counts:
+                del self._counts[key]
+            self._counts[key] = count
+            while len(self._counts) > self.max_entries:
+                self._counts.popitem(last=False)
+
+    def get_stats(self) -> dict:
+        with self._lock:
+            return {"entries": len(self._counts)}
+
+
+def count_messages_memoized(
+    memo: TokenCountMemo,
+    tokenizer: _MessageCountingTokenizer,
+    messages: list[dict[str, Any]],
+) -> int:
+    """``tokenizer.count_messages(messages)``, memoizing each message's count.
+
+    Only correct for additive tokenizers — see module docstring. Enforced at
+    runtime via the ``ADDITIVE_COUNTS`` capability flag (``tokenizers/base``):
+    non-additive or unflagged tokenizers get a plain (correct, unmemoized)
+    ``count_messages`` call instead. The memo is also bound to the tokenizer
+    instance — a swap (count fail-open downgrade) clears stale counts rather
+    than serving numbers computed under a different tokenizer.
+    """
+    if not getattr(tokenizer, "ADDITIVE_COUNTS", False):
+        return tokenizer.count_messages(messages)
+    memo.bind_or_reset(tokenizer)
+    total = 0
+    for msg in messages:
+        key = TokenCountMemo.message_hash(msg)
+        count = memo.get(key)
+        if count is None:
+            count = tokenizer.count_message(msg)
+            memo.put(key, count)
+        total += count
+    return total + tokenizer.REPLY_OVERHEAD

--- a/headroom/ccr/context_tracker.py
+++ b/headroom/ccr/context_tracker.py
@@ -88,6 +88,7 @@ class CompressedContext:
     query_context: str  # The query/context when compression happened
     sample_content: str  # Preview of what was compressed (for relevance matching)
     workspace_key: str  # Stable per-project identity (see ProjectResolver in storage_router)
+    session_id: str | None = None  # Conversation identity (see analyze_query)
 
 
 @dataclass
@@ -167,6 +168,7 @@ class ContextTracker:
         compressed_count: int,
         *,
         workspace_key: str,
+        session_id: str | None = None,
         query_context: str = "",
         sample_content: str = "",
     ) -> None:
@@ -206,6 +208,7 @@ class ContextTracker:
             query_context=query_context,
             sample_content=sample_content[:2000],  # Limit sample size
             workspace_key=workspace_key,
+            session_id=session_id,
         )
 
         # Add or update context
@@ -232,6 +235,7 @@ class ContextTracker:
         current_turn: int | None = None,
         *,
         workspace_key: str,
+        session_id: str | None = None,
     ) -> list[ExpansionRecommendation]:
         """Analyze a query to find relevant compressed contexts.
 
@@ -277,6 +281,18 @@ class ContextTracker:
             # entries that belong to a different project than the one
             # the current request resolved to.
             if context.workspace_key != workspace_key:
+                continue
+
+            # Session filter (#2186): a NEW session (e.g. started after
+            # Claude Code's /compact) must not have old compressed content
+            # surfaced back into it — the whole point of compacting was to
+            # drop it. Only enforced when both sides have a concrete id;
+            # legacy/no-session callers keep workspace-only scoping.
+            if (
+                session_id is not None
+                and context.session_id is not None
+                and context.session_id != session_id
+            ):
                 continue
 
             # Check age

--- a/headroom/ccr/tool_injection.py
+++ b/headroom/ccr/tool_injection.py
@@ -144,6 +144,42 @@ in tool results to find the hash for each compressed output.
 """
 
 
+def create_stable_system_instructions(
+    retrieval_endpoint: str = "/v1/retrieve",
+) -> str:
+    """Create session-stable CCR retrieval instructions (no hash list).
+
+    Same purpose as ``create_system_instructions`` but WITHOUT the per-turn
+    ``**Available hashes:**`` list. Once a session injects this text, it must
+    stay byte-identical every subsequent turn or the segment it lives in
+    busts the provider's prompt cache each time the enumerated hashes change.
+    The model can always find a compressed output's hash from the marker
+    already present in that tool result (``[N items compressed to M.
+    Retrieve more: hash=abc123]``), so the separate list was redundant, not
+    load-bearing.
+
+    Args:
+        retrieval_endpoint: The endpoint path for retrieval (unused in the
+            text today, kept for signature parity with
+            ``create_system_instructions``).
+
+    Returns:
+        Static instruction text to append to the system prompt.
+    """
+    return f"""
+## Compressed Context Available
+
+Some tool outputs have been compressed to reduce context size. If you need
+the full uncompressed data, you can retrieve it using the `{CCR_TOOL_NAME}` tool.
+
+**How to retrieve:**
+- Call `{CCR_TOOL_NAME}(hash="<hash>")` to get the full original content back
+
+Look for markers like `[N items compressed to M. Retrieve more: hash=abc123]`
+in tool results to find the hash for each compressed output.
+"""
+
+
 @dataclass
 class CCRToolInjector:
     """Manages CCR tool injection into LLM requests.
@@ -362,8 +398,12 @@ class CCRToolInjector:
         if not self.inject_system_instructions or not self.has_compressed_content:
             return messages
 
-        instructions = create_system_instructions(
-            self._detected_hashes,
+        # Use the hash-free stable variant. create_system_instructions embeds
+        # an "Available hashes" list that changes every turn as new content is
+        # compressed, which busts the provider's prompt cache on the system
+        # segment. The list is redundant — each compressed tool result carries
+        # its own retrievable hash in its marker — so drop it here.
+        instructions = create_stable_system_instructions(
             self.retrieval_endpoint,
         )
 

--- a/headroom/config.py
+++ b/headroom/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import fnmatch
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import InitVar, dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -738,6 +738,13 @@ class TransformResult:
     cache_metrics: CachePrefixMetrics | None = None  # Populated by CacheAligner
     timing: dict[str, float] = field(default_factory=dict)  # transform_name → ms
     waste_signals: WasteSignals | None = None  # Detected waste in original messages
+    # Deferred-mode escape hatch: when the pipeline ran with
+    # defer_waste_signals=True and the inline gate would have parsed, this
+    # zero-arg closure performs that exact parse (same message refs, same
+    # tokenizer, same token gate already applied). Callers run it off the
+    # request path and feed the result into the outcome funnel. None when the
+    # gate declined or deferral was off.
+    waste_signals_provider: Callable[[], WasteSignals | None] | None = None
 
     @property
     def transforms_summary(self) -> dict[str, int]:

--- a/headroom/observability/metrics.py
+++ b/headroom/observability/metrics.py
@@ -435,12 +435,43 @@ class HeadroomOtelMetrics:
                 )
 
         if waste_signals:
-            for signal_name, token_count in waste_signals.items():
-                if token_count > 0:
-                    self._waste_signal_tokens.add(
-                        token_count,
-                        self._attrs(model=model, provider=provider, signal=signal_name),
-                    )
+            self._record_waste_signal_counters(
+                model=model, provider=provider, waste_signals=waste_signals
+            )
+
+    def _record_waste_signal_counters(
+        self,
+        *,
+        model: str | None,
+        provider: str | None,
+        waste_signals: dict[str, int],
+    ) -> None:
+        for signal_name, token_count in waste_signals.items():
+            if token_count > 0:
+                self._waste_signal_tokens.add(
+                    token_count,
+                    self._attrs(model=model, provider=provider, signal=signal_name),
+                )
+
+    def record_waste_signals(
+        self,
+        *,
+        model: str | None = None,
+        provider: str | None = None,
+        waste_signals: dict[str, int],
+    ) -> None:
+        """Record waste-signal counters alone (perf review F5).
+
+        For callers that deferred waste-signal detection out of
+        ``record_pipeline_run`` (proxy background job) and derive it later —
+        calling ``record_pipeline_run`` again here would double-count
+        ``_compression_runs``/tokens/duration, which were already recorded
+        synchronously with ``waste_signals=None``.
+        """
+        if waste_signals:
+            self._record_waste_signal_counters(
+                model=model, provider=provider, waste_signals=waste_signals
+            )
 
     def record_compression_failure(
         self,

--- a/headroom/proxy/ccr_session_tracker.py
+++ b/headroom/proxy/ccr_session_tracker.py
@@ -85,3 +85,56 @@ class SessionCcrTracker:
 
         with self._lock:
             self._sessions.clear()
+
+
+class SessionExpansionDedupTracker:
+    """Bounded LRU tracker for per-session CCR proactive-expansion dedup.
+
+    Prevents the same compressed-content hash from being proactively
+    re-injected more than once per session (#2186): a same-messages
+    re-request or a continued conversation must not receive duplicate
+    expansion blocks for content the agent already saw this session.
+    Dedup is per-session, not global — a different conversation may
+    legitimately need the same expansion.
+    """
+
+    def __init__(self, max_sessions: int) -> None:
+        if max_sessions <= 0:
+            raise ValueError("max_sessions must be > 0")
+        self._max_sessions = max_sessions
+        self._lock = threading.RLock()
+        self._sessions: OrderedDict[str, set[str]] = OrderedDict()
+
+    def filter_new(self, session_id: str, hash_keys: list[str]) -> list[str]:
+        """Return the subset of hash_keys not yet injected for this session."""
+
+        if not session_id:
+            raise ValueError("session_id must be non-empty")
+        with self._lock:
+            seen = self._sessions.get(session_id)
+            if seen is None:
+                return list(hash_keys)
+            return [h for h in hash_keys if h not in seen]
+
+    def record_injected(self, session_id: str, hash_keys: list[str]) -> None:
+        """Mark hash_keys as injected for this session."""
+
+        if not session_id:
+            raise ValueError("session_id must be non-empty")
+        if not hash_keys:
+            return
+        with self._lock:
+            seen = self._sessions.get(session_id)
+            if seen is None:
+                seen = set()
+                self._sessions[session_id] = seen
+            seen.update(hash_keys)
+            self._sessions.move_to_end(session_id)
+            while len(self._sessions) > self._max_sessions:
+                self._sessions.popitem(last=False)
+
+    def reset(self) -> None:
+        """Clear all session state."""
+
+        with self._lock:
+            self._sessions.clear()

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -68,8 +68,79 @@ def _strip_index_from_content_blocks(content: Any) -> None:
             _strip_index_from_content_blocks(block.get("content"))
 
 
+def _append_ccr_instructions_to_system(body: dict[str, Any]) -> bool:
+    """Append stable CCR retrieval instructions to an Anthropic body."""
+    from headroom.ccr.tool_injection import create_stable_system_instructions
+
+    marker = "Compressed Context Available"
+    instructions = create_stable_system_instructions().strip()
+    system = body.get("system")
+
+    if isinstance(system, str):
+        if marker in system:
+            return False
+        body["system"] = f"{system}\n\n{instructions}" if system else instructions
+        return True
+
+    if isinstance(system, list):
+        for block in system:
+            if isinstance(block, dict) and marker in str(block.get("text", "")):
+                return False
+            if isinstance(block, str) and marker in block:
+                return False
+        system.append({"type": "text", "text": instructions})
+        return True
+
+    body["system"] = instructions
+    return True
+
+
 class AnthropicHandlerMixin:
     """Mixin providing Anthropic API handler methods for HeadroomProxy."""
+
+    def _start_waste_signal_task(
+        self,
+        result,  # noqa: ANN001
+        *,
+        model: str,
+        provider_name: str,
+    ):  # noqa: ANN201
+        provider = getattr(result, "waste_signals_provider", None)
+        if provider is None:
+            return None
+
+        def _job() -> dict[str, int] | None:
+            try:
+                from headroom.observability import get_otel_metrics
+
+                waste_signals = provider()
+                if waste_signals is None:
+                    return None
+                signals_dict = waste_signals.to_dict()
+                get_otel_metrics().record_waste_signals(
+                    model=model,
+                    provider=provider_name,
+                    waste_signals=signals_dict,
+                )
+                return signals_dict
+            except Exception:
+                logger.debug("Background waste-signal detection failed", exc_info=True)
+                return None
+
+        task = asyncio.create_task(self._run_compression_background(_job))
+        tasks = getattr(self, "_waste_signal_tasks", None)
+        if tasks is None:
+            tasks = set()
+            self._waste_signal_tasks = tasks
+
+        def _on_done(t) -> None:  # noqa: ANN001
+            tasks.discard(t)
+            if not t.cancelled():
+                t.exception()
+
+        tasks.add(task)
+        task.add_done_callback(_on_done)
+        return task
 
     async def _count_tokens_offloaded(self, model, messages):  # noqa: ANN001, ANN201
         from headroom.proxy.token_counting import count_tokens_offloaded
@@ -1838,12 +1909,6 @@ class AnthropicHandlerMixin:
                 self.config.ccr_inject_tool or self.config.ccr_inject_system_instructions
             ) and not _bypass:
                 inject_system_instructions = self.config.ccr_inject_system_instructions
-                if inject_system_instructions and frozen_message_count > 0:
-                    logger.info(
-                        f"[{request_id}] CCR: skipping system instruction injection "
-                        f"(frozen prefix={frozen_message_count}) to preserve cache"
-                    )
-                    inject_system_instructions = False
                 configured_inject_tool = self.config.ccr_inject_tool
                 if configured_inject_tool and frozen_message_count > 0:
                     logger.info(
@@ -1855,11 +1920,12 @@ class AnthropicHandlerMixin:
                 injector = CCRToolInjector(
                     provider="anthropic",
                     inject_tool=False,  # routed through sticky helper below
-                    inject_system_instructions=inject_system_instructions,
+                    inject_system_instructions=False,
                 )
                 injector.scan_for_markers(optimized_messages)
                 if inject_system_instructions and injector.has_compressed_content:
-                    optimized_messages = injector.inject_into_system_message(optimized_messages)
+                    if _append_ccr_instructions_to_system(body):
+                        body_mutation_tracker.mark_mutated("ccr_system_instructions")
 
                 # Sticky-on tool registration (PR-B7): always inject the
                 # retrieval tool once a session has done CCR, regardless
@@ -3388,12 +3454,14 @@ class AnthropicHandlerMixin:
                                 await self.metrics.record_cache_bust(bust_tokens)
 
                         # Update prefix cache tracker for next turn
-                        next_original_messages = copy.deepcopy(original_client_messages)
-                        next_forwarded_messages = copy.deepcopy(optimized_messages)
+                        # Shallow outer-list copies only: update_from_response()
+                        # makes the single defensive deepcopy at record time.
+                        next_original_messages = list(original_client_messages)
+                        next_forwarded_messages = list(optimized_messages)
                         assistant_message = self._assistant_message_from_response_json(resp_json)
                         if assistant_message is not None:
-                            next_original_messages.append(copy.deepcopy(assistant_message))
-                            next_forwarded_messages.append(copy.deepcopy(assistant_message))
+                            next_original_messages.append(assistant_message)
+                            next_forwarded_messages.append(assistant_message)
 
                         # Cache-miss attribution (#1313): when this turn expected a
                         # prompt-cache hit but got cr_tokens == 0, decide whether the

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -31,7 +31,7 @@ from headroom.proxy.auth_mode import classify_auth_mode, classify_client
 from headroom.proxy.compression_decision import CompressionDecision
 from headroom.proxy.forwarded_headers import resolve_client_ip
 from headroom.proxy.handlers._debug_dump import _debug_dump_mode, _redact_debug_value
-from headroom.proxy.helpers import extract_tags
+from headroom.proxy.helpers import extract_tags, injection_target_already_forwarded
 from headroom.proxy.image_isolation import run_image_compression_isolated
 from headroom.proxy.memory_decision import MemoryDecision
 from headroom.proxy.memory_query import MemoryQuery
@@ -1964,6 +1964,7 @@ class AnthropicHandlerMixin:
                                     workspace_key=ccr_workspace_key,
                                     query_context=entry.get("query_context", ""),
                                     sample_content=entry.get("compressed_content", "")[:500],
+                                    session_id=session_id,
                                 )
                     elif self.ccr_context_tracker and not ccr_workspace_key:
                         logger.info(
@@ -1998,7 +1999,23 @@ class AnthropicHandlerMixin:
                         user_query,
                         self._turn_counter,
                         workspace_key=ccr_workspace_key,
+                        session_id=session_id,
                     )
+                    expansion_dedup_tracker = None
+                    if recommendations and session_id:
+                        from headroom.proxy.helpers import (
+                            get_session_expansion_dedup_tracker,
+                        )
+
+                        expansion_dedup_tracker = get_session_expansion_dedup_tracker()
+                        new_hash_keys = set(
+                            expansion_dedup_tracker.filter_new(
+                                session_id, [r.hash_key for r in recommendations]
+                            )
+                        )
+                        recommendations = [
+                            r for r in recommendations if r.hash_key in new_hash_keys
+                        ]
                     if recommendations:
                         expansions = self.ccr_context_tracker.execute_expansions(recommendations)
                         if expansions:
@@ -2018,14 +2035,32 @@ class AnthropicHandlerMixin:
                                     f"[{request_id}] CCR: skipping proactive expansion append "
                                     "in cache mode to preserve next-turn prefix stability"
                                 )
-                            else:
-                                optimized_messages = (
-                                    self._append_context_to_latest_non_frozen_user_turn(
-                                        optimized_messages,
-                                        expansion_text,
-                                        frozen_message_count=frozen_message_count,
-                                    )
+                            elif injection_target_already_forwarded(
+                                optimized_messages,
+                                prefix_tracker=prefix_tracker,
+                                current_original_messages=original_client_messages,
+                            ):
+                                logger.info(
+                                    f"[{request_id}] CCR: skipping proactive expansion append — "
+                                    "tail position already forwarded last turn "
+                                    "(would double-inject, #2186)"
                                 )
+                            else:
+                                new_optimized = self._append_context_to_latest_non_frozen_user_turn(
+                                    optimized_messages,
+                                    expansion_text,
+                                    frozen_message_count=frozen_message_count,
+                                )
+                                # The helper returns the SAME list object unchanged
+                                # when the latest turn is frozen or has no eligible
+                                # text block — nothing was injected, so don't mark
+                                # the hashes as seen (a later turn may retry).
+                                if new_optimized is not optimized_messages:
+                                    optimized_messages = new_optimized
+                                    if expansion_dedup_tracker and session_id:
+                                        expansion_dedup_tracker.record_injected(
+                                            session_id, [e["hash"] for e in expansions]
+                                        )
 
             # Traffic Learner: Extract patterns from inbound tool results
             if self.traffic_learner:
@@ -2111,6 +2146,21 @@ class AnthropicHandlerMixin:
                                     request_id=request_id,
                                     session_id=session_id,
                                     decision="skipped_cache_mode",
+                                    bytes_injected=0,
+                                    query=user_query,
+                                )
+                            elif injection_target_already_forwarded(
+                                optimized_messages,
+                                prefix_tracker=prefix_tracker,
+                                current_original_messages=original_client_messages,
+                            ):
+                                # Tail position already forwarded last turn; the
+                                # overlay replayed it byte-identical, so appending
+                                # here would double-inject (#2186).
+                                log_memory_injection(
+                                    request_id=request_id,
+                                    session_id=session_id,
+                                    decision="skipped_already_forwarded",
                                     bytes_injected=0,
                                     query=user_query,
                                 )

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -3353,6 +3353,7 @@ class OpenAIHandlerMixin:
                         from headroom.proxy.helpers import (
                             append_text_to_latest_user_chat_message,
                             get_memory_injection_mode,
+                            injection_target_already_forwarded,
                             log_memory_injection,
                         )
 
@@ -3362,6 +3363,21 @@ class OpenAIHandlerMixin:
                                 request_id=request_id,
                                 session_id=None,
                                 decision="skipped_disabled",
+                                bytes_injected=0,
+                                query=None,
+                            )
+                        elif injection_target_already_forwarded(
+                            optimized_messages,
+                            prefix_tracker=openai_prefix_tracker,
+                            current_original_messages=original_client_messages,
+                        ):
+                            # Tail position already forwarded last turn; the
+                            # overlay replayed it byte-identical, so appending
+                            # here would double-inject (#2186).
+                            log_memory_injection(
+                                request_id=request_id,
+                                session_id=None,
+                                decision="skipped_already_forwarded",
                                 bytes_injected=0,
                                 query=None,
                             )

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -3738,6 +3738,7 @@ class OpenAIHandlerMixin:
                         waste_signals=waste_signals_dict,
                         prefix_tracker=openai_prefix_tracker,
                         optimized_messages=optimized_messages,
+                        original_messages=original_client_messages,
                     )
                 else:
                     # Non-streaming: use send_openai_message() → JSON
@@ -3956,6 +3957,7 @@ class OpenAIHandlerMixin:
                         cache_read_tokens=cache_read_tokens,
                         cache_write_tokens=cache_write_tokens,
                         messages=optimized_messages,
+                        original_messages=original_client_messages,
                     )
 
                     await self._record_request_outcome(
@@ -4280,6 +4282,7 @@ class OpenAIHandlerMixin:
                     cache_read_tokens=cache_read_tokens,
                     cache_write_tokens=cache_write_tokens,
                     messages=optimized_messages,
+                    original_messages=original_client_messages,
                 )
 
                 # OpenAI has no write penalty — uncached = total - cached
@@ -4607,7 +4610,9 @@ class OpenAIHandlerMixin:
         # chat handler uses so multi-endpoint clients within one
         # conversation share the sticky-token set.
         _responses_session_id = self.session_tracker_store.compute_session_id(
-            request, model, messages
+            request,
+            model,
+            messages,
         )
         from headroom.proxy.helpers import (
             get_session_beta_tracker as _get_session_beta_tracker_resp,

--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -913,11 +913,11 @@ class StreamingMixin:
         # outside the metric funnel. Run it before the funnel so the next
         # request inherits correct prefix state regardless of metric path.
         if prefix_tracker is not None:
-            import copy as _copy
-
             forwarded_messages = body.get("messages", [])
-            next_forwarded = _copy.deepcopy(forwarded_messages)
-            next_original = _copy.deepcopy(original_messages or forwarded_messages)
+            # Shallow outer-list copies only: update_from_response() makes
+            # the single defensive deepcopy at record time (perf review F1).
+            next_forwarded = list(forwarded_messages)
+            next_original = list(original_messages or forwarded_messages)
 
             if full_sse_data and provider == "anthropic":
                 _parsed = (
@@ -928,8 +928,8 @@ class StreamingMixin:
                 if _parsed:
                     asst_msg = self._assistant_message_from_response_json(_parsed)
                     if asst_msg is not None:
-                        next_forwarded.append(_copy.deepcopy(asst_msg))
-                        next_original.append(_copy.deepcopy(asst_msg))
+                        next_forwarded.append(asst_msg)
+                        next_original.append(asst_msg)
 
             # Cache-miss attribution (#1313), streaming Anthropic path. Mirror
             # the non-streaming handler: classify BEFORE update_from_response
@@ -1808,23 +1808,23 @@ class StreamingMixin:
                 # sibling). Run before the outcome funnel so prefix state
                 # is consistent regardless of metric path.
                 if prefix_tracker is not None:
-                    import copy as _copy
-
                     tracker_messages = (
                         optimized_messages
                         if optimized_messages is not None
                         else body.get("messages", [])
                     )
-                    next_forwarded = _copy.deepcopy(tracker_messages)
-                    next_original = _copy.deepcopy(original_messages or tracker_messages)
+                    # Shallow outer-list copies only: update_from_response() makes
+                    # the single defensive deepcopy at record time (perf review F1).
+                    next_forwarded = list(tracker_messages)
+                    next_original = list(original_messages or tracker_messages)
                     if full_sse_bytes:
                         parsed = self._parse_sse_to_response(
                             full_sse_bytes.decode("utf-8", errors="replace"), provider
                         )
                         asst_msg = self._assistant_message_from_response_json(parsed)
                         if asst_msg is not None:
-                            next_forwarded.append(_copy.deepcopy(asst_msg))
-                            next_original.append(_copy.deepcopy(asst_msg))
+                            next_forwarded.append(asst_msg)
+                            next_original.append(asst_msg)
                     cache_read_tokens = stream_state["cache_read_input_tokens"] or 0
                     cache_write_tokens = stream_state["cache_creation_input_tokens"] or 0
                     if provider == "anthropic" and hasattr(prefix_tracker, "classify_cache_miss"):
@@ -1899,6 +1899,7 @@ class StreamingMixin:
         waste_signals: dict[str, int] | None = None,
         prefix_tracker: Any | None = None,
         optimized_messages: list[dict] | None = None,
+        original_messages: list[dict] | None = None,
     ) -> StreamingResponse:
         """Stream OpenAI chat completion response from backend.
 
@@ -2040,6 +2041,7 @@ class StreamingMixin:
                         cache_read_tokens=cache_read_tokens,
                         cache_write_tokens=cache_write_tokens,
                         messages=tracker_messages,
+                        original_messages=original_messages,
                     )
 
                 # CCR Feedback: record headroom_retrieve tool calls so

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -78,6 +78,9 @@ from headroom.proxy.ccr_marker_policy import (
     should_inject_ccr_tool as _should_inject_ccr_tool,
 )
 from headroom.proxy.ccr_session_tracker import SessionCcrTracker as _SessionCcrTracker
+from headroom.proxy.ccr_session_tracker import (
+    SessionExpansionDedupTracker as _SessionExpansionDedupTracker,
+)
 from headroom.proxy.internal_header_policy import (
     INTERNAL_HEADER_PREFIX,
     STRIP_INTERNAL_HEADERS_DEFAULT,
@@ -378,6 +381,41 @@ def log_memory_injection(
         bytes_injected,
         query_hash,
     )
+
+
+def injection_target_already_forwarded(
+    messages: list[dict[str, Any]],
+    *,
+    prefix_tracker: Any,
+    current_original_messages: list[dict[str, Any]],
+) -> bool:
+    """True when appending to ``messages[-1]`` would double-inject.
+
+    Shared guard for CCR proactive-expansion and memory-context injection on
+    both the Anthropic and OpenAI paths: all of them append to the tail
+    message via a provider-specific "append to latest user turn" helper. On a
+    same-messages re-request (or any turn whose tail position was already
+    part of last turn's forwarded output), ``overlay_cached_prefix`` has
+    already replayed that position's bytes byte-identical — including
+    whatever was injected into it last turn. Injecting again there would
+    append a second copy and bust the cache from that point on (#2186).
+
+    "Already forwarded" = the tail index falls within last turn's forwarded
+    message count AND this turn's originals are a full append-only extension
+    of last turn's originals — the same condition under which the overlay
+    actually replayed that position (see
+    ``headroom.cache.prefix_tracker.is_append_only_extension``).
+    """
+    from headroom.cache.prefix_tracker import is_append_only_extension
+
+    target_index = len(messages) - 1
+    if target_index < 0:
+        return False
+    previous_forwarded = prefix_tracker.get_last_forwarded_messages()
+    if target_index >= len(previous_forwarded):
+        return False
+    previous_original = prefix_tracker.get_last_original_messages()
+    return is_append_only_extension(current_original_messages, previous_original)
 
 
 def append_text_to_latest_user_chat_message(
@@ -2241,6 +2279,29 @@ def _reset_session_ccr_tracker_for_test() -> None:
     global _session_ccr_tracker
     with _session_ccr_tracker_lock:
         _session_ccr_tracker = None
+
+
+# Process-wide singleton for per-session CCR proactive-expansion dedup (#2186).
+_session_expansion_dedup_tracker_lock = threading.Lock()
+_session_expansion_dedup_tracker: _SessionExpansionDedupTracker | None = None
+
+
+def get_session_expansion_dedup_tracker() -> _SessionExpansionDedupTracker:
+    """Return the process-wide :class:`SessionExpansionDedupTracker` singleton."""
+    global _session_expansion_dedup_tracker
+    with _session_expansion_dedup_tracker_lock:
+        if _session_expansion_dedup_tracker is None:
+            _session_expansion_dedup_tracker = _SessionExpansionDedupTracker(
+                max_sessions=get_tool_tracker_max_sessions()
+            )
+        return _session_expansion_dedup_tracker
+
+
+def _reset_session_expansion_dedup_tracker_for_test() -> None:
+    """Clear the process-wide expansion-dedup tracker (test-only)."""
+    global _session_expansion_dedup_tracker
+    with _session_expansion_dedup_tracker_lock:
+        _session_expansion_dedup_tracker = None
 
 
 def has_new_ccr_markers(

--- a/headroom/proxy/outcome.py
+++ b/headroom/proxy/outcome.py
@@ -130,6 +130,14 @@ class RequestOutcome:
     #     new bookkeeping at the call sites.
     transforms_applied: tuple[str, ...] = ()
     waste_signals: dict[str, int] | None = None
+    # Deferred waste-signal detection: an asyncio.Task resolving to the same
+    # ``to_dict()`` form as ``waste_signals``, started by the Anthropic handler
+    # right after the pipeline ran (overlapping the upstream call).
+    # ``emit_request_outcome`` collects it opportunistically (done-only, never
+    # waits) so the metrics and request-log funnels record the signals the
+    # inline path would have produced without adding response latency.
+    # Ignored when ``waste_signals`` is already populated.
+    waste_signals_task: Any | None = None
     num_messages: int = 0
     turn_id: str | None = None
     request_messages: list[dict[str, Any]] | None = None
@@ -367,6 +375,23 @@ async def emit_request_outcome(handler: Any, outcome: RequestOutcome) -> None:
         await handler.metrics.record_failed(provider=outcome.provider)
         return
 
+    # Deferred waste-signal collection: the task was started right after the
+    # pipeline ran, so by the time the upstream response arrives it has
+    # usually long finished. Collection is strictly opportunistic — this
+    # funnel is awaited BEFORE the response is returned on the non-streaming
+    # path, so it must never wait on the single-worker background executor
+    # (which can be busy for seconds with a deferred compression job). If the
+    # task isn't done yet, only this request's per-row attribution is lost
+    # (telemetry-only, fail open); the task keeps running and still records
+    # its OTel counter.
+    waste_signals = outcome.waste_signals
+    task = outcome.waste_signals_task
+    if waste_signals is None and task is not None and task.done():
+        try:
+            waste_signals = task.result()
+        except Exception:
+            waste_signals = None
+
     # Output-shaping savings ledger (counterfactual estimator). The shaper
     # tags each request's (arm, stratum) onto ``transforms_applied``; feed the
     # observed output tokens to the recorder so it can produce an honest
@@ -408,7 +433,7 @@ async def emit_request_outcome(handler: Any, outcome: RequestOutcome) -> None:
         overhead_ms=outcome.overhead_ms,
         ttfb_ms=outcome.ttfb_ms,
         pipeline_timing=outcome.pipeline_timing,
-        waste_signals=outcome.waste_signals,
+        waste_signals=waste_signals,
         cache_read_tokens=outcome.cache_read_tokens,
         cache_write_tokens=outcome.cache_write_tokens,
         cache_write_5m_tokens=outcome.cache_write_5m_tokens,
@@ -467,7 +492,7 @@ async def emit_request_outcome(handler: Any, outcome: RequestOutcome) -> None:
                 cache_write_tokens=outcome.cache_write_tokens,
                 uncached_input_tokens=outcome.uncached_input_tokens,
                 transforms_applied=list(outcome.transforms_applied),
-                waste_signals=outcome.waste_signals,
+                waste_signals=waste_signals,
                 request_messages=outcome.request_messages,
                 compressed_messages=outcome.compressed_messages,
                 turn_id=outcome.turn_id,

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -4,7 +4,7 @@ A full-featured LLM proxy with optimization, caching, rate limiting,
 and observability.
 
 Features:
-- Context optimization (SmartCrusher, CacheAligner — live-zone-only after Phase B)
+- Context optimization (ContentRouter/SmartCrusher — live-zone-only after Phase B)
 - Semantic caching (save costs on repeated queries)
 - Rate limiting (token bucket)
 - Retry with exponential backoff
@@ -46,6 +46,7 @@ from urllib.parse import urlsplit
 if TYPE_CHECKING:
     from ..backends.base import Backend
     from ..cache.compression_cache import CompressionCache
+    from ..cache.token_count_memo import TokenCountMemo
     from ..memory.tracker import MemoryTracker
     from .outcome import RequestOutcome
 
@@ -81,7 +82,6 @@ from headroom.ccr import (
 )
 from headroom.config import (
     DEFAULT_EXCLUDE_TOOLS,
-    CacheAlignerConfig,
     ReadLifecycleConfig,
 )
 from headroom.dashboard import get_dashboard_html
@@ -183,7 +183,6 @@ from headroom.telemetry import get_telemetry_collector
 from headroom.telemetry.beacon import is_telemetry_enabled
 from headroom.telemetry.toin import get_toin
 from headroom.transforms import (
-    CacheAligner,
     CodeAwareCompressor,
     CodeCompressorConfig,
     CompressionStrategy,
@@ -934,7 +933,6 @@ class HeadroomProxy(
                 return router_config
             return replace(router_config, enable_kompress=not kompress_disabled)
 
-        cache_aligner = CacheAligner(CacheAlignerConfig(enabled=False))
         anthropic_router = ContentRouter(
             _router_config_for(anthropic_kompress_disabled), observer=self.metrics
         )
@@ -952,11 +950,11 @@ class HeadroomProxy(
             _intercept_prefix = [ToolResultInterceptorTransform()]
 
         self.anthropic_pipeline = TransformPipeline(
-            transforms=[*_intercept_prefix, cache_aligner, anthropic_router],
+            transforms=[*_intercept_prefix, anthropic_router],
             provider=self.anthropic_provider,
         )
         self.openai_pipeline = TransformPipeline(
-            transforms=[*_intercept_prefix, cache_aligner, openai_router],
+            transforms=[*_intercept_prefix, openai_router],
             provider=self.openai_provider,
         )
 
@@ -997,10 +995,16 @@ class HeadroomProxy(
         # Compression cache store for token mode (session-scoped). The dict
         # itself is mutated under `_compression_caches_lock`; the per-session
         # `CompressionCache` instances have their own internal lock guarding
-        # `_cache`/`_stable_hashes`/`_first_seen` against concurrent
+        # `_cache`/`_stable_hashes` against concurrent
         # async-dispatched requests for the same session.
         self._compression_caches: dict[str, CompressionCache] = {}
         self._compression_caches_lock = threading.RLock()
+
+        # Per-session memoized message token counts (perf review F2). Same
+        # session-scoped-dict + eviction pattern as `_compression_caches`;
+        # each `TokenCountMemo` has its own internal lock guarding `_counts`.
+        self._token_count_memos: dict[str, TokenCountMemo] = {}
+        self._token_count_memos_lock = threading.RLock()
 
         self.logger = (
             RequestLogger(
@@ -1537,6 +1541,30 @@ class HeadroomProxy(
 
                 self._compression_caches[session_id] = CompressionCache()
             return self._compression_caches[session_id]
+
+    def _get_token_count_memo(self, session_id: str) -> TokenCountMemo:
+        """Get or create a TokenCountMemo for a session (perf review F2).
+
+        Same thread-safety and eviction contract as `_get_compression_cache`.
+        """
+        with self._token_count_memos_lock:
+            if session_id not in self._token_count_memos:
+                from headroom.cache.token_count_memo import TokenCountMemo
+
+                if len(self._token_count_memos) >= MAX_COMPRESSION_CACHE_SESSIONS:
+                    oldest_keys = list(self._token_count_memos.keys())[
+                        : MAX_COMPRESSION_CACHE_SESSIONS // 4
+                    ]
+                    for key in oldest_keys:
+                        del self._token_count_memos[key]
+                    logger.info(
+                        "Evicted %d token-count memos (exceeded %d max sessions)",
+                        len(oldest_keys),
+                        MAX_COMPRESSION_CACHE_SESSIONS,
+                    )
+
+                self._token_count_memos[session_id] = TokenCountMemo()
+            return self._token_count_memos[session_id]
 
     def _setup_code_aware(self, config: ProxyConfig, transforms: list) -> str:
         """Set up code-aware compression if enabled.

--- a/headroom/tokenizers/base.py
+++ b/headroom/tokenizers/base.py
@@ -55,6 +55,12 @@ class BaseTokenizer(ABC):
     MESSAGE_OVERHEAD = 4
     REPLY_OVERHEAD = 3  # Assistant reply start tokens
 
+    # True when count_messages(msgs) == sum(count_message(m)) + REPLY_OVERHEAD
+    # (the base per-message loop). Per-message memoization (TokenCountMemo)
+    # is only sound under this identity; subclasses that encode the whole
+    # conversation jointly (chat templates) MUST set this False.
+    ADDITIVE_COUNTS = True
+
     # Oversized-blob token estimation (see _count_serialized). Serializing a blob
     # is cheap; running count_text over the whole multi-megabyte string is what
     # blocks the proxy event loop, so a large blob is counted from an even-spread

--- a/headroom/tokenizers/estimator.py
+++ b/headroom/tokenizers/estimator.py
@@ -141,7 +141,9 @@ class EstimatingTokenCounter(BaseTokenizer):
         Returns:
             Number of dense-script characters in the text.
         """
-        return len(self.CJK_PATTERN.findall(text))
+        # sum(1 for _ in finditer) avoids materializing the full match list
+        # findall would build (perf review F2).
+        return sum(1 for _ in self.CJK_PATTERN.finditer(text))
 
     def _detect_ratio(self, text: str) -> float:
         """Detect optimal chars-per-token ratio based on content.
@@ -161,7 +163,7 @@ class EstimatingTokenCounter(BaseTokenizer):
                 pass
 
         # Check for code
-        code_matches = len(self.CODE_PATTERN.findall(text))
+        code_matches = sum(1 for _ in self.CODE_PATTERN.finditer(text))
         if code_matches > len(text) / 500:  # ~2 matches per KB
             return self.CHARS_PER_TOKEN_CODE
 
@@ -181,15 +183,15 @@ class EstimatingTokenCounter(BaseTokenizer):
         """
         overhead = 0
 
-        # URLs typically tokenize to more tokens
-        urls = self.URL_PATTERN.findall(text)
-        for url in urls:
+        # URLs typically tokenize to more tokens. Iterate finditer directly
+        # (not findall) so the full match list is never materialized (F2).
+        for match in self.URL_PATTERN.finditer(text):
+            url = match.group()
             # Each URL component adds overhead
             overhead += url.count("/") + url.count("?") + url.count("&")
 
         # UUIDs are typically 8-10 tokens despite being 36 chars
-        uuids = self.UUID_PATTERN.findall(text)
-        overhead += len(uuids) * 2  # Each UUID adds ~2 extra tokens
+        overhead += sum(1 for _ in self.UUID_PATTERN.finditer(text)) * 2
 
         return overhead
 

--- a/headroom/tokenizers/huggingface.py
+++ b/headroom/tokenizers/huggingface.py
@@ -257,6 +257,10 @@ class HuggingFaceTokenizer(BaseTokenizer):
         tokens = counter.count_text("Hello, world!")
     """
 
+    # count_messages uses apply_chat_template over the whole conversation when
+    # available — NOT the additive per-message loop. Never memoize per-message.
+    ADDITIVE_COUNTS = False
+
     # Overhead per message (varies by model, this is a reasonable default)
     MESSAGE_OVERHEAD = 4
     REPLY_OVERHEAD = 3

--- a/headroom/tokenizers/mistral.py
+++ b/headroom/tokenizers/mistral.py
@@ -120,6 +120,10 @@ class MistralTokenizer(BaseTokenizer):
 
     MESSAGE_OVERHEAD = 4
     REPLY_OVERHEAD = 3
+    # count_messages uses encode_chat_completion over the whole conversation
+    # when available — NOT the additive per-message loop. Never memoize
+    # per-message.
+    ADDITIVE_COUNTS = False
 
     def __init__(self, model: str = "mistral-large"):
         """Initialize Mistral tokenizer.

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -4390,7 +4390,14 @@ class ContentRouter(Transform):
         # to preserve pre-F2.2 behaviour for non-proxy callers.
         self._runtime_compression_policy = kwargs.get("compression_policy")
 
-        tokens_before = sum(tokenizer.count_text(str(m.get("content", ""))) for m in messages)
+        # perf review F3: avoid str()-ing Anthropic content-block lists (repr
+        # punctuation inflated context_pressure). Reuse the pipeline's
+        # already-correct count when available (tokens_before_hint, plumbed
+        # in pipeline.py); only recount here for direct SDK callers that skip
+        # the pipeline.
+        tokens_before = kwargs.get("tokens_before_hint")
+        if tokens_before is None:
+            tokens_before = tokenizer.count_messages(messages)
         context = kwargs.get("context", "")
         hook_biases: dict[int, float] = kwargs.get("biases") or {}
 
@@ -5116,9 +5123,10 @@ class ContentRouter(Transform):
                 transformed_messages, frozen_message_count, transforms_applied, route_counts
             )
 
-        tokens_after = sum(
-            tokenizer.count_text(str(m.get("content", ""))) for m in transformed_messages
-        )
+        # perf review F3 (twin of the tokens_before fix above): same repr-based
+        # str() bug inflated tokens_after, which would understate reported
+        # savings relative to the now-accurate tokens_before.
+        tokens_after = tokenizer.count_messages(transformed_messages)
 
         # Log routing summary
         parts = []

--- a/headroom/transforms/pipeline.py
+++ b/headroom/transforms/pipeline.py
@@ -248,6 +248,18 @@ class TransformPipeline:
                 - request_id: Optional request ID for diff artifact.
                 - waste_messages: Optional richer conversion of the same request
                   used for waste-signal detection only (never transformed).
+                - defer_waste_signals: Skip the inline waste-signal re-parse;
+                  ``TransformResult.waste_signals`` is always None. When the
+                  inline gate would have parsed, the result instead carries a
+                  ``waste_signals_provider`` closure the caller runs off-path
+                  (the Anthropic proxy handler does, in a background task that
+                  feeds the outcome funnel). Default False.
+
+            Note: ``apply`` also injects ``tokens_before_hint`` (the
+            already-computed ``tokens_before``) into the kwargs passed to
+            every transform, so transforms needing a pre-transform token
+            count (e.g. ContentRouter's context-pressure calc) can reuse it
+            instead of recounting the messages themselves.
 
         Returns:
             Combined TransformResult.
@@ -257,6 +269,11 @@ class TransformPipeline:
         waste_signal_token_limit = int(
             kwargs.pop("waste_signal_token_limit", MAX_WASTE_SIGNAL_DETECTION_TOKENS)
         )
+        # perf review F5: skip the inline telemetry-only re-parse on the proxy's
+        # critical path. Defaults False so SDK/library callers (and `simulate`)
+        # keep identical inline behavior; the proxy passes True via
+        # `proxy_pipeline_kwargs` and re-parses off-path instead (anthropic.py).
+        defer_waste_signals = bool(kwargs.pop("defer_waste_signals", False))
         tokenizer = self._get_tokenizer(model)
         provider_name = self._provider_name()
 
@@ -282,6 +299,10 @@ class TransformPipeline:
         t_count = time.perf_counter()
         tokens_before = tokenizer.count_messages(messages)
         count_ms = (time.perf_counter() - t_count) * 1000
+        # Count-hint plumbing (perf review F2/F3): pass the already-computed
+        # tokens_before through **kwargs so transforms (ContentRouter) can
+        # reuse it instead of re-counting the same messages themselves.
+        kwargs["tokens_before_hint"] = tokens_before
 
         logger.debug(
             "Pipeline starting: %d messages, %d tokens, model=%s",
@@ -372,6 +393,13 @@ class TransformPipeline:
 
                     # Update messages for next transform
                     current_messages = result.messages
+
+                    # Keep the count hint honest for the NEXT transform: this
+                    # transform may have changed the messages (e.g. the
+                    # HEADROOM_INTERCEPT_ENABLED interceptor runs before the
+                    # ContentRouter), so the pipeline-entry count no longer
+                    # describes what the next transform receives.
+                    kwargs["tokens_before_hint"] = result.tokens_after
 
                     # Use token counts reported by the transform itself — avoids
                     # redundant O(N) recount of the full message list after each step.
@@ -480,11 +508,35 @@ class TransformPipeline:
             # pass a richer waste_messages list that is parsed instead — it is
             # telemetry-only and never transformed.
             waste_signals: WasteSignals | None = None
+            waste_signals_provider: Callable[[], WasteSignals | None] | None = None
             saved_enough = (
                 tokens_before > tokens_after
                 and (tokens_before - tokens_after) > _MIN_TOKENS_SAVED_FOR_WASTE_SIGNALS
             )
-            if saved_enough and tokens_before > waste_signal_token_limit:
+            if defer_waste_signals:
+                # perf review F5: keep the telemetry-only re-parse off the
+                # critical path, but evaluate the SAME gate here (this call's
+                # own token counts, including the waste_signal_token_limit
+                # override) and hand the caller a closure over the exact
+                # inputs the inline parse would have used. The caller runs it
+                # off-path (anthropic.py background task) and feeds the result
+                # into the outcome funnel.
+                if saved_enough and tokens_before <= waste_signal_token_limit:
+                    deferred_input = waste_messages or messages
+                    deferred_compressed = current_messages
+
+                    def _deferred_waste_parse() -> WasteSignals | None:
+                        from ..parser import parse_messages
+
+                        _, _, deferred_ws = parse_messages(
+                            deferred_input,
+                            tokenizer,
+                            compressed_messages=deferred_compressed,
+                        )
+                        return deferred_ws if deferred_ws.total() > 0 else None
+
+                    waste_signals_provider = _deferred_waste_parse
+            elif saved_enough and tokens_before > waste_signal_token_limit:
                 # Telemetry-only re-parse would risk the compression timeout on a
                 # request this large (#296); skip it and keep the result.
                 logger.debug(
@@ -542,6 +594,7 @@ class TransformPipeline:
             diff_artifact=diff_artifact,
             timing=all_timing,
             waste_signals=waste_signals,
+            waste_signals_provider=waste_signals_provider,
         )
 
     def simulate(

--- a/tests/test_agent_savings.py
+++ b/tests/test_agent_savings.py
@@ -412,6 +412,15 @@ def test_agent_savings_config_mismatches_reports_unparseable_values(monkeypatch)
     ]
 
 
+def test_proxy_pipeline_kwargs_does_not_defer_waste_signals() -> None:
+    """proxy_pipeline_kwargs feeds ALL provider handlers, but only the
+    Anthropic messages route compensates for deferral (background task +
+    outcome collection) — so the shared kwargs must NOT defer, or the other
+    routes silently lose waste-signal telemetry. The Anthropic handler passes
+    defer_waste_signals=True explicitly at its covered call sites."""
+    assert "defer_waste_signals" not in proxy_pipeline_kwargs(ProxyConfig())
+
+
 def test_agent_90_profile_applies_to_proxy_config_runtime_kwargs() -> None:
     config = ProxyConfig(savings_profile="agent-90")
 

--- a/tests/test_anthropic_pre_upstream_backpressure.py
+++ b/tests/test_anthropic_pre_upstream_backpressure.py
@@ -280,14 +280,20 @@ class _DummyAnthropicHandler(AnthropicHandlerMixin):
         return SimpleNamespace(
             apply_cached=lambda m: m,
             compute_frozen_count=lambda m: 0,
+            prepare_turn=lambda m, t: (min(t, 0), m),
             mark_stable_from_messages=lambda *a, **k: None,
-            should_defer_compression=lambda h: False,
             mark_stable=lambda h: None,
             content_hash=lambda c: "h",
             update_from_result=lambda *a, **k: None,
             _cache={},
             _stable_hashes=set(),
         )
+
+    def _get_token_count_memo(self, session_id):
+        from headroom.cache.token_count_memo import TokenCountMemo
+
+        self._memo = getattr(self, "_memo", TokenCountMemo())
+        return self._memo
 
 
 def _build_request(body: dict, headers: dict[str, str]) -> Request:

--- a/tests/test_anthropic_stage_timings.py
+++ b/tests/test_anthropic_stage_timings.py
@@ -131,14 +131,20 @@ class _DummyAnthropicHandler(AnthropicHandlerMixin):
         return SimpleNamespace(
             apply_cached=lambda m: m,
             compute_frozen_count=lambda m: 0,
+            prepare_turn=lambda m, t: (min(t, 0), m),
             mark_stable_from_messages=lambda *a, **k: None,
-            should_defer_compression=lambda h: False,
             mark_stable=lambda h: None,
             content_hash=lambda c: "h",
             update_from_result=lambda *a, **k: None,
             _cache={},
             _stable_hashes=set(),
         )
+
+    def _get_token_count_memo(self, session_id):
+        from headroom.cache.token_count_memo import TokenCountMemo
+
+        self._memo = getattr(self, "_memo", TokenCountMemo())
+        return self._memo
 
 
 def _build_request(body: dict, headers: dict[str, str]) -> Request:

--- a/tests/test_cache/test_prefix_tracker.py
+++ b/tests/test_cache/test_prefix_tracker.py
@@ -166,31 +166,6 @@ class TestPrefixCacheTracker:
         assert stats.compression_foregone_tokens == 700
         assert stats.net_benefit_tokens == 7300
 
-    def test_should_force_compress_outside_frozen(self, tracker):
-        """Messages outside frozen prefix should always be compressed."""
-        tracker._cached_message_count = 3
-        assert tracker.should_force_compress(5, 1000, 200) is True
-
-    def test_should_force_compress_when_savings_exceed_discount(self, tracker):
-        """For Anthropic (90% discount), compression must save >90% to be worth it."""
-        tracker._cached_message_count = 5
-
-        # 95% savings > 90% discount — should force compress
-        assert tracker.should_force_compress(2, 1000, 50) is True
-
-        # 50% savings < 90% discount — should NOT force compress
-        assert tracker.should_force_compress(2, 1000, 500) is False
-
-    def test_should_force_compress_openai(self, openai_tracker):
-        """For OpenAI (50% discount), compression must save >50% to be worth it."""
-        openai_tracker._cached_message_count = 5
-
-        # 60% savings > 50% discount — should force compress
-        assert openai_tracker.should_force_compress(2, 1000, 400) is True
-
-        # 40% savings < 50% discount — should NOT force compress
-        assert openai_tracker.should_force_compress(2, 1000, 600) is False
-
     def test_estimate_message_tokens(self):
         """Token estimation should roughly match character / 3.5."""
         messages = [

--- a/tests/test_canonical_pipeline.py
+++ b/tests/test_canonical_pipeline.py
@@ -15,6 +15,7 @@ from headroom.pipeline import (
     summarize_routing_markers,
 )
 from headroom.providers.base import Provider, TokenCounter
+from headroom.tokenizers.base import BaseTokenizer
 from headroom.transforms import ContentRouter, TransformPipeline
 from headroom.transforms.content_router import CompressionStrategy
 
@@ -158,7 +159,7 @@ def test_default_transform_pipeline_always_uses_content_router() -> None:
 
 
 def test_content_router_protects_instruction_roles_but_compresses_tool_outputs() -> None:
-    class Tokenizer:
+    class Tokenizer(BaseTokenizer):
         def count_text(self, text: str) -> int:
             return max(1, len(text.split()))
 

--- a/tests/test_ccr_tool_injection.py
+++ b/tests/test_ccr_tool_injection.py
@@ -240,7 +240,7 @@ class TestCCRToolInjector:
         assert tools == []
 
     def test_inject_system_instructions(self):
-        """System instructions are injected when compression detected."""
+        """System instructions are injected (hash-free) when compression detected."""
         messages = [
             {"role": "system", "content": "You are helpful."},
             {
@@ -254,7 +254,12 @@ class TestCCRToolInjector:
         updated = injector.inject_into_system_message(messages)
 
         assert "Compressed Context Available" in updated[0]["content"]
-        assert "abc123def456abc123def456" in updated[0]["content"]
+        # The injected instructions are the hash-free stable variant, so the
+        # per-turn hash list no longer leaks into the system segment (keeps it
+        # byte-stable for the prompt cache); the model finds each hash from the
+        # marker in its own tool result instead.
+        assert "abc123def456abc123def456" not in updated[0]["content"]
+        assert CCR_TOOL_NAME in updated[0]["content"]
 
     def test_process_request_full_flow(self):
         """process_request handles complete injection flow."""

--- a/tests/test_cold_start_fast_pass.py
+++ b/tests/test_cold_start_fast_pass.py
@@ -171,14 +171,20 @@ class _DummyAnthropicHandler(AnthropicHandlerMixin):
         return SimpleNamespace(
             apply_cached=lambda m: m,
             compute_frozen_count=lambda m: 0,
+            prepare_turn=lambda m, t: (min(t, 0), m),
             mark_stable_from_messages=lambda *a, **k: None,
-            should_defer_compression=lambda h: False,
             mark_stable=lambda h: None,
             content_hash=lambda c: "h",
             update_from_result=lambda *a: self.comp_cache_updates.append(a),
             _cache={},
             _stable_hashes=set(),
         )
+
+    def _get_token_count_memo(self, session_id):
+        from headroom.cache.token_count_memo import TokenCountMemo
+
+        self._memo = getattr(self, "_memo", TokenCountMemo())
+        return self._memo
 
 
 def _build_request(body: dict) -> Request:

--- a/tests/test_compression_cache.py
+++ b/tests/test_compression_cache.py
@@ -260,35 +260,6 @@ class TestCompressionCacheFrozenCount:
         assert ha in cache._stable_hashes
         assert hb not in cache._stable_hashes  # msg[2] not included
 
-    def test_should_defer_compression_new_content(self, cache: CompressionCache) -> None:
-        """First-time content should NOT be deferred — there is no
-        prefix-cache entry to preserve, so compression carries no bust
-        cost. Issue #327: prior behavior deferred first-sight, which
-        marked every fresh tool_result as stable and disabled
-        compression for typical Claude Code workloads.
-        """
-        h = CompressionCache.content_hash("brand new content")
-        assert cache.should_defer_compression(h, ttl_seconds=300, batch_window=30) is False
-        # Subsequent sightings within TTL should defer (batch window).
-        assert cache.should_defer_compression(h, ttl_seconds=300, batch_window=30) is True
-
-    def test_should_defer_compression_records_first_seen(self, cache: CompressionCache) -> None:
-        """First-sight call must record the timestamp so subsequent
-        in-window calls can defer. Without this the deferral pathway
-        for genuinely-repeated content stops working."""
-        h = CompressionCache.content_hash("seen-twice content")
-        cache.should_defer_compression(h)  # first sight
-        assert h in cache._first_seen
-
-    def test_should_defer_compression_near_ttl(self, cache: CompressionCache) -> None:
-        """Content near TTL boundary should NOT be deferred."""
-        import time
-
-        h = CompressionCache.content_hash("old content")
-        # Backdate first_seen to simulate age near TTL
-        cache._first_seen[h] = time.time() - 280  # 280s old, TTL=300, window=30
-        assert cache.should_defer_compression(h, ttl_seconds=300, batch_window=30) is False
-
 
 class TestCompressionCacheApplyAndUpdate:
     def test_apply_cached_swaps_tool_results(self, cache: CompressionCache) -> None:
@@ -687,3 +658,237 @@ def test_get_compression_cache_returns_same_instance_under_contention() -> None:
     first = results[0]
     for c in results[1:]:
         assert c is first, "Concurrent _get_compression_cache returned different instances"
+
+
+# ─── Phase 3: prepare_turn parity + lock hygiene ────────────────────────────
+#
+# `prepare_turn` is a single-pass replacement for the
+# compute_frozen_count -> mark_stable_from_messages -> apply_cached sequence
+# (perf review F4). These tests prove it produces IDENTICAL results and
+# IDENTICAL cache side effects to the old 3-call sequence on a range of
+# fixture transcripts, so the merge cannot silently drift behavior.
+
+
+def _old_three_call_sequence(
+    cache: CompressionCache, messages: list[dict], tracker_frozen_count: int
+) -> tuple[int, list[dict]]:
+    """The exact sequence prepare_turn replaces (mirrors anthropic.py pre-Phase-3)."""
+    cache_frozen_count = cache.compute_frozen_count(messages)
+    frozen_count = min(tracker_frozen_count, cache_frozen_count)
+    cache.mark_stable_from_messages(messages, frozen_count)
+    working_messages = cache.apply_cached(messages)
+    return frozen_count, working_messages
+
+
+def _seeded_cache(
+    pre_compressed: dict[str, tuple[str, int]] | None = None,
+    pre_stable: set[str] | None = None,
+) -> CompressionCache:
+    c = CompressionCache()
+    for content_hash, (compressed, tokens_saved) in (pre_compressed or {}).items():
+        c.store_compressed(content_hash, compressed, tokens_saved=tokens_saved)
+    for content_hash in pre_stable or set():
+        c.mark_stable(content_hash)
+    return c
+
+
+_PREPARE_TURN_FIXTURES = [
+    pytest.param(
+        [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "t1", "name": "x", "input": {}}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "uncached output"}
+                ],
+            },
+            {"role": "user", "content": "follow up"},
+        ],
+        10,
+        None,
+        None,
+        id="cold_cache_no_hits",
+    ),
+    pytest.param(
+        [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "warm tool output"}
+                ],
+            },
+            {"role": "user", "content": "more"},
+        ],
+        1,
+        {CompressionCache.content_hash("warm tool output"): ("compressed warm", 4)},
+        None,
+        id="warm_cache_hit_tracker_clamp",
+    ),
+    pytest.param(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "tool_call_id": "tc1", "content": "openai tool output"},
+            {"role": "assistant", "content": "done"},
+        ],
+        5,
+        {CompressionCache.content_hash("openai tool output"): ("compressed openai", 3)},
+        None,
+        id="openai_format",
+    ),
+    pytest.param(
+        [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t1",
+                        "content": [{"type": "text", "text": "list-of-blocks tool output"}],
+                    }
+                ],
+            },
+            {"role": "user", "content": "more"},
+        ],
+        5,
+        {
+            CompressionCache.content_hash("list-of-blocks tool output"): (
+                "compressed list-blocks",
+                2,
+            )
+        },
+        None,
+        id="list_of_blocks_content",
+    ),
+    pytest.param(
+        [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t1",
+                        "content": "excluded read output",
+                    }
+                ],
+            },
+            {"role": "user", "content": "more"},
+        ],
+        5,
+        None,
+        {CompressionCache.content_hash("excluded read output")},
+        id="stable_hash_without_compression",
+    ),
+    pytest.param(
+        [
+            {"role": "user", "content": "start"},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "cached A"}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t2", "content": "uncached B"}],
+            },
+            {"role": "user", "content": "end"},
+        ],
+        5,
+        {CompressionCache.content_hash("cached A"): ("compressed A", 2)},
+        None,
+        id="multiple_tool_results_partial_cache",
+    ),
+    pytest.param([], 0, None, None, id="empty_messages"),
+]
+
+
+class TestCompressionCachePrepareTurn:
+    """Parity tests: prepare_turn must match the old 3-call sequence exactly."""
+
+    @pytest.mark.parametrize(
+        "messages,tracker_frozen_count,pre_compressed,pre_stable", _PREPARE_TURN_FIXTURES
+    )
+    def test_prepare_turn_matches_old_sequence(
+        self,
+        messages: list[dict],
+        tracker_frozen_count: int,
+        pre_compressed: dict[str, tuple[str, int]] | None,
+        pre_stable: set[str] | None,
+    ) -> None:
+        cache_old = _seeded_cache(pre_compressed, pre_stable)
+        cache_new = _seeded_cache(pre_compressed, pre_stable)
+
+        frozen_old, working_old = _old_three_call_sequence(
+            cache_old, messages, tracker_frozen_count
+        )
+        frozen_new, working_new = cache_new.prepare_turn(messages, tracker_frozen_count)
+
+        assert frozen_new == frozen_old
+        assert working_new == working_old
+        assert cache_new._stable_hashes == cache_old._stable_hashes
+        assert set(cache_new._cache.keys()) == set(cache_old._cache.keys())
+        assert cache_new._hits == cache_old._hits
+        assert cache_new._misses == cache_old._misses
+
+    def test_prepare_turn_does_not_mutate_input_messages(self, cache: CompressionCache) -> None:
+        original_content = "big tool output"
+        h = CompressionCache.content_hash(original_content)
+        cache.store_compressed(h, "small output", tokens_saved=5)
+
+        msg = {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t1", "content": original_content}],
+        }
+        messages = [msg, {"role": "user", "content": "tail"}]
+        cache.prepare_turn(messages, 5)
+
+        assert msg["content"][0]["content"] == original_content
+
+    def test_prepare_turn_concurrent_calls_do_not_corrupt_state(self) -> None:
+        """Lock-hygiene regression: concurrent prepare_turn + store_compressed
+        calls on the same cache must not corrupt `_cache` / `_stable_hashes`
+        (the merged single-pass walk still hashes outside the lock and only
+        touches shared state inside it)."""
+        import threading
+
+        cache = CompressionCache(max_entries=1_000_000)
+        n_threads = 16
+        per_thread = 50
+        errors: list[Exception] = []
+
+        def worker(tid: int) -> None:
+            try:
+                for i in range(per_thread):
+                    content = f"thread-{tid}-item-{i}"
+                    h = CompressionCache.content_hash(content)
+                    cache.store_compressed(h, f"compressed-{tid}-{i}", tokens_saved=3)
+                    messages = [
+                        {"role": "user", "content": "start"},
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "tool_result", "tool_use_id": "t1", "content": content}
+                            ],
+                        },
+                        {"role": "user", "content": "tail"},
+                    ]
+                    frozen, working = cache.prepare_turn(messages, 5)
+                    assert frozen in (0, 1, 2)
+                    assert len(working) == 3
+            except Exception as e:  # pragma: no cover
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Concurrent prepare_turn/store_compressed raised: {errors}"
+        stats = cache.get_stats()
+        assert stats["entries"] == n_threads * per_thread

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -336,6 +336,7 @@ class TestTransformResult:
             "cache_metrics",
             "timing",
             "waste_signals",
+            "waste_signals_provider",
         }
         assert field_names == expected_fields
 

--- a/tests/test_content_router_single_item_deadline.py
+++ b/tests/test_content_router_single_item_deadline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 
 import headroom.transforms.kompress_compressor as kc
+from headroom.tokenizers.base import BaseTokenizer
 from headroom.transforms.content_detector import ContentType
 from headroom.transforms.content_router import (
     CompressionStrategy,
@@ -14,7 +15,7 @@ from headroom.transforms.content_router import (
 from headroom.transforms.kompress_compressor import KompressCompressor, KompressConfig
 
 
-class _Tokenizer:
+class _Tokenizer(BaseTokenizer):
     def count_text(self, content: str) -> int:
         return len(content.split())
 
@@ -133,6 +134,9 @@ def test_single_cache_miss_deadline_starts_before_kompress_load(monkeypatch, cap
     class _Tokenizer:
         def count_text(self, content: str) -> int:
             return len(content.split())
+
+        def count_messages(self, messages: list[dict[str, str]]) -> int:
+            return sum(self.count_text(message.get("content", "")) for message in messages)
 
         def __call__(self, words, **_kwargs):
             rows = words if words and isinstance(words[0], list) else [words]

--- a/tests/test_content_router_user_blocks.py
+++ b/tests/test_content_router_user_blocks.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from headroom.tokenizers.base import BaseTokenizer
 from headroom.transforms.content_router import ContentRouter, ContentRouterConfig
 
 
-class _Tokenizer:
+class _Tokenizer(BaseTokenizer):
     def count_text(self, text: str) -> int:
         return max(1, len(str(text)) // 4)
 

--- a/tests/test_cross_turn_cache_safety.py
+++ b/tests/test_cross_turn_cache_safety.py
@@ -19,6 +19,7 @@ turn; WITH it the prefix stays stable.
 from headroom.cache.prefix_tracker import (
     PrefixCacheTracker,
     PrefixFreezeConfig,
+    normalize_message_cache_control,
     overlay_cached_prefix,
 )
 
@@ -138,3 +139,58 @@ def test_cache_create_stays_bounded_to_the_delta_with_overlay():
     # with conversation length. Assert the last turn creates no more than the
     # first (which had no cache to reuse).
     assert creates[-1] <= creates[0] + 1
+
+
+def test_recorded_state_not_mutated_by_downstream_consumers():
+    """Guard for the ref-return contract (perf review F1): get_last_original/
+    forwarded_messages() now return the tracker's actual recorded lists, not
+    deep copies. overlay_cached_prefix splices those refs directly into its
+    output, so normalize_message_cache_control and memory injection may both
+    receive dicts that ARE the recorded state. None of them may mutate in
+    place — a future turn's replay depends on the recorded bytes staying
+    exactly what was recorded at update_from_response time.
+    """
+    import copy
+
+    from headroom.proxy.handlers.anthropic import AnthropicHandlerMixin
+
+    tracker = PrefixCacheTracker("anthropic", PrefixFreezeConfig(min_cached_tokens=0))
+
+    # Turn 1: a message carrying cache_control (normalize has something to
+    # strip) so the recorded state exercises that mutation path too.
+    turn1 = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "hello", "cache_control": {"type": "ephemeral"}}],
+        }
+    ]
+    counts = [_toklen(m) for m in turn1]
+    tracker.update_from_response(
+        0, sum(counts), turn1, message_token_counts=counts, original_messages=turn1
+    )
+
+    # Independent snapshot of turn 1's recorded state — the ground truth.
+    snapshot_original = copy.deepcopy(tracker.get_last_original_messages())
+    snapshot_forwarded = copy.deepcopy(tracker.get_last_forwarded_messages())
+
+    # Turn 2: append-only extension driven through overlay + normalize +
+    # memory injection — the three consumers the mutation audit covers.
+    turn2_original = turn1 + [{"role": "user", "content": "turn 2"}]
+    frozen = tracker.get_frozen_message_count()
+    forwarded = overlay_cached_prefix(
+        turn2_original,
+        turn2_original,
+        tracker.get_last_original_messages(),
+        tracker.get_last_forwarded_messages(),
+    )
+    forwarded = normalize_message_cache_control(forwarded)
+    forwarded = AnthropicHandlerMixin._append_context_to_latest_non_frozen_user_turn(
+        forwarded, "injected memory", frozen_message_count=frozen
+    )
+
+    assert tracker.get_last_original_messages() == snapshot_original, (
+        "turn 1's recorded original messages were mutated by a downstream consumer"
+    )
+    assert tracker.get_last_forwarded_messages() == snapshot_forwarded, (
+        "turn 1's recorded forwarded messages were mutated by a downstream consumer"
+    )

--- a/tests/test_injection_cache_safety.py
+++ b/tests/test_injection_cache_safety.py
@@ -1,0 +1,213 @@
+"""Cache-safe CCR proactive-expansion and memory injection gating (#2186).
+
+Both proactive-expansion and memory injection append to the live-zone tail
+message (``_append_context_to_latest_non_frozen_user_turn`` / the OpenAI
+sibling). Before this fix, that append ran unconditionally in token mode:
+
+  (a) On a same-messages re-request, ``overlay_cached_prefix`` replays last
+      turn's already-injected tail byte-identical, then the handler appends
+      AGAIN -> the final segment busts and grows unboundedly turn over turn.
+  (b) ``execute_expansions`` had no per-session dedup, so the same
+      compressed-content hash could be re-injected across requests.
+  (c) Claude Code's ``/compact`` starts a new session (new conversation-
+      scoped session id, phase 2), but the process-wide ``ContextTracker``
+      is workspace-scoped only, so old compressed content tracked under the
+      pre-compact session could surface right back into the fresh one.
+
+This covers all three at the unit level: the shared guard
+(``injection_target_already_forwarded``), the per-session expansion dedup
+tracker, and ``ContextTracker``'s session-scoped ``analyze_query``.
+"""
+
+from __future__ import annotations
+
+from headroom.cache.prefix_tracker import PrefixCacheTracker
+from headroom.ccr.context_tracker import ContextTracker, ContextTrackerConfig
+from headroom.proxy.ccr_session_tracker import SessionExpansionDedupTracker
+from headroom.proxy.helpers import injection_target_already_forwarded
+
+# ─── injection_target_already_forwarded ──────────────────────────────────
+
+
+def test_fresh_tail_message_allows_injection() -> None:
+    """(b) A genuinely new turn's tail was never forwarded -> inject."""
+    tracker = PrefixCacheTracker("anthropic")
+    turn1 = [{"role": "user", "content": "hello"}]
+    tracker.update_from_response(
+        cache_read_tokens=0, cache_write_tokens=10, messages=turn1, original_messages=turn1
+    )
+
+    turn2 = [*turn1, {"role": "assistant", "content": "hi"}, {"role": "user", "content": "more"}]
+    assert (
+        injection_target_already_forwarded(
+            turn2, prefix_tracker=tracker, current_original_messages=turn2
+        )
+        is False
+    )
+
+
+def test_same_messages_re_request_blocks_injection() -> None:
+    """(a) Re-sending the exact same messages -> tail already forwarded, skip."""
+    tracker = PrefixCacheTracker("anthropic")
+    turn1 = [{"role": "user", "content": "hello"}]
+    tracker.update_from_response(
+        cache_read_tokens=0, cache_write_tokens=10, messages=turn1, original_messages=turn1
+    )
+
+    # Identical re-request: same messages, same originals.
+    assert (
+        injection_target_already_forwarded(
+            turn1, prefix_tracker=tracker, current_original_messages=turn1
+        )
+        is True
+    )
+
+
+def test_diverged_history_allows_injection() -> None:
+    """Client rewrote history (not append-only) -> not guaranteed replayed, inject."""
+    tracker = PrefixCacheTracker("anthropic")
+    turn1 = [{"role": "user", "content": "hello"}]
+    tracker.update_from_response(
+        cache_read_tokens=0, cache_write_tokens=10, messages=turn1, original_messages=turn1
+    )
+
+    diverged = [{"role": "user", "content": "totally different opener"}]
+    assert (
+        injection_target_already_forwarded(
+            diverged, prefix_tracker=tracker, current_original_messages=diverged
+        )
+        is False
+    )
+
+
+def test_no_prior_turn_allows_injection() -> None:
+    """Cold tracker (first-ever turn) -> nothing to have double-injected into."""
+    tracker = PrefixCacheTracker("anthropic")
+    turn1 = [{"role": "user", "content": "hello"}]
+    assert (
+        injection_target_already_forwarded(
+            turn1, prefix_tracker=tracker, current_original_messages=turn1
+        )
+        is False
+    )
+
+
+# ─── SessionExpansionDedupTracker ─────────────────────────────────────────
+
+
+def test_expansion_dedup_blocks_repeat_hash_same_session() -> None:
+    """(c) Same hash proposed twice in one session -> injected only once."""
+    dedup = SessionExpansionDedupTracker(max_sessions=10)
+
+    first = dedup.filter_new("session-a", ["hash1", "hash2"])
+    assert first == ["hash1", "hash2"]
+    dedup.record_injected("session-a", first)
+
+    second = dedup.filter_new("session-a", ["hash1", "hash2", "hash3"])
+    assert second == ["hash3"]
+
+
+def test_expansion_dedup_is_per_session_not_global() -> None:
+    """Different sessions may legitimately need the same expansion."""
+    dedup = SessionExpansionDedupTracker(max_sessions=10)
+    dedup.record_injected("session-a", ["hash1"])
+
+    assert dedup.filter_new("session-b", ["hash1"]) == ["hash1"]
+    assert dedup.filter_new("session-a", ["hash1"]) == []
+
+
+def test_expansion_dedup_lru_eviction() -> None:
+    dedup = SessionExpansionDedupTracker(max_sessions=1)
+    dedup.record_injected("session-a", ["hash1"])
+    dedup.record_injected("session-b", ["hash2"])  # evicts session-a
+
+    assert dedup.filter_new("session-a", ["hash1"]) == ["hash1"]
+    assert dedup.filter_new("session-b", ["hash2"]) == []
+
+
+# ─── ContextTracker session-scoped analyze_query (#2186 /compact repro) ──
+
+
+def test_compact_new_session_does_not_see_old_sessions_expansion() -> None:
+    """(d) A fresh session (post-/compact) must not get old content surfaced
+    back into it, even though the workspace is unchanged."""
+    tracker = ContextTracker(ContextTrackerConfig(enabled=True, proactive_expansion=True))
+    tracker.track_compression(
+        hash_key="abc123",
+        turn_number=1,
+        tool_name="Bash",
+        original_count=100,
+        compressed_count=10,
+        workspace_key="ws-repo",
+        session_id="session-before-compact",
+        query_context="find auth files",
+        sample_content="auth_middleware.py handles authentication",
+    )
+
+    # New session, same workspace, a query that would otherwise match.
+    recs = tracker.analyze_query(
+        "what about the authentication middleware?",
+        current_turn=1,
+        workspace_key="ws-repo",
+        session_id="session-after-compact",
+    )
+    assert recs == []
+
+    # The ORIGINAL session still sees its own tracked content.
+    recs_same_session = tracker.analyze_query(
+        "what about the authentication middleware?",
+        current_turn=1,
+        workspace_key="ws-repo",
+        session_id="session-before-compact",
+    )
+    assert len(recs_same_session) == 1
+    assert recs_same_session[0].hash_key == "abc123"
+
+
+def test_analyze_query_without_session_id_keeps_legacy_workspace_only_scoping() -> None:
+    """Backward compatibility: omitting session_id on both sides (legacy
+    callers, existing tests) preserves workspace-only scoping."""
+    tracker = ContextTracker(ContextTrackerConfig(enabled=True, proactive_expansion=True))
+    tracker.track_compression(
+        hash_key="abc123",
+        turn_number=1,
+        tool_name="Bash",
+        original_count=100,
+        compressed_count=10,
+        workspace_key="ws-repo",
+        query_context="find auth files",
+        sample_content="auth_middleware.py handles authentication",
+    )
+
+    recs = tracker.analyze_query(
+        "what about the authentication middleware?",
+        current_turn=1,
+        workspace_key="ws-repo",
+    )
+    assert len(recs) == 1
+
+
+# ─── handler wiring tripwire ──────────────────────────────────────────────
+
+
+def test_anthropic_handler_wires_expansion_dedup_and_forwarded_guard() -> None:
+    """The dedup and double-inject guards must stay wired into the handler.
+
+    The unit guards above cannot detect the handler simply not calling them —
+    in that case the same context is proactively re-injected on every turn of
+    a session (the injection is transient, so each next request looks
+    identical) and net savings degrade to zero. Assert the anthropic handler
+    source still references every guard.
+    """
+    import inspect
+
+    import headroom.proxy.handlers.anthropic as anthropic_handler
+
+    src = inspect.getsource(anthropic_handler)
+    for needle in (
+        "get_session_expansion_dedup_tracker",
+        ".filter_new(",
+        ".record_injected(",
+        "injection_target_already_forwarded",
+    ):
+        assert needle in src, f"anthropic handler lost expansion-guard wiring: {needle}"

--- a/tests/test_openai_cross_turn_cache_safety.py
+++ b/tests/test_openai_cross_turn_cache_safety.py
@@ -1,0 +1,174 @@
+"""Cross-turn cache-safety regression for the OpenAI-format proxy path.
+
+Companion to test_cross_turn_cache_safety.py (Anthropic path, commit 248ae0f3 /
+#1850). All three OpenAI-path ``tracker.update_from_response`` call sites
+(openai.py:3413, openai.py:3710, streaming.py:1935) used to omit
+``original_messages``, so ``PrefixCacheTracker`` fell back to storing the
+FORWARDED (compressed) bytes as "originals". The overlay's append-only check
+then diverged at message 0 on turn 2 and never replayed the cached prefix,
+busting the provider's prompt cache on every turn.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from headroom.cache.prefix_tracker import PrefixCacheTracker, overlay_cached_prefix
+from headroom.proxy.server import ProxyConfig, create_app
+
+# ─── Mechanism-level: proves the fix is load-bearing ────────────────────
+#
+# Mirrors test_cross_turn_cache_safety.py's drive loop, isolating exactly the
+# OpenAI-handler bug: calling update_from_response WITHOUT original_messages
+# (the old, broken call shape) vs WITH it (current code).
+
+
+def _drive_two_turns(*, record_originals: bool) -> tuple[list[dict], list[dict]]:
+    """Simulate 2 append-only turns. Returns (turn1_forwarded, turn2_overlaid)."""
+    tracker = PrefixCacheTracker("openai")
+
+    turn1_original = [{"role": "user", "content": "please read this long file: " + "x" * 100}]
+    turn1_forwarded = [{"role": "user", "content": "SHORT"}]  # turn 1: pipeline compresses it
+
+    tracker.update_from_response(
+        cache_read_tokens=0,
+        cache_write_tokens=50,
+        messages=turn1_forwarded,
+        **({"original_messages": turn1_original} if record_originals else {}),
+    )
+
+    # Turn 2: client resends turn 1 verbatim (append-only) plus a new message.
+    # The pipeline skips compressing already-forwarded content this turn (as
+    # the real one does for a frozen/stable prefix), so it emits the RAW
+    # original bytes unless the overlay steps in.
+    turn2_original = [*turn1_original, {"role": "user", "content": "continue"}]
+    turn2_pipeline_output = list(turn2_original)
+
+    overlaid = overlay_cached_prefix(
+        turn2_pipeline_output,
+        turn2_original,
+        tracker.get_last_original_messages(),
+        tracker.get_last_forwarded_messages(),
+    )
+    return turn1_forwarded, overlaid
+
+
+def test_missing_original_messages_busts_cache_on_turn_2() -> None:
+    """Regression: omitting original_messages (the pre-fix call shape) busts the cache."""
+    turn1_forwarded, overlaid = _drive_two_turns(record_originals=False)
+    # Without originals recorded, the tracker's "originals" == turn1_forwarded
+    # (the compressed bytes), which never equals turn2's raw client prefix ->
+    # append-only guard fails -> overlay is a no-op -> turn 2 forwards the raw
+    # bytes, diverging from what the provider actually cached.
+    assert overlaid[0] != turn1_forwarded[0]
+
+
+def test_recording_original_messages_keeps_prefix_byte_identical() -> None:
+    """Fix: passing original_messages lets the overlay replay the cached prefix."""
+    turn1_forwarded, overlaid = _drive_two_turns(record_originals=True)
+    assert overlaid[0] == turn1_forwarded[0]
+
+
+# ─── Handler-level: proves the real openai.py wiring is correct ─────────
+
+
+def _make_client() -> TestClient:
+    config = ProxyConfig(
+        optimize=True,
+        mode="token",
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+        log_requests=False,
+        ccr_inject_tool=False,
+        ccr_handle_responses=False,
+        ccr_context_tracking=False,
+        image_optimize=False,
+    )
+    return TestClient(create_app(config))
+
+
+def test_openai_direct_path_threads_original_messages_into_tracker() -> None:
+    """handle_openai_chat (no-backend path) must record raw client messages as
+    originals, not the pipeline's compressed output — else the two-turn
+    overlay replay (the cache-safety mechanism) never engages."""
+    with _make_client() as client:
+        proxy = client.app.state.proxy
+        real_tracker = PrefixCacheTracker("openai")
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
+        )
+        proxy.session_tracker_store.get_or_create = lambda session_id, provider: real_tracker
+
+        calls = {"n": 0}
+
+        def _fake_apply(**kwargs):
+            calls["n"] += 1
+            msgs = list(kwargs["messages"])
+            if calls["n"] == 1:
+                # First turn: pipeline compresses the long message.
+                msgs = [{**m, "content": "SHORT"} for m in msgs]
+            # Later turns: pipeline skips the already-stable prefix, emitting
+            # whatever the caller sent (mirrors real frozen-prefix behavior).
+            return SimpleNamespace(
+                messages=msgs,
+                transforms_applied=["test:compress"] if calls["n"] == 1 else [],
+                timing={},
+                tokens_before=100,
+                tokens_after=10,
+                waste_signals=None,
+            )
+
+        proxy.openai_pipeline.apply = _fake_apply
+
+        captured_bodies: list[dict] = []
+
+        async def _fake_retry(method, url, headers, body, stream=False, **kwargs):
+            captured_bodies.append(body)
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl_1",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 3, "total_tokens": 13},
+                },
+            )
+
+        proxy._retry_request = _fake_retry
+
+        turn1_original = [{"role": "user", "content": "please read this long file: " + "x" * 100}]
+        r1 = client.post(
+            "/v1/chat/completions",
+            headers={"authorization": "Bearer [REDACTED:Bearer token]"},
+            json={"model": "gpt-4o-mini", "messages": turn1_original, "stream": False},
+        )
+        assert r1.status_code == 200, r1.text
+        turn1_forwarded = captured_bodies[0]["messages"]
+        assert turn1_forwarded[0]["content"] == "SHORT"
+
+        turn2_original = [*turn1_original, {"role": "user", "content": "continue"}]
+        r2 = client.post(
+            "/v1/chat/completions",
+            headers={"authorization": "Bearer [REDACTED:Bearer token]"},
+            json={"model": "gpt-4o-mini", "messages": turn2_original, "stream": False},
+        )
+        assert r2.status_code == 200, r2.text
+        turn2_forwarded = captured_bodies[1]["messages"]
+
+        # The fix: turn 2 replays turn 1's compressed prefix byte-for-byte
+        # instead of re-forwarding the raw original, which would bust the
+        # provider's cache.
+        assert turn2_forwarded[0] == turn1_forwarded[0] == {"role": "user", "content": "SHORT"}

--- a/tests/test_proxy/test_anthropic_ccr_deferred_injection.py
+++ b/tests/test_proxy/test_anthropic_ccr_deferred_injection.py
@@ -61,6 +61,11 @@ class _FakeCompressionCache:
     def mark_stable_from_messages(self, messages, frozen_count) -> None:  # noqa: ARG002
         return None
 
+    def prepare_turn(self, messages, tracker_frozen_count):  # noqa: ANN001
+        frozen = min(tracker_frozen_count, self.compute_frozen_count(messages))
+        self.mark_stable_from_messages(messages, frozen)
+        return frozen, self.apply_cached(messages)
+
     def update_from_result(self, originals, compressed) -> None:  # noqa: ARG002
         return None
 
@@ -119,8 +124,8 @@ def test_frozen_prefix_skips_marker_emission_when_tool_injection_is_deferred(mon
         _disable_pipeline_extensions(proxy)
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
         proxy._get_compression_cache = lambda session_id: _FakeCompressionCache(
@@ -202,8 +207,8 @@ def test_unfrozen_prefix_keeps_reversible_ccr_path(monkeypatch) -> None:
         _disable_pipeline_extensions(proxy)
 
         fake_tracker = _FakePrefixTracker(frozen_count=0)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -276,8 +281,8 @@ def test_token_mode_reclamp_keeps_reversible_ccr_path_when_effective_prefix_drop
         _disable_pipeline_extensions(proxy)
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
         proxy._get_compression_cache = lambda session_id: _FakeCompressionCache(frozen_count=0)
@@ -353,8 +358,8 @@ def test_token_mode_compresses_frozen_prefix_turns_when_tool_is_not_already_pres
         _disable_pipeline_extensions(proxy)
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
         proxy._get_compression_cache = lambda session_id: _FakeCompressionCache(frozen_count=1)
@@ -429,8 +434,8 @@ def test_existing_retrieve_tool_keeps_reversible_ccr_path_when_prefix_is_frozen(
         _disable_pipeline_extensions(proxy)
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -517,8 +522,8 @@ def test_cache_mode_compresses_delta_but_replays_cached_prefix_when_markers_are_
         fake_tracker = _FakePrefixTracker(frozen_count=1)
         fake_tracker._last_original_messages = [original_messages[0]]
         fake_tracker._last_forwarded_messages = previous_forwarded_messages
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -609,8 +614,8 @@ def test_cache_mode_exact_prefix_replay_forwards_cached_compressed_prefix_when_t
         fake_tracker = _FakePrefixTracker(frozen_count=1)
         fake_tracker._last_original_messages = original_messages.copy()
         fake_tracker._last_forwarded_messages = previous_forwarded_messages
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -700,8 +705,8 @@ def test_token_mode_cached_messages_skip_cache_update_when_pipeline_result_is_un
         cache.update_from_result = lambda originals, compressed: cache_updates.append(  # type: ignore[method-assign]
             (originals, compressed)
         )
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
         proxy._get_compression_cache = lambda session_id: cache
@@ -773,8 +778,8 @@ def test_non_token_non_cache_mode_keeps_compression_and_injects_tool_for_new_mar
         _disable_pipeline_extensions(proxy)
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -866,8 +871,8 @@ def test_non_token_non_cache_mode_keeps_reversible_path_and_records_waste_signal
         _disable_pipeline_extensions(proxy)
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -953,8 +958,8 @@ def test_cache_mode_existing_retrieve_tool_keeps_exact_prefix_replay(monkeypatch
         fake_tracker = _FakePrefixTracker(frozen_count=1)
         fake_tracker._last_original_messages = original_messages.copy()
         fake_tracker._last_forwarded_messages = previous_forwarded_messages
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -1041,8 +1046,8 @@ def test_cache_mode_existing_retrieve_tool_compresses_only_the_unfrozen_delta(
         fake_tracker = _FakePrefixTracker(frozen_count=1)
         fake_tracker._last_original_messages = [original_messages[0]]
         fake_tracker._last_forwarded_messages = previous_forwarded_messages
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -1151,8 +1156,8 @@ def test_non_token_non_cache_mode_preserves_original_messages_when_result_is_unc
         _disable_pipeline_extensions(proxy)
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -1227,8 +1232,8 @@ def test_non_token_non_cache_mode_recovers_from_compression_errors(monkeypatch) 
         _disable_pipeline_extensions(proxy)
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
         proxy.anthropic_pipeline.apply = lambda **kwargs: (_ for _ in ()).throw(
@@ -1298,8 +1303,8 @@ def test_cache_mode_without_stable_delta_keeps_original_messages(monkeypatch) ->
                 "content": "[100 items compressed to 10. Retrieve more: hash=unrelatedhashunrelatedhash]",
             }
         ]
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 

--- a/tests/test_proxy_anthropic_cache_stability.py
+++ b/tests/test_proxy_anthropic_cache_stability.py
@@ -342,8 +342,8 @@ def test_token_mode_freeze_is_capped_by_prefix_tracker() -> None:
         proxy.config.image_optimize = False
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -359,6 +359,11 @@ def test_token_mode_freeze_is_capped_by_prefix_tracker() -> None:
 
             def mark_stable_from_messages(self, messages, up_to):  # noqa: ANN001
                 pass
+
+            def prepare_turn(self, messages, tracker_frozen_count):  # noqa: ANN001
+                frozen = min(tracker_frozen_count, self.compute_frozen_count(messages))
+                self.mark_stable_from_messages(messages, frozen)
+                return frozen, self.apply_cached(messages)
 
         proxy._get_compression_cache = lambda session_id: _FakeCompressionCache()
 
@@ -417,8 +422,8 @@ def test_memory_context_avoids_system_mutation_when_prefix_frozen() -> None:
         proxy.config.ccr_proactive_expansion = False
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -483,8 +488,8 @@ def test_ccr_system_instruction_injection_disabled_when_prefix_frozen(monkeypatc
         proxy.config.ccr_inject_system_instructions = True
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -550,8 +555,8 @@ def test_ccr_tool_injection_disabled_when_prefix_frozen(monkeypatch) -> None:
         proxy.config.ccr_inject_system_instructions = False
 
         fake_tracker = _FakePrefixTracker(frozen_count=1)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -607,6 +612,128 @@ def test_ccr_tool_injection_disabled_when_prefix_frozen(monkeypatch) -> None:
         assert captured["inject_tool"] is False
 
 
+def test_ccr_system_instructions_routed_to_body_system_not_messages() -> None:
+    """#A2: system-instruction injection must land in ``body["system"]``,
+    never as a ``role:"system"`` message — the Messages API rejects that
+    shape with a 400 on every marker-bearing turn."""
+    captured = {"body": None}
+    with _make_proxy_client() as client:
+        proxy = client.app.state.proxy
+        proxy.config.optimize = False
+        proxy.config.image_optimize = False
+        proxy.config.ccr_inject_tool = False
+        proxy.config.ccr_inject_system_instructions = True
+
+        fake_tracker = _FakePrefixTracker(frozen_count=1)
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
+        )
+        proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
+
+        async def _fake_retry(method, url, headers, body, stream=False, **kwargs):  # noqa: ANN001
+            captured["body"] = body
+            return httpx.Response(
+                200,
+                json={
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "ok"}],
+                    "usage": {
+                        "input_tokens": 20,
+                        "output_tokens": 3,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                    },
+                },
+            )
+
+        proxy._retry_request = _fake_retry
+
+        marker = "[100 items compressed to 10. Retrieve more: hash=abcdef0123456789abcdef01]"
+        response = client.post(
+            "/v1/messages",
+            headers={"x-api-key": "test-key", "anthropic-version": "2023-06-01"},
+            json={
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 64,
+                "system": "You are a helpful assistant.",
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi"},
+                    {"role": "user", "content": marker},
+                ],
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        body = captured["body"]
+        assert all(m.get("role") != "system" for m in body["messages"])
+        assert len(body["messages"]) == 3
+        assert "Compressed Context Available" in str(body["system"])
+
+
+def test_ccr_system_instructions_stable_across_turns() -> None:
+    """Once injected, the ``body["system"]`` segment must stay byte-identical
+    turn over turn or it busts the provider's prompt-cache prefix (#A2)."""
+    captured: dict = {"bodies": []}
+    with _make_proxy_client() as client:
+        proxy = client.app.state.proxy
+        proxy.config.optimize = False
+        proxy.config.image_optimize = False
+        proxy.config.ccr_inject_tool = False
+        proxy.config.ccr_inject_system_instructions = True
+
+        fake_tracker = _FakePrefixTracker(frozen_count=1)
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
+        )
+        proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
+
+        async def _fake_retry(method, url, headers, body, stream=False, **kwargs):  # noqa: ANN001
+            captured["bodies"].append(body)
+            return httpx.Response(
+                200,
+                json={
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "ok"}],
+                    "usage": {
+                        "input_tokens": 20,
+                        "output_tokens": 3,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                    },
+                },
+            )
+
+        proxy._retry_request = _fake_retry
+
+        marker = "[100 items compressed to 10. Retrieve more: hash=abcdef0123456789abcdef01]"
+        payload = {
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 64,
+            "system": "You are a helpful assistant.",
+            "messages": [{"role": "user", "content": marker}],
+        }
+
+        r1 = client.post(
+            "/v1/messages",
+            headers={"x-api-key": "test-key", "anthropic-version": "2023-06-01"},
+            json=payload,
+        )
+        r2 = client.post(
+            "/v1/messages",
+            headers={"x-api-key": "test-key", "anthropic-version": "2023-06-01"},
+            json=payload,
+        )
+
+        assert r1.status_code == 200, r1.text
+        assert r2.status_code == 200, r2.text
+        assert captured["bodies"][0]["system"] == captured["bodies"][1]["system"]
+
+
 def test_previous_turns_always_frozen_only_final_turn_mutable() -> None:
     captured = {}
     with _make_proxy_client() as client:
@@ -616,8 +743,8 @@ def test_previous_turns_always_frozen_only_final_turn_mutable() -> None:
         proxy.config.image_optimize = False
 
         fake_tracker = _FakePrefixTracker(frozen_count=0)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -802,8 +929,8 @@ def test_token_mode_does_not_force_freeze_all_previous_turns() -> None:
         proxy.config.image_optimize = False
 
         fake_tracker = _FakePrefixTracker(frozen_count=0)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -819,6 +946,11 @@ def test_token_mode_does_not_force_freeze_all_previous_turns() -> None:
 
             def mark_stable_from_messages(self, messages, up_to):  # noqa: ANN001
                 pass
+
+            def prepare_turn(self, messages, tracker_frozen_count):  # noqa: ANN001
+                frozen = min(tracker_frozen_count, self.compute_frozen_count(messages))
+                self.mark_stable_from_messages(messages, frozen)
+                return frozen, self.apply_cached(messages)
 
         proxy._get_compression_cache = lambda session_id: _FakeCompressionCache()
 
@@ -886,8 +1018,8 @@ def test_cache_mode_restores_frozen_prefix_if_transform_mutates_history() -> Non
         proxy.config.image_optimize = False
 
         fake_tracker = _FakePrefixTracker(frozen_count=0)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -956,8 +1088,8 @@ def test_cache_mode_does_not_forward_latest_turn_rewrites() -> None:
         proxy.config.image_optimize = False
 
         fake_tracker = _FakePrefixTracker(frozen_count=0)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
 
@@ -1039,8 +1171,8 @@ def test_cache_mode_reuses_prior_forwarded_prefix_and_compresses_only_new_suffix
         tracker.get_last_original_messages = lambda: tracker._last_original_messages.copy()
         tracker.get_last_forwarded_messages = lambda: tracker._last_forwarded_messages.copy()
 
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: tracker
 
@@ -1145,8 +1277,8 @@ def test_cache_mode_skips_same_message_append_rewrite_to_preserve_stability() ->
         tracker.get_last_original_messages = lambda: tracker._last_original_messages.copy()
         tracker.get_last_forwarded_messages = lambda: tracker._last_forwarded_messages.copy()
 
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stable-session"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stable-session"
         )
         proxy.session_tracker_store.get_or_create = lambda session_id, provider: tracker
 
@@ -1243,6 +1375,14 @@ class _IssueFakeCompCache:
     def mark_stable_from_messages(self, messages, up_to):  # noqa: ANN001
         self.calls.append(("mark_stable_from_messages", (up_to,), {}))
 
+    def prepare_turn(self, messages, tracker_frozen_count):  # noqa: ANN001
+        """Delegates to the instrumented sub-methods so `.calls` recording
+        and the should_defer_compression/mark_stable absence assertions
+        stay meaningful, unchanged."""
+        frozen = min(tracker_frozen_count, self.compute_frozen_count(messages))
+        self.mark_stable_from_messages(messages, frozen)
+        return frozen, self.apply_cached(messages)
+
     def update_from_result(self, originals, compressed):  # noqa: ANN001
         self.calls.append(("update_from_result", (), {}))
 
@@ -1293,7 +1433,7 @@ def _drive_request(
     proxy = client.app.state.proxy
 
     fake_tracker = _FakePrefixTracker(frozen_count=prefix_tracker_frozen)
-    proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
+    proxy.session_tracker_store.compute_session_id = lambda request, model, messages, **_kwargs: (
         "issue-327-session"
     )
     proxy.session_tracker_store.get_or_create = lambda session_id, provider: fake_tracker
@@ -1582,8 +1722,8 @@ def test_issue_327_streaming_and_non_streaming_compute_same_frozen_count() -> No
 
         proxy = client.app.state.proxy
         fake_tracker = _FakePrefixTracker(frozen_count=12)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stream-parity-A"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stream-parity-A"
         )
         proxy.session_tracker_store.get_or_create = lambda s, p: fake_tracker
         proxy._get_compression_cache = lambda s: fake_cache_a
@@ -1639,8 +1779,8 @@ def test_issue_327_streaming_and_non_streaming_compute_same_frozen_count() -> No
 
         proxy = client.app.state.proxy
         fake_tracker = _FakePrefixTracker(frozen_count=12)
-        proxy.session_tracker_store.compute_session_id = lambda request, model, messages: (
-            "stream-parity-B"
+        proxy.session_tracker_store.compute_session_id = (
+            lambda request, model, messages, **_kwargs: "stream-parity-B"
         )
         proxy.session_tracker_store.get_or_create = lambda s, p: fake_tracker
         proxy._get_compression_cache = lambda s: fake_cache_b

--- a/tests/test_proxy_handler_helpers.py
+++ b/tests/test_proxy_handler_helpers.py
@@ -9,8 +9,12 @@ from unittest.mock import patch
 
 import httpx
 from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
 
-from headroom.proxy.handlers.anthropic import AnthropicHandlerMixin
+from headroom.proxy.handlers.anthropic import (
+    AnthropicHandlerMixin,
+    _append_ccr_instructions_to_system,
+)
 from headroom.proxy.handlers.openai import (
     OpenAIHandlerMixin,
     _decode_openai_bearer_payload,
@@ -18,7 +22,7 @@ from headroom.proxy.handlers.openai import (
     _prefers_http1_passthrough,
 )
 from headroom.proxy.helpers import _headroom_bypass_enabled
-from headroom.proxy.server import HeadroomProxy
+from headroom.proxy.server import HeadroomProxy, ProxyConfig, create_app
 
 
 def _jwt(payload: object) -> str:
@@ -1073,3 +1077,284 @@ def test_handle_streaming_passthrough_client_disconnect():
         )
     )
     assert response.status_code == 204
+
+
+def _make_proxy_client(**config_overrides) -> TestClient:
+    config = ProxyConfig(
+        optimize=False,
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+        log_requests=False,
+        ccr_inject_tool=False,
+        ccr_handle_responses=False,
+        ccr_context_tracking=False,
+        image_optimize=False,
+        **config_overrides,
+    )
+    return TestClient(create_app(config))
+
+
+def test_append_ccr_instructions_to_system_when_absent() -> None:
+    """#A2: with no ``system`` field, instructions become the whole string."""
+    body: dict = {}
+    mutated = _append_ccr_instructions_to_system(body)
+    assert mutated is True
+    assert "Compressed Context Available" in body["system"]
+
+
+def test_append_ccr_instructions_to_system_appends_to_string() -> None:
+    body = {"system": "You are a helpful assistant."}
+    mutated = _append_ccr_instructions_to_system(body)
+    assert mutated is True
+    assert body["system"].startswith("You are a helpful assistant.")
+    assert "Compressed Context Available" in body["system"]
+
+
+def test_append_ccr_instructions_to_system_string_is_idempotent() -> None:
+    """Calling twice must not duplicate the block (keeps the segment stable)."""
+    body = {"system": "You are a helpful assistant."}
+    _append_ccr_instructions_to_system(body)
+    first = body["system"]
+    mutated_again = _append_ccr_instructions_to_system(body)
+    assert mutated_again is False
+    assert body["system"] == first
+    assert body["system"].count("Compressed Context Available") == 1
+
+
+def test_append_ccr_instructions_to_system_appends_new_block_for_list() -> None:
+    """List-shaped system prompts get a NEW block; existing cache_control
+    breakpoints on prior blocks must be left untouched (#A2)."""
+    original_block = {
+        "type": "text",
+        "text": "You are a helpful assistant.",
+        "cache_control": {"type": "ephemeral"},
+    }
+    body = {"system": [dict(original_block)]}
+    mutated = _append_ccr_instructions_to_system(body)
+    assert mutated is True
+    assert body["system"][0] == original_block
+    assert len(body["system"]) == 2
+    assert "Compressed Context Available" in body["system"][1]["text"]
+    assert "cache_control" not in body["system"][1]
+
+
+def test_append_ccr_instructions_to_system_list_is_idempotent() -> None:
+    body = {"system": [{"type": "text", "text": "You are a helpful assistant."}]}
+    _append_ccr_instructions_to_system(body)
+    mutated_again = _append_ccr_instructions_to_system(body)
+    assert mutated_again is False
+    assert len(body["system"]) == 2
+
+
+# ─── Phase 4: deferred waste-signal task (perf review F5) ──────────────────
+#
+# The gate itself (savings threshold + size limit, including the
+# waste_signal_token_limit override) lives in TransformPipeline.apply, which
+# attaches a waste_signals_provider closure to its result only when the gate
+# passes — see tests/test_transforms/test_pipeline_waste_signal_limit.py.
+# These tests cover the handler side: task creation, OTel recording, the
+# resolved value the outcome funnel collects, and fail-open behavior.
+
+
+def test_start_waste_signal_task_returns_none_without_provider(monkeypatch) -> None:
+    """No provider on the result (gate declined, or deferral off) → no task."""
+    handler = object.__new__(HeadroomProxy)
+    created: list = []
+    monkeypatch.setattr(
+        "headroom.proxy.handlers.anthropic.asyncio.create_task",
+        lambda coro: created.append(coro),
+    )
+    assert (
+        handler._start_waste_signal_task(
+            SimpleNamespace(waste_signals_provider=None), model="m", provider_name="anthropic"
+        )
+        is None
+    )
+    assert handler._start_waste_signal_task(None, model="m", provider_name="anthropic") is None
+    assert created == []
+
+
+def test_start_waste_signal_task_records_metrics_and_resolves_dict(monkeypatch) -> None:
+    """Happy path: the task runs the pipeline's provider closure on the
+    background executor, records the narrow OTel counter (not
+    `record_pipeline_run`, which would double-count tokens/duration), and
+    resolves to the to_dict() form the outcome funnel collects."""
+    handler = object.__new__(HeadroomProxy)
+
+    async def _immediate_run(fn):  # noqa: ANN001, ANN202
+        return fn()
+
+    handler._run_compression_background = _immediate_run
+
+    recorded: dict = {}
+
+    def _fake_record_waste_signals(*, model, provider, waste_signals):  # noqa: ANN001
+        recorded["model"] = model
+        recorded["provider"] = provider
+        recorded["waste_signals"] = waste_signals
+
+    monkeypatch.setattr(
+        "headroom.observability.get_otel_metrics",
+        lambda: SimpleNamespace(record_waste_signals=_fake_record_waste_signals),
+    )
+
+    result = SimpleNamespace(
+        waste_signals_provider=lambda: SimpleNamespace(
+            total=lambda: 5, to_dict=lambda: {"duplicate_tool_result": 5}
+        )
+    )
+
+    async def _drive():
+        task = handler._start_waste_signal_task(
+            result, model="claude-sonnet", provider_name="anthropic"
+        )
+        assert task is not None
+        # Strong reference held until done (bare create_task is GC-unsafe).
+        assert task in handler._waste_signal_tasks
+        resolved = await task
+        assert resolved == {"duplicate_tool_result": 5}
+        await asyncio.sleep(0)  # let the done-callback run
+        assert task not in handler._waste_signal_tasks
+
+    asyncio.run(_drive())
+
+    assert recorded["model"] == "claude-sonnet"
+    assert recorded["provider"] == "anthropic"
+    assert recorded["waste_signals"] == {"duplicate_tool_result": 5}
+
+
+def test_start_waste_signal_task_skips_otel_when_provider_returns_none(monkeypatch) -> None:
+    """Provider ran but found nothing → resolve None, record nothing."""
+    handler = object.__new__(HeadroomProxy)
+
+    async def _immediate_run(fn):  # noqa: ANN001, ANN202
+        return fn()
+
+    handler._run_compression_background = _immediate_run
+
+    called: list = []
+    monkeypatch.setattr(
+        "headroom.observability.get_otel_metrics",
+        lambda: SimpleNamespace(record_waste_signals=lambda **k: called.append(k)),
+    )
+
+    async def _drive():
+        task = handler._start_waste_signal_task(
+            SimpleNamespace(waste_signals_provider=lambda: None),
+            model="m",
+            provider_name="anthropic",
+        )
+        assert await task is None
+
+    asyncio.run(_drive())
+    assert called == []
+
+
+def test_start_waste_signal_task_fails_open_on_parse_error(monkeypatch) -> None:
+    """Fail-open: an exception inside the provider must never propagate, must
+    not record metrics, and must resolve the task to None."""
+    handler = object.__new__(HeadroomProxy)
+
+    async def _immediate_run(fn):  # noqa: ANN001, ANN202
+        return fn()
+
+    handler._run_compression_background = _immediate_run
+
+    def _raise():  # noqa: ANN202
+        raise RuntimeError("boom")
+
+    called: list = []
+    monkeypatch.setattr(
+        "headroom.observability.get_otel_metrics",
+        lambda: SimpleNamespace(record_waste_signals=lambda **k: called.append(k)),
+    )
+
+    async def _drive():
+        task = handler._start_waste_signal_task(
+            SimpleNamespace(waste_signals_provider=_raise),
+            model="m",
+            provider_name="anthropic",
+        )
+        assert await task is None  # must not raise
+
+    asyncio.run(_drive())
+    assert called == []
+
+
+def _funnel_harness(seen: dict) -> SimpleNamespace:
+    class _Metrics:
+        async def record_request(self, **kwargs):  # noqa: ANN003, ANN202
+            seen["metrics_waste_signals"] = kwargs.get("waste_signals")
+
+        async def record_failed(self, **kwargs):  # noqa: ANN003, ANN202
+            raise AssertionError("should not be called for a 200 outcome")
+
+    class _Logger:
+        def log(self, request_log):  # noqa: ANN001, ANN202
+            seen["log_waste_signals"] = request_log.waste_signals
+
+    return SimpleNamespace(metrics=_Metrics(), cost_tracker=None, logger=_Logger())
+
+
+def _outcome_with_task(task):  # noqa: ANN001, ANN202
+    from headroom.proxy.outcome import RequestOutcome
+
+    return RequestOutcome(
+        request_id="r1",
+        provider="anthropic",
+        model="m",
+        original_tokens=100,
+        optimized_tokens=50,
+        output_tokens=10,
+        tokens_saved=50,
+        attempted_input_tokens=100,
+        waste_signals=None,
+        waste_signals_task=task,
+    )
+
+
+def test_emit_request_outcome_collects_finished_deferred_waste_signals() -> None:
+    """The outcome funnel picks up a completed deferred task's result and
+    feeds it to the metrics and request-log consumers, restoring the inline
+    path's funnel fidelity."""
+    from headroom.proxy.outcome import emit_request_outcome
+
+    seen: dict = {}
+    handler = _funnel_harness(seen)
+
+    async def _drive():
+        async def _signals() -> dict[str, int]:
+            return {"duplicate_tool_result": 3}
+
+        task = asyncio.create_task(_signals())
+        await task  # parse finished during the (much longer) upstream call
+        await emit_request_outcome(handler, _outcome_with_task(task))
+
+    asyncio.run(_drive())
+    assert seen["metrics_waste_signals"] == {"duplicate_tool_result": 3}
+    assert seen["log_waste_signals"] == {"duplicate_tool_result": 3}
+
+
+def test_emit_request_outcome_never_waits_on_pending_waste_task() -> None:
+    """Collection is done-only: a still-running task (busy background
+    executor) must not delay the response path — the funnel records None
+    and moves on immediately."""
+    from headroom.proxy.outcome import emit_request_outcome
+
+    seen: dict = {}
+    handler = _funnel_harness(seen)
+
+    async def _drive():
+        never_done: asyncio.Future = asyncio.get_running_loop().create_future()
+        task = asyncio.ensure_future(never_done)
+        try:
+            await asyncio.wait_for(
+                emit_request_outcome(handler, _outcome_with_task(task)), timeout=0.5
+            )
+        finally:
+            task.cancel()
+
+    asyncio.run(_drive())
+    assert seen["metrics_waste_signals"] is None
+    assert seen["log_waste_signals"] is None

--- a/tests/test_token_count_memo.py
+++ b/tests/test_token_count_memo.py
@@ -1,0 +1,239 @@
+"""Parity tests for TokenCountMemo (perf review F2).
+
+The memo's correctness hinges on: tokenizer.count_messages(messages) ==
+sum(tokenizer.count_message(m) for m in messages) + tokenizer.REPLY_OVERHEAD.
+These tests prove the memoized count matches the direct count exactly across
+message shapes the Claude Code route actually sends (text, tool_use,
+tool_result string content, tool_result list-of-blocks content, images), using
+EstimatingTokenCounter — the only tokenizer the proxy uses for Claude models
+(tokenizers/registry.py `_create_anthropic`).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from headroom.cache.token_count_memo import TokenCountMemo, count_messages_memoized
+from headroom.tokenizers.estimator import EstimatingTokenCounter
+
+FIXTURES = [
+    pytest.param(
+        [
+            {"role": "user", "content": "hello there"},
+            {"role": "assistant", "content": "hi, how can I help?"},
+        ],
+        id="plain_text",
+    ),
+    pytest.param(
+        [
+            {"role": "user", "content": "do something"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "t1", "name": "my_tool", "input": {"a": 1}}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "tool output data"}
+                ],
+            },
+        ],
+        id="tool_use_and_result_string",
+    ),
+    pytest.param(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t1",
+                        "content": [{"type": "text", "text": "list-of-blocks tool output"}],
+                    }
+                ],
+            },
+        ],
+        id="tool_result_list_of_blocks",
+    ),
+    pytest.param(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look at this"},
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"},
+                    },
+                ],
+            },
+        ],
+        id="text_and_image_block",
+    ),
+    pytest.param(
+        [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "hi", "name": "alice"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "search", "arguments": '{"q": "test"}'},
+                    }
+                ],
+            },
+        ],
+        id="system_name_and_tool_calls",
+    ),
+    pytest.param([], id="empty_messages"),
+    pytest.param([{"role": "user", "content": "solo message"}], id="single_message"),
+]
+
+
+@pytest.mark.parametrize("messages", FIXTURES)
+def test_memoized_count_matches_direct_count(messages) -> None:
+    tokenizer = EstimatingTokenCounter()
+    memo = TokenCountMemo()
+
+    direct = tokenizer.count_messages(messages)
+    memoized = count_messages_memoized(memo, tokenizer, messages)
+
+    assert memoized == direct
+
+
+def test_memoized_count_stable_across_repeated_calls_cold_and_warm() -> None:
+    """Same messages, memo cold then warm — count must not drift."""
+    tokenizer = EstimatingTokenCounter()
+    memo = TokenCountMemo()
+    messages = [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "output"}],
+        },
+    ]
+    direct = tokenizer.count_messages(messages)
+
+    cold = count_messages_memoized(memo, tokenizer, messages)
+    warm = count_messages_memoized(memo, tokenizer, messages)
+
+    assert cold == direct
+    assert warm == direct
+
+
+def test_memoized_count_handles_append_only_delta() -> None:
+    """Only the new tail message should require a fresh count; the frozen
+    prefix's per-message entries must already be memoized (cache hits)."""
+    tokenizer = EstimatingTokenCounter()
+    memo = TokenCountMemo()
+    turn1 = [{"role": "user", "content": "turn one"}]
+    turn2 = turn1 + [{"role": "assistant", "content": "turn two reply"}]
+
+    count_messages_memoized(memo, tokenizer, turn1)
+    prefix_key = TokenCountMemo.message_hash(turn1[0])
+    assert memo.get(prefix_key) is not None
+
+    memoized_turn2 = count_messages_memoized(memo, tokenizer, turn2)
+    assert memoized_turn2 == tokenizer.count_messages(turn2)
+
+
+def test_message_hash_differs_for_different_messages() -> None:
+    h1 = TokenCountMemo.message_hash({"role": "user", "content": "a"})
+    h2 = TokenCountMemo.message_hash({"role": "user", "content": "b"})
+    assert h1 != h2
+
+
+def test_message_hash_same_for_identical_messages() -> None:
+    m = {"role": "user", "content": "same content"}
+    assert TokenCountMemo.message_hash(dict(m)) == TokenCountMemo.message_hash(dict(m))
+
+
+class TestTokenCountMemoEviction:
+    def test_eviction_at_max_entries(self) -> None:
+        memo = TokenCountMemo(max_entries=3)
+        memo.put("a", 1)
+        memo.put("b", 2)
+        memo.put("c", 3)
+        memo.get("a")  # touch "a" so it's not the least-recently-used
+        memo.put("d", 4)  # should evict "b" (oldest untouched)
+
+        assert memo.get("a") == 1
+        assert memo.get("b") is None
+        assert memo.get("c") == 3
+        assert memo.get("d") == 4
+
+    def test_get_stats_reports_entry_count(self) -> None:
+        memo = TokenCountMemo()
+        memo.put("a", 1)
+        memo.put("b", 2)
+        assert memo.get_stats()["entries"] == 2
+
+
+class TestTokenizerCapabilityGuards:
+    """Runtime enforcement of the additive-counts precondition and the
+    memo↔tokenizer binding (review findings 3 and 4)."""
+
+    def test_non_additive_tokenizer_bypasses_memo(self) -> None:
+        """A tokenizer flagged non-additive (HuggingFace/Mistral chat-template
+        counting) must get a plain count_messages call — never per-message
+        memoization, which would be systematically wrong for it."""
+
+        class _JointTokenizer:
+            ADDITIVE_COUNTS = False
+            REPLY_OVERHEAD = 3
+
+            def count_message(self, message) -> int:  # noqa: ANN001
+                raise AssertionError("per-message path must not be used")
+
+            def count_messages(self, messages) -> int:  # noqa: ANN001
+                return 1234
+
+        memo = TokenCountMemo()
+        assert (
+            count_messages_memoized(memo, _JointTokenizer(), [{"role": "user", "content": "x"}])
+            == 1234
+        )
+        assert memo.get_stats()["entries"] == 0
+
+    def test_unflagged_tokenizer_bypasses_memo(self) -> None:
+        """Duck-typed tokenizers without the ADDITIVE_COUNTS flag get the
+        conservative (correct, unmemoized) path."""
+
+        class _Unflagged:
+            REPLY_OVERHEAD = 3
+
+            def count_message(self, message) -> int:  # noqa: ANN001
+                raise AssertionError("per-message path must not be used")
+
+            def count_messages(self, messages) -> int:  # noqa: ANN001
+                return 99
+
+        memo = TokenCountMemo()
+        assert count_messages_memoized(memo, _Unflagged(), [{"role": "user", "content": "x"}]) == 99
+        assert memo.get_stats()["entries"] == 0
+
+    def test_tokenizer_swap_clears_memo(self) -> None:
+        """Counts computed under one tokenizer must not be served after a
+        swap (the count fail-open path downgrades to a fresh estimator
+        mid-session): the memo rebinds and recounts."""
+        messages = [{"role": "user", "content": "hello world " * 50}]
+        a = EstimatingTokenCounter()
+        b = EstimatingTokenCounter(chars_per_token=1.0)  # very different ratio
+
+        memo = TokenCountMemo()
+        count_a = count_messages_memoized(memo, a, messages)
+        count_b = count_messages_memoized(memo, b, messages)
+
+        assert count_b == b.count_messages(messages)
+        assert count_b != count_a  # stale count under `a` was not reused
+
+    def test_same_tokenizer_keeps_memo_bound(self) -> None:
+        messages = [{"role": "user", "content": "hello world " * 50}]
+        tokenizer = EstimatingTokenCounter()
+        memo = TokenCountMemo()
+        count_messages_memoized(memo, tokenizer, messages)
+        entries = memo.get_stats()["entries"]
+        count_messages_memoized(memo, tokenizer, messages)
+        assert memo.get_stats()["entries"] == entries  # no clear, warm hits

--- a/tests/test_transforms/test_content_router.py
+++ b/tests/test_transforms/test_content_router.py
@@ -600,6 +600,38 @@ class TestTransformInterface:
         assert result.messages[0]["content"] == "Hello"
         assert result.messages[1]["content"] == "Hi there!"
 
+    def test_apply_consumes_tokens_before_hint(self, default_config, tokenizer):
+        """apply() uses tokens_before_hint from kwargs instead of recounting."""
+        router = ContentRouter(default_config)
+        messages = [{"role": "user", "content": "small"}]
+
+        result = router.apply(messages, tokenizer, tokens_before_hint=12_345)
+
+        assert result.tokens_before == 12_345
+
+    def test_apply_does_not_inflate_tokens_for_block_list_content(self, default_config, tokenizer):
+        """apply() must not str() Anthropic content-block lists when counting
+        tokens (perf review F3) — that counts Python repr punctuation
+        (brackets, quotes, key names) as if it were real content, inflating
+        tokens_before/context_pressure. No hint provided here, so this
+        exercises the direct-SDK fallback path.
+        """
+        router = ContentRouter(default_config)
+        block_messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hi"}] * 20,
+            }
+        ]
+        repr_based_count = sum(
+            tokenizer.count_text(str(m.get("content", ""))) for m in block_messages
+        )
+
+        result = router.apply(block_messages, tokenizer)
+
+        assert result.tokens_before == tokenizer.count_messages(block_messages)
+        assert result.tokens_before < repr_based_count
+
 
 # =============================================================================
 # TestCompressorDisabling

--- a/tests/test_transforms/test_pipeline_waste_signal_limit.py
+++ b/tests/test_transforms/test_pipeline_waste_signal_limit.py
@@ -10,6 +10,7 @@ result stays on the critical path.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 from headroom.config import HeadroomConfig, TransformResult
@@ -51,7 +52,7 @@ class _ShrinkTransform(Transform):
         )
 
 
-def _run(monkeypatch, *, before: int, after: int, limit: int):
+def _run(monkeypatch, *, before: int, after: int, limit: int, defer_waste_signals: bool = False):
     """Run the pipeline with a stub transform; return (result, parse_called)."""
     pipeline = TransformPipeline(HeadroomConfig())
     pipeline.transforms = [_ShrinkTransform()]
@@ -73,6 +74,7 @@ def _run(monkeypatch, *, before: int, after: int, limit: int):
         model_limit=1_000_000,
         record_metrics=False,
         waste_signal_token_limit=limit,
+        defer_waste_signals=defer_waste_signals,
     )
     return result, parse_called
 
@@ -93,3 +95,136 @@ def test_small_request_still_runs_waste_signal_detection(monkeypatch):
     _result, parse_called = _run(monkeypatch, before=10_000, after=5_000, limit=100_000)
 
     assert parse_called is True, "waste-signal parse must still run below the limit"
+
+
+def test_defer_waste_signals_skips_inline_parse_even_when_small(monkeypatch):
+    """perf review F5: proxy callers set defer_waste_signals=True, which skips
+    the inline re-parse regardless of size — it re-derives off-path instead.
+    SDK callers never pass this flag (default False), so the two tests above
+    already guard that their inline behavior is unchanged."""
+    result, parse_called = _run(
+        monkeypatch, before=10_000, after=5_000, limit=100_000, defer_waste_signals=True
+    )
+
+    assert parse_called is False, "defer_waste_signals must skip the inline parse entirely"
+    assert result.waste_signals is None
+    assert "test:shrink" in result.transforms_applied
+    assert result.messages[-1]["content"] == "compressed"
+    # The gate would have parsed inline, so the deferred provider is attached
+    # for the caller to run off-path.
+    assert result.waste_signals_provider is not None
+
+
+def test_defer_provider_runs_the_same_parse_lazily(monkeypatch):
+    """Calling the deferred provider performs the parse the inline path would
+    have done (same messages, same tokenizer), returning the WasteSignals."""
+    fake_ws = SimpleNamespace(total=lambda: 2, to_dict=lambda: {"duplicate_tool_result": 2})
+
+    result, _ = _run(
+        monkeypatch, before=10_000, after=5_000, limit=100_000, defer_waste_signals=True
+    )
+    monkeypatch.setattr("headroom.parser.parse_messages", lambda *a, **k: ([], {}, fake_ws))
+
+    assert result.waste_signals_provider() is fake_ws
+
+
+def test_defer_provider_absent_when_savings_too_small(monkeypatch):
+    """Gate parity: below _MIN_TOKENS_SAVED_FOR_WASTE_SIGNALS the inline path
+    would not have parsed, so deferral must not attach a provider either."""
+    result, parse_called = _run(
+        monkeypatch, before=100, after=99, limit=100_000, defer_waste_signals=True
+    )
+
+    assert parse_called is False
+    assert result.waste_signals_provider is None
+
+
+def test_defer_provider_absent_above_size_limit(monkeypatch):
+    """Gate parity: the waste_signal_token_limit override is honored under
+    deferral exactly as inline (#296 size cap)."""
+    result, parse_called = _run(
+        monkeypatch, before=200_000, after=180_000, limit=100_000, defer_waste_signals=True
+    )
+
+    assert parse_called is False
+    assert result.waste_signals_provider is None
+
+
+def test_pipeline_injects_tokens_before_hint_into_transform_kwargs(monkeypatch):
+    """perf review F2/F3 plumbing: apply() must pass the already-computed
+    tokens_before to every transform via kwargs, so ContentRouter (Phase 6)
+    can reuse it instead of recounting messages itself."""
+    pipeline = TransformPipeline(HeadroomConfig())
+    tokenizer = _FakeTokenizer(before=12_345, after=12_345)
+    monkeypatch.setattr(pipeline, "_get_tokenizer", lambda _model: tokenizer)
+
+    captured_kwargs: dict[str, Any] = {}
+
+    class _CaptureTransform(Transform):
+        name = "test_capture"
+
+        def apply(self, messages, tokenizer, **kwargs: Any):  # noqa: ANN001
+            captured_kwargs.update(kwargs)
+            return TransformResult(
+                messages=messages,
+                tokens_before=tokenizer.count_messages(messages),
+                tokens_after=tokenizer.count_messages(messages),
+                transforms_applied=["test:capture"],
+            )
+
+    pipeline.transforms = [_CaptureTransform()]
+
+    pipeline.apply(
+        [{"role": "user", "content": "x" * 100}],
+        model="claude-3-5-sonnet",
+        model_limit=1_000_000,
+        record_metrics=False,
+    )
+
+    assert captured_kwargs.get("tokens_before_hint") == 12_345
+
+
+def test_tokens_before_hint_refreshes_after_each_transform(monkeypatch):
+    """An earlier transform that changes the messages (e.g. the
+    HEADROOM_INTERCEPT_ENABLED interceptor before the ContentRouter) must not
+    leave later transforms holding the stale pipeline-entry count: the hint is
+    refreshed from each transform's reported tokens_after."""
+    pipeline = TransformPipeline(HeadroomConfig())
+    tokenizer = _FakeTokenizer(before=10_000, after=10_000)
+    monkeypatch.setattr(pipeline, "_get_tokenizer", lambda _model: tokenizer)
+
+    hints_seen: list[int] = []
+
+    class _ShrinkReporting(Transform):
+        name = "test_shrink_reporting"
+
+        def apply(self, messages, tokenizer, **kwargs: Any):  # noqa: ANN001
+            hints_seen.append(kwargs.get("tokens_before_hint"))
+            return TransformResult(
+                messages=messages,
+                tokens_before=10_000,
+                tokens_after=4_000,  # removed content
+                transforms_applied=["test:shrink_reporting"],
+            )
+
+    class _Capture(Transform):
+        name = "test_capture_second"
+
+        def apply(self, messages, tokenizer, **kwargs: Any):  # noqa: ANN001
+            hints_seen.append(kwargs.get("tokens_before_hint"))
+            return TransformResult(
+                messages=messages,
+                tokens_before=kwargs.get("tokens_before_hint", 0),
+                tokens_after=kwargs.get("tokens_before_hint", 0),
+                transforms_applied=["test:capture_second"],
+            )
+
+    pipeline.transforms = [_ShrinkReporting(), _Capture()]
+    pipeline.apply(
+        [{"role": "user", "content": "x" * 100}],
+        model="claude-3-5-sonnet",
+        model_limit=1_000_000,
+        record_metrics=False,
+    )
+
+    assert hints_seen == [10_000, 4_000]

--- a/tests/test_transforms_content_router.py
+++ b/tests/test_transforms_content_router.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 import headroom.transforms.content_router as content_router_module
+from headroom.tokenizers.base import BaseTokenizer
 from headroom.transforms.content_detector import ContentType, DetectionResult
 from headroom.transforms.content_router import (
     CompressionCache,
@@ -391,7 +392,7 @@ def test_normal_compress_path_still_uses_content_detection(
 def test_force_kompress_apply_uses_lightweight_detection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    class FakeTokenizer:
+    class FakeTokenizer(BaseTokenizer):
         def count_text(self, text: str) -> int:
             return len(text.split())
 
@@ -442,7 +443,7 @@ def test_force_kompress_apply_uses_lightweight_detection(
 def test_force_kompress_apply_lightweight_detection_protects_recent_code(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    class FakeTokenizer:
+    class FakeTokenizer(BaseTokenizer):
         def count_text(self, text: str) -> int:
             return len(text.split())
 
@@ -1183,8 +1184,8 @@ def test_detect_content_python_backend_skips_native(
 # ---------------------------------------------------------------------------
 
 
-class _ChurnTokenizer:
-    """Word-count tokenizer; apply() only calls ``count_text``."""
+class _ChurnTokenizer(BaseTokenizer):
+    """Word-count tokenizer."""
 
     def count_text(self, text: str) -> int:
         return len(str(text).split())

--- a/tests/test_websearch_tool_result_protection.py
+++ b/tests/test_websearch_tool_result_protection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from headroom.config import DEFAULT_EXCLUDE_TOOLS
 from headroom.proxy.server import HeadroomProxy, ProxyConfig
+from headroom.tokenizers.base import BaseTokenizer
 from headroom.transforms.content_detector import ContentType
 from headroom.transforms.content_router import (
     CompressionStrategy,
@@ -13,7 +14,7 @@ from headroom.transforms.content_router import (
 )
 
 
-class _Tokenizer:
+class _Tokenizer(BaseTokenizer):
     def count_text(self, text: str) -> int:
         return max(1, len(text) // 4)
 


### PR DESCRIPTION
## Description

Supersedes #2249, re-rooted onto current `main` as two clean commits. This PR carries both token-mode workstreams from that branch **plus the guard wiring that branch had lost**: #2249's head was missing the Anthropic call sites for the CCR expansion guards (they were dropped in an upstream sync merge on that branch), so as pushed it still re-injected the same proactively-expanded contexts on every turn.

**1. CCR proactive-expansion re-injection loop (the bug).** Proactive expansion injects retrieved context into the **forwarded body only** — the client transcript never carries it. The next turn looks identical to the tracker (markers still present, query still relevant), so the same compressed-content hashes are expanded and re-injected on **every turn**: each request gains the full retrieval payload again, net savings degrade to zero, and the transient tail append busts the provider prefix cache from that position on. Related: #2186 (closed with a workaround — this addresses the general mechanism, not just compact summaries).

**2. Restore provider prompt-cache hit rate in `--mode token`.** The OpenAI chat paths omitted `original_messages` on `PrefixCacheTracker.update_from_response`, so the tracker recorded forwarded (compressed) bytes as "originals" and the append-only check diverged every turn (#1850). Anthropic-native requests with `ccr_inject_system_instructions=True` hit a prepend branch inserting a `role:"system"` message the Messages API 400s on.

**3. Cut per-turn CPU on the token-mode hot path.** The path was O(full transcript) per turn where it should be O(delta): redundant full-transcript deepcopies (4–6/turn), repeated tool_result hash walks, up to 6 full-transcript token counts per request, telemetry re-parse on the critical path, and repr-based router counting.

Closes #1850.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [x] Code refactoring (no functional changes)

## Changes Made

**Commit 1 — `fix(proxy/ccr)`: expansion dedup + double-inject guards**

- `headroom/proxy/ccr_session_tracker.py`: new `SessionExpansionDedupTracker` (bounded LRU) — a hash is proactively expanded at most once per session; explicit `headroom_retrieve` calls are unaffected.
- `headroom/proxy/handlers/anthropic.py`: pass `session_id` to `track_compression`/`analyze_query`; filter recommendations through `filter_new()`; `record_injected()` only after a *real* append (the append helper is a no-op when the latest turn is frozen or has no eligible text block — a later turn may retry); gate the proactive-expansion append and the memory-context append behind `injection_target_already_forwarded()`.
- `headroom/proxy/handlers/openai.py`: same gate on the memory-context append.
- `headroom/proxy/helpers.py`: shared `injection_target_already_forwarded()` + dedup-tracker singleton.
- `headroom/cache/prefix_tracker.py`: `is_append_only_extension()` — the same append-only condition `overlay_cached_prefix` uses.
- `headroom/ccr/context_tracker.py`: entries record their session id; `analyze_query` skips contexts tracked under a different session (post-`/compact` sessions don't resurface pre-compact content). Legacy/no-session callers keep workspace-only scoping.
- `tests/test_injection_cache_safety.py` (new): unit coverage for the three guards + a tripwire asserting the anthropic handler keeps them wired (the failure mode is silent — compression still runs, savings just net to zero).

**Commit 2 — `perf(proxy)`: squash-import of #2249's workstreams**

- **openai/streaming:** pass raw client messages as `original_messages` to `update_from_response` in both non-streaming branches and the streaming finalizer.
- **anthropic system:** append CCR system instructions to top-level `body["system"]` via a static, hash-free `create_stable_system_instructions` block (idempotent, preserves prior `cache_control` breakpoints) — never a `role:"system"` message.
- **cache/prefix_tracker:** getters return internal references under a documented read-only contract; single defensive deepcopy stays at record time.
- **cache/compression_cache:** `prepare_turn` does one extract+hash walk (replacing `compute_frozen_count`/`mark_stable_from_messages`/`apply_cached`); shallow-copy swaps; hashing outside the lock.
- **transforms/pipeline + agent_savings + observability/metrics + proxy/outcome:** `defer_waste_signals` moves the telemetry-only re-parse off the critical path (Anthropic route only; background task collected done-only by the outcome funnel).
- **cache/token_count_memo (new) + tokenizers + server:** per-session `TokenCountMemo` for recount sites, guarded by an `ADDITIVE_COUNTS` tokenizer capability flag; estimator regex uses `finditer`.
- **transforms/content_router:** no `str()`-serializing of block lists; consumes `tokens_before_hint`.
- **dead code:** removed the disabled `CacheAligner` stage and `should_defer_compression`/`should_force_compress`.
- **tests:** `test_openai_cross_turn_cache_safety.py`, `test_token_count_memo.py` (new); extended anthropic cache-stability, CCR deferred-injection, cross-turn mutation-guard, pipeline waste-signal, handler-helper, and content-router suites.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ HOME=$(mktemp -d) pytest <29 suites: injection_cache_safety, ccr_context_tracker, ccr_session_tracker,
    proxy_ccr, ccr_tool_injection, token_count_memo, compression_cache, cross_turn_cache_safety,
    openai_cross_turn_cache_safety, proxy_{anthropic,openai}_cache_stability, proxy_handler_helpers,
    cold_start_fast_pass, agent_savings, anthropic_stage_timings, canonical_pipeline,
    transforms_content_router, pipeline_waste_signal_limit, websearch_tool_result_protection,
    anthropic_pre_upstream_backpressure, content_router_*, config, cache/prefix_tracker,
    proxy/anthropic_ccr_deferred_injection, memory_injection_*> -q
595 passed, 4 warnings in 23.33s

$ ruff check headroom/ tests/
All checks passed!

$ mypy headroom
Found 1 error in 1 file (checked 511 source files)
# headroom/observability/metrics.py:324 — pre-existing on main (code verbatim on 1588f5e0,
# get_meter(name, version: str | None)); untouched by this PR.
```

## Real Behavior Proof

- Environment: macOS 15 (darwin 25.4.0), Python 3.13, headroom proxy 0.33.0-dev started as `headroom proxy --port 8787 --mode token --backend anthropic`, Claude Code as the client, `savings_profile=coding`.
- Exact command / steps: run a long agentic Claude Code session through the proxy so the transcript accumulates CCR compression markers, then keep asking questions whose keywords match the tracked compressed contexts, so `ContextTracker.analyze_query` recommends the same hashes on every turn. Watch `~/.headroom/logs/proxy.log` for `Proactively expanded` and compare `tok_before`/`tok_after`/`tok_saved` on the `PERF` line of each turn.
- Observed result: the two recommended hashes were re-expanded and re-injected on every subsequent turn. `tok_saved` was 1,740 on the turn before the first expansion and **0 on every turn after it**; from msgs=27 on, the forwarded request was *larger* than the client's original (`tok_after > tok_before` by +2,214 → +6,865 tokens) — the proxy added more than compression removed. One turn also logged `CACHE-BUST ... tokens_lost=8,500`, caused by the tail double-inject. Log excerpt from that session (build without these guards, i.e. the code path commit 1 changes):

  ```text
  11:47:32 PERF model=claude-opus-5 msgs=19 tok_before=31521 tok_after=29781 tok_saved=1740
  11:47:32 CCR: Proactively expanded 2 context(s) based on query relevance     # hashes A+B, 340+801 items
  11:47:37 PERF model=claude-opus-5 msgs=21 tok_before=34210 tok_after=34447 tok_saved=0
  11:47:54 headroom_retrieve ... hash=A ... hash=B                             # same hashes, next turn
  11:47:59 PERF model=claude-opus-5 msgs=27 tok_before=35893 tok_after=38107 tok_saved=0
  11:48:25 PERF model=claude-opus-5 msgs=33 tok_before=36932 tok_after=43797 tok_saved=0
  ```

- Not tested: no live-traffic run of *this* branch yet — the reproduction above is from the unguarded build, and the guarded behavior is so far only verified by the unit suites listed under Testing (dedup filter, session-scoped `analyze_query`, `injection_target_already_forwarded`, handler-wiring tripwire). The post-fix log signature to confirm on a live run is `CCR: skipping proactive expansion append — tail position already forwarded last turn` plus a `tok_saved` that stays positive across turns. Also not exercised live: the OpenAI `original_messages` recording fix (#1850) and the per-turn CPU reductions (no before/after latency profile captured). Manual testing stays unchecked and the PR stays in draft until that run is done.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A (proxy-internal behavior; log evidence above).

## Additional Notes

- **Supersedes #2249** (closed in favor of this PR). Rationale: that branch's pushed head had lost the anthropic guard wiring in an upstream sync merge (helpers/tracker/tests survived, the call sites didn't — silent because the unit tests only cover the helpers), and its history carried several main-sync merges. This PR re-roots the same content onto current `main` as two clean commits, with the guards complete. The 8 reviews on #2249 apply to content that is byte-similar here; deliberate deltas: `record_injected()` fires only after a real append, the expansion payload does not carry an unused `tokens` field, and the handler tripwire test is new.
- **Overlap with #2500:** touches the same three files (`anthropic.py`, `openai.py`, `helpers.py`) but disjoint hunks (tool-search deferral / tool_reference recovery); either merge order is trivial.
- Docs checklist item is N/A: no user-facing configuration or documented behavior changes.
- The mypy finding above is pre-existing on `main` and untouched here (see Test Output).
