### PR TITLE
fix(kompress): load merged v2 PyTorch checkpoint

### DIFF
--- a/headroom/transforms/kompress_compressor.py
+++ b/headroom/transforms/kompress_compressor.py
@@ -22,6 +22,7 @@ import os
 import re
 import threading
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -39,6 +40,21 @@ logger = logging.getLogger(__name__)
 
 # Default HuggingFace model ID
 HF_MODEL_ID = "chopratejas/kompress-v2-base"
+_MERGED_PYTORCH_CHECKPOINT = "merged.pt"
+_LEGACY_PYTORCH_CHECKPOINT = "model.safetensors"
+_MERGED_STATE_DICT_TARGETS = (
+    ("encoder_state_dict", "encoder"),
+    ("token_head_state_dict", "token_head"),
+    ("span_conv_state_dict", "span_conv"),
+)
+
+
+def _canonical_kompress_model_id(model_id: str) -> str:
+    """Canonicalize known model IDs so artifact selection and pinning agree."""
+    if model_id.casefold() == HF_MODEL_ID.casefold():
+        return HF_MODEL_ID
+    return model_id
+
 
 # Tokens matching this pattern are always kept regardless of model score.
 # Numbers, ALLCAPS identifiers, dotted paths, unix paths, file extensions,
@@ -507,9 +523,18 @@ def _get_model_class() -> type:
     class HeadroomCompressorModel(nn.Module):
         """Dual-head ModernBERT: token classification + span importance CNN."""
 
-        def __init__(self, model_name: str = "answerdotai/ModernBERT-base"):
+        def __init__(
+            self,
+            model_name: str = "answerdotai/ModernBERT-base",
+            *,
+            local_files_only: bool = False,
+        ):
             super().__init__()
-            self.encoder = AutoModel.from_pretrained(model_name, attn_implementation="eager")
+            self.encoder = AutoModel.from_pretrained(
+                model_name,
+                attn_implementation="eager",
+                local_files_only=local_files_only,
+            )
             hidden_size = self.encoder.config.hidden_size  # 768
 
             # Head 1: Token keep/discard
@@ -561,6 +586,58 @@ def _get_model_class() -> type:
 
 
 # ── Model Loading ─────────────────────────────────────────────────────
+
+
+def _load_state_dict_exact(
+    module: Any,
+    state_dict: Mapping[str, Any],
+    *,
+    label: str,
+    source: str,
+) -> None:
+    """Load a state dict and fail loudly when it does not match the module."""
+    missing, unexpected = module.load_state_dict(state_dict, strict=False)
+    if missing or unexpected:
+        raise RuntimeError(
+            f"{source}: {label} state_dict mismatch "
+            f"(missing={list(missing)[:5]}, unexpected={list(unexpected)[:5]})"
+        )
+
+
+def _load_merged_pytorch_checkpoint(
+    model: Any,
+    checkpoint: Any,
+    *,
+    source: str,
+) -> None:
+    """Load the structured, LoRA-merged Kompress v2 checkpoint."""
+    if not isinstance(checkpoint, Mapping):
+        raise RuntimeError(f"{source}: expected a mapping, got {type(checkpoint).__name__}")
+
+    missing_sections = [
+        checkpoint_key
+        for checkpoint_key, _module_name in _MERGED_STATE_DICT_TARGETS
+        if checkpoint_key not in checkpoint
+    ]
+    if missing_sections:
+        raise RuntimeError(
+            f"{source}: missing checkpoint sections {missing_sections}; "
+            f"found {sorted(str(key) for key in checkpoint)}"
+        )
+
+    for checkpoint_key, module_name in _MERGED_STATE_DICT_TARGETS:
+        state_dict = checkpoint[checkpoint_key]
+        if not isinstance(state_dict, Mapping):
+            raise RuntimeError(
+                f"{source}: '{checkpoint_key}' must be a state_dict mapping, "
+                f"got {type(state_dict).__name__}"
+            )
+        _load_state_dict_exact(
+            getattr(model, module_name),
+            state_dict,
+            label=module_name,
+            source=source,
+        )
 
 
 class _OnnxModel:
@@ -664,6 +741,7 @@ def _load_kompress_onnx(
     the local cache only; a cache miss raises :class:`KompressModelNotCached`
     instead of hitting the network.
     """
+    model_id = _canonical_kompress_model_id(model_id)
     with _kompress_lock:
         if model_id in _kompress_cache:
             return _kompress_cache[model_id]
@@ -726,21 +804,30 @@ def _load_kompress_pytorch(
 ) -> tuple[Any, Any, str]:
     """Download PyTorch model from HuggingFace and load with torch.
 
+    The default Kompress v2 repository uses ``merged.pt`` because its
+    ``model.safetensors`` contains an unmerged PEFT/LoRA module tree that does
+    not match :class:`HeadroomCompressorModel`. Custom model repositories retain
+    the legacy full-model ``model.safetensors`` contract.
+
     When ``allow_download`` is ``False`` weights and tokenizer are loaded from
     the local cache only; a cache miss raises :class:`KompressModelNotCached`.
     """
     import torch
     from transformers import AutoTokenizer
 
+    model_id = _canonical_kompress_model_id(model_id)
     with _kompress_lock:
         if model_id in _kompress_cache:
             return _kompress_cache[model_id]
 
         logger.info("Downloading Kompress PyTorch model from %s ...", model_id)
 
+        checkpoint_filename = (
+            _MERGED_PYTORCH_CHECKPOINT if model_id == HF_MODEL_ID else _LEGACY_PYTORCH_CHECKPOINT
+        )
         try:
             weights_path = hf_hub_download_local_first(
-                model_id, "model.safetensors", allow_network=allow_download
+                model_id, checkpoint_filename, allow_network=allow_download
             )
         except _NOT_CACHED_ERRORS as exc:
             if not allow_download:
@@ -748,12 +835,30 @@ def _load_kompress_pytorch(
             raise
 
         HeadroomCompressorModel = _get_model_class()
-        model = HeadroomCompressorModel()
+        try:
+            model = HeadroomCompressorModel(local_files_only=not allow_download)
+        except _NOT_CACHED_ERRORS as exc:
+            if not allow_download:
+                raise KompressModelNotCached("answerdotai/ModernBERT-base") from exc
+            raise
 
-        from safetensors.torch import load_file
+        checkpoint_source = f"{model_id}/{checkpoint_filename}"
+        if checkpoint_filename == _MERGED_PYTORCH_CHECKPOINT:
+            checkpoint = torch.load(weights_path, map_location="cpu", weights_only=True)
+            _load_merged_pytorch_checkpoint(model, checkpoint, source=checkpoint_source)
+        else:
+            from safetensors.torch import load_file
 
-        state_dict = load_file(weights_path)
-        model.load_state_dict(state_dict, strict=False)
+            state_dict = load_file(weights_path)
+            missing, unexpected = model.load_state_dict(state_dict, strict=False)
+            if missing or unexpected:
+                logger.warning(
+                    "%s: legacy custom-model state_dict mismatch "
+                    "(missing=%s, unexpected=%s); continuing with partial load",
+                    checkpoint_source,
+                    list(missing)[:5],
+                    list(unexpected)[:5],
+                )
 
         if device == "auto":
             if torch.cuda.is_available():
@@ -821,6 +926,7 @@ def _load_kompress(
 
     Models are cached by model_id — multiple models can coexist.
     """
+    model_id = _canonical_kompress_model_id(model_id)
     if model_id in _kompress_cache:
         return _kompress_cache[model_id]
 
@@ -879,6 +985,8 @@ def unload_kompress_model(model_id: str | None = None) -> bool:
     Args:
         model_id: Specific model to unload. If None, unloads all cached models.
     """
+    if model_id is not None:
+        model_id = _canonical_kompress_model_id(model_id)
     with _kompress_lock:
         if model_id is not None:
             if model_id in _kompress_cache:
@@ -936,6 +1044,7 @@ def ensure_background_download(model_id: str = HF_MODEL_ID, device: str = "auto"
     completes the deep path activates on subsequent requests without ever
     blocking one on the network.
     """
+    model_id = _canonical_kompress_model_id(model_id)
     if model_id in _kompress_cache:
         return
     with _download_threads_lock:
@@ -971,6 +1080,7 @@ def warm_kompress_model(
     Returns ``True`` if the model is loaded and ready, ``False`` if Kompress is
     unavailable or the load failed.
     """
+    model_id = _canonical_kompress_model_id(model_id)
     if not is_kompress_available():
         return False
     try:
@@ -1006,6 +1116,9 @@ class KompressConfig:
     model_id: str = HF_MODEL_ID
     chunk_words: int = 350
     score_threshold: float = 0.5
+
+    def __post_init__(self) -> None:
+        self.model_id = _canonical_kompress_model_id(self.model_id)
 
 
 @dataclass

--- a/scripts/export_kompress_v2_onnx.py
+++ b/scripts/export_kompress_v2_onnx.py
@@ -65,32 +65,17 @@ def _build_core(model_id: str):
     import torch
     from huggingface_hub import hf_hub_download
 
-    from headroom.transforms.kompress_compressor import _get_model_class
+    from headroom.transforms.kompress_compressor import (
+        _get_model_class,
+        _load_merged_pytorch_checkpoint,
+    )
 
     ckpt_path = hf_hub_download(model_id, "merged.pt")
-    ckpt = torch.load(ckpt_path, map_location="cpu")
-    for key in ("encoder_state_dict", "token_head_state_dict", "span_conv_state_dict"):
-        if key not in ckpt:
-            raise RuntimeError(
-                f"merged.pt missing '{key}'. Found: {sorted(ckpt)}. "
-                "This script targets the v2 'merged' checkpoint format."
-            )
-
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=True)
     core = _get_model_class()(model_name=BASE_MODEL)
 
-    def _strict_load(module, sd, label: str) -> None:
-        missing, unexpected = module.load_state_dict(sd, strict=False)
-        if missing or unexpected:
-            raise RuntimeError(
-                f"{label}: state_dict mismatch (missing={list(missing)[:5]}, "
-                f"unexpected={list(unexpected)[:5]}). Architecture drifted from the checkpoint."
-            )
-        logger.info("  %s loaded (%d tensors, exact match)", label, len(sd))
-
     logger.info("Loading merged.pt (checkpoint_kind=%s)", ckpt.get("checkpoint_kind"))
-    _strict_load(core.encoder, ckpt["encoder_state_dict"], "encoder")
-    _strict_load(core.token_head, ckpt["token_head_state_dict"], "token_head")
-    _strict_load(core.span_conv, ckpt["span_conv_state_dict"], "span_conv")
+    _load_merged_pytorch_checkpoint(core, ckpt, source=f"{model_id}/merged.pt")
 
     core.eval()
     return core

--- a/tests/test_transforms/test_kompress_compressor.py
+++ b/tests/test_transforms/test_kompress_compressor.py
@@ -9,8 +9,11 @@ Covers:
 """
 
 import logging
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 # ── Import safety (the whole point of the fix) ─────────────────────────
 
@@ -192,6 +195,238 @@ class TestKompressBackendSelection:
         assert options.inter_op_num_threads == 1
         assert options.enable_cpu_mem_arena is False
         assert options.enable_mem_pattern is False
+
+
+class _FakeStateDictModule:
+    def __init__(
+        self,
+        *,
+        missing: list[str] | None = None,
+        unexpected: list[str] | None = None,
+    ) -> None:
+        self.missing = missing or []
+        self.unexpected = unexpected or []
+        self.loaded: list[object] = []
+
+    def load_state_dict(self, state_dict, *, strict=False):
+        assert strict is False
+        self.loaded.append(state_dict)
+        return self.missing, self.unexpected
+
+
+class _FakeKompressModel:
+    def __init__(self) -> None:
+        self.encoder = _FakeStateDictModule()
+        self.token_head = _FakeStateDictModule()
+        self.span_conv = _FakeStateDictModule()
+        self.full_model = _FakeStateDictModule()
+        self.device = None
+        self.eval_called = False
+
+    def load_state_dict(self, state_dict, *, strict=False):
+        return self.full_model.load_state_dict(state_dict, strict=strict)
+
+    def to(self, device):
+        self.device = device
+        return self
+
+    def eval(self):
+        self.eval_called = True
+        return self
+
+
+class TestKompressPyTorchCheckpointLoading:
+    @pytest.mark.parametrize(
+        "requested_model_id",
+        [
+            "chopratejas/kompress-v2-base",
+            "Chopratejas/Kompress-V2-Base",
+        ],
+    )
+    def test_default_v2_model_loads_merged_checkpoint(
+        self,
+        monkeypatch,
+        requested_model_id,
+    ) -> None:
+        import headroom.transforms.kompress_compressor as kmod
+
+        downloads: list[tuple[str, str, bool]] = []
+        load_calls: list[tuple[str, str, bool]] = []
+        model_class_calls: list[bool] = []
+        checkpoint = {
+            "encoder_state_dict": {"encoder.weight": object()},
+            "token_head_state_dict": {"token_head.weight": object()},
+            "span_conv_state_dict": {"span_conv.weight": object()},
+            "checkpoint_kind": "merged",
+        }
+        model = _FakeKompressModel()
+
+        fake_torch = ModuleType("torch")
+        fake_torch.cuda = SimpleNamespace(is_available=lambda: False)
+        fake_torch.backends = SimpleNamespace(mps=SimpleNamespace(is_available=lambda: False))
+
+        def fake_torch_load(path, *, map_location, weights_only):
+            load_calls.append((path, map_location, weights_only))
+            return checkpoint
+
+        fake_torch.load = fake_torch_load
+
+        class FakeAutoTokenizer:
+            @staticmethod
+            def from_pretrained(model_name, *, local_files_only):
+                return ("tokenizer", model_name, local_files_only)
+
+        fake_transformers = ModuleType("transformers")
+        fake_transformers.AutoTokenizer = FakeAutoTokenizer
+
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+        monkeypatch.setattr(kmod, "_kompress_cache", {})
+
+        def fake_model_class(*, local_files_only=False):
+            model_class_calls.append(local_files_only)
+            return model
+
+        monkeypatch.setattr(kmod, "_get_model_class", lambda: fake_model_class)
+        monkeypatch.setattr(
+            kmod,
+            "hf_hub_download_local_first",
+            lambda repo_id, filename, *, allow_network: (
+                downloads.append((repo_id, filename, allow_network)) or "/cache/merged.pt"
+            ),
+        )
+
+        loaded_model, tokenizer, backend = kmod._load_kompress_pytorch(
+            requested_model_id,
+            allow_download=False,
+        )
+
+        assert downloads == [(kmod.HF_MODEL_ID, "merged.pt", False)]
+        assert model_class_calls == [True]
+        assert load_calls == [("/cache/merged.pt", "cpu", True)]
+        assert model.encoder.loaded == [checkpoint["encoder_state_dict"]]
+        assert model.token_head.loaded == [checkpoint["token_head_state_dict"]]
+        assert model.span_conv.loaded == [checkpoint["span_conv_state_dict"]]
+        assert model.device == "cpu"
+        assert model.eval_called is True
+        assert loaded_model is model
+        assert tokenizer == ("tokenizer", "answerdotai/ModernBERT-base", True)
+        assert backend == "pytorch"
+
+    def test_cache_only_load_does_not_download_base_model(self, monkeypatch) -> None:
+        import headroom.transforms.kompress_compressor as kmod
+
+        fake_torch = ModuleType("torch")
+        fake_transformers = ModuleType("transformers")
+        fake_transformers.AutoTokenizer = object()
+        constructor_calls: list[bool] = []
+
+        def unavailable_model_class(*, local_files_only=False):
+            constructor_calls.append(local_files_only)
+            raise OSError("ModernBERT is not cached")
+
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+        monkeypatch.setattr(kmod, "_kompress_cache", {})
+        monkeypatch.setattr(kmod, "_get_model_class", lambda: unavailable_model_class)
+        monkeypatch.setattr(
+            kmod,
+            "hf_hub_download_local_first",
+            lambda repo_id, filename, *, allow_network: "/cache/merged.pt",
+        )
+
+        with pytest.raises(kmod.KompressModelNotCached, match="ModernBERT-base"):
+            kmod._load_kompress_pytorch(kmod.HF_MODEL_ID, allow_download=False)
+
+        assert constructor_calls == [True]
+
+    def test_custom_model_keeps_legacy_safetensors_contract(
+        self,
+        monkeypatch,
+        caplog,
+    ) -> None:
+        import headroom.transforms.kompress_compressor as kmod
+
+        downloads: list[tuple[str, str, bool]] = []
+        state_dict = {"legacy.weight": object()}
+        model = _FakeKompressModel()
+        model.full_model = _FakeStateDictModule(missing=["optional.weight"])
+
+        fake_torch = ModuleType("torch")
+        fake_torch.cuda = SimpleNamespace(is_available=lambda: False)
+        fake_torch.backends = SimpleNamespace(mps=SimpleNamespace(is_available=lambda: False))
+
+        class FakeAutoTokenizer:
+            @staticmethod
+            def from_pretrained(model_name, *, local_files_only):
+                return ("tokenizer", model_name, local_files_only)
+
+        fake_transformers = ModuleType("transformers")
+        fake_transformers.AutoTokenizer = FakeAutoTokenizer
+        fake_safetensors = ModuleType("safetensors")
+        fake_safetensors.__path__ = []
+        fake_safetensors_torch = ModuleType("safetensors.torch")
+        fake_safetensors_torch.load_file = lambda path: state_dict
+
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+        monkeypatch.setitem(sys.modules, "safetensors", fake_safetensors)
+        monkeypatch.setitem(sys.modules, "safetensors.torch", fake_safetensors_torch)
+        monkeypatch.setattr(kmod, "_kompress_cache", {})
+        monkeypatch.setattr(
+            kmod,
+            "_get_model_class",
+            lambda: lambda **_kwargs: model,
+        )
+        monkeypatch.setattr(
+            kmod,
+            "hf_hub_download_local_first",
+            lambda repo_id, filename, *, allow_network: (
+                downloads.append((repo_id, filename, allow_network)) or "/cache/model.safetensors"
+            ),
+        )
+
+        with caplog.at_level(logging.WARNING, logger=kmod.logger.name):
+            loaded_model, _tokenizer, backend = kmod._load_kompress_pytorch(
+                "org/custom-kompress",
+                allow_download=False,
+            )
+
+        assert downloads == [("org/custom-kompress", "model.safetensors", False)]
+        assert model.full_model.loaded == [state_dict]
+        assert loaded_model is model
+        assert backend == "pytorch"
+        assert "continuing with partial load" in caplog.text
+
+    def test_merged_checkpoint_requires_all_sections(self) -> None:
+        import headroom.transforms.kompress_compressor as kmod
+
+        with pytest.raises(RuntimeError, match="span_conv_state_dict"):
+            kmod._load_merged_pytorch_checkpoint(
+                _FakeKompressModel(),
+                {
+                    "encoder_state_dict": {},
+                    "token_head_state_dict": {},
+                },
+                source="org/model/merged.pt",
+            )
+
+    def test_merged_checkpoint_rejects_state_dict_mismatch(self) -> None:
+        import headroom.transforms.kompress_compressor as kmod
+
+        model = _FakeKompressModel()
+        model.encoder = _FakeStateDictModule(missing=["encoder.layer.0.weight"])
+
+        with pytest.raises(RuntimeError, match="encoder state_dict mismatch"):
+            kmod._load_merged_pytorch_checkpoint(
+                model,
+                {
+                    "encoder_state_dict": {},
+                    "token_head_state_dict": {},
+                    "span_conv_state_dict": {},
+                },
+                source="org/model/merged.pt",
+            )
 
 
 # ── KompressResult ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Fixes the PyTorch Kompress fallback for the default
`chopratejas/kompress-v2-base` model. The loader previously downloaded the
unmerged PEFT `model.safetensors` and accepted its incompatible key layout with
`strict=False`, leaving the encoder at the stock ModernBERT weights.

The default v2 path now loads the canonical structured `merged.pt` artifact and
requires exact matches for the merged encoder, token head, and span-convolution
state dictionaries.

Closes #2714

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Load `merged.pt` for the pinned default Kompress v2 PyTorch model.
- Validate all three merged state-dict sections and fail loudly on architecture drift.
- Canonicalize case variants of the known model ID so artifact selection and revision pinning agree.
- Keep custom model repositories on the existing `model.safetensors` contract while surfacing partial-load mismatches.
- Make cache-only PyTorch loading pass `local_files_only=True` to the ModernBERT base model.
- Reuse the same merged-checkpoint validator in the ONNX export script.
- Add regression coverage for merged loading, missing sections, state-dict mismatch, case variants, cache-only loading, and legacy custom models.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest -q \
    tests/test_transforms/test_kompress_compressor.py \
    tests/test_kompress_failsafe.py \
    tests/test_kompress_must_keep.py \
    tests/test_kompress_request_nonblocking.py

collected 81 items
============================== 81 passed in 7.91s ==============================

$ python -m ruff check \
    headroom/transforms/kompress_compressor.py \
    scripts/export_kompress_v2_onnx.py \
    tests/test_transforms/test_kompress_compressor.py
All checks passed!

$ python -m ruff format --check \
    headroom/transforms/kompress_compressor.py \
    scripts/export_kompress_v2_onnx.py \
    tests/test_transforms/test_kompress_compressor.py
3 files already formatted
```

## Real Behavior Proof

- Environment: macOS Apple Silicon, Python 3.13.14, torch 2.13.0,
  transformers 5.14.1, CPU PyTorch backend.
- Exact command / steps: After populating the pinned model assets once, ran
  this cache-only inference command with Hugging Face and Transformers network
  access disabled:

```bash
PYTHONPATH=. \
HF_HUB_OFFLINE=1 \
TRANSFORMERS_OFFLINE=1 \
python - <<'PY'
import torch
from headroom.transforms.kompress_compressor import _load_kompress_pytorch

requested = "Chopratejas/Kompress-V2-Base"
model, tokenizer, backend = _load_kompress_pytorch(
    requested,
    device="cpu",
    allow_download=False,
)
encoded = tokenizer(
    "Headroom keeps errors and removes repetitive tool output.",
    return_tensors="pt",
)
with torch.no_grad():
    scores = model.get_scores(encoded["input_ids"], encoded["attention_mask"])
print(f"requested_model_id={requested}")
print(f"backend={backend}")
print(f"score_shape={tuple(scores.shape)}")
print(f"finite_scores={bool(torch.isfinite(scores).all())}")
PY
```

- Observed result: The real merged checkpoint loaded through the PyTorch
  backend and returned a finite score tensor for all 12 input tokens:

```text
requested_model_id=Chopratejas/Kompress-V2-Base
backend=pytorch
score_shape=(1, 12)
finite_scores=True
```

  This ran with network access disabled after the pinned real
  `merged.pt` and ModernBERT assets were populated, proving the cache-only path,
  case canonicalization, exact merged checkpoint load, and inference all work
  together. The shared ONNX export `_build_core()` path also loaded the real
  checkpoint and returned an eval-mode `HeadroomCompressorModel`.

- Not tested: CUDA or MPS execution, Windows/Linux runtime behavior, a real
  third-party custom Kompress repository, full repository test suite, or a full
  ONNX export/quantization run.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing related unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- Documentation changes are not required because this corrects the artifact
  loaded behind the existing PyTorch backend without changing its public API.
- Full mypy and full-suite pytest were not run; validation was limited to the
  directly related Kompress tests and modified-file lint/format checks.
