### PR TITLE
feat(router): let a registered lossless provider compete on the general path

### DIFF
--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -2498,6 +2498,25 @@ class ContentRouter(Transform):
                 continue
             if len(cand) < len(best):
                 best, best_label = cand, f"lossless_{kind}"
+
+        # A registered lossless provider (headroom.transforms.lossless_provider)
+        # competes on the GENERAL path too, not only on excluded-tool output via
+        # `_lossless_compact_excluded`. Without this an external fold only ever
+        # saw Read/Grep/Glob-style results, so it was inert for gateway traffic
+        # (`/v1/compress`), where tool names are the caller's own. Same contract
+        # (information-preserving + deterministic) and we keep whichever output
+        # is smaller, so a provider can only improve on the built-in folds.
+        provider = get_lossless_provider()
+        if provider is not None:
+            try:
+                supplied = provider(content)
+            except Exception:  # noqa: BLE001 - a broken provider must not break routing
+                logger.debug("lossless provider failed in _lossless_first", exc_info=True)
+                supplied = None
+            if supplied is not None:
+                cand, kind = supplied
+                if isinstance(cand, str) and len(cand) < len(best):
+                    best, best_label = cand, f"lossless_{kind}"
         return best, best_label
 
     @staticmethod

--- a/tests/test_lossless_first_dispatch.py
+++ b/tests/test_lossless_first_dispatch.py
@@ -105,6 +105,44 @@ def test_has_lossless_fold_admits_small_block_below_size_floor():
     assert router._has_lossless_fold("def f():\n    return 1\n") is False
 
 
+def test_registered_provider_competes_on_the_general_path():
+    # A registered lossless provider must be consulted for ANY block, not only
+    # excluded-tool output — that gate made external folds inert for gateway
+    # traffic (/v1/compress), where tool names are the caller's own. The smaller
+    # output wins, so a provider can only improve on the built-in folds.
+    from headroom.transforms.lossless_provider import set_lossless_provider
+
+    block = _grep_block()
+    baseline, _, _ = _compress(block, lossless=True)
+    better = "SHORTER-THAN-ANY-BUILTIN-FOLD\n"
+    assert len(better) < len(baseline)
+
+    try:
+        set_lossless_provider(lambda content: (better, "plugin"))
+        out, was, tr = _compress(block + "\n", lossless=True)  # fresh cache key
+        assert was is True
+        assert out == better
+        assert tr == ["router:tool_result:lossless_plugin"]
+
+        # A provider that loses to the built-in fold is ignored, not adopted.
+        set_lossless_provider(lambda content: (content + "padding" * 100, "plugin"))
+        out2, _, tr2 = _compress(block + "\n\n", lossless=True)
+        assert tr2 == ["router:tool_result:lossless_search"]
+        assert len(out2) < len(block)
+
+        # A raising provider must not break routing.
+        set_lossless_provider(_raise)
+        out3, was3, _ = _compress(block + "\n\n\n", lossless=True)
+        assert was3 is True
+        assert len(out3) < len(block)
+    finally:
+        set_lossless_provider(None)
+
+
+def _raise(content: str):
+    raise RuntimeError("broken provider")
+
+
 def test_lossless_mode_non_foldable_is_lossless_noop_not_ratio_too_high():
     # In lossless-only mode, code with no byte-lossless fold is left verbatim.
     # That is NOT a rejected compression, so it must not be bucketed as


### PR DESCRIPTION
## Description

A lossless provider registered through `headroom.transforms.lossless_provider` was only ever consulted from `_lossless_compact_excluded`, which is gated on `DEFAULT_EXCLUDE_TOOLS` (`config.py:216` — `Read/Grep/Glob/Write/Edit/WebSearch/WebFetch`).

Gateway traffic carries the **caller's own** tool names. `POST /v1/compress` is what LiteLLM's `headroom` guardrail calls (https://docs.litellm.ai/docs/proxy/headroom), and those requests contain tools like `search_docs` / `run_ci` / `fetch_rows` — never a name in the exclusion set. So a registered provider was structurally inert for every gateway/sidecar deployment: the seam exists, but nothing could reach it.

This consults the provider in `_lossless_first` (STAGE 0 — runs for every block on every path) and keeps whichever output is smaller.

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/transforms/content_router.py` — `_lossless_first` now also asks `get_lossless_provider()` and adopts its result only when it is strictly smaller than the best built-in fold. A provider that raises is logged at debug and ignored.
- `tests/test_lossless_first_dispatch.py` — new test covering all three branches: provider wins when smaller, is ignored when larger, and a raising provider does not break routing.

Properties that keep this safe:

- **Strict no-op with no provider registered** — the default. Byte-identical routing.
- **Best-of, not authoritative** — unlike `_lossless_compact_excluded` (where a provider replaces the built-ins), here the built-in folds still run and the smaller output wins, so a provider can never do worse than the built-ins.
- The seam contract is unchanged: information-preserving + deterministic + per-block. Determinism is now load-bearing on every block rather than only excluded-tool ones, which is worth stating in the seam docs — a non-deterministic provider would bust the prefix cache everywhere.

Side effect worth knowing: `_has_lossless_fold` shares this path, so a provider also admits small blocks that sit under the lossy `min_chars` floor.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_lossless_first_dispatch.py -q
7 passed in 5.55s

$ python -m pytest tests/test_lossless_excluded_compaction.py tests/test_lossless_mode.py \
    tests/test_lossless_then_lossy.py tests/test_lossless_diff_fold_guard.py \
    tests/test_bash_search_lossless_fold.py -q
77 passed, 2 warnings in 8.38s

$ python -m pytest tests/test_router_external_dispatch.py tests/test_router_registry_dispatch.py \
    tests/test_content_router_exclude_tools.py tests/test_content_router_tool_role_reversibility.py -q
49 passed in 6.92s

$ ruff check headroom/transforms/content_router.py
All checks passed!

$ ruff format --check headroom/transforms/content_router.py
1 file already formatted

$ mypy headroom/transforms/content_router.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- **Environment:** macOS arm64, Python 3.12.6, `.venv`, proxy built via `create_app(_proxy_config_from_env())` with the default `coding` savings profile; Kompress both disabled and offloaded to a remote `kompress-v2-base` endpoint.
- **Exact command / steps:** `POST /v1/compress` over `TestClient` with an OpenAI-shaped payload — 4 `role:tool` messages (a CI log with ANSI escapes and repeated lines, a 160-path listing, a 150-line grep dump, a 150-row JSON array) under non-excluded tool names (`run_ci`, `list_files`, `code_search`, `fetch_rows`). Ran twice per configuration: once with no provider registered, once with a provider registered via `set_lossless_provider`.
- **Observed result:**

  | Kompress | no provider registered | provider registered |
  |---|---|---|
  | off | 19,284 → 10,265 tokens (46.8%) | 19,284 → **7,879 (59.1%)** |
  | on (remote) | 19,284 → 9,366 tokens (51.4%) | 19,284 → **7,146 (62.9%)** |

  Before this change the right-hand column was identical to the left — the registered provider was never called on this payload. Marker count was 0 in all four runs.
- **Not tested:** `tests/test_transforms_content_router.py` does not complete on this machine. It wedges on the 5th test after ~40s; that test passes in 5.7s when run alone. Verified **pre-existing and unrelated**: with this diff stashed, the clean tree completes exactly the same 4 tests in a 200s budget and stalls at the same test. Not a model download either (same stall under `HF_HUB_OFFLINE=1 HEADROOM_OFFLINE=1`). Suspected #575 (native Magika/ONNX detector deadlock — the watchdog cannot interrupt a native GIL hold, as the `ponytail:` note at `content_router.py:4969` already records). Worth a separate issue.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

Docs unchecked: there is no extension-authoring doc in `docs/` or `wiki/` to update yet (`plugins/headroom-oauth2/SPEC.md` is the de-facto reference). The seam's own docstring in `headroom/transforms/lossless_provider.py` describes the excluded-tool framing and should be broadened when that doc lands.

Companion PR: `/v1/compress` marker-free default. Independent of this one — different file, no shared tests.
