### PR TITLE
feat(mcp)!: port MCP servers to SDK 2.x

### DIFF
--- a/headroom/ccr/mcp_server.py
+++ b/headroom/ccr/mcp_server.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import contextlib
+import contextvars
 import json
 import logging
 import os
@@ -48,11 +49,12 @@ try:
 except ImportError:
     _HAS_FCNTL = False
 
-# Try to import MCP SDK
+# Try to import MCP SDK (2.x: handlers are constructor callbacks, results are
+# typed ``*Result`` models rather than bare lists).
 try:
     from mcp.server import Server
     from mcp.server.stdio import stdio_server
-    from mcp.types import TextContent, Tool
+    from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
 
     MCP_AVAILABLE = True
 except ImportError:
@@ -87,6 +89,14 @@ _READ_ENABLED = os.environ.get("HEADROOM_MCP_READ", "off").lower().strip() in (
 )
 
 DEFAULT_PROXY_URL = os.environ.get("HEADROOM_PROXY_URL", "http://127.0.0.1:8787")
+
+# MCP 2.x removed ``Server.request_context``; the per-request context is now only
+# handed to the handler as an argument. ``_current_client()`` needs it three frames
+# below the handler, so we stash it here instead of threading it through every
+# ``_handle_*`` signature. A ContextVar rather than an instance attribute because
+# concurrent tool calls on one server would race on ``self`` — this is the same
+# mechanism 1.x used internally to back ``request_context``.
+_request_ctx: contextvars.ContextVar[Any] = contextvars.ContextVar("headroom_mcp_request_ctx")
 
 # How often the parent-death watchdog polls os.getppid() (seconds). When the
 # launching MCP client is SIGKILLed, stdin EOF may never arrive and the SDK's
@@ -383,8 +393,14 @@ class HeadroomMCPServer:
         if not MCP_AVAILABLE or Server is None:
             raise ImportError("MCP SDK not installed. Install with: pip install mcp")
 
-        self.server: Server = Server("headroom")
-        self._setup_handlers()
+        # MCP 2.x registers handlers as constructor callbacks. Bound methods are
+        # resolved at call time, so passing them here does not require the rest of
+        # ``__init__`` to have run.
+        self.server: Server = Server(
+            "headroom",
+            on_list_tools=self._on_list_tools,
+            on_call_tool=self._on_call_tool,
+        )
 
     def _get_local_store(self) -> Any:
         """Get the shared compression store singleton (lazy init).
@@ -606,147 +622,156 @@ class HeadroomMCPServer:
             )
         return None
 
-    def _setup_handlers(self) -> None:
-        """Register all MCP tool handlers."""
+    async def _on_list_tools(self, ctx: Any, params: Any = None) -> ListToolsResult:
+        """MCP ``tools/list`` handler."""
+        tools = [
+            Tool(
+                name=COMPRESS_TOOL_NAME,
+                description=(
+                    "Compress content to save context window space. "
+                    "Use this on large tool outputs, file contents, search results, "
+                    "or any content you want to shrink before reasoning over it. "
+                    f"The original is stored and can be retrieved later via mcp__headroom__{CCR_TOOL_NAME}. "
+                    "Returns compressed text + a hash for retrieval."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "type": "string",
+                            "description": (
+                                "The content to compress. Can be any text: file contents, "
+                                "JSON, search results, logs, code, etc."
+                            ),
+                        },
+                    },
+                    "required": ["content"],
+                },
+            ),
+            Tool(
+                name=CCR_TOOL_NAME,
+                description=(
+                    "Retrieve original uncompressed content by hash. "
+                    "Use this when you need full details from previously compressed content. "
+                    "The hash comes from headroom_compress results or from compression "
+                    "markers like [N items compressed... hash=abc123]."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "hash": {
+                            "type": "string",
+                            "description": "Hash key from compression (e.g., 'abc123' from hash=abc123)",
+                        },
+                    },
+                    "required": ["hash"],
+                },
+            ),
+            Tool(
+                name=STATS_TOOL_NAME,
+                description=(
+                    "Show compression statistics for this session: "
+                    "total compressions, tokens saved, estimated cost savings, "
+                    "and recent compression events."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                },
+            ),
+        ]
 
-        @self.server.list_tools()
-        async def list_tools() -> list[Tool]:
-            tools = [
+        # Conditionally add headroom_read (behind feature flag)
+        if _READ_ENABLED:
+            tools.append(
                 Tool(
-                    name=COMPRESS_TOOL_NAME,
+                    name=READ_TOOL_NAME,
                     description=(
-                        "Compress content to save context window space. "
-                        "Use this on large tool outputs, file contents, search results, "
-                        "or any content you want to shrink before reasoning over it. "
-                        f"The original is stored and can be retrieved later via mcp__headroom__{CCR_TOOL_NAME}. "
-                        "Returns compressed text + a hash for retrieval."
+                        "Read a file with smart caching. First read returns full content "
+                        "and caches it. Subsequent reads of the same unchanged file return "
+                        "a lightweight cache marker (~20 tokens instead of thousands). "
+                        f"Use mcp__headroom__{CCR_TOOL_NAME} with the hash to get full content if needed. "
+                        "Use this INSTEAD of the built-in Read tool for significant token savings."
                     ),
-                    inputSchema={
+                    input_schema={
                         "type": "object",
                         "properties": {
-                            "content": {
+                            "file_path": {
                                 "type": "string",
+                                "description": "Absolute path to the file to read.",
+                            },
+                            "fresh": {
+                                "type": "boolean",
                                 "description": (
-                                    "The content to compress. Can be any text: file contents, "
-                                    "JSON, search results, logs, code, etc."
+                                    "Force a fresh read, bypassing cache. Use after context "
+                                    "compaction, in subagents, or when you need guaranteed "
+                                    "current content."
                                 ),
                             },
                         },
-                        "required": ["content"],
+                        "required": ["file_path"],
                     },
-                ),
-                Tool(
-                    name=CCR_TOOL_NAME,
-                    description=(
-                        "Retrieve original uncompressed content by hash. "
-                        "Use this when you need full details from previously compressed content. "
-                        "The hash comes from headroom_compress results or from compression "
-                        "markers like [N items compressed... hash=abc123]."
-                    ),
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "hash": {
-                                "type": "string",
-                                "description": "Hash key from compression (e.g., 'abc123' from hash=abc123)",
-                            },
-                        },
-                        "required": ["hash"],
-                    },
-                ),
-                Tool(
-                    name=STATS_TOOL_NAME,
-                    description=(
-                        "Show compression statistics for this session: "
-                        "total compressions, tokens saved, estimated cost savings, "
-                        "and recent compression events."
-                    ),
-                    inputSchema={
-                        "type": "object",
-                        "properties": {},
-                        "required": [],
-                    },
-                ),
-            ]
-
-            # Conditionally add headroom_read (behind feature flag)
-            if _READ_ENABLED:
-                tools.append(
-                    Tool(
-                        name=READ_TOOL_NAME,
-                        description=(
-                            "Read a file with smart caching. First read returns full content "
-                            "and caches it. Subsequent reads of the same unchanged file return "
-                            "a lightweight cache marker (~20 tokens instead of thousands). "
-                            f"Use mcp__headroom__{CCR_TOOL_NAME} with the hash to get full content if needed. "
-                            "Use this INSTEAD of the built-in Read tool for significant token savings."
-                        ),
-                        inputSchema={
-                            "type": "object",
-                            "properties": {
-                                "file_path": {
-                                    "type": "string",
-                                    "description": "Absolute path to the file to read.",
-                                },
-                                "fresh": {
-                                    "type": "boolean",
-                                    "description": (
-                                        "Force a fresh read, bypassing cache. Use after context "
-                                        "compaction, in subagents, or when you need guaranteed "
-                                        "current content."
-                                    ),
-                                },
-                            },
-                            "required": ["file_path"],
-                        },
-                    )
                 )
-
-            return tools
-
-        @self.server.call_tool()
-        async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
-            started = time.perf_counter()
-            logger.info(
-                "event=mcp_tool_call_received tool=%s arguments=%s",
-                name,
-                json.dumps(arguments, ensure_ascii=False, default=str),
             )
-            try:
-                if name == COMPRESS_TOOL_NAME:
-                    result = await self._handle_compress(arguments)
-                elif name == CCR_TOOL_NAME:
-                    result = await self._handle_retrieve(arguments)
-                elif name == STATS_TOOL_NAME:
-                    result = await self._handle_stats()
-                elif name == READ_TOOL_NAME and _READ_ENABLED:
-                    result = await self._handle_read(arguments)
-                else:
-                    result = [
-                        TextContent(
-                            type="text",
-                            text=json.dumps({"error": f"Unknown tool: {name}"}),
-                        )
-                    ]
-                logger.info(
-                    "event=mcp_tool_call_completed tool=%s duration_ms=%.2f output=%s",
-                    name,
-                    (time.perf_counter() - started) * 1000.0,
-                    json.dumps(
-                        [getattr(item, "text", str(item)) for item in result],
-                        ensure_ascii=False,
-                        default=str,
-                    ),
-                )
-                return result
-            except Exception as e:
-                logger.error(f"Tool {name} failed: {e}", exc_info=True)
-                return [
+
+        return ListToolsResult(tools=tools)
+
+    async def _on_call_tool(self, ctx: Any, params: Any) -> CallToolResult:
+        """MCP ``tools/call`` handler."""
+        name = params.name
+        # 2.x types ``arguments`` as optional; the ``_handle_*`` helpers all call
+        # ``.get()`` on it, so normalise before dispatching.
+        arguments: dict[str, Any] = params.arguments or {}
+        started = time.perf_counter()
+        logger.info(
+            "event=mcp_tool_call_received tool=%s arguments=%s",
+            name,
+            json.dumps(arguments, ensure_ascii=False, default=str),
+        )
+        token = _request_ctx.set(ctx)
+        try:
+            if name == COMPRESS_TOOL_NAME:
+                result = await self._handle_compress(arguments)
+            elif name == CCR_TOOL_NAME:
+                result = await self._handle_retrieve(arguments)
+            elif name == STATS_TOOL_NAME:
+                result = await self._handle_stats()
+            elif name == READ_TOOL_NAME and _READ_ENABLED:
+                result = await self._handle_read(arguments)
+            else:
+                result = [
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"error": f"Unknown tool: {name}"}),
+                    )
+                ]
+            logger.info(
+                "event=mcp_tool_call_completed tool=%s duration_ms=%.2f output=%s",
+                name,
+                (time.perf_counter() - started) * 1000.0,
+                json.dumps(
+                    [getattr(item, "text", str(item)) for item in result],
+                    ensure_ascii=False,
+                    default=str,
+                ),
+            )
+            # ponytail: is_error left unset, matching 1.x behaviour where the SDK
+            # wrapped a returned list as a success. Flagging error payloads as
+            # is_error=True is a behaviour change — separate PR, not this port.
+            return CallToolResult(content=list(result))
+        except Exception as e:
+            logger.error(f"Tool {name} failed: {e}", exc_info=True)
+            return CallToolResult(
+                content=[
                     TextContent(
                         type="text",
                         text=json.dumps({"error": str(e)}),
                     )
                 ]
+            )
+        finally:
+            _request_ctx.reset(token)
 
     async def _handle_compress(self, arguments: dict[str, Any]) -> list[TextContent]:
         """Handle headroom_compress tool call."""
@@ -802,7 +827,10 @@ class HeadroomMCPServer:
         if override:
             return override
         try:
-            params = self.server.request_context.session.client_params
+            ctx = _request_ctx.get(None)
+            if ctx is None:
+                return "unknown"
+            params = ctx.session.client_params
             info = getattr(params, "clientInfo", None) if params else None
             name = getattr(info, "name", None)
             if name:

--- a/headroom/memory/mcp_server.py
+++ b/headroom/memory/mcp_server.py
@@ -36,7 +36,7 @@ from typing import Any
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
 
 from headroom.memory.backends.local import LocalBackend, LocalBackendConfig
 
@@ -55,7 +55,7 @@ _TOOLS = [
             "project context, user preferences, org info, codenames, debugging history, "
             "or anything that might have been discussed before."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "query": {
@@ -86,7 +86,7 @@ _TOOLS = [
             "Good:  facts: ['Repo owner is Tejas C.', 'User prefers dark mode']\n"
             "Bad:   facts: ['Repo owner is Tejas C. Prefers dark mode.']"
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "facts": {
@@ -159,7 +159,8 @@ async def _warm_up_backend(backend: LocalBackend, user_id: str) -> None:
 def create_memory_server(db_path: str, user_id: str = "default") -> Server:
     """Create an MCP server backed by headroom's local memory."""
 
-    server = Server("headroom-memory")
+    # MCP 2.x takes handlers as constructor callbacks, so the ``Server`` is built
+    # at the end of this factory once the handler closures below exist.
     _backend: LocalBackend | None = None
     _init_task: asyncio.Task[LocalBackend] | None = None
 
@@ -225,25 +226,33 @@ def create_memory_server(db_path: str, user_id: str = "default") -> Server:
                 _init_task = None
             raise
 
-    @server.list_tools()
-    async def list_tools() -> list[Tool]:
+    async def on_list_tools(ctx: Any, params: Any = None) -> ListToolsResult:
         # Kick off background init on first list_tools (called at MCP handshake)
         if _backend is None:
             _start_backend_init()
-        return _TOOLS
+        return ListToolsResult(tools=list(_TOOLS))
 
-    @server.call_tool()
-    async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    async def on_call_tool(ctx: Any, params: Any) -> CallToolResult:
+        name = params.name
+        # 2.x types ``arguments`` as optional; the handlers below index into it.
+        arguments: dict[str, Any] = params.arguments or {}
         backend = await _get_backend()
 
+        content: list[TextContent]
         if name == "memory_search":
-            return await _handle_search(backend, arguments, user_id)
+            content = await _handle_search(backend, arguments, user_id)
         elif name == "memory_save":
-            return await _handle_save(backend, arguments, user_id)
+            content = await _handle_save(backend, arguments, user_id)
+        else:
+            content = [TextContent(type="text", text=f"Unknown tool: {name}")]
 
-        return [TextContent(type="text", text=f"Unknown tool: {name}")]
+        return CallToolResult(content=list(content))
 
-    return server
+    return Server(
+        "headroom-memory",
+        on_list_tools=on_list_tools,
+        on_call_tool=on_call_tool,
+    )
 
 
 async def _handle_search(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ proxy = [
     "orjson>=3.9.14; platform_python_implementation != 'PyPy'",
     "httpx[http2]>=0.24.0",
     "openai>=2.14.0",             # OpenAI API format support
-    "mcp>=1.28.1,<2.0.0",         # MCP server (headroom_compress, retrieve, stats)
+    "mcp>=2.0.0",                 # MCP server (headroom_compress, retrieve, stats)
     "magika>=0.6.0",              # ML content detection for ContentRouter
     "zstandard>=0.20.0",          # Decompress zstd request bodies (Codex, etc.)
     "websockets>=13.0",           # WebSocket proxy for /v1/responses (Codex gpt-5.4+)
@@ -225,7 +225,7 @@ autogen = [
 ]
 # MCP server for Claude Code integration
 mcp = [
-    "mcp>=1.28.1,<2.0.0",
+    "mcp>=2.0.0",
     "httpx>=0.24.0",
     "starlette>=0.27.0",
     "uvicorn>=0.23.0,<1.0",

--- a/tests/_mcp_stub.py
+++ b/tests/_mcp_stub.py
@@ -19,14 +19,17 @@ def _build_mcp_sdk_stub() -> dict[str, ModuleType]:
     mcp_types_module = type(sys)("mcp.types")
 
     class DummyServer:
-        def __init__(self, name: str) -> None:
+        """Mirrors the MCP 2.x surface: handlers arrive as constructor callbacks.
+
+        Deliberately does NOT expose ``list_tools()`` / ``call_tool()`` decorators.
+        Those were the 1.x API, and a stub that keeps accepting them lets a caller
+        still on decorators pass its tests while the real SDK rejects it — which is
+        how the 2.0.0 startup crash reached users with a green suite.
+        """
+
+        def __init__(self, name: str, **handlers) -> None:
             self.name = name
-
-        def list_tools(self):
-            return lambda fn: fn
-
-        def call_tool(self):
-            return lambda fn: fn
+            self.handlers = handlers
 
         def create_initialization_options(self):
             return {}
@@ -39,6 +42,16 @@ def _build_mcp_sdk_stub() -> dict[str, ModuleType]:
         def __init__(self, **kwargs) -> None:
             self.kwargs = kwargs
 
+    class DummyListToolsResult:
+        def __init__(self, tools=None, **kwargs) -> None:
+            self.tools = list(tools or [])
+            self.kwargs = kwargs
+
+    class DummyCallToolResult:
+        def __init__(self, content=None, **kwargs) -> None:
+            self.content = list(content or [])
+            self.kwargs = kwargs
+
     async def dummy_stdio_server():
         raise RuntimeError("stdio_server should not run in unit tests")
 
@@ -46,6 +59,8 @@ def _build_mcp_sdk_stub() -> dict[str, ModuleType]:
     mcp_stdio_module.stdio_server = dummy_stdio_server
     mcp_types_module.TextContent = DummyTextContent
     mcp_types_module.Tool = DummyTool
+    mcp_types_module.ListToolsResult = DummyListToolsResult
+    mcp_types_module.CallToolResult = DummyCallToolResult
 
     return {
         "mcp": mcp_module,

--- a/tests/test_mcp_sdk2_contract.py
+++ b/tests/test_mcp_sdk2_contract.py
@@ -1,0 +1,106 @@
+"""Contract tests against the REAL MCP SDK (no stub).
+
+Every other MCP test in this suite goes through ``tests/_mcp_stub.py``, which
+replaces the SDK in ``sys.modules``. That is fast and dependency-free, but it
+means a breaking change in the real SDK is invisible: the ``mcp`` 2.0.0 release
+removed the ``Server.list_tools()``/``call_tool()`` decorators and every stubbed
+test stayed green while ``headroom mcp serve`` crashed on startup for anyone who
+installed it (#2642).
+
+These tests import the SDK for real so that class of breakage fails here first.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+# ``mcp`` is an optional extra; skip rather than fail where it isn't installed.
+mcp_types = pytest.importorskip("mcp.types", reason="mcp SDK not installed")
+mcp_server = pytest.importorskip("mcp.server", reason="mcp SDK not installed")
+
+from headroom.ccr.mcp_server import (  # noqa: E402 - must follow importorskip
+    CCR_TOOL_NAME,
+    COMPRESS_TOOL_NAME,
+    STATS_TOOL_NAME,
+    HeadroomMCPServer,
+    _request_ctx,
+)
+
+
+def _server() -> HeadroomMCPServer:
+    return HeadroomMCPServer(proxy_url="http://127.0.0.1:8787")
+
+
+def _client_ctx(name: str) -> SimpleNamespace:
+    """Minimal stand-in for ``ServerRequestContext`` for client attribution."""
+    return SimpleNamespace(
+        session=SimpleNamespace(
+            client_params=SimpleNamespace(clientInfo=SimpleNamespace(name=name))
+        )
+    )
+
+
+def test_sdk_registers_handlers_via_constructor_not_decorators() -> None:
+    """The canary: 2.x dropped the decorator surface headroom used to rely on.
+
+    If a future SDK reintroduces or re-removes either shape, this fails loudly
+    instead of surfacing as a startup crash in front of a user.
+    """
+    assert not hasattr(mcp_server.Server, "list_tools")
+    assert not hasattr(mcp_server.Server, "call_tool")
+    # ``request_context`` moved to a per-call handler argument.
+    assert not hasattr(mcp_server.Server, "request_context")
+
+
+def test_server_constructs_and_advertises_tools_capability() -> None:
+    srv = _server()
+    opts = srv.server.create_initialization_options()
+    assert opts.capabilities.tools is not None
+
+
+def test_list_tools_returns_typed_result() -> None:
+    result = asyncio.run(_server()._on_list_tools(None, None))
+    assert isinstance(result, mcp_types.ListToolsResult)
+    names = {t.name for t in result.tools}
+    assert {COMPRESS_TOOL_NAME, CCR_TOOL_NAME, STATS_TOOL_NAME} <= names
+
+
+def test_call_tool_returns_typed_result_and_dispatches_on_params_name() -> None:
+    params = mcp_types.CallToolRequestParams(name="nope", arguments={})
+    result = asyncio.run(_server()._on_call_tool(None, params))
+    assert isinstance(result, mcp_types.CallToolResult)
+    assert "Unknown tool: nope" in result.content[0].text
+
+
+def test_call_tool_tolerates_omitted_arguments() -> None:
+    """2.x types ``arguments`` as optional; the ``_handle_*`` helpers call ``.get()``."""
+    params = mcp_types.CallToolRequestParams(name="nope")
+    result = asyncio.run(_server()._on_call_tool(None, params))
+    assert isinstance(result, mcp_types.CallToolResult)
+
+
+def test_current_client_resolves_from_request_context() -> None:
+    """Replaces the removed ``Server.request_context`` lookup.
+
+    ``_current_client`` swallows all exceptions and returns "unknown", so a broken
+    port degrades silently into mis-attributed savings rather than crashing. Assert
+    the name actually resolves, not merely that the call survives.
+    """
+    srv = _server()
+    token = _request_ctx.set(_client_ctx("claude-code"))
+    try:
+        assert srv._current_client() == "claude-code"
+    finally:
+        _request_ctx.reset(token)
+    assert srv._current_client() == "unknown"
+
+
+def test_request_context_does_not_leak_between_calls() -> None:
+    """A ContextVar left set would mis-attribute the next call's client."""
+    srv = _server()
+    params = mcp_types.CallToolRequestParams(name="nope", arguments={})
+    asyncio.run(srv._on_call_tool(_client_ctx("claude-code"), params))
+    assert _request_ctx.get(None) is None

--- a/tests/test_mcp_stub.py
+++ b/tests/test_mcp_stub.py
@@ -12,18 +12,34 @@ from tests import _mcp_stub as mcp_stub
 def test_build_mcp_sdk_stub_exposes_minimum_sdk_contract() -> None:
     modules = mcp_stub._build_mcp_sdk_stub()
 
-    server = modules["mcp.server"].Server("headroom")
-    assert server.name == "headroom"
+    # MCP 2.x: handlers are constructor callbacks, not decorators.
+    async def on_list_tools(ctx, params=None):  # pragma: no cover - identity only
+        return None
 
-    sentinel = object()
-    assert server.list_tools()(sentinel) is sentinel
-    assert server.call_tool()(sentinel) is sentinel
+    async def on_call_tool(ctx, params):  # pragma: no cover - identity only
+        return None
+
+    server = modules["mcp.server"].Server(
+        "headroom", on_list_tools=on_list_tools, on_call_tool=on_call_tool
+    )
+    assert server.name == "headroom"
+    assert server.handlers == {"on_list_tools": on_list_tools, "on_call_tool": on_call_tool}
     assert server.create_initialization_options() == {}
+
+    # The 1.x decorator surface must be gone: keeping it would let a caller still
+    # on decorators pass its tests while the real 2.x SDK rejects it.
+    assert not hasattr(server, "list_tools")
+    assert not hasattr(server, "call_tool")
 
     tool = modules["mcp.types"].Tool(name="search")
     text = modules["mcp.types"].TextContent(text="payload")
     assert tool.kwargs == {"name": "search"}
     assert text.kwargs == {"text": "payload"}
+
+    tools_result = modules["mcp.types"].ListToolsResult(tools=[tool])
+    call_result = modules["mcp.types"].CallToolResult(content=[text])
+    assert tools_result.tools == [tool]
+    assert call_result.content == [text]
 
     with pytest.raises(RuntimeError, match="should not run"):
         asyncio.run(modules["mcp.server.stdio"].stdio_server())

--- a/tests/test_memory/test_mcp_server.py
+++ b/tests/test_memory/test_mcp_server.py
@@ -11,24 +11,20 @@ mcp_server_mod = import_module_with_mcp_stub("headroom.memory.mcp_server")
 
 
 class _CapturingServer:
-    def __init__(self, name: str) -> None:
+    """MCP 2.x takes handlers as constructor callbacks rather than decorators."""
+
+    def __init__(self, name: str, on_list_tools=None, on_call_tool=None, **_: object) -> None:
         self.name = name
-        self.list_tools_handler = None
-        self.call_tool_handler = None
+        self.list_tools_handler = on_list_tools
+        self.call_tool_handler = on_call_tool
 
-    def list_tools(self):
-        def decorator(handler):
-            self.list_tools_handler = handler
-            return handler
 
-        return decorator
+class _CallParams:
+    """Stand-in for ``mcp.types.CallToolRequestParams``."""
 
-    def call_tool(self):
-        def decorator(handler):
-            self.call_tool_handler = handler
-            return handler
-
-        return decorator
+    def __init__(self, name: str, arguments: dict | None = None) -> None:
+        self.name = name
+        self.arguments = arguments
 
 
 def test_warm_up_backend_batches_embedding_and_indexing() -> None:
@@ -102,11 +98,11 @@ def test_tool_call_waits_for_handshake_warm_up(monkeypatch) -> None:
         monkeypatch.setattr(mcp_server_mod, "_handle_search", handle_search)
 
         server = mcp_server_mod.create_memory_server("memory.db", user_id="alice")
-        await server.list_tools_handler()
+        await server.list_tools_handler(None, None)
         await warm_up_started.wait()
 
         tool_call = asyncio.create_task(
-            server.call_tool_handler("memory_search", {"query": "preferences"})
+            server.call_tool_handler(None, _CallParams("memory_search", {"query": "preferences"}))
         )
         await asyncio.sleep(0)
 
@@ -114,7 +110,7 @@ def test_tool_call_waits_for_handshake_warm_up(monkeypatch) -> None:
         assert not tool_call.done()
 
         release_warm_up.set()
-        assert await tool_call == ["search result"]
+        assert (await tool_call).content == ["search result"]
         handle_search.assert_awaited_once_with(
             backend,
             {"query": "preferences"},
@@ -151,7 +147,7 @@ def test_failed_handshake_init_is_discarded_and_retried(monkeypatch) -> None:
         monkeypatch.setattr(mcp_server_mod, "_handle_search", handle_search)
 
         server = mcp_server_mod.create_memory_server("memory.db", user_id="alice")
-        await server.list_tools_handler()
+        await server.list_tools_handler(None, None)
         await first_warm_up_started.wait()
 
         fail_first_warm_up.set()
@@ -161,9 +157,10 @@ def test_failed_handshake_init_is_discarded_and_retried(monkeypatch) -> None:
         failed_backend.close.assert_awaited_once()
         handle_search.assert_not_awaited()
 
-        assert await server.call_tool_handler("memory_search", {"query": "preferences"}) == [
-            "search result"
-        ]
+        result = await server.call_tool_handler(
+            None, _CallParams("memory_search", {"query": "preferences"})
+        )
+        assert result.content == ["search result"]
         handle_search.assert_awaited_once_with(
             ready_backend,
             {"query": "preferences"},
@@ -201,7 +198,9 @@ def test_concurrent_tool_calls_share_backend_initialization(monkeypatch) -> None
         server = mcp_server_mod.create_memory_server("memory.db", user_id="alice")
         calls = [
             asyncio.create_task(
-                server.call_tool_handler("memory_search", {"query": f"query-{index}"})
+                server.call_tool_handler(
+                    None, _CallParams("memory_search", {"query": f"query-{index}"})
+                )
             )
             for index in range(2)
         ]
@@ -212,7 +211,10 @@ def test_concurrent_tool_calls_share_backend_initialization(monkeypatch) -> None
         handle_search.assert_not_awaited()
 
         release_warm_up.set()
-        assert await asyncio.gather(*calls) == [["search result"], ["search result"]]
+        assert [r.content for r in await asyncio.gather(*calls)] == [
+            ["search result"],
+            ["search result"],
+        ]
         assert handle_search.await_count == 2
         assert all(call.args[0] is backend for call in handle_search.await_args_list)
 


### PR DESCRIPTION
## Description

MCP SDK 2.0.0 removed the `Server.list_tools()` / `call_tool()` decorators and `Server.request_context`, replacing them with constructor callbacks and a per-call context argument. #2642 pinned `mcp<2.0.0` to stop the resulting startup crash; this ports both MCP servers to the 2.x interface so the pin can eventually be lifted.

**Draft — blocked on an upstream dependency, not on review.** See "Blocker" below. The code is complete and verified against a real `mcp` 2.0.0 install; it cannot merge until `strands-agents` supports MCP 2.x.

Follow-up to #2642.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Blocker: `strands-agents` caps `mcp<2.0.0`

`uv lock --upgrade-package mcp` fails to resolve:

```text
And because strands-agents>=1.2.0,<=1.26.0 depends on mcp>=1.11.0,<2.0.0
and mcp>=1.23.0,<2.0.0, we can conclude that strands-agents>=0.1.0
depends on mcp>=1.8.0,<2.0.0.
And because headroom-ai[strands] depends on strands-agents>=0.1.0
and headroom-ai[all] depends on mcp>=2.0.0, we can conclude that
headroom-ai[all] and headroom-ai[strands] are incompatible.
```

`strands-agents` 1.50.2 (latest) declares `mcp<2.0.0,>=1.23.0`, and the `strands` extra (`pyproject.toml:215`) is included in `all`. So `uv.lock` still pins `mcp 1.28.1` in this PR and **CI is expected to fail** until one of:

1. `strands-agents` relaxes its `mcp` cap upstream (preferred — no action here);
2. `strands` is dropped from the `all` extra;
3. Headroom straddles both majors behind a compat shim (doubles the MCP test surface; not recommended).

Since #2642's pin already restored working behaviour, there is no urgency — this branch can sit until option 1 lands.

## Changes Made

- `headroom/ccr/mcp_server.py`, `headroom/memory/mcp_server.py`: register handlers as `on_list_tools` / `on_call_tool` constructor callbacks, return `ListToolsResult` / `CallToolResult`, and read `params.name` / `params.arguments`. In the memory server the `Server(...)` construction moved to the end of the factory, since 2.x needs the handler closures to exist first.
- `_current_client()` reads the per-request context from a `ContextVar` instead of the removed `Server.request_context`. This is deliberately the same mechanism 1.x used internally (`mcp/server/lowlevel/server.py:109` in 1.28.1); an instance attribute would race across concurrent tool calls.
- `Tool(inputSchema=)` → `input_schema=` (6 sites). The camelCase alias still resolves at runtime via pydantic's `populate_by_name`, but mypy rejects it.
- Normalise `params.arguments or {}` — 2.x types `arguments` as optional while every `_handle_*` helper calls `.get()` on it.
- `tests/_mcp_stub.py` mirrored the **1.x** decorator API (`list_tools()` returning `lambda fn: fn`), so every stubbed MCP test stayed green while the real server crashed on startup. Moved to the 2.x shape with the decorator surface removed, so a caller still on decorators now fails loudly.
- `tests/test_mcp_sdk2_contract.py` (new): drives the real SDK rather than the stub, including a canary asserting `Server` has no `list_tools` / `call_tool` / `request_context`.
- `pyproject.toml`: `mcp>=1.28.1,<2.0.0` → `mcp>=2.0.0` (both the `proxy` deps and the `mcp` extra).

`is_error` is deliberately left unset on error payloads, matching 1.x behaviour where the SDK wrapped a returned list as a success. Flagging error payloads as `is_error=True` is a behaviour change and belongs in its own PR.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

Because the lock cannot be regenerated (see Blocker), the 2.x runs used a scratch venv with `mcp==2.0.0`; the stubbed suite runs in the repo venv.

```text
$ # real mcp 2.0.0
$ PYTHONPATH=. python -m pytest tests/test_mcp_sdk2_contract.py -q
7 passed, 1 warning in 0.83s

$ PYTHONPATH=. python -m pytest tests/test_cli/test_mcp.py -q
19 passed, 1 warning in 0.98s

$ # stubbed suite, repo venv
$ python -m pytest tests/test_ccr_mcp_server.py tests/test_memory/test_mcp_server.py tests/test_mcp_stub.py -q
37 passed, 20 warnings in 6.82s

$ ruff check <changed files> && ruff format --check <changed files>
All checks passed!
6 files already formatted

$ PYTHONPATH=. mypy headroom/ccr/mcp_server.py headroom/memory/mcp_server.py
(no errors in either file)
```

The new contract test is a real guard, not a no-op — it fails against 1.28.1 and passes against 2.0.0:

```text
$ # mcp 1.28.1
$ python -m pytest tests/test_mcp_sdk2_contract.py -q
7 failed in 0.58s
```

## Real Behavior Proof

- **Environment:** macOS (Darwin arm64), Python 3.12, scratch venv with `mcp==2.0.0` + `httpx`; repo venv at `mcp==1.28.1` left untouched.
- **Exact command / steps:** constructed `HeadroomMCPServer(proxy_url=...)` and drove `_on_list_tools` / `_on_call_tool` directly against the real SDK, plus `create_initialization_options()` for the handshake shape.
- **Observed result:**
  - `ListToolsResult` with `['headroom_compress', 'headroom_retrieve', 'headroom_stats']`
  - `capabilities.tools: list_changed=False` — matches the handshake output in #2642's proof
  - `CallToolResult` returned for an unknown tool, and for `arguments` omitted entirely
  - `_current_client()` resolves to `claude-code` inside a request and `unknown` outside it
  - ContextVar is empty after a call returns (no cross-request leak)
- **Not tested:** an end-to-end `headroom mcp serve` stdio handshake driven over a real subprocess (the manual check done in #2642); a live MCP client session against Claude Code or OpenCode; Windows/Linux.

## Review Readiness

- [x] I have performed a self-review
- [ ] This PR is ready for human review — **draft: blocked on `strands-agents`, and CI cannot pass until `uv.lock` can be regenerated**

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

**Why the stubbed suite could not have caught the 2.0.0 crash.** `tests/_mcp_stub.py` replaces the SDK in `sys.modules` with a `DummyServer` that hardcoded the 1.x decorator shape. Combined with `uv.lock` fixing `mcp` at 1.28.1 and `security.yml`'s `uv export --frozen` reading that lock, nothing in CI ever resolves a new upstream major. The 45 tests cited in #2642 were green throughout.

**The durable fix is not in this PR.** A scheduled job that resolves dependencies *unpinned* would have caught `mcp` 2.0.0 before users did, and would catch the next breaking major too. The contract test added here only helps once something actually resolves 2.x. Worth filing separately.

**Docs not updated** — no user-facing behaviour changes, but the `mcp` extra's version requirement should be revisited if option 2 or 3 above is chosen.
