### PR TITLE
fix(cache): anchor the message breakpoint to the static prefix when a message grows in place

### DIFF
--- a/headroom/cache/prefix_tracker.py
+++ b/headroom/cache/prefix_tracker.py
@@ -21,6 +21,7 @@ import hashlib
 import itertools
 import json
 import logging
+import os
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -384,8 +385,81 @@ def _stable_leading_block_run(
     return k
 
 
+# Env kill switch for the stable-boundary breakpoint placement below. Default on;
+# set to 0/false/no/off to restore the newest-block placement unconditionally.
+# This sits on the cache-key path of every Anthropic request, so it needs a
+# rollback that does not require shipping a new build.
+_STABLE_BOUNDARY_ENV = "HEADROOM_STABLE_BOUNDARY_BREAKPOINT"
+
+# Below this many blocks a message cannot benefit from relocation: the provider
+# walks back up to 20 content-block boundaries from the breakpoint looking for a
+# previous write, so a short message's prefix is still found from the newest
+# block, and anchoring backwards would only shrink what gets cached.
+_MIN_BLOCKS_FOR_RELOCATION = 20
+
+
+def _stable_boundary_enabled() -> bool:
+    return os.environ.get(_STABLE_BOUNDARY_ENV, "").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _breakpoint_index(
+    content: list[Any],
+    msg: dict[str, Any],
+    msg_idx: int,
+    previous_forwarded_messages: list[dict[str, Any]] | None,
+) -> int:
+    """Index within ``content`` that should carry the single message breakpoint.
+
+    Default is the newest block, which is right whenever the provider's 20-block
+    lookback can still reach last turn's write from there — a cold turn, or a
+    conversation that grows by appending messages.
+
+    It is wrong for a message that grows IN PLACE with a varying tail: the
+    breakpoint then rides a block that never repeats, so no stable prefix is ever
+    found and the whole message re-writes every turn. For that shape the
+    breakpoint belongs at the end of the static prefix, which is the previous
+    turn's counterpart message compared block by block.
+
+    The counterpart is looked up by position AND role: the recorded forwarded
+    list is last turn's, so a growing conversation only lines up where the shape
+    really is stable, and any mismatch falls back to the newest block.
+    """
+    newest = len(content) - 1
+    if not previous_forwarded_messages or not _stable_boundary_enabled():
+        return newest
+    if len(content) < _MIN_BLOCKS_FOR_RELOCATION or msg_idx >= len(previous_forwarded_messages):
+        return newest
+    counterpart = previous_forwarded_messages[msg_idx]
+    if not isinstance(counterpart, dict) or counterpart.get("role") != msg.get("role"):
+        return newest
+    previous_blocks = counterpart.get("content")
+    if not isinstance(previous_blocks, list):
+        return newest
+    run = _stable_leading_block_run(content, previous_blocks)
+    # Only anchor backwards when the stable run is real (the message diverged
+    # before its end) and covers most of the message. A short run would cache
+    # less than the newest-block placement writes, which is a worse trade even
+    # though it reads.
+    if 1 <= run < len(content) and run * 2 >= len(content):
+        logger.debug(
+            "cache breakpoint anchored to the stable run of %d/%d blocks in message %d "
+            "(its newest block varies turn over turn)",
+            run,
+            len(content),
+            msg_idx,
+        )
+        return run - 1
+    return newest
+
+
 def normalize_message_cache_control(
     messages: list[dict[str, Any]],
+    previous_forwarded_messages: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """Own message-level cache_control placement so breakpoints stay bounded.
 
@@ -396,13 +470,29 @@ def normalize_message_cache_control(
     so on a long conversation the accumulation eventually 400s.
 
     Fix: strip EVERY message-level cache_control and re-place a **single**
-    ephemeral breakpoint on the last block of the last block-style message. One
-    breakpoint caches the whole message prefix up to it, and — because the
-    provider's cache key is message CONTENT, not marker presence (moving the
-    breakpoint forward is the documented client pattern and it hits) — stripping
-    and re-placing markers never busts. system/tools breakpoints live outside
-    ``messages`` and are left untouched (they still count toward the 4 limit, so
-    holding messages to one breakpoint leaves room for them).
+    ephemeral breakpoint. One breakpoint caches the whole message prefix up to
+    it, and — because the provider's cache key is message CONTENT, not marker
+    presence (moving the breakpoint forward is the documented client pattern and
+    it hits) — stripping and re-placing markers never busts. system/tools
+    breakpoints live outside ``messages`` and are left untouched (they still
+    count toward the 4 limit, so holding messages to one breakpoint leaves room
+    for them).
+
+    WHERE that one breakpoint goes is the last block of the last block-style
+    message — except when that message grew IN PLACE since last turn. Sub-call
+    shapes pack a transcript into one block-style message and rewrite its tail
+    each turn, so a breakpoint on its newest block can never match next turn and
+    pins ``cache_read`` at the system+tools constant forever, however stable the
+    rest of the message is. When ``previous_forwarded_messages`` shows that the
+    same message diverged partway through, the breakpoint is anchored to the end
+    of its byte-stable leading run instead: that boundary IS cached, so the run
+    reads from cache and the breakpoint advances one turn behind the growth.
+
+    Relocation only fires when the stable run covers most of the message
+    (otherwise anchoring backwards would cache less than it saves) and only for
+    the same message position and role, so a main conversation — whose newest
+    message is genuinely new each turn — keeps the newest-block placement.
+    ``HEADROOM_STABLE_BOUNDARY_BREAKPOINT=0`` restores it unconditionally.
 
     Headroom owns WHERE the breakpoint goes; the client still owns WHAT it says:
     the re-placed marker reuses the newest client marker verbatim, so an explicit
@@ -442,7 +532,8 @@ def normalize_message_cache_control(
         msg = out[last_block_idx]
         content = list(msg["content"])
         marker = dict(last_marker) if last_marker else {"type": "ephemeral"}
-        content[-1] = {**content[-1], "cache_control": marker}
+        bp_idx = _breakpoint_index(content, msg, last_block_idx, previous_forwarded_messages)
+        content[bp_idx] = {**content[bp_idx], "cache_control": marker}
         out[last_block_idx] = {**msg, "content": content}
         changed = True
     return out if changed else messages

--- a/headroom/cache/prefix_tracker.py
+++ b/headroom/cache/prefix_tracker.py
@@ -359,6 +359,31 @@ def overlay_cached_prefix(
     return list(prev_fwd[:k]) + list(optimized_messages[k:])
 
 
+def _stable_leading_block_run(
+    current_blocks: list[Any],
+    previous_blocks: list[Any] | None,
+) -> int:
+    """Length of the longest leading run of content blocks that canonicalize-
+    equal the previous turn's blocks.
+
+    Uses :func:`_canonicalize_for_prefix_compare`, which drops ``cache_control``
+    and other non-semantic keys, so a moved breakpoint or per-turn annotation
+    churn does not shorten the run. Two blocks canonicalize-equal iff their
+    forwarded content is the same, which is exactly what the provider's prefix
+    cache keys on — so this run is the part of a message that can still be read
+    from cache.
+    """
+    if not previous_blocks:
+        return 0
+    limit = min(len(current_blocks), len(previous_blocks))
+    k = 0
+    while k < limit and _canonicalize_for_prefix_compare(
+        current_blocks[k]
+    ) == _canonicalize_for_prefix_compare(previous_blocks[k]):
+        k += 1
+    return k
+
+
 def normalize_message_cache_control(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -806,6 +831,67 @@ def _lineage_snapshot(obj: Any) -> Any:
     return obj
 
 
+def _is_message_continuation(recorded: Any, incoming: Any) -> bool:
+    """Return True iff ``incoming`` is ``recorded`` grown in place.
+
+    Client histories are append-only at MESSAGE granularity, which is what
+    lineage matching assumes — except for sub-call shapes that pack a transcript
+    into one block-style message and extend that message's block list each turn.
+    Such a turn is the same conversation continuing, but its newest message is
+    not equal to the recorded one, so the whole-message prefix test rejects it.
+
+    "Grown in place" is deliberately narrow, because a false match makes two
+    concurrent conversations share one tracker (the thrash lineages exist to
+    prevent): same role, block-style content that did not shrink, and a leading
+    run of byte-stable blocks covering MOST of the recorded version. Templated
+    fan-outs that diverge in their newest message share few or no leading blocks
+    and are still split apart.
+    """
+    if not (isinstance(recorded, dict) and isinstance(incoming, dict)):
+        return False
+    if recorded.get("role") != incoming.get("role"):
+        return False
+    old = recorded.get("content")
+    new = incoming.get("content")
+    if not (isinstance(old, list) and isinstance(new, list)):
+        return False
+    if not old or len(new) < len(old):
+        return False
+    run = _stable_leading_block_run(new, old)
+    return run * 2 >= len(old)
+
+
+def _chain_matches(chain: Any, snap: Any, strict: bool) -> bool:
+    """Does ``snap`` continue the conversation recorded as ``chain``?
+
+    ``strict`` requires every recorded message to re-compare equal. Otherwise the
+    recorded messages before the last must still match exactly and the last one
+    only has to have grown in place (see :func:`_is_message_continuation`).
+    """
+    if len(chain) > len(snap):
+        return False
+    if strict:
+        return bool(snap[: len(chain)] == chain)
+    head = len(chain) - 1
+    return bool(snap[:head] == chain[:head]) and _is_message_continuation(chain[head], snap[head])
+
+
+def _match_lineage(family: OrderedDict[str, Any], snap: Any) -> str | None:
+    """Pick the recorded lineage that this history continues, or None.
+
+    Longest matching chain wins, so the walk goes longest-first and returns on
+    the first hit. A whole-message prefix match is preferred; only when no chain
+    matches strictly does an in-place-growth match count, so an exact
+    continuation is never displaced by a looser one.
+    """
+    by_length = sorted(family.items(), key=lambda kv: len(kv[1]), reverse=True)
+    for strict in (True, False):
+        for key, chain in by_length:
+            if _chain_matches(chain, snap, strict):
+                return key
+    return None
+
+
 class SessionTrackerStore:
     """Manages PrefixCacheTracker instances across sessions.
 
@@ -918,14 +1004,7 @@ class SessionTrackerStore:
 
         family = self._lineages.setdefault(session_id, OrderedDict())
 
-        # Longest recorded chain that prefixes the incoming history wins.
-        best_key: str | None = None
-        best_len = -1
-        for key, chain in family.items():
-            if len(chain) > len(snap) or len(chain) <= best_len:
-                continue
-            if snap[: len(chain)] == chain:
-                best_key, best_len = key, len(chain)
+        best_key = _match_lineage(family, snap)
 
         if best_key is None:
             cap = self._default_config.max_lineages_per_session

--- a/headroom/cache/prefix_tracker.py
+++ b/headroom/cache/prefix_tracker.py
@@ -922,6 +922,13 @@ def _lineage_snapshot(obj: Any) -> Any:
     return obj
 
 
+# Absolute floor on the stable leading run before a message counts as having
+# grown in place. A shared boilerplate preamble runs to a few blocks, while the
+# shapes this exists for keep runs in the hundreds, so this separates "same
+# conversation, extended" from "two conversations that open the same way".
+_MIN_CONTINUATION_RUN_BLOCKS = 8
+
+
 def _is_message_continuation(recorded: Any, incoming: Any) -> bool:
     """Return True iff ``incoming`` is ``recorded`` grown in place.
 
@@ -932,11 +939,22 @@ def _is_message_continuation(recorded: Any, incoming: Any) -> bool:
     not equal to the recorded one, so the whole-message prefix test rejects it.
 
     "Grown in place" is deliberately narrow, because a false match makes two
-    concurrent conversations share one tracker (the thrash lineages exist to
-    prevent): same role, block-style content that did not shrink, and a leading
-    run of byte-stable blocks covering MOST of the recorded version. Templated
-    fan-outs that diverge in their newest message share few or no leading blocks
-    and are still split apart.
+    concurrent conversations share one tracker — the thrash lineages exist to
+    prevent. All of the following must hold:
+
+    * same role, block-style content on both sides, and no blocks lost;
+    * a leading run of byte-stable blocks that is both substantial in absolute
+      terms and MOST of the recorded version — injected boilerplate can bracket a
+      message on both sides, so a few shared blocks is not a conversation
+      identity;
+    * an unchanged FINAL block. Conversations that pack the same parent
+      transcript differ in the instruction they append after it, so the tail is
+      what distinguishes siblings from a continuation of one stream. The shapes
+      this exists for keep a fixed suffix pinned at the end while the blocks
+      before it churn.
+
+    Anything that fails these keeps its own lineage, which is the pre-existing
+    behaviour and merely forgoes the cache win.
     """
     if not (isinstance(recorded, dict) and isinstance(incoming, dict)):
         return False
@@ -948,21 +966,30 @@ def _is_message_continuation(recorded: Any, incoming: Any) -> bool:
         return False
     if not old or len(new) < len(old):
         return False
+    if old[-1] != new[-1]:
+        return False
     run = _stable_leading_block_run(new, old)
-    return run * 2 >= len(old)
+    return run >= _MIN_CONTINUATION_RUN_BLOCKS and run * 2 >= len(old)
 
 
 def _chain_matches(chain: Any, snap: Any, strict: bool) -> bool:
     """Does ``snap`` continue the conversation recorded as ``chain``?
 
-    ``strict`` requires every recorded message to re-compare equal. Otherwise the
-    recorded messages before the last must still match exactly and the last one
-    only has to have grown in place (see :func:`_is_message_continuation`).
+    ``strict`` requires every recorded message to re-compare equal, and matches a
+    chain that the history merely extends with further messages.
+
+    The loose pass is narrower, not just weaker: the message COUNT must be
+    unchanged, every message before the last must still match exactly, and only
+    the last one may differ, by having grown in place (see
+    :func:`_is_message_continuation`). A history that both gained messages and
+    rewrote an older one did not grow in place, and starts a fresh lineage.
     """
     if len(chain) > len(snap):
         return False
     if strict:
         return bool(snap[: len(chain)] == chain)
+    if len(snap) != len(chain):
+        return False
     head = len(chain) - 1
     return bool(snap[:head] == chain[:head]) and _is_message_continuation(chain[head], snap[head])
 

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -1616,6 +1616,12 @@ class AnthropicHandlerMixin:
                 overlay_cached_prefix,
             )
 
+            # Read the previously-forwarded prefix once and reuse it for both the
+            # overlay replay and the breakpoint placement below — each call deep-
+            # copies the whole transcript and both only READ it, so one copy is
+            # enough on this per-request hot path.
+            _prev_forwarded = prefix_tracker.get_last_forwarded_messages()
+
             # On a confirmed-cold turn we deliberately do NOT replay the previously
             # forwarded prefix: the cache is dead (nothing to keep byte-identical for)
             # and the replay would clobber the whole-prefix recompaction we just did.
@@ -1626,7 +1632,7 @@ class AnthropicHandlerMixin:
                     optimized_messages,
                     original_client_messages,
                     prefix_tracker.get_last_original_messages(),
-                    prefix_tracker.get_last_forwarded_messages(),
+                    _prev_forwarded,
                 )
                 _overlay_replayed = _ov != optimized_messages
                 if _overlay_replayed:
@@ -1636,10 +1642,12 @@ class AnthropicHandlerMixin:
             # Own cache_control placement: the client moves the breakpoint each
             # turn and the overlay replays past markers, so they accumulate ~1/turn
             # and Anthropic hard-errors at >4. Strip message-level markers and keep
-            # a single breakpoint on the last block (caches the whole prefix;
-            # content-keyed cache so re-placing never busts). Applied last so the
+            # a single breakpoint (caches the whole prefix; content-keyed cache so
+            # re-placing never busts). Pass last turn's forwarded messages so the
+            # breakpoint can be anchored to the static prefix of a message that
+            # grows in place, whose newest block never repeats. Applied last so the
             # forwarded AND recorded (next_forwarded) messages stay bounded.
-            _norm = normalize_message_cache_control(optimized_messages)
+            _norm = normalize_message_cache_control(optimized_messages, _prev_forwarded)
             if _norm is not optimized_messages:
                 optimized_messages = _norm
 

--- a/tests/test_cache/test_prefix_tracker.py
+++ b/tests/test_cache/test_prefix_tracker.py
@@ -655,6 +655,79 @@ class TestConversationLineageResolution:
         assert fresh is not tracker
         assert store.active_sessions == 2
 
+    @staticmethod
+    def _in_place_growth(stable: int, churn: int, tail: str) -> list[dict]:
+        """The sub-call shape: a transcript packed into ONE block-style message
+        whose leading blocks are stable and whose tail is rewritten each turn.
+        This history grows at BLOCK granularity, not message granularity."""
+        blocks = [{"type": "text", "text": f"stable {i} " + "x" * 200} for i in range(stable)]
+        blocks += [{"type": "text", "text": f"{tail} churn {i}"} for i in range(churn)]
+        return [{"role": "user", "content": "kickoff"}, {"role": "user", "content": blocks}]
+
+    def test_in_place_message_growth_keeps_its_lineage(self, store):
+        """Lineage matching assumes histories append MESSAGES. A conversation
+        whose newest message grows in place used to fail that test on every turn
+        and get a FRESH tracker each time — no frozen prefix, no overlay replay,
+        and one leaked lineage per turn. It must reuse its own tracker instead."""
+        sid = "sub-call"
+        first = None
+        for turn, churn in enumerate([2, 4, 7, 11], start=1):
+            history = self._in_place_growth(20, churn, f"t{turn}")
+            tracker = store.resolve_tracker(sid, "anthropic", messages=history)
+            first = first or tracker
+            assert tracker is first, f"turn {turn} switched trackers"
+            # The previous turn's state has to actually ARRIVE, not just exist.
+            if turn > 1:
+                assert tracker.get_last_forwarded_messages(), f"turn {turn} lost prev messages"
+            tracker.update_from_response(
+                cache_read_tokens=1000,
+                cache_write_tokens=500,
+                messages=history,
+                original_messages=history,
+            )
+        assert store.active_sessions == 1, "one conversation must not leak lineages"
+        assert first._turn_number == 4
+
+    def test_fan_out_diverging_in_its_newest_message_still_splits(self, store):
+        """Guard on the loosened match: templated fan-outs share the head and
+        differ from the first block of the newest message. They must keep
+        separate trackers (that thrash is what lineages exist to prevent)."""
+        sid = "shared-fallback-id"
+        a = self._in_place_growth(0, 6, "agent-a")
+        b = self._in_place_growth(0, 6, "agent-b")
+        assert store.resolve_tracker(sid, "anthropic", messages=a) is not store.resolve_tracker(
+            sid, "anthropic", messages=b
+        )
+
+    def test_mostly_rewritten_newest_message_gets_a_fresh_tracker(self, store):
+        """Continuation requires MOST of the recorded message to survive. A
+        message rewritten past that point is a new conversation, not growth."""
+        sid = "shared"
+        tracker = store.resolve_tracker(
+            sid, "anthropic", messages=self._in_place_growth(2, 20, "t1")
+        )
+        rewritten = self._in_place_growth(2, 20, "t2")  # only 2 of 22 blocks survive
+        assert store.resolve_tracker(sid, "anthropic", messages=rewritten) is not tracker
+
+    def test_shrinking_newest_message_gets_a_fresh_tracker(self, store):
+        """Growth only. A shorter block list means the client dropped content,
+        so the provider's cache line for it is gone."""
+        sid = "shared"
+        tracker = store.resolve_tracker(
+            sid, "anthropic", messages=self._in_place_growth(20, 8, "t1")
+        )
+        shrunk = self._in_place_growth(20, 2, "t1")
+        assert store.resolve_tracker(sid, "anthropic", messages=shrunk) is not tracker
+
+    def test_strict_prefix_match_wins_over_in_place_growth(self, store):
+        """An exact continuation must never be displaced by a looser one."""
+        sid = "shared"
+        base = self._in_place_growth(20, 4, "t1")
+        exact = store.resolve_tracker(sid, "anthropic", messages=base)
+        # A second lineage that would ALSO match `base` under in-place growth.
+        store.resolve_tracker(sid, "anthropic", messages=self._in_place_growth(20, 2, "t1"))
+        assert store.resolve_tracker(sid, "anthropic", messages=base) is exact
+
     @pytest.mark.parametrize("messages", [None, []], ids=["none", "empty"])
     def test_resolve_without_messages_matches_legacy_get_or_create(self, store, messages):
         tracker = store.resolve_tracker("sid", "anthropic", messages=messages)

--- a/tests/test_cache/test_prefix_tracker.py
+++ b/tests/test_cache/test_prefix_tracker.py
@@ -656,12 +656,22 @@ class TestConversationLineageResolution:
         assert store.active_sessions == 2
 
     @staticmethod
-    def _in_place_growth(stable: int, churn: int, tail: str) -> list[dict]:
+    def _in_place_growth(
+        stable: int, churn: int, tail: str, suffix: str = "end of transcript"
+    ) -> list[dict]:
         """The sub-call shape: a transcript packed into ONE block-style message
-        whose leading blocks are stable and whose tail is rewritten each turn.
-        This history grows at BLOCK granularity, not message granularity."""
+        whose leading blocks are stable, whose middle churns, and which keeps a
+        fixed instruction pinned at the very end. This history grows at BLOCK
+        granularity, not message granularity.
+
+        The pinned suffix mirrors the captured production shape, where the final
+        blocks are byte-identical turn over turn while the blocks before them are
+        rewritten. ``suffix`` is what distinguishes sibling conversations that
+        pack the same parent transcript.
+        """
         blocks = [{"type": "text", "text": f"stable {i} " + "x" * 200} for i in range(stable)]
         blocks += [{"type": "text", "text": f"{tail} churn {i}"} for i in range(churn)]
+        blocks += [{"type": "text", "text": suffix}]
         return [{"role": "user", "content": "kickoff"}, {"role": "user", "content": blocks}]
 
     def test_in_place_message_growth_keeps_its_lineage(self, store):
@@ -718,6 +728,76 @@ class TestConversationLineageResolution:
         )
         shrunk = self._in_place_growth(20, 2, "t1")
         assert store.resolve_tracker(sid, "anthropic", messages=shrunk) is not tracker
+
+    def test_shared_preamble_does_not_merge_parallel_subagents(self, store):
+        """Parallel subagents of the same type open with the same injected
+        boilerplate and then diverge. Sharing a preamble is not a conversation
+        identity — they must keep separate trackers, or they thrash one."""
+        sid = "shared-fallback-id"
+        preamble = {"type": "text", "text": "<system-reminder>shared boilerplate</system-reminder>"}
+
+        def spawn(name: str) -> list[dict]:
+            return [
+                {"role": "user", "content": [preamble, {"type": "text", "text": f"task {name}"}]}
+            ]
+
+        a = store.resolve_tracker(sid, "anthropic", messages=spawn("a"))
+        b = store.resolve_tracker(sid, "anthropic", messages=spawn("b"))
+        assert a is not b
+        assert store.active_sessions == 2
+
+    def test_boilerplate_on_both_ends_is_not_enough_to_share_a_lineage(self, store):
+        """Injected boilerplate can bracket a message on BOTH sides — a preamble
+        in front and a reminder pinned at the end. Two conversations then agree
+        on their first blocks and their last block while differing in the only
+        part that is theirs, so a proportional test alone ("most of the recorded
+        blocks survived") would merge them. A few shared blocks is not identity.
+        """
+        sid = "shared-fallback-id"
+        head = [{"type": "text", "text": f"boilerplate {i}"} for i in range(2)]
+        pinned = {"type": "text", "text": "<system-reminder>stay on task</system-reminder>"}
+
+        def spawn(name: str) -> list[dict]:
+            content = [*head, {"type": "text", "text": f"task {name}"}, pinned]
+            return [{"role": "user", "content": content}]
+
+        a = store.resolve_tracker(sid, "anthropic", messages=spawn("a"))
+        b = store.resolve_tracker(sid, "anthropic", messages=spawn("b"))
+        assert a is not b
+        assert store.active_sessions == 2
+
+    def test_sibling_sub_calls_over_one_transcript_do_not_ping_pong(self, store):
+        """Two sub-call streams can pack the SAME parent transcript and differ
+        only in the instruction appended after it. Their leading blocks match
+        almost entirely, so without a tail check they would trade one tracker
+        back and forth on every turn — forever, since neither ever gains a
+        message to tell them apart."""
+        sid = "shared-fallback-id"
+        seen: dict[str, PrefixCacheTracker] = {}
+        for turn, churn in enumerate([2, 4, 7], start=1):
+            for stream in ("summarize", "title"):
+                history = self._in_place_growth(
+                    30, churn, f"t{turn}", suffix=f"instruction: {stream}"
+                )
+                tracker = store.resolve_tracker(sid, "anthropic", messages=history)
+                seen.setdefault(stream, tracker)
+                assert tracker is seen[stream], f"[{stream}] turn {turn} switched trackers"
+                tracker.update_from_response(
+                    cache_read_tokens=1000,
+                    cache_write_tokens=500,
+                    messages=history,
+                    original_messages=history,
+                )
+        assert seen["summarize"] is not seen["title"]
+
+    def test_added_message_plus_rewritten_older_one_is_not_in_place_growth(self, store):
+        """Growing in place means the message COUNT held still. A history that
+        gained a message AND rewrote an earlier one was rewritten, not grown."""
+        sid = "shared"
+        base = self._in_place_growth(30, 4, "t1")
+        tracker = store.resolve_tracker(sid, "anthropic", messages=base)
+        grown_and_rewritten = [*self._in_place_growth(30, 9, "t2"), {"role": "assistant", "c": 1}]
+        assert store.resolve_tracker(sid, "anthropic", messages=grown_and_rewritten) is not tracker
 
     def test_strict_prefix_match_wins_over_in_place_growth(self, store):
         """An exact continuation must never be displaced by a looser one."""

--- a/tests/test_cache_control_move_bust.py
+++ b/tests/test_cache_control_move_bust.py
@@ -243,13 +243,18 @@ def _blocks(*texts):
     return [{"type": "text", "text": t} for t in texts]
 
 
-def _grown(stable: int, churn: int, tail: str):
-    """One block-style message: `stable` unchanging blocks, then a varying tail."""
+def _grown(stable: int, churn: int, tail: str, suffix: str = "end-of-transcript"):
+    """One block-style message shaped like the captured production sub-call:
+    `stable` unchanging blocks, a churning middle, and a fixed instruction
+    pinned at the very end (the real shape's final blocks are byte-identical
+    turn over turn while the blocks before them are rewritten).
+    """
     return {
         "role": "user",
         "content": _blocks(
             *[f"stable-{i}" for i in range(stable)],
             *[f"{tail}-churn-{i}" for i in range(churn)],
+            suffix,
         ),
     }
 
@@ -291,7 +296,7 @@ def test_breakpoint_anchors_to_static_prefix_when_message_grows_in_place():
     ]
     turns = _drive_turns(shapes)
 
-    assert turns[0][1] == 42, "cold turn has nothing to compare — newest block"
+    assert turns[0][1] == 43, "cold turn has nothing to compare — newest block"
     for forwarded, bp in turns[1:]:
         blocks = forwarded[-1]["content"]
         assert bp == 39, f"breakpoint must sit at the end of the static prefix, got {bp}"

--- a/tests/test_cache_control_move_bust.py
+++ b/tests/test_cache_control_move_bust.py
@@ -224,3 +224,139 @@ def test_normalize_ttl_survives_many_turns():
         conv = normalize_message_cache_control(conv)
         assert _markers(conv) == 1
         assert conv[-1]["content"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+# ── fix-4: a message that grows IN PLACE needs the breakpoint off its newest ──
+# block. Sub-call shapes pack a transcript into one block-style message and
+# rewrite its tail each turn, so the newest block never repeats and the whole
+# message re-writes forever (cache_read pinned at the system+tools constant).
+# These tests drive the REAL path — resolve_tracker -> normalize -> record — so
+# they fail if the previous turn's state never reaches the placement decision,
+# which is how the first attempt at this fix passed while doing nothing.
+
+from headroom.cache.prefix_tracker import SessionTrackerStore  # noqa: E402
+
+LOOKBACK = 20  # provider walks back this many block boundaries from a breakpoint
+
+
+def _blocks(*texts):
+    return [{"type": "text", "text": t} for t in texts]
+
+
+def _grown(stable: int, churn: int, tail: str):
+    """One block-style message: `stable` unchanging blocks, then a varying tail."""
+    return {
+        "role": "user",
+        "content": _blocks(
+            *[f"stable-{i}" for i in range(stable)],
+            *[f"{tail}-churn-{i}" for i in range(churn)],
+        ),
+    }
+
+
+def _bp_index(messages):
+    """Index of the breakpoint inside the last block-style message."""
+    for msg in reversed(messages):
+        content = msg.get("content")
+        if isinstance(content, list):
+            return next(
+                (i for i, b in enumerate(content) if isinstance(b, dict) and "cache_control" in b),
+                -1,
+            )
+    return -1
+
+
+def _drive_turns(shapes, provider="anthropic", session="sub-call"):
+    """Replay `shapes` through the live path; return [(forwarded, breakpoint)]."""
+    store = SessionTrackerStore(PrefixFreezeConfig())
+    out = []
+    for client in shapes:
+        tracker = store.resolve_tracker(session, provider, messages=client)
+        forwarded = normalize_message_cache_control(client, tracker.get_last_forwarded_messages())
+        out.append((forwarded, _bp_index(forwarded)))
+        tracker.update_from_response(
+            cache_read_tokens=1000,
+            cache_write_tokens=1000,
+            messages=forwarded,
+            original_messages=client,
+        )
+    return out
+
+
+def test_breakpoint_anchors_to_static_prefix_when_message_grows_in_place():
+    """The production shape: 40 stable blocks + a tail rewritten every turn."""
+    shapes = [
+        [B("user", "kickoff"), _grown(40, churn, f"t{turn}")]
+        for turn, churn in enumerate([3, 5, 8], start=1)
+    ]
+    turns = _drive_turns(shapes)
+
+    assert turns[0][1] == 42, "cold turn has nothing to compare — newest block"
+    for forwarded, bp in turns[1:]:
+        blocks = forwarded[-1]["content"]
+        assert bp == 39, f"breakpoint must sit at the end of the static prefix, got {bp}"
+        assert bp < len(blocks) - 1, "must NOT ride the varying tail"
+        assert _markers(forwarded) == 1
+
+
+def test_relocated_breakpoint_stays_within_provider_lookback():
+    """Chaining property: each turn's breakpoint must be reachable from the
+    region the previous turn wrote, or the relocation only helps once."""
+    shapes = [[B("user", "kickoff"), _grown(30 + turn, 4, f"t{turn}")] for turn in range(1, 6)]
+    turns = _drive_turns(shapes)
+    previous_bp = turns[0][1]
+    for _, bp in turns[1:]:
+        assert bp - previous_bp <= LOOKBACK, f"breakpoint jumped {bp - previous_bp} blocks"
+        previous_bp = bp
+
+
+def test_breakpoint_stays_newest_when_conversation_appends_messages():
+    """A main conversation grows by appending MESSAGES; its newest message is
+    genuinely new, so the newest-block placement (which the provider's lookback
+    reaches) must be left alone."""
+    conv = []
+    shapes = []
+    for turn in range(1, 6):
+        conv = [*conv, B("user", f"turn-{turn}"), B("assistant", f"reply-{turn}")]
+        shapes.append(list(conv))
+    for forwarded, bp in _drive_turns(shapes):
+        assert bp == len(forwarded[-1]["content"]) - 1, "main conversation must keep newest block"
+
+
+def test_breakpoint_stays_newest_for_short_messages():
+    """Under the lookback window there is nothing to gain and cache to lose."""
+    shapes = [
+        [B("user", "kickoff"), _grown(4, churn, f"t{turn}")]
+        for turn, churn in enumerate([1, 2, 3], start=1)
+    ]
+    for forwarded, bp in _drive_turns(shapes):
+        assert bp == len(forwarded[-1]["content"]) - 1
+
+
+def test_breakpoint_stays_newest_when_most_of_the_message_changed():
+    """A short stable run would cache less than the newest-block placement
+    writes — relocating there reads a little and forfeits a lot."""
+    shapes = [[B("user", "kickoff"), _grown(5, 30, f"t{turn}")] for turn in range(1, 4)]
+    for forwarded, bp in _drive_turns(shapes):
+        assert bp == len(forwarded[-1]["content"]) - 1
+
+
+def test_kill_switch_restores_newest_block(monkeypatch):
+    monkeypatch.setenv("HEADROOM_STABLE_BOUNDARY_BREAKPOINT", "0")
+    shapes = [
+        [B("user", "kickoff"), _grown(40, churn, f"t{turn}")]
+        for turn, churn in enumerate([3, 5, 8], start=1)
+    ]
+    for forwarded, bp in _drive_turns(shapes):
+        assert bp == len(forwarded[-1]["content"]) - 1
+
+
+def test_relocation_never_adds_a_second_marker_or_edits_content():
+    shapes = [
+        [B("user", "kickoff"), _grown(40, churn, f"t{turn}")]
+        for turn, churn in enumerate([3, 5], start=1)
+    ]
+    turns = _drive_turns([list(s) for s in shapes])
+    for client, (forwarded, _) in zip(shapes, turns, strict=True):
+        assert _markers(forwarded) == 1  # bounded regardless of where it moved
+        assert _strip_cache_control(forwarded) == _strip_cache_control(client)

--- a/tests/test_proxy_anthropic_cache_stability.py
+++ b/tests/test_proxy_anthropic_cache_stability.py
@@ -1720,3 +1720,95 @@ def test_issue_327_streaming_and_non_streaming_compute_same_frozen_count() -> No
         f"{captured_b['frozen_message_count']}. The optimization path must "
         f"be identical for both."
     )
+
+
+def _bp_index_of_last_message(body: dict) -> int:
+    """Index of the cache_control breakpoint inside the last block-style message."""
+    for message in reversed(body["messages"]):
+        content = message.get("content")
+        if isinstance(content, list):
+            return next(
+                (i for i, b in enumerate(content) if isinstance(b, dict) and "cache_control" in b),
+                -1,
+            )
+    return -1
+
+
+def test_handler_passes_previous_forwarded_messages_to_breakpoint_placement() -> None:
+    """The breakpoint can only move off the newest block if the HANDLER hands
+    last turn's forwarded messages to normalize_message_cache_control.
+
+    Store-level tests cannot catch that wiring: the parameter defaults to None,
+    so dropping it at the call site silently degrades to newest-block placement
+    with every unit test still green — which is exactly how an earlier attempt at
+    this fix shipped inert. This drives two real requests through the proxy and
+    asserts the second forwarded body anchors to the static prefix.
+    """
+    stable, suffix = 40, {"type": "text", "text": "end-of-transcript"}
+
+    def grown(turn: int, churn: int) -> list[dict]:
+        blocks = [{"type": "text", "text": f"stable-{i}"} for i in range(stable)]
+        blocks += [{"type": "text", "text": f"t{turn}-churn-{i}"} for i in range(churn)]
+        return [
+            {"role": "user", "content": "kickoff"},
+            {"role": "user", "content": [*blocks, suffix]},
+        ]
+
+    captured: dict[str, dict] = {}
+    with _make_proxy_client() as client:
+        proxy = client.app.state.proxy
+        proxy.config.mode = "token"
+
+        async def _fake_retry(method, url, headers, body, stream=False, **kwargs):  # noqa: ANN001
+            captured["body"] = body
+            return httpx.Response(
+                200,
+                json={
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "ok"}],
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 3,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                    },
+                },
+            )
+
+        proxy._retry_request = _fake_retry
+
+        breakpoints = []
+        for turn, churn in enumerate([3, 5], start=1):
+            response = client.post(
+                "/v1/messages",
+                headers={"x-api-key": "test-key", "anthropic-version": "2023-06-01"},
+                json={
+                    "model": "claude-sonnet-4-6",
+                    "max_tokens": 128,
+                    "system": "SYS",
+                    "messages": grown(turn, churn),
+                },
+            )
+            assert response.status_code == 200
+            body = captured["body"]
+            breakpoints.append(_bp_index_of_last_message(body))
+            # Exactly one message-level breakpoint survives, on every turn.
+            assert (
+                sum(
+                    1
+                    for m in body["messages"]
+                    if isinstance(m.get("content"), list)
+                    for b in m["content"]
+                    if isinstance(b, dict) and "cache_control" in b
+                )
+                == 1
+            )
+
+    cold, warm = breakpoints
+    assert cold == stable + 3, "cold turn has no previous turn to compare — newest block"
+    assert warm == stable - 1, (
+        f"warm turn must anchor to the end of the static prefix, got {warm} — "
+        "the handler is not passing previous_forwarded_messages"
+    )


### PR DESCRIPTION
## Description

`normalize_message_cache_control` re-places its single message-level breakpoint on the **newest block** of the last block-style message. That is correct for histories that grow by appending messages: the provider walks back up to 20 content-block boundaries from a breakpoint looking for a previous write, so it still finds last turn's.

It is wrong for a message that grows **in place with a varying tail**. One caller shape (`msgs=2`, sonnet) packs a transcript into a single block-style message and rewrites its last few blocks every turn. The breakpoint then rides a block that never repeats, no stable prefix is ever found, and the message re-writes in full forever — `cache_read` pinned at the system+tools constant while `cache_write` grows with the transcript. Anthropic's documented guidance covers this case exactly: place the breakpoint at the end of the static prefix rather than on the varying block.

Fixing that alone is a no-op, which #2671 recorded without identifying why. The cause is upstream of the breakpoint: `SessionTrackerStore.resolve_tracker` matches a conversation to its tracker by requiring the recorded messages to be a whole-**message** prefix of the incoming history (`snap[:len(chain)] == chain`), assuming client histories only ever append messages. This shape appends **blocks to its last message**, so the recorded last message never re-compares equal and the conversation reads as diverged on every turn — a fresh tracker each time, frozen prefix permanently 0, nothing for `overlay_cached_prefix` to replay, and one leaked lineage per turn until the family hits `max_lineages_per_session`. Reproduced in isolation: 5 turns of the captured shape give **5 distinct trackers**; with this change, **1**.

Hence two commits — the lineage match has to be repaired before any breakpoint logic can see the previous turn.

Fixes defect 2 of #2671. Defect 1 is #2672; #2671 can close once both land.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `resolve_tracker` now also matches a lineage whose recorded last message **grew in place**: the messages before it must still compare equal, and the last one must share the same role, have block-style content that did not shrink, and keep a leading run of byte-stable blocks covering most of the recorded version. Extracted to `_match_lineage` / `_chain_matches` / `_is_message_continuation`, which keeps `resolve_tracker`'s complexity below where it started.
- Strict whole-message matches are tried first, so an exact continuation is never displaced by a looser one.
- Rewritten heads (client-side compaction), shrunk messages, and templated fan-outs that diverge from the first block of their newest message all still start a fresh lineage — the concurrent-conversation split from #2085 is unchanged.
- `normalize_message_cache_control` takes an optional `previous_forwarded_messages` and picks its breakpoint via a new `_breakpoint_index`, which compares the target message against **its own counterpart from last turn** (same position, same role) and anchors to the end of that message's byte-stable leading run.
- Relocation requires all of: a run that is real (the message diverged before its end), a run covering most of the message, and a message longer than the 20-block lookback window. A main conversation therefore keeps newest-block placement untouched.
- Comparison goes through the existing `_canonicalize_for_prefix_compare`, so last turn's `cache_control` marker does not shorten the run.
- `HEADROOM_STABLE_BOUNDARY_BREAKPOINT=0` restores newest-block placement unconditionally, without a redeploy.
- Handler reads the previously-forwarded prefix once and shares it between the overlay replay and the breakpoint decision, rather than deep-copying the transcript twice per request.

Commit 3 narrows the continuation match after review found it merged conversations that lineages exist to keep apart. All three narrowings are pinned by tests that fail without them:

- The **final block must be unchanged.** Two sub-call streams over one parent transcript — a summarizer and a titler, say — share nearly every leading block and differ only in the instruction appended at the end. They traded one tracker back and forth every turn and never recovered, since neither ever gains a message to tell them apart. The real growing shape keeps a fixed suffix pinned at the end while the blocks before it churn, so the tail is exactly what separates the two cases.
- The stable run must clear an **absolute floor**, not just a proportion. Injected boilerplate can bracket a message on both sides, leaving two conversations agreeing on their first blocks and their last while differing in the only part that is theirs.
- The loose pass requires an **unchanged message count.** It previously ignored everything after the recorded chain, so a two-message chain could match any longer history whose second message shared half its blocks. A history that gained a message and rewrote an older one was rewritten, not grown.

Worth stating plainly for reviewers: no wrong content could be forwarded in either case. The per-message canonical guards in `overlay_cached_prefix` and `extract_cache_stable_delta` stop a mismatched tracker from replaying another conversation's bytes; the damage was cache thrash and polluted frozen counts.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

New tests drive the real sequence — `resolve_tracker` → `normalize_message_cache_control` → `update_from_response` — rather than hand-building previous-turn state. That distinction is the point: the earlier attempt at this fix passed its unit tests precisely *because* they supplied the previous-turn state that production never delivered. These fail if that state stops arriving.

Covered: the in-place-growth shape; the chaining property (each breakpoint reachable from the previous write); main conversations keeping newest-block placement; short messages and mostly-rewritten messages declining relocation; the kill switch; marker-count and content invariants. Guard tests pin the lineage splits that must not regress — diverging fan-outs, rewritten heads, shrinking messages, strict-match precedence.

Both new test groups are red on the base commit for the right reason (`AssertionError: turn 2 switched trackers`).

Every guard in this PR was mutation-tested — each one reverted in turn, confirming a test goes red. Without this, a guard is just an assertion nobody checks:

| mutation | caught by |
|---|---|
| handler drops `previous_forwarded_messages` | `test_handler_passes_previous_forwarded_messages_to_breakpoint_placement` |
| drop the stable-tail requirement | `test_sibling_sub_calls_over_one_transcript_do_not_ping_pong` |
| drop the absolute run floor | `test_boilerplate_on_both_ends_is_not_enough_to_share_a_lineage` |
| drop the message-count guard | `test_added_message_plus_rewritten_older_one_is_not_in_place_growth` |
| breakpoint back to newest block | 2 tests |
| lineage loose pass disabled | 4 tests |

### Test Output

```text
$ python -m pytest -q
11 failed, 9662 passed, 557 skipped, 5889 warnings in 357.44s (0:05:57)

$ python -m ruff check .
All checks passed!

$ python -m mypy headroom
Success: no issues found in 506 source files

# Red on base (28aa53dc) for the right reason, before the fix:
$ python -m pytest tests/test_cache/test_prefix_tracker.py -q \
    -k test_in_place_message_growth_keeps_its_lineage
    assert tracker is first, f"turn {turn} switched trackers"
E   AssertionError: turn 2 switched trackers
FAILED tests/test_cache/test_prefix_tracker.py::TestConversationLineageResolution::test_in_place_message_growth_keeps_its_lineage
```

The 11 failures are pre-existing and unrelated — the identical set fails on the base commit with the same command, so this branch introduces zero regressions. They are dashboard Playwright tests, `readyz` kompress-state tests, an ONNX image-classification test, and two CLI wrap/recover tests:

```text
tests/test_cli/test_recover_codex.py::test_recovery_records_sockets_and_secures_both_backups
tests/test_cli/test_unwrap_claude.py::test_unwrap_claude_stops_claude_owned_persistent_deployment
tests/test_dashboard/test_live_feed.py::test_live_feed_button_exists
tests/test_dashboard/test_live_feed.py::test_live_feed_drawer_opens
tests/test_dashboard/test_live_feed.py::test_live_feed_fetches_and_displays
tests/test_dashboard/test_live_feed.py::test_live_feed_shows_empty_state
tests/test_image_compression.py::TestOnnxRouter::test_full_classify_with_image
tests/test_proxy_health.py::test_readyz_excludes_kompress_from_aggregate_readiness
tests/test_proxy_health.py::test_readyz_keeps_pending_kompress_unloaded
tests/test_proxy_health.py::test_readyz_kompress_state_matrix[null-None-False-expected0]
tests/test_proxy_health.py::test_readyz_never_calls_lazy_kompress_getters
```

The cache and proxy suites this PR touches are green:

```text
$ python -m pytest tests/test_cache/ tests/test_cache_control_move_bust.py \
    tests/test_cross_turn_cache_safety.py tests/test_cache_ttl_preserved.py \
    tests/test_proxy_anthropic_cache_stability.py -q
314 passed, 2 skipped, 1 warning in 14.26s
```

## Real Behavior Proof

- Environment: local Headroom proxy on macOS (darwin 25.4.0), Python 3.13.14, serving real Claude Code traffic against `claude-sonnet-5` and `claude-opus-5`, running this branch's two commits applied to the daily-driver checkout.
- Exact command / steps: apply both commits, restart the proxy (`python -m headroom.cli proxy`), use it normally for ~9 minutes, then run the frozen parser from the #2671 baseline unmodified over the post-restart log slice — `python parse_perf.py post-fix.log`.
- Observed result: the relocation fires and chains as designed, the sub-call `cache_read` pin at 36,952 is broken, per-turn `cache_write` for that shape drops from ~28–48k to 42–109, and the `msgs<=4` bucket goes from 43.1% hit / 54.9% of all cache write to 92.4% hit / 14.0% — details below.
- Not tested: the OpenAI handler (unchanged — `normalize_message_cache_control` has a single call site, in the Anthropic handler, so non-Anthropic providers are unaffected); durability beyond a 41-turn / 9-minute window, which is far smaller than the 1678-turn baseline and the 235-turn soak behind #2672, so the magnitude below is directional while the mechanism is confirmed; load, concurrency, and multi-workspace behaviour beyond normal interactive use.

The relocation chains with the anchor tracking one turn behind the growth, the gap staying well inside the 20-block lookback:

```text
stable run / blocks:  131/134 → 131/135 → 132/136 → 133/137 → 134/138
                    → 135/139 → 136/140 → 138/141 → 138/142 → 139/143 → 140/144
```

The pin is broken. Consecutive turns of one affected sub-call conversation:

| tok_before | cache_read | cache_write | hit |
|---:|---:|---:|---:|
| 40,292 | 0 | 65,362 | 0% (cold) |
| 40,405 | 36,952 ← the pinned constant | 28,323 | 57% |
| 40,497 | 65,275 | 0 | 100% |
| 40,567 | 65,275 | 42 | 100% |
| 40,645 | 65,317 | 42 | 100% |
| 40,814 | 65,359 | 109 | 100% |

`cache_read` now tracks the conversation upward instead of pinning, and per-turn `cache_write` falls from ~28–48k to 42–109. `frozen=1` also starts appearing on `msgs=2` requests that were always `frozen=0` before — direct evidence the tracker survives across turns instead of being recreated.

Bucket totals from the same parser, against the figures in #2671:

| sub-call bucket (`msgs<=4`) | hit | share of all cache write |
|---|---:|---:|
| baseline (1678 turns) | 58.8% | 44.8% |
| after defect 1 fixed in #2672 (235 turns) | 43.1% | 54.9% |
| this change (41 turns) | **92.4%** | **14.0%** |

Aggregate over the window: 91.06%. No 400s and no `cache_control` errors were observed.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

- **Documentation:** N/A — no user-facing surface changes. The behaviour is described in the two functions' docstrings, including why the newest-block default stays correct for ordinary conversations.
- **Why three commits:** the first two are separable defects and each stands on its own (the lineage fix also stops the per-turn tracker and lineage churn regardless of breakpoints), but the breakpoint fix is inert without the lineage fix, so shipping only the second would repeat the earlier no-op. The third narrows the continuation predicate in response to review; it is kept separate so the reasoning behind each guard stays readable, and can be squashed on merge.
- **Measurement predates commit 3.** The live numbers above were taken with the looser predicate. Commit 3 only *rejects* matches, so it can reduce how often the win applies but cannot inflate it; the affected shape (runs of 100+ blocks behind a pinned suffix) still matches. Re-measuring after the narrowing is the obvious follow-up and I am happy to do it before merge if you would rather not take that on trust.
- **Correction to #2671:** the issue body describes this caller as growing "append-only". It does not — it rewrites its tail behind a fixed 2-block suffix. That is precisely why the anchor has to be the *stable leading run* rather than an append-only assumption, which would have missed it.
- **Rollback:** `HEADROOM_STABLE_BOUNDARY_BREAKPOINT=0` disables the relocation and restores the previous placement. The lineage change has no switch; it is a match-predicate widening whose failure mode is the pre-existing behaviour (a fresh lineage).
