### PR TITLE
fix(proxy): read model-router env vars on the CLI entrypoints

### DIFF
--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -14,6 +14,7 @@ from headroom.providers.registry import (
     resolve_api_targets,
     resolve_extra_headers,
 )
+from headroom.proxy.model_router import ModelRouterConfig
 from headroom.proxy.modes import PROXY_MODE_CACHE, normalize_proxy_mode
 
 from .main import main
@@ -1194,6 +1195,13 @@ def proxy(
         else frozenset(),
         tool_profiles=_parse_tool_profiles([]) or None,
         smart_crusher_with_compaction=_get_env_bool_optional("HEADROOM_SMART_CRUSHER_COMPACTION"),
+        # Cost-aware model routing (#1706) is configured purely by env, and this
+        # is the entrypoint `headroom proxy` uses, so it has to read it here —
+        # `_proxy_config_from_env()` only runs on the multi-worker/factory path.
+        model_router=ModelRouterConfig.from_env(
+            os.environ.get("HEADROOM_MODEL_ROUTER_ENABLED"),
+            os.environ.get("HEADROOM_MODEL_ROUTES"),
+        ),
         savings_profile=os.environ.get("HEADROOM_SAVINGS_PROFILE") or "coding",
         target_ratio=target_ratio,
         compress_system_messages=_get_env_bool_optional("HEADROOM_COMPRESS_SYSTEM_MESSAGES"),

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -806,8 +806,18 @@ class HeadroomProxy(
         self.metrics = PrometheusMetrics(cost_tracker=self.cost_tracker, stateless=config.stateless)
 
         # Cost-aware model routing (issue #1706). Disabled unless configured, so
-        # the default request path is unchanged.
+        # the default request path is unchanged. Logged once at startup: routing
+        # is invisible when off (no per-request decision line is emitted), so an
+        # entrypoint that never wired the config, or a rule set that failed to
+        # parse, would otherwise show up only as an unexplained bill.
         self.model_router = ModelRouter(config.model_router)
+        if self.model_router.enabled:
+            logger.info(
+                "model router: enabled, %d rule(s)",
+                len(config.model_router.routes) if config.model_router else 0,
+            )
+        else:
+            logger.info("model router: disabled")
 
         # Initialize transforms based on routing mode.
         #
@@ -5621,6 +5631,12 @@ if __name__ == "__main__":
             _get_env_bool("HEADROOM_SMART_CRUSHER_COMPACTION", False)
             if "HEADROOM_SMART_CRUSHER_COMPACTION" in os.environ
             else None
+        ),
+        # Cost-aware model routing (#1706): env-only config, so every entrypoint
+        # that builds its own ProxyConfig has to read it (see also cli/proxy.py).
+        model_router=ModelRouterConfig.from_env(
+            os.environ.get("HEADROOM_MODEL_ROUTER_ENABLED"),
+            os.environ.get("HEADROOM_MODEL_ROUTES"),
         ),
         cache_enabled=cache_enabled,
         cache_ttl_seconds=_get_env_int("HEADROOM_CACHE_TTL", args.cache_ttl),

--- a/tests/test_proxy/test_model_router_wiring.py
+++ b/tests/test_proxy/test_model_router_wiring.py
@@ -2,6 +2,11 @@
 
 Covers env -> ProxyConfig, ProxyConfig -> live proxy, and the presence of the
 routing block in the Anthropic request handler.
+
+The env -> ProxyConfig half is checked once per entrypoint that builds its own
+ProxyConfig, not just via ``_proxy_config_from_env``: that helper only runs on
+the factory/multi-worker path, so testing it alone let #2764 through — the
+router was unreachable from ``headroom proxy``, the documented way to run it.
 """
 
 from __future__ import annotations
@@ -9,15 +14,24 @@ from __future__ import annotations
 import inspect
 import json
 import logging
-from unittest.mock import AsyncMock, MagicMock
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from click.testing import CliRunner
 from fastapi.testclient import TestClient
 
+from headroom.cli.main import main
 from headroom.proxy.handlers.anthropic import AnthropicHandlerMixin
 from headroom.proxy.model_router import ModelRoute, ModelRouter, ModelRouterConfig
 from headroom.proxy.server import ProxyConfig, _proxy_config_from_env, create_app
+
+ROUTES_JSON = (
+    '[{"name":"small","max_input_tokens":4000,"require_no_tools":true,'
+    '"to_model":"claude-haiku-4-5"}]'
+)
 
 MESSAGES = "/v1/messages"
 
@@ -89,6 +103,46 @@ def test_proxy_config_from_env_router_disabled_by_default(monkeypatch) -> None:
     assert not config.model_router.enabled
 
 
+def _cli_config(env: dict[str, str]) -> ProxyConfig:
+    """Build the ProxyConfig `headroom proxy` would run with, without serving."""
+    captured: dict = {}
+
+    def mock_run_server(config, **kwargs):
+        captured["config"] = config
+
+    with patch("headroom.proxy.server.run_server", mock_run_server):
+        result = CliRunner().invoke(main, ["proxy"], env=env, catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    return captured["config"]
+
+
+def test_cli_proxy_reads_router_from_env() -> None:
+    # Regression for #2764: the click CLI built its own ProxyConfig and never
+    # passed model_router, so both env vars were silently ignored on the
+    # single-worker path -- with no log line, the only symptom was the bill.
+    config = _cli_config(
+        {"HEADROOM_MODEL_ROUTER_ENABLED": "1", "HEADROOM_MODEL_ROUTES": ROUTES_JSON}
+    )
+    assert config.model_router is not None
+    assert config.model_router.enabled
+    assert config.model_router.routes[0].to_model == "claude-haiku-4-5"
+
+
+def test_cli_proxy_router_disabled_by_default() -> None:
+    config = _cli_config({})
+    assert config.model_router is not None
+    assert not config.model_router.enabled
+
+
+def test_cli_proxy_router_disabled_on_malformed_routes() -> None:
+    # from_env fails open to disabled; the CLI must not turn that into a crash.
+    config = _cli_config(
+        {"HEADROOM_MODEL_ROUTER_ENABLED": "1", "HEADROOM_MODEL_ROUTES": "{not json"}
+    )
+    assert config.model_router is not None
+    assert not config.model_router.enabled
+
+
 def test_create_app_wires_model_router() -> None:
     config = ProxyConfig(
         optimize=False,
@@ -116,6 +170,55 @@ def test_create_app_router_disabled_when_unset() -> None:
     app = create_app(ProxyConfig(optimize=False, cost_tracking_enabled=False))
     with TestClient(app) as client:
         assert not client.app.state.proxy.model_router.enabled
+
+
+@contextmanager
+def _captured_proxy_logs() -> Iterator[list[str]]:
+    """Collect ``headroom.proxy`` records.
+
+    Not ``caplog``: ``create_app`` reconfigures logging while it runs, which
+    drops pytest's root handler mid-call, so a record emitted during app
+    construction never reaches it. A handler attached to the logger itself
+    survives that.
+    """
+    messages: list[str] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            messages.append(record.getMessage())
+
+    logger = logging.getLogger("headroom.proxy")
+    handler = _Collector()
+    previous_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    try:
+        yield messages
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+
+def test_router_state_is_logged_at_startup() -> None:
+    # Routing emits nothing when off, so without this line an unwired entrypoint
+    # (#2764) or a rule set that failed to parse looks identical to "no traffic
+    # matched a rule".
+    with _captured_proxy_logs() as messages:
+        create_app(
+            ProxyConfig(
+                optimize=False,
+                cost_tracking_enabled=False,
+                model_router=ModelRouterConfig(
+                    enabled=True,
+                    routes=(ModelRoute(to_model="cheap", max_input_tokens=10_000, name="small"),),
+                ),
+            )
+        )
+    assert "model router: enabled, 1 rule(s)" in messages
+
+    with _captured_proxy_logs() as messages:
+        create_app(ProxyConfig(optimize=False, cost_tracking_enabled=False))
+    assert "model router: disabled" in messages
 
 
 def test_handler_delegates_to_maybe_route_model() -> None:


### PR DESCRIPTION
## Description

`HEADROOM_MODEL_ROUTER_ENABLED` and `HEADROOM_MODEL_ROUTES` are only consumed by
`_proxy_config_from_env()`, which `run_server()` reaches only on the multi-worker branch
(`workers > 1` swaps in the `create_app_from_env` factory). Both entrypoints that build
their own `ProxyConfig` — the click `headroom proxy` command and the argparse server main —
omitted `model_router` entirely, so cost-aware routing (#1706) is unreachable from the
documented way to run the proxy.

Nothing surfaces the misconfiguration: with the router absent no decision line is logged and
`/stats` carries no router config, so setting both variables looks identical to "no traffic
matched a rule". The only remaining path to the feature is `--workers > 1`, which the
codebase itself warns against for cache-sensitive deployments (per-process prefix tracker,
CCR retrieval busts, partial `/stats` per worker).

Closes #2764

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cli/proxy.py`: build `model_router` from `ModelRouterConfig.from_env(...)`, the
  same call the factory path uses. Matches how the surrounding env-only options are already
  read in that `ProxyConfig(...)` (`HEADROOM_COMPRESS_USER_MESSAGES`, `HEADROOM_MIN_TOKENS`, …).
- `headroom/proxy/server.py` (argparse main): same wiring — this entrypoint was missing it too.
- `HeadroomProxy.__init__`: log the resolved state once, `model router: enabled, N rule(s)`
  or `model router: disabled`, so a future entrypoint that forgets to wire it — or a rule set
  that failed to parse — is visible at startup rather than only in the bill.
- `tests/test_proxy/test_model_router_wiring.py`: cover the CLI entrypoint, not just
  `_proxy_config_from_env`.

`from_env` keeps failing open to disabled on malformed JSON; no behaviour changes when the
env vars are unset.

I wired the two call sites rather than defaulting the `ProxyConfig.model_router` field from
env, to keep the change in the shape those functions already use and avoid giving a dataclass
an implicit environment dependency. Happy to switch to the field-default form if you'd prefer
one place every future entrypoint inherits — say the word and I'll push that instead.

## Testing

- [ ] Unit tests pass (`pytest`) — see note below: the full suite has pre-existing failures on `main`
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

Four new tests, all of which fail on the unpatched tree:

- `test_cli_proxy_reads_router_from_env` — CLI config has the router enabled, rule parsed
- `test_cli_proxy_router_disabled_by_default` — no env, disabled
- `test_cli_proxy_router_disabled_on_malformed_routes` — fails open, does not crash
- `test_router_state_is_logged_at_startup` — both log states

The log test attaches a handler to the `headroom.proxy` logger instead of using `caplog`:
`create_app` reconfigures logging while it runs and drops pytest's root handler mid-call, so
a record emitted during app construction never reaches `caplog`.

### Test Output

```text
# targeted suite, with the fix
$ uv run pytest tests/test_proxy/test_model_router_wiring.py -q
17 passed, 1 warning in 2.31s

# same file, with the two source changes stashed (the four new tests are the regression)
FAILED tests/test_proxy/test_model_router_wiring.py::test_cli_proxy_reads_router_from_env
FAILED tests/test_proxy/test_model_router_wiring.py::test_cli_proxy_router_disabled_by_default
FAILED tests/test_proxy/test_model_router_wiring.py::test_cli_proxy_router_disabled_on_malformed_routes
FAILED tests/test_proxy/test_model_router_wiring.py::test_router_state_is_logged_at_startup
4 failed, 13 passed, 1 warning in 2.12s

$ uv run --with ruff ruff check .
All checks passed!

$ uv run mypy headroom/cli/proxy.py headroom/proxy/server.py
Success: no issues found in 2 source files

# full suite (tests/test_memory_eval.py excluded: needs litellm, not in dev+proxy extras)
$ uv run pytest tests/ -q --ignore=tests/test_memory_eval.py
38 failed, 9794 passed, 538 skipped, 5913 warnings, 2 errors in 601.28s
```

On the full-suite failures: re-running just that failed set with my two source changes
stashed still fails 35 of the 38 on an otherwise clean `origin/main`, and the handful that
flip between runs are the live/network ones (`*_live*`, the langchain live errors) — the same
set fails with and without this patch, so they are pre-existing and flaky rather than
introduced here. Nothing in the failing set touches the model router or CLI config.

## Real Behavior Proof

- Environment: macOS 15 (Darwin 25.6.0), Python 3.14.6, `headroom-ai` installed with pipx
  from `main` at `0cb72f45`, `--mode cache` (default), upstream an Anthropic-compatible
  endpoint on loopback.

- Exact command / steps: same rules and same request on every run.

  ```json
  [{"name":"trivial-opus->haiku","from_models":["claude-opus-4-8"],
    "max_input_tokens":4096,"require_no_tools":true,"to_model":"claude-haiku-4-5"}]
  ```

  ```json
  {"model":"claude-opus-4-8","max_tokens":12,
   "messages":[{"role":"user","content":"Reply with the single word OK."}]}
  ```

  1. Before the patch, the documented entrypoint:
     `HEADROOM_MODEL_ROUTER_ENABLED=1 HEADROOM_MODEL_ROUTES="$ROUTES" headroom proxy --host 127.0.0.1 --port 8787`
  2. Before the patch, the factory (control, to prove the router itself works):
     `HEADROOM_MODEL_ROUTER_ENABLED=1 HEADROOM_MODEL_ROUTES="$ROUTES" python -m uvicorn headroom.proxy.server:create_app_from_env --factory --host 127.0.0.1 --port 8788`
  3. After the patch, step 1 again.

- Observed result: before the patch the documented entrypoint did not route at all (response
  `model` came back `claude-opus-4-8`, nothing logged), while the factory path routed the
  identical request to `claude-haiku-4-5`; after the patch the CLI entrypoint routes to
  `claude-haiku-4-5` too and logs `model router: enabled, 1 rule(s)` at startup. Per step:
  1. Response `model` was `claude-opus-4-8` — not routed. `/stats` showed
     `"router": {"route_counts": {}}` and no `model_router` under `config`. No routing line
     anywhere in the proxy log.
  2. Response `model` was `claude-haiku-4-5` — routed. In the same run a request carrying
     `tools` stayed on `claude-opus-4-8`, and a `claude-sonnet-5` source model was left
     alone, so `require_no_tools` and `from_models` behave as documented.
  3. Response `model` was `claude-haiku-4-5`, matching the factory path, and startup logged
     `model router: enabled, 1 rule(s)`. With the env vars unset it logs
     `model router: disabled` and the request is untouched.

- Not tested: the OpenAI/Gemini/Bedrock paths (routing is Anthropic-only today, and
  #2354 is extending that separately); Windows and Linux supervised runners; multi-worker
  startup, which already worked and is unchanged.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A, the documented env vars
      were already correct; this makes them work on the documented entrypoint
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — untouched, as is `uv.lock`

## Additional Notes

- No dependency changes. `uv.lock` deliberately left unmodified.
- Prior art for the same class of bug: #948, where `HEADROOM_EXCLUDE_TOOLS` was parsed in
  `server.py` but never passed by `cli/proxy.py`'s `ProxyConfig(...)`. That is the argument
  for the field-default variant mentioned above, if you want to stop this recurring.
- The missing `max_tokens` condition on `ModelRoute` that I hit while testing this is filed
  separately as #2765 and is not part of this PR.
- Two open PRs extend the same env surface and inherit this path: #2395 (shadow mode) and
  #2354 (OpenAI paths). Shadow mode is affected most directly, since its whole purpose is
  observing decisions that on the CLI entrypoint were never made.
