### PR TITLE
feat(proxy): default /v1/compress to marker-free output

### DIFF
--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -8252,21 +8252,20 @@ class OpenAIHandlerMixin:
             with contextlib.suppress(Exception):
                 await websocket.close()
 
-    def _lossy_inline_pipeline(self) -> Any:
-        """Cached pipeline for ``/v1/compress`` ``config.mode="lossy_inline"``.
+    def _derived_compress_pipeline(self, key: str, **overrides: Any) -> Any:
+        """Cached ``/v1/compress`` pipeline derived from the live OpenAI router.
 
-        Runs the lossless byte/data fold first, then Kompresses the folded
-        remainder (``lossless_then_lossy``). ``ccr_inject_marker=False`` makes
-        every compressor (Kompress, SmartCrusher, search/log/config) emit inline
-        lossy output with NO ``<<ccr:…>>`` / ``Retrieve more: hash=`` marker and
-        NO CCR store write, so the result is safe to forward straight to a
-        provider with no retrieval round-trip. Derived once from the live OpenAI
-        router's config and reused read-only across requests.
+        ``overrides`` are applied to the live ContentRouter's config, so the
+        derived pipeline inherits every operator setting (Kompress on/off,
+        exclusions, profile knobs) and differs only in what the caller needs.
 
         ponytail: a first-request race just builds it twice — both are
         equivalent and Kompress weights are cached at module level, so no lock.
         """
-        cached = getattr(self, "_lossy_inline_pipeline_cache", None)
+        cache = getattr(self, "_compress_pipeline_cache", None)
+        if cache is None:
+            cache = self._compress_pipeline_cache = {}
+        cached = cache.get(key)
         if cached is not None:
             return cached
 
@@ -8277,29 +8276,69 @@ class OpenAIHandlerMixin:
         base = find_content_router(self.openai_pipeline)
         if base is None:  # ponytail: nothing to derive from — use default pipeline
             return self.openai_pipeline
-        cfg = replace(
-            base.config,
+        pipeline = TransformPipeline(
+            transforms=[ContentRouter(replace(base.config, **overrides), observer=self.metrics)],
+            provider=self.openai_provider,
+        )
+        cache[key] = pipeline
+        return pipeline
+
+    def _no_ccr_pipeline(self) -> Any:
+        """Default ``/v1/compress`` pipeline: compress, but emit no CCR markers.
+
+        Every caller of this route is a gateway/sidecar or SDK client that
+        forwards the returned messages straight to a provider. A
+        ``Retrieve more: hash=`` marker is only useful to a caller that also
+        injects the ``headroom_retrieve`` tool AND can reach ``/v1/retrieve``
+        (loopback-only). LiteLLM's `headroom` guardrail — the main consumer —
+        does neither: it swaps ``messages`` and forwards. So markers here are a
+        dangling pointer for the model plus a pointless CCR store write.
+        ``config.mode="ccr"`` opts back in for callers that do run the loop
+        (e.g. the TypeScript SDK's ``retrieve``/``handleToolCall``).
+
+        Nothing else changes: same compressors, same aggressiveness. Measured
+        identical token savings to the marker-on default on OpenAI-shaped
+        gateway traffic.
+        """
+        return self._derived_compress_pipeline(
+            "no_ccr",
+            ccr_inject_marker=False,  # no markers in returned content
+            ccr_enabled=False,  # no CCR store writes
+        )
+
+    def _lossy_inline_pipeline(self) -> Any:
+        """Pipeline for ``/v1/compress`` ``config.mode="lossy_inline"``.
+
+        Runs the lossless byte/data fold first, then Kompresses the folded
+        remainder (``lossless_then_lossy``), marker-free like
+        :meth:`_no_ccr_pipeline`. Kept as a distinct mode because the
+        fold-then-Kompress ordering is a different compression posture, not a
+        different CCR setting.
+        """
+        return self._derived_compress_pipeline(
+            "lossy_inline",
             lossless=False,  # lossy mode (not lossless-only)
             lossless_then_lossy=True,  # fold first, then Kompress the remainder
             ccr_inject_marker=False,  # inline, marker-free everywhere
             ccr_enabled=False,  # no CCR store writes
             smart_crusher_lossless_only=False,  # keep SmartCrusher lossy
-        )  # enable_kompress inherited: on by default, off if operator disabled it
-        pipeline = TransformPipeline(
-            transforms=[ContentRouter(cfg, observer=self.metrics)],
-            provider=self.openai_provider,
         )
-        self._lossy_inline_pipeline_cache = pipeline
-        return pipeline
 
     async def handle_compress(self, request: Request) -> JSONResponse:
         """Compress messages without calling an LLM.
 
         POST /v1/compress
         Body: {"messages": [...], "model": "...", "config": {}}
-        ``config.mode="lossy_inline"`` (alias ``"lossless_then_lossy"``) selects
-        the marker-free lossless-then-lossy pipeline whose output needs no CCR
-        retrieval round-trip — the mode to use behind a gateway/sidecar.
+
+        ``config.mode`` selects the pipeline:
+
+        * unset (default) — marker-free; forward the result straight to a
+          provider with no CCR retrieval round-trip (see _no_ccr_pipeline).
+        * ``"ccr"`` — CCR markers + store writes, for a caller that injects the
+          ``headroom_retrieve`` tool and can reach loopback ``/v1/retrieve``.
+        * ``"lossy_inline"`` (alias ``"lossless_then_lossy"``) — marker-free,
+          lossless fold first then Kompress the remainder.
+
         Returns compressed messages + metrics.
         """
         from fastapi.responses import JSONResponse
@@ -8402,14 +8441,16 @@ class OpenAIHandlerMixin:
             target_ratio = compress_config.get("target_ratio")
             protect_recent = compress_config.get("protect_recent")
             protect_analysis_context = compress_config.get("protect_analysis_context")
-            # Marker-free lossless-then-lossy mode: safe to forward downstream
-            # with no CCR retrieval round-trip (see _lossy_inline_pipeline).
+            # Mode selection. Default is marker-free (see _no_ccr_pipeline):
+            # no caller of this route can resolve a CCR marker unless it opts in
+            # with mode="ccr", which restores the full marker + store behaviour.
             mode = compress_config.get("mode")
-            pipeline = (
-                self._lossy_inline_pipeline()
-                if mode in ("lossy_inline", "lossless_then_lossy")
-                else self.openai_pipeline
-            )
+            if mode in ("lossy_inline", "lossless_then_lossy"):
+                pipeline = self._lossy_inline_pipeline()
+            elif mode == "ccr":
+                pipeline = self.openai_pipeline
+            else:
+                pipeline = self._no_ccr_pipeline()
 
             pipeline_kwargs: dict = {
                 "model_limit": context_limit,

--- a/tests/test_ccr_row_drop_store_bridge.py
+++ b/tests/test_ccr_row_drop_store_bridge.py
@@ -385,6 +385,9 @@ def test_v1_compress_then_v1_retrieve_resolves_marker_hash() -> None:
     ]
     req = {
         "model": "gpt-4o",
+        # /v1/compress is marker-free by default (no gateway caller can resolve a
+        # marker); mode="ccr" is the opt-in for callers that run the retrieve loop.
+        "config": {"mode": "ccr"},
         "messages": [
             {"role": "user", "content": "Get items"},
             {

--- a/tests/test_platform_stabilization_functional.py
+++ b/tests/test_platform_stabilization_functional.py
@@ -73,7 +73,7 @@ def test_v1_compress_success_reports_actual_metrics(monkeypatch) -> None:
     with TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 12345)) as client:
         response = client.post(
             "/v1/compress",
-            json={"model": "gpt-4o", "messages": request_messages},
+            json={"model": "gpt-4o", "messages": request_messages, "config": {"mode": "ccr"}},
         )
 
     body = response.json()

--- a/tests/test_proxy_compress_endpoint.py
+++ b/tests/test_proxy_compress_endpoint.py
@@ -477,6 +477,9 @@ class TestCompressEndpointDoesNotBlockLoop:
                     json={
                         "messages": [{"role": "user", "content": "hello world"}],
                         "model": "gpt-4",
+                        # mode="ccr" routes to `openai_pipeline` (the default is a
+                        # derived marker-free pipeline); this test patches that one.
+                        "config": {"mode": "ccr"},
                     },
                 )
             )


### PR DESCRIPTION
## Description

`POST /v1/compress` emits CCR retrieval markers by default. A marker is only useful to a caller that **also** injects the `headroom_retrieve` tool **and** can reach `/v1/retrieve`. Neither holds for the callers this route exists for:

- Tool injection lives in the provider request handlers (`handlers/anthropic.py:1894`, `should_inject_ccr_tool`). `handle_compress` never touches `tools` — it reads `messages` + `model` and returns messages.
- Every `/v1/retrieve*` route is `Depends(_require_loopback)` (`server.py:4422, 4470, 4749, 4781`) with no remote opt-in. `HEADROOM_COMPRESS_ALLOW_REMOTE` drops the loopback dependency on `/v1/compress` **only** (`server.py:4898`), so a remote gateway can compress but physically cannot rehydrate.
- LiteLLM's `headroom` guardrail — the main consumer of this route — swaps `messages` in `pre_call` and forwards (https://docs.litellm.ai/docs/proxy/headroom). It never injects a tool and never calls back.

So today a gateway forwards a `Retrieve more: hash=…` pointer the model cannot follow, and the proxy pays a CCR store write nobody will ever read.

This makes the route marker-free by default. `config.mode="ccr"` opts back in for callers that do run the retrieve loop.

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `_no_ccr_pipeline()` — new default for `/v1/compress`: the live router config with `ccr_inject_marker=False, ccr_enabled=False`. Nothing else differs, so compressors and aggressiveness are unchanged.
- `config.mode` dispatch in `handle_compress`: unset → marker-free (default), `"ccr"` → the existing `openai_pipeline` with markers + store writes, `"lossy_inline"` / `"lossless_then_lossy"` → unchanged.
- `_derived_compress_pipeline(key, **overrides)` — one cached helper replacing the copy-pasted pipeline-derivation block; `_lossy_inline_pipeline` now uses it too. Net simplification despite the added mode.
- Docstring on `handle_compress` documents all three modes.
- Two tests updated to send `config: {"mode": "ccr"}`, which is now the explicit opt-in they were implicitly relying on.

### Behavior change

A caller that relied on default markers now gets none. The only in-tree caller that can resolve them is the TypeScript SDK (`sdk/typescript/src/client.ts:398 retrieve`, `:422 handleToolCall`); it needs `config: {"mode": "ccr"}` to keep today's behavior. Recommend landing that SDK default in the same release so SDK behavior is unchanged and only gateway callers — for whom markers were never resolvable — see the difference.

Deliberately not adding a `HEADROOM_COMPRESS_DEFAULT_MODE` compat env: a flag nobody sets becomes permanent debt, and the wire-level opt-in (`mode`) already covers the one caller that needs it.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_proxy_compress_endpoint.py tests/test_ccr_row_drop_store_bridge.py -q
24 passed in 17.13s

$ python -m pytest tests/test_gateway_sidecar_ports.py tests/test_compress_api.py -q
29 passed

$ ruff check headroom/proxy/handlers/openai.py
All checks passed!

$ ruff format --check headroom/proxy/handlers/openai.py
1 file already formatted

$ mypy headroom/proxy/handlers/openai.py
Success: no issues found in 1 source file
```

No new tests: the two updated tests now pin both sides of the switch — `test_v1_compress_then_v1_retrieve_resolves_marker_hash` proves `mode:"ccr"` still produces a marker the store resolves, and the rest of `test_proxy_compress_endpoint.py` exercises the new default path.

## Real Behavior Proof

- **Environment:** macOS arm64, Python 3.12.6, `.venv`, proxy built from `_proxy_config_from_env()` with the default `coding` profile, Kompress offloaded to a remote `kompress-v2-base` endpoint, `HEADROOM_COMPRESSION_TIMEOUT_SECONDS=300`.
- **Exact command / steps:** `POST /v1/compress` over `TestClient` with an OpenAI-shaped payload (system + RAG user blob + assistant `tool_calls` + a 200-row JSON tool result + a 300-line log tool result + assistant text), counting `Retrieve …: hash=` / `<<ccr:` occurrences in the returned messages. Compared: default route, `--no-ccr` at the config level, `config.mode="lossy_inline"`, `--lossless`.
- **Observed result:**

  | Config | tokens | saved |
  |---|---|---|
  | default (before this PR: markers on) | 37,791 → 24,415 | 35.4% |
  | markers off (this PR's default) | 37,791 → 24,415 | **35.4% — identical** |
  | `mode="lossy_inline"` | 37,791 → 25,129 | 33.5% |
  | `--lossless` | 37,791 → 35,100 | 7.1% |

  Turning markers off costs nothing on gateway-shaped traffic. `lossy_inline` is slightly worse than the new default because it also flips `lossless_then_lossy`, which reorders the search fold — worth knowing for anyone who reached for that mode as the "safe for a sidecar" option.
- **Not tested:** `tests/test_transforms_content_router.py` does not complete on this machine (wedges on its 5th test; passes in 5.7s alone). Verified pre-existing — the clean tree stalls identically at the same test, including under `HF_HUB_OFFLINE=1 HEADROOM_OFFLINE=1`. Unrelated to this diff, which does not touch the router. Suspected #575.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

Docs unchecked — follow-ups worth doing in the same release:

- `docs/content/docs/litellm.mdx` and `wiki/proxy.md` should document the `config.mode` values.
- The TS SDK default (`mode:"ccr"`) described above.
- Operational note for anyone running this behind a gateway with remote ML inference: `COMPRESSION_TIMEOUT_SECONDS` defaults to 30 (`helpers.py:687`), and a remote Kompress endpoint makes one sequential call per unit. On a large payload it trips the executor timeout and the handler fails open — returning `compression_skipped: true` with `tokens_before: 0`, which reads as "nothing to save" rather than "we gave up". Separate PR, but the zeroed counters in that response are misleading and worth fixing.

Companion PR: #2661 (lossless provider on the general path). Independent — different file, no shared tests.
