### PR TITLE
feat(dashboard): show origin vs compressed prompt text in Recent Requests

### DIFF
--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -75,6 +75,10 @@
         .diff-before { background: var(--diff-before-body); }
         .diff-after-header { background: var(--diff-after-header); }
         .diff-after { background: var(--diff-after-body); }
+        .diff-origin-header { background: var(--diff-before-header); }
+        .diff-origin { background: var(--diff-before-body); }
+        .diff-compressed-header { background: var(--diff-after-header); }
+        .diff-compressed { background: var(--diff-after-body); }
         .ttl-bucket-gradient-card { background: var(--ttl-card-bg); }
 
         /* Light mode: invert the gray text scale (dark bg grays → light bg grays) */
@@ -944,6 +948,35 @@
                                                         </div>
                                                     </div>
                                                 </template>
+                                                <!-- Origin vs compressed prompt text -->
+                                                <div class="mt-4">
+                                                    <div class="text-xs text-gray-500 uppercase tracking-wide mb-2">Prompt Text</div>
+                                                    <template x-if="log_full_messages && hasRequestTextContent(req)">
+                                                        <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+                                                            <div class="rounded border border-red-900/30 overflow-hidden flex flex-col max-h-52">
+                                                                <div class="diff-origin-header px-2 py-1 border-b border-red-900/30 shrink-0">
+                                                                    <span class="text-[10px] text-red-400 uppercase tracking-wide font-semibold">Origin Text</span>
+                                                                </div>
+                                                                <pre class="diff-origin p-2 font-mono text-[11px] text-gray-300 overflow-auto flex-1 whitespace-pre-wrap m-0"
+                                                                     x-text="requestOriginPreview(req)"></pre>
+                                                            </div>
+                                                            <div class="rounded border border-emerald-900/30 overflow-hidden flex flex-col max-h-52">
+                                                                <div class="diff-compressed-header px-2 py-1 border-b border-emerald-900/30 shrink-0">
+                                                                    <span class="text-[10px] text-emerald-400 uppercase tracking-wide font-semibold">Compressed Text</span>
+                                                                    <span class="text-[9px] text-emerald-500/70 normal-case ml-1">sent to LLM</span>
+                                                                </div>
+                                                                <pre class="diff-compressed p-2 font-mono text-[11px] text-gray-300 overflow-auto flex-1 whitespace-pre-wrap m-0"
+                                                                     x-text="requestCompressedPreview(req)"></pre>
+                                                            </div>
+                                                        </div>
+                                                    </template>
+                                                    <template x-if="log_full_messages && !hasRequestTextContent(req)">
+                                                        <p class="text-xs text-gray-500 italic">No message content captured for this request.</p>
+                                                    </template>
+                                                    <template x-if="!log_full_messages">
+                                                        <p class="text-xs text-gray-500 italic">Enable HEADROOM_LOG_MESSAGES=true to see origin vs compressed text.</p>
+                                                    </template>
+                                                </div>
                                             </div>
                                         </template>
                                     </div>
@@ -2009,12 +2042,77 @@
                     container.innerHTML = html;
                 },
 
+                extractMessageText(content) {
+                    if (content == null) return '';
+                    if (typeof content === 'string') return content;
+                    if (Array.isArray(content)) {
+                        const parts = [];
+                        for (const block of content) {
+                            if (typeof block === 'string') {
+                                parts.push(block);
+                            } else if (block && typeof block === 'object') {
+                                if (typeof block.text === 'string') {
+                                    parts.push(block.text);
+                                } else if (typeof block.content === 'string' || Array.isArray(block.content)) {
+                                    parts.push(this.extractMessageText(block.content));
+                                } else {
+                                    parts.push(JSON.stringify(block));
+                                }
+                            } else {
+                                parts.push(String(block));
+                            }
+                        }
+                        return parts.join('\n');
+                    }
+                    return String(content);
+                },
+
+                flattenMessages(messages) {
+                    if (!messages || !messages.length) return '';
+                    const multi = messages.length > 1;
+                    return messages.map(m => {
+                        const role = (m && m.role) ? m.role : '?';
+                        const text = this.extractMessageText(m ? m.content : null);
+                        return multi ? `[${role}] ${text}` : text;
+                    }).join('\n\n');
+                },
+
+                truncateDisplayText(text, limit = 2000) {
+                    if (!text) return '';
+                    return text.substring(0, limit) + (text.length > limit ? '\n\n[truncated]' : '');
+                },
+
+                hasRequestTextContent(req) {
+                    const originText = this.flattenMessages(req?.request_messages || []);
+                    const compressed = req?.compressed_messages;
+                    return originText.length > 0
+                        || (Array.isArray(compressed) && compressed.length > 0);
+                },
+
+                requestOriginPreview(req) {
+                    return this.truncateDisplayText(this.flattenMessages(req?.request_messages || []));
+                },
+
+                requestCompressedPreview(req) {
+                    const originText = this.flattenMessages(req?.request_messages || []);
+                    const compressedRaw = req?.compressed_messages;
+                    const hasCompressedSnapshot = Array.isArray(compressedRaw) && compressedRaw.length > 0;
+                    if (!hasCompressedSnapshot) {
+                        if (originText.length > 0) {
+                            return 'No compressed snapshot — same as origin\n\n'
+                                + this.truncateDisplayText(originText);
+                        }
+                        return '';
+                    }
+                    return this.truncateDisplayText(this.flattenMessages(compressedRaw));
+                },
+
                 renderTransformationCard(t, idx) {
                     const msgs = (t.request_messages || []).map(m => m.content || '').join('');
                     const response = t.response_content || '';
                     const hasMessages = msgs.length > 0 || response.length > 0;
-                    const before = msgs.substring(0, 2000) + (msgs.length > 2000 ? '\n\n[truncated]' : '');
-                    const after = response.substring(0, 2000) + (response.length > 2000 ? '\n\n[truncated]' : '');
+                    const before = this.truncateDisplayText(msgs);
+                    const after = this.truncateDisplayText(response);
 
                     const time = t.timestamp ? new Date(t.timestamp).toLocaleTimeString() : '--:--:--';
                     const model = (t.model || 'unknown').replace(/^(anthropic\.|openai\.)/, '').substring(0, 25);

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -3548,40 +3548,49 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         return "missing"
 
     def _build_recent_request_payload(limit: int = RECENT_REQUEST_LOG_WINDOW) -> dict[str, Any]:
-        recent_request_logs = proxy.logger.get_recent(limit) if proxy.logger else []
+        log_full_messages = bool(proxy and proxy.config.log_full_messages)
+        if proxy and proxy.logger:
+            if log_full_messages:
+                recent_request_logs = proxy.logger.get_recent_with_messages(limit)
+            else:
+                recent_request_logs = proxy.logger.get_recent(limit)
+        else:
+            recent_request_logs = []
         dashboard_recent_requests = []
         for log in reversed(recent_request_logs):
             token_accounting_status = _recent_request_token_accounting_status(log)
-            dashboard_recent_requests.append(
-                {
-                    "request_id": log.get("request_id"),
-                    "timestamp": log.get("timestamp"),
-                    "provider": resolve_display_provider(
-                        log.get("provider"),
-                        openai_api_url=proxy.config.openai_api_url,
-                        provider_name=proxy.config.provider_name,
-                    ),
-                    "model": log.get("model"),
-                    "input_tokens_original": _recent_request_optional_number(
-                        log, "input_tokens_original"
-                    ),
-                    "input_tokens_optimized": _recent_request_optional_number(
-                        log, "input_tokens_optimized"
-                    ),
-                    "output_tokens": _recent_request_optional_number(log, "output_tokens"),
-                    "tokens_saved": _recent_request_optional_number(log, "tokens_saved"),
-                    "savings_percent": _recent_request_optional_number(log, "savings_percent"),
-                    "optimization_latency_ms": _recent_request_optional_number(
-                        log, "optimization_latency_ms"
-                    ),
-                    "total_latency_ms": _recent_request_optional_number(log, "total_latency_ms"),
-                    "has_exact_tokens": token_accounting_status == "complete",
-                    "token_accounting_status": token_accounting_status,
-                    "transforms_applied": log.get("transforms_applied", []),
-                    "waste_signals": log.get("waste_signals"),
-                    "tool_schema_saved_tokens": _tool_schema_saved_from_tags(log.get("tags")),
-                }
-            )
+            entry: dict[str, Any] = {
+                "request_id": log.get("request_id"),
+                "timestamp": log.get("timestamp"),
+                "provider": resolve_display_provider(
+                    log.get("provider"),
+                    openai_api_url=proxy.config.openai_api_url,
+                    provider_name=proxy.config.provider_name,
+                ),
+                "model": log.get("model"),
+                "input_tokens_original": _recent_request_optional_number(
+                    log, "input_tokens_original"
+                ),
+                "input_tokens_optimized": _recent_request_optional_number(
+                    log, "input_tokens_optimized"
+                ),
+                "output_tokens": _recent_request_optional_number(log, "output_tokens"),
+                "tokens_saved": _recent_request_optional_number(log, "tokens_saved"),
+                "savings_percent": _recent_request_optional_number(log, "savings_percent"),
+                "optimization_latency_ms": _recent_request_optional_number(
+                    log, "optimization_latency_ms"
+                ),
+                "total_latency_ms": _recent_request_optional_number(log, "total_latency_ms"),
+                "has_exact_tokens": token_accounting_status == "complete",
+                "token_accounting_status": token_accounting_status,
+                "transforms_applied": log.get("transforms_applied", []),
+                "waste_signals": log.get("waste_signals"),
+                "tool_schema_saved_tokens": _tool_schema_saved_from_tags(log.get("tags")),
+            }
+            if log_full_messages:
+                entry["request_messages"] = log.get("request_messages")
+                entry["compressed_messages"] = log.get("compressed_messages")
+            dashboard_recent_requests.append(entry)
         dashboard_recent_requests = dashboard_recent_requests[:25]
         return {
             "request_logs": recent_request_logs[-10:],

--- a/tests/test_dashboard_live_feed_template.py
+++ b/tests/test_dashboard_live_feed_template.py
@@ -1,0 +1,36 @@
+"""Template regression tests for Recent Requests origin vs compressed text panes."""
+
+from __future__ import annotations
+
+import re
+
+from headroom.dashboard import get_dashboard_html
+
+
+def _method_body(html: str, name: str) -> str:
+    match = re.search(rf"{name}\([^)]*\) \{{(?P<body>.*?)\n\s*\}},", html, re.S)
+    assert match is not None, f"method {name} not found in dashboard template"
+    return match.group("body")
+
+
+def test_recent_requests_shows_origin_and_compressed_labels() -> None:
+    html = get_dashboard_html()
+
+    assert "Origin Text" in html
+    assert "Compressed Text" in html
+    assert "sent to LLM" in html
+    assert "requestOriginPreview(req)" in html
+    assert "requestCompressedPreview(req)" in html
+    assert "hasRequestTextContent(req)" in html
+
+
+def test_recent_request_preview_helpers_use_message_snapshots() -> None:
+    html = get_dashboard_html()
+
+    origin_body = _method_body(html, "requestOriginPreview")
+    compressed_body = _method_body(html, "requestCompressedPreview")
+
+    assert "request_messages" in origin_body
+    assert "compressed_messages" in compressed_body
+    assert "flattenMessages" in origin_body
+    assert "flattenMessages" in compressed_body

--- a/tests/test_proxy_stats_recent_requests.py
+++ b/tests/test_proxy_stats_recent_requests.py
@@ -20,6 +20,16 @@ class FakeRequestLogger:
         self._logs = value
 
     def get_recent(self, limit: int) -> list[dict[str, object]]:
+        return [
+            {
+                k: v
+                for k, v in entry.items()
+                if k not in ("request_messages", "compressed_messages", "response_content")
+            }
+            for entry in self._logs[-limit:]
+        ]
+
+    def get_recent_with_messages(self, limit: int) -> list[dict[str, object]]:
         return self._logs[-limit:]
 
 
@@ -231,3 +241,85 @@ def test_stats_preserves_default_smart_crusher_compaction_state() -> None:
 
     assert response.status_code == 200
     assert response.json()["config"]["smart_crusher_with_compaction"] is None
+
+
+def test_stats_recent_requests_includes_message_snapshots_when_logging_enabled() -> None:
+    app = create_app(
+        ProxyConfig(
+            optimize=False,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=False,
+            log_requests=False,
+            log_full_messages=True,
+            ccr_inject_tool=False,
+            ccr_handle_responses=False,
+            ccr_context_tracking=False,
+            http2=False,
+        )
+    )
+    logger = FakeRequestLogger()
+    app.state.proxy.logger = logger
+    logger.logs = [
+        FakeLogEntry(
+            {
+                "timestamp": "2026-06-11T10:00:00Z",
+                "provider": "anthropic",
+                "model": "claude-sonnet",
+                "input_tokens_original": 100,
+                "input_tokens_optimized": 60,
+                "tokens_saved": 40,
+                "savings_percent": 40.0,
+                "request_messages": [{"role": "user", "content": "original prompt"}],
+                "compressed_messages": [{"role": "user", "content": "compressed prompt"}],
+            }
+        )
+    ]
+
+    with TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 12345)) as client:
+        payload = client.get("/stats?cached=1").json()
+
+    recent = payload["recent_requests"][0]
+    assert recent["request_messages"] == [{"role": "user", "content": "original prompt"}]
+    assert recent["compressed_messages"] == [{"role": "user", "content": "compressed prompt"}]
+
+
+def test_stats_recent_requests_omits_message_snapshots_when_logging_disabled() -> None:
+    app = create_app(
+        ProxyConfig(
+            optimize=False,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=False,
+            log_requests=False,
+            log_full_messages=False,
+            ccr_inject_tool=False,
+            ccr_handle_responses=False,
+            ccr_context_tracking=False,
+            http2=False,
+        )
+    )
+    logger = FakeRequestLogger()
+    app.state.proxy.logger = logger
+    logger.logs = [
+        FakeLogEntry(
+            {
+                "timestamp": "2026-06-11T10:00:00Z",
+                "provider": "anthropic",
+                "model": "claude-sonnet",
+                "input_tokens_original": 100,
+                "input_tokens_optimized": 60,
+                "tokens_saved": 40,
+                "savings_percent": 40.0,
+                "request_messages": [{"role": "user", "content": "original prompt"}],
+                "compressed_messages": [{"role": "user", "content": "compressed prompt"}],
+            }
+        )
+    ]
+
+    with TestClient(app, base_url="http://127.0.0.1", client=("127.0.0.1", 12345)) as client:
+        payload = client.get("/stats?cached=1").json()
+
+    recent = payload["recent_requests"][0]
+    assert "request_messages" not in recent
+    assert "compressed_messages" not in recent


### PR DESCRIPTION
## Summary
- Include `request_messages` / `compressed_messages` in `/stats` `recent_requests` when `log_full_messages` is enabled (loopback-only path)
- Add Origin Text vs Compressed Text (sent to LLM) panes in expanded Recent Requests rows on the existing dashboard
- Add template + stats regression tests for the new UI and payload gating

## Test plan
- [ ] Start proxy with `headroom proxy --log-messages`
- [ ] Send traffic that triggers compression
- [ ] Open `/dashboard`, expand a Recent Requests row
- [ ] Confirm left pane shows origin prompt text and right pane shows compressed text sent upstream (not the model response)
- [ ] Confirm without `--log-messages` the expanded row shows the enable-logging hint and omits message snapshots from `/stats`
- [ ] Run `pytest tests/test_dashboard_live_feed_template.py tests/test_proxy_stats_recent_requests.py`