### PR TITLE
fix(copilot): add --native mode for Enterprise claude-sonnet-5

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -32,7 +32,7 @@ import subprocess
 import sys
 import time
 import urllib.parse
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, cast
 
@@ -3000,6 +3000,40 @@ def _normalize_proxy_api_url(url: object) -> str | None:
     return normalized or None
 
 
+def _proxy_anthropic_upstream_mismatch(
+    running_config: dict[str, object], requested: str | None
+) -> bool:
+    """True when a running proxy's Anthropic upstream differs from what we want.
+
+    ``anthropic_api_url`` defaults to ``None`` on the proxy, so "not reported"
+    means "using the default upstream" — which is why a plain ``wrap claude``
+    reusing a plain proxy still matches and is not needlessly restarted.
+    """
+    running = _normalize_proxy_api_url(running_config.get("anthropic_api_url"))
+    if running is None:
+        return False
+    return running != _normalize_proxy_api_url(requested) if requested else True
+
+
+def _build_copilot_native_launch_env(
+    *,
+    port: int,
+    environ: dict[str, str] | None = None,
+    project: str | None = None,
+) -> tuple[dict[str, str], list[str]]:
+    """Launch env for native (non-BYOK) Copilot routing through the proxy."""
+    from headroom.providers.copilot.wrap import build_native_launch_env
+
+    return build_native_launch_env(port=port, environ=environ, project=project)
+
+
+def _native_api_url_supported(*, environ: Mapping[str, str] | None = None) -> bool | None:
+    """Whether the installed Copilot CLI honours ``COPILOT_API_URL`` (None=unknown)."""
+    from headroom.providers.copilot.wrap import native_api_url_supported
+
+    return native_api_url_supported(environ=environ)
+
+
 def _proxy_version(payload: dict[str, Any] | None) -> str | None:
     """Return the running proxy version when it exposes one."""
     if payload is None:
@@ -3513,6 +3547,12 @@ def _ensure_proxy(
                         requested_openai_url = _normalize_proxy_api_url(openai_api_url)
                         if running_openai_url != requested_openai_url:
                             missing.append("openai-api-url")
+                    # Compared even when the caller wants the DEFAULT upstream
+                    # (anthropic_api_url is None). `wrap copilot --native` pins
+                    # Anthropic at the Copilot host; reusing that for
+                    # `wrap claude` would send Claude traffic to Copilot.
+                    if _proxy_anthropic_upstream_mismatch(running_config, anthropic_api_url):
+                        missing.append("anthropic-api-url")
                     if not missing:
                         click.echo(f"  Proxy already running on port {port}")
                         click.echo(f"  Dashboard:    http://127.0.0.1:{port}/dashboard")
@@ -3532,6 +3572,7 @@ def _ensure_proxy(
                             learn,
                             code_graph,
                             openai_api_url,
+                            anthropic_api_url,
                             copilot_subscription_seed_requested,
                         )
                     ):
@@ -3577,6 +3618,8 @@ def _ensure_proxy(
                         requested_openai_url = _normalize_proxy_api_url(openai_api_url)
                         if running_openai_url != requested_openai_url:
                             missing.append("openai-api-url")
+                    if _proxy_anthropic_upstream_mismatch(running_config, anthropic_api_url):
+                        missing.append("anthropic-api-url")
 
                     if missing:
                         flags_str = ", ".join(f"--{f}" for f in missing)
@@ -3665,13 +3708,18 @@ def _ensure_proxy(
                     and running_config.get("savings_profile") != expected_savings_profile
                 ):
                     missing.append("savings-profile")
-                if openai_api_url:
-                    running_openai_url = _normalize_proxy_api_url(
-                        running_config.get("openai_api_url")
-                    )
-                    requested_openai_url = _normalize_proxy_api_url(openai_api_url)
-                    if running_openai_url != requested_openai_url:
-                        missing.append("openai-api-url")
+                # Compared even when the caller wants the DEFAULT upstream
+                # (`*_api_url is None`). After `wrap copilot --native` (both
+                # upstreams pinned at Copilot), a later `wrap claude` must not
+                # silently reuse that proxy.
+                for _label, _key, _requested in (
+                    ("openai-api-url", "openai_api_url", openai_api_url),
+                    ("anthropic-api-url", "anthropic_api_url", anthropic_api_url),
+                ):
+                    if _normalize_proxy_api_url(
+                        running_config.get(_key)
+                    ) != _normalize_proxy_api_url(_requested):
+                        missing.append(_label)
                 if vertex_api_url or clear_vertex_api_url:
                     running_vertex_url = _normalize_proxy_api_url(
                         running_config.get("vertex_api_url")
@@ -3684,11 +3732,25 @@ def _ensure_proxy(
                     flags_str = ", ".join(
                         f if f.startswith("--") else f"--{f.replace('_', '-')}" for f in missing
                     )
+                    # Upstream mismatches cannot be shared safely: that would send
+                    # this session's traffic to a different vendor. Isolate instead
+                    # of reusing or disrupting attached wrappers.
+                    upstream_conflict = [flag for flag in missing if flag.endswith("-api-url")]
                     other_wrappers = helpers._live_proxy_clients(port, exclude_self=True)
-                    if other_wrappers:
-                        # Another wrapper is attached to this proxy; restarting it
-                        # to add flags would drop their in-flight requests. Reuse
-                        # the running proxy as-is rather than disrupt them.
+                    if upstream_conflict and other_wrappers:
+                        click.echo(
+                            f"  Proxy on port {port} is pinned to a different upstream "
+                            f"({', '.join(upstream_conflict)}) and {len(other_wrappers)} "
+                            "other wrapper(s) are attached."
+                        )
+                        click.echo(
+                            "  Starting a dedicated proxy for this session rather than "
+                            "sharing it or disrupting them."
+                        )
+                        isolated_copilot_subscription_proxy = True
+                    elif other_wrappers:
+                        # A genuinely missing *feature* is safe to live without;
+                        # restarting would drop other sessions' in-flight requests.
                         click.echo(
                             f"  Proxy on port {port} is missing: {flags_str}, but "
                             f"{len(other_wrappers)} other wrapper(s) are attached."
@@ -3725,7 +3787,7 @@ def _ensure_proxy(
                             )
                             return None, port
 
-            if not needs_restart:
+            if not needs_restart and not isolated_copilot_subscription_proxy:
                 click.echo(f"  Proxy already running on port {port}")
                 click.echo(f"  Dashboard:    http://127.0.0.1:{port}/dashboard")
                 return None, port
@@ -3995,6 +4057,7 @@ def _launch_tool(
     anyllm_provider: str | None = None,
     region: str | None = None,
     openai_api_url: str | None = None,
+    anthropic_api_url: str | None = None,
     copilot_api_token: str | None = None,
     copilot_refresh_oauth_token: str | None = None,
     copilot_api_token_expires_at: float | None = None,
@@ -4031,6 +4094,7 @@ def _launch_tool(
             anyllm_provider=anyllm_provider,
             region=region,
             openai_api_url=openai_api_url,
+            anthropic_api_url=anthropic_api_url,
             copilot_api_token=copilot_api_token,
             copilot_refresh_oauth_token=copilot_refresh_oauth_token,
             copilot_api_token_expires_at=copilot_api_token_expires_at,
@@ -4926,6 +4990,16 @@ def _require_copilot_subscription_resolution() -> CopilotSubscriptionTokenResolu
     ),
 )
 @click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option(
+    "--native",
+    is_flag=True,
+    help=(
+        "Experimental: route Copilot's own GitHub-authenticated API through Headroom "
+        "instead of using the BYOK provider override. Keeps Copilot's native model "
+        "routing (needed for Enterprise aliases like claude-sonnet-5). Implies "
+        "--subscription; no --model required."
+    ),
+)
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
 @click.argument("copilot_args", nargs=-1, type=click.UNPROCESSED)
 def copilot(
@@ -4938,6 +5012,7 @@ def copilot(
     wire_api: str | None,
     subscription: bool,
     memory: bool,
+    native: bool,
     verbose: bool,
     copilot_args: tuple[str, ...],
 ) -> None:
@@ -4955,10 +5030,11 @@ def copilot(
         headroom wrap copilot --backend anyllm --anyllm-provider groq -- --model gpt-4o
         headroom wrap copilot --provider-type openai --wire-api responses -- --model gpt-5.4
         headroom wrap copilot --subscription -- --model gpt-4.1
+        headroom wrap copilot --native -- --model claude-sonnet-5
 
     \b
-    Copilot hosted API (--subscription and the implicit OAuth path) routes to the
-    generic host https://api.githubcopilot.com, which serves the full model set.
+    Copilot hosted API (--subscription, --native, and the implicit OAuth path) routes
+    to the generic host https://api.githubcopilot.com, which serves the full model set.
     Enterprise / data-residency accounts provisioned on a dedicated host pin it
     explicitly with GITHUB_COPILOT_API_URL (the override flows through to upstream).
     See TESTING-copilot-subscription.md for details.
@@ -4981,6 +5057,27 @@ def copilot(
                 f"Stop it or rerun with --backend {running_backend}."
             )
         effective_backend = running_backend or effective_backend
+
+    # --native replaces BYOK interposition rather than layering on it.
+    if native:
+        subscription = True
+        if provider_type == "anthropic":
+            raise click.ClickException(
+                "--native routes Copilot's own API through Headroom and does not use the "
+                "BYOK provider override; do not combine it with --provider-type anthropic."
+            )
+        if wire_api is not None:
+            raise click.ClickException(
+                "--wire-api pins one BYOK wire API for the whole session, which is exactly "
+                "what --native avoids: the wire is chosen per request from the model. "
+                "Drop --wire-api."
+            )
+        if no_proxy:
+            raise click.ClickException(
+                "--native cannot be combined with --no-proxy: it needs to start a proxy "
+                "whose Anthropic and OpenAI upstreams both point at the Copilot host, and "
+                "an already-running proxy cannot be repointed at runtime."
+            )
 
     effective_provider_type = _resolve_copilot_provider_type(effective_backend, provider_type)
     if subscription:
@@ -5009,6 +5106,9 @@ def copilot(
     copilot_api_token_expires_at: float | None = None
     client_bearer: str | None = None
     subscription_resolution: CopilotSubscriptionTokenResolution | None = None
+    # Only set in --native mode: the native CLI sends Claude traffic on the
+    # Anthropic wire, so the proxy's Anthropic upstream must point at Copilot too.
+    copilot_native_anthropic_url: str | None = None
     if _should_use_copilot_oauth(
         backend=effective_backend,
         provider_type=provider_type,
@@ -5027,71 +5127,115 @@ def copilot(
                 "GITHUB_COPILOT_TOKEN / GITHUB_COPILOT_GITHUB_TOKEN."
             )
 
-        selected_model = _copilot_model_from_args(copilot_args, env)
-
-        # ``--model auto`` is a Copilot-internal routing token that the BYOK
-        # API rejects with ``400 The requested model is not supported``.  In
-        # subscription/OAuth mode we route to the real Copilot hosted API, so
-        # Copilot's own native auto-selection works fine — we just need to
-        # strip the ``--model auto`` flag before launch so Copilot doesn't
-        # forward it to the provider endpoint.
-        if _is_auto_model(selected_model):
-            copilot_args = _strip_auto_model_args(copilot_args)
-            selected_model = None
-            click.echo(
-                "  Note: '--model auto' is not forwarded to the Copilot API "
-                "(it would cause a 400). Removed it; Copilot will use its own "
-                "automatic model selection."
+        if native:
+            openai_api_url = (
+                subscription_resolution.api_url
+                if subscription_resolution is not None
+                else resolve_copilot_api_url(client_bearer)
             )
+            env, env_vars_display = _build_copilot_native_launch_env(
+                port=port,
+                environ=env,
+                project=_project_name_from_cwd(),
+            )
+            # Native CLI drives BOTH wires off one base URL: Claude over
+            # /v1/messages and OpenAI over /responses or /chat/completions.
+            env["GITHUB_COPILOT_API_URL"] = openai_api_url
+            env["OPENAI_TARGET_API_URL"] = openai_api_url
+            env["ANTHROPIC_TARGET_API_URL"] = openai_api_url
+            copilot_native_anthropic_url = openai_api_url
+            copilot_proxy_token = client_bearer
+            if subscription_resolution is not None:
+                copilot_refresh_oauth_token = subscription_resolution.refresh_oauth_token
+                copilot_api_token_expires_at = subscription_resolution.api_token_expires_at
+            env_vars_display.append(f"COPILOT_UPSTREAM={openai_api_url}")
 
-        effective_wire_api = wire_api or (
-            _copilot_default_wire_api_for_model(selected_model) if subscription else "completions"
-        )
-        env["COPILOT_PROVIDER_TYPE"] = "openai"
-        # Per-project savings: the Copilot CLI cannot send custom headers, so
-        # the project rides as a /p/<name> base-URL prefix the proxy strips.
-        env["COPILOT_PROVIDER_BASE_URL"] = _with_project_prefix(
-            f"http://127.0.0.1:{port}/v1", _project_name_from_cwd()
-        )
-        env["COPILOT_PROVIDER_WIRE_API"] = effective_wire_api
-        env["COPILOT_PROVIDER_BEARER_TOKEN"] = client_bearer
-        env["GITHUB_COPILOT_USE_TOKEN_EXCHANGE"] = "false"
-        env.pop("COPILOT_PROVIDER_API_KEY", None)
-        # Hand the exact token we resolved (and, for --subscription, validated
-        # against GitHub) to the proxy explicitly via copilot_proxy_token below.
-        # The proxy pins it as GITHUB_COPILOT_API_TOKEN, so upstream auth is
-        # deterministic instead of the proxy re-running unvalidated discovery
-        # (read_cached_oauth_token returns the *first* candidate, which may not
-        # be the one the wrapper approved → environment-dependent 401s). Passing
-        # it as a launch argument — rather than mutating this process's global
-        # os.environ — keeps the token off shared state and out of unrelated
-        # code paths.
-        copilot_proxy_token = client_bearer
-        if subscription_resolution is not None:
-            copilot_refresh_oauth_token = subscription_resolution.refresh_oauth_token
-            copilot_api_token_expires_at = subscription_resolution.api_token_expires_at
-        env_vars_display = [
-            "COPILOT_PROVIDER_TYPE=openai",
-            f"COPILOT_PROVIDER_BASE_URL={env['COPILOT_PROVIDER_BASE_URL']}",
-            f"COPILOT_PROVIDER_WIRE_API={effective_wire_api}",
-            (
-                "COPILOT_AUTH_MODE=github-subscription-experimental"
+            support = _native_api_url_supported(environ=os.environ)
+            if support is False:
+                click.echo(
+                    "  Warning: this Copilot CLI build does not appear to honour "
+                    "COPILOT_API_URL. If that is right, the CLI will bypass Headroom "
+                    "entirely and you will silently get no compression. Check the "
+                    f"dashboard at http://127.0.0.1:{port}/dashboard shows traffic; if "
+                    "it does not, re-run without --native to use BYOK mode."
+                )
+            elif support is None and verbose:
+                click.echo(
+                    "  Note: could not verify COPILOT_API_URL support in the installed CLI "
+                    "(it is undocumented). Proceeding; check the dashboard shows traffic."
+                )
+            click.echo(
+                "  Native mode: Copilot keeps its own model routing, so aliases like "
+                "claude-sonnet-5 work on Enterprise/Business tenants and --model is optional."
+            )
+        else:
+            selected_model = _copilot_model_from_args(copilot_args, env)
+
+            # ``--model auto`` is a Copilot-internal routing token that the BYOK
+            # API rejects with ``400 The requested model is not supported``.  In
+            # subscription/OAuth mode we route to the real Copilot hosted API, so
+            # Copilot's own native auto-selection works fine — we just need to
+            # strip the ``--model auto`` flag before launch so Copilot doesn't
+            # forward it to the provider endpoint.
+            if _is_auto_model(selected_model):
+                copilot_args = _strip_auto_model_args(copilot_args)
+                selected_model = None
+                click.echo(
+                    "  Note: '--model auto' is not forwarded to the Copilot API "
+                    "(it would cause a 400). Removed it; Copilot will use its own "
+                    "automatic model selection."
+                )
+
+            effective_wire_api = wire_api or (
+                _copilot_default_wire_api_for_model(selected_model)
                 if subscription
-                else "COPILOT_AUTH_MODE=github-oauth"
-            ),
-        ]
-        # Non-subscription OAuth keeps upstream's generic-host policy from
-        # #610. Subscription mode can use the endpoint returned by the Copilot
-        # token exchange, which is how Business accounts advertise their API
-        # host without requiring users to configure it manually.
-        openai_api_url = (
-            subscription_resolution.api_url
-            if subscription_resolution is not None
-            else resolve_copilot_api_url(client_bearer)
-        )
-        env["GITHUB_COPILOT_API_URL"] = openai_api_url
-        env["OPENAI_TARGET_API_URL"] = openai_api_url
-        env_vars_display.append(f"COPILOT_PROVIDER_API_URL={openai_api_url}")
+                else "completions"
+            )
+            env["COPILOT_PROVIDER_TYPE"] = "openai"
+            # Per-project savings: the Copilot CLI cannot send custom headers, so
+            # the project rides as a /p/<name> base-URL prefix the proxy strips.
+            env["COPILOT_PROVIDER_BASE_URL"] = _with_project_prefix(
+                f"http://127.0.0.1:{port}/v1", _project_name_from_cwd()
+            )
+            env["COPILOT_PROVIDER_WIRE_API"] = effective_wire_api
+            env["COPILOT_PROVIDER_BEARER_TOKEN"] = client_bearer
+            env["GITHUB_COPILOT_USE_TOKEN_EXCHANGE"] = "false"
+            env.pop("COPILOT_PROVIDER_API_KEY", None)
+            # Hand the exact token we resolved (and, for --subscription, validated
+            # against GitHub) to the proxy explicitly via copilot_proxy_token below.
+            # The proxy pins it as GITHUB_COPILOT_API_TOKEN, so upstream auth is
+            # deterministic instead of the proxy re-running unvalidated discovery
+            # (read_cached_oauth_token returns the *first* candidate, which may not
+            # be the one the wrapper approved → environment-dependent 401s). Passing
+            # it as a launch argument — rather than mutating this process's global
+            # os.environ — keeps the token off shared state and out of unrelated
+            # code paths.
+            copilot_proxy_token = client_bearer
+            if subscription_resolution is not None:
+                copilot_refresh_oauth_token = subscription_resolution.refresh_oauth_token
+                copilot_api_token_expires_at = subscription_resolution.api_token_expires_at
+            env_vars_display = [
+                "COPILOT_PROVIDER_TYPE=openai",
+                f"COPILOT_PROVIDER_BASE_URL={env['COPILOT_PROVIDER_BASE_URL']}",
+                f"COPILOT_PROVIDER_WIRE_API={effective_wire_api}",
+                (
+                    "COPILOT_AUTH_MODE=github-subscription-experimental"
+                    if subscription
+                    else "COPILOT_AUTH_MODE=github-oauth"
+                ),
+            ]
+            # Non-subscription OAuth keeps upstream's generic-host policy from
+            # #610. Subscription mode can use the endpoint returned by the Copilot
+            # token exchange, which is how Business accounts advertise their API
+            # host without requiring users to configure it manually.
+            openai_api_url = (
+                subscription_resolution.api_url
+                if subscription_resolution is not None
+                else resolve_copilot_api_url(client_bearer)
+            )
+            env["GITHUB_COPILOT_API_URL"] = openai_api_url
+            env["OPENAI_TARGET_API_URL"] = openai_api_url
+            env_vars_display.append(f"COPILOT_PROVIDER_API_URL={openai_api_url}")
     else:
         env, env_vars_display = _build_copilot_launch_env(
             port=port,
@@ -5151,6 +5295,9 @@ def copilot(
         anyllm_provider=anyllm_provider,
         region=region,
         openai_api_url=openai_api_url,
+        # None outside --native, so the BYOK path keeps the proxy's default
+        # Anthropic upstream and stays byte-identical to before.
+        anthropic_api_url=copilot_native_anthropic_url,
         copilot_api_token=copilot_proxy_token,
         copilot_refresh_oauth_token=copilot_refresh_oauth_token,
         copilot_api_token_expires_at=copilot_api_token_expires_at,

--- a/headroom/providers/copilot/__init__.py
+++ b/headroom/providers/copilot/__init__.py
@@ -8,13 +8,17 @@ from .vscode import (
     vscode_user_dir,
 )
 from .wrap import (
+    COPILOT_BYOK_ENV_VARS,
+    COPILOT_NATIVE_API_URL_ENV,
     build_launch_env,
+    build_native_launch_env,
     copilot_model_from_args,
     default_wire_api_for_model,
     detect_running_proxy_backend,
     is_auto_model,
     model_configured,
     model_prefers_responses_api,
+    native_api_url_supported,
     provider_key_source,
     query_proxy_config,
     resolve_provider_type,
@@ -23,13 +27,17 @@ from .wrap import (
 )
 
 __all__ = [
+    "COPILOT_BYOK_ENV_VARS",
+    "COPILOT_NATIVE_API_URL_ENV",
     "build_launch_env",
+    "build_native_launch_env",
     "copilot_model_from_args",
     "default_wire_api_for_model",
     "detect_running_proxy_backend",
     "is_auto_model",
     "model_prefers_responses_api",
     "model_configured",
+    "native_api_url_supported",
     "provider_key_source",
     "query_proxy_config",
     "resolve_provider_type",

--- a/headroom/providers/copilot/wrap.py
+++ b/headroom/providers/copilot/wrap.py
@@ -151,6 +151,109 @@ def default_wire_api_for_model(model: str | None) -> str:
     return "responses" if model_prefers_responses_api(model) else "completions"
 
 
+#: Copilot CLI env var that redirects its **native** (GitHub-authenticated)
+#: API surface. Undocumented in ``copilot help environment``, but the shipped
+#: CLI resolves every native call through a helper that checks it first.
+#: Redirecting this (instead of BYOK) leaves Copilot's own model routing intact,
+#: which is what makes Enterprise aliases like ``claude-sonnet-5`` work.
+COPILOT_NATIVE_API_URL_ENV = "COPILOT_API_URL"
+
+#: BYOK variables that must be cleared in native mode. Any leftover keeps the
+#: CLI on the single-model BYOK path and makes ``--native`` look like a no-op.
+COPILOT_BYOK_ENV_VARS: tuple[str, ...] = (
+    "COPILOT_PROVIDER_BASE_URL",
+    "COPILOT_PROVIDER_TYPE",
+    "COPILOT_PROVIDER_API_KEY",
+    "COPILOT_PROVIDER_BEARER_TOKEN",
+    "COPILOT_PROVIDER_WIRE_API",
+    "COPILOT_PROVIDER_TRANSPORT",
+    "COPILOT_PROVIDER_AZURE_API_VERSION",
+    "COPILOT_PROVIDER_MODEL_ID",
+    "COPILOT_PROVIDER_WIRE_MODEL",
+    "COPILOT_PROVIDER_MODEL_LIMITS_ID",
+    "COPILOT_PROVIDER_MAX_PROMPT_TOKENS",
+    "COPILOT_PROVIDER_MAX_OUTPUT_TOKENS",
+    "COPILOT_PROVIDER_HEADERS",
+)
+
+
+def _version_key(path: str) -> tuple[int, ...]:
+    """Sortable version tuple from a bundle directory name (``.../1.0.77``)."""
+    name = os.path.basename(path.rstrip(os.sep))
+    parts: list[int] = []
+    for piece in name.split("."):
+        digits = "".join(ch for ch in piece if ch.isdigit())
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts) or (0,)
+
+
+def native_api_url_supported(
+    *, environ: Mapping[str, str] | None = None, home: str | None = None
+) -> bool | None:
+    """Best-effort check that the installed CLI honours ``COPILOT_API_URL``.
+
+    Returns ``True`` when the newest shipped bundle references the variable,
+    ``False`` when a bundle was found and does not, and ``None`` when no bundle
+    could be located (unknown — caller should proceed with a note).
+    """
+    env = environ if environ is not None else os.environ
+    resolved_home = home if home is not None else os.path.expanduser("~")
+    local = env.get("LOCALAPPDATA") or env.get("HOME") or resolved_home
+    roots = [
+        os.path.join(local, "copilot", "pkg"),
+        os.path.join(resolved_home, ".local", "share", "copilot", "pkg"),
+    ]
+
+    bundles: list[tuple[tuple[int, ...], str]] = []
+    for root in roots:
+        if not os.path.isdir(root):
+            continue
+        for dirpath, _dirnames, filenames in os.walk(root):
+            if "app.js" in filenames:
+                bundles.append((_version_key(dirpath), os.path.join(dirpath, "app.js")))
+    if not bundles:
+        return None
+
+    bundles.sort()
+    read_any = False
+    for _key, path in reversed(bundles):
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                read_any = True
+                carry = ""
+                overlap = len(COPILOT_NATIVE_API_URL_ENV) - 1
+                while chunk := fh.read(1 << 20):
+                    if COPILOT_NATIVE_API_URL_ENV in carry + chunk:
+                        return True
+                    carry = chunk[-overlap:] if overlap else ""
+        except OSError:
+            continue
+        return False
+    return False if read_any else None
+
+
+def build_native_launch_env(
+    *,
+    port: int,
+    environ: Mapping[str, str] | None = None,
+    project: str | None = None,
+) -> tuple[dict[str, str], list[str]]:
+    """Build the launch environment for native (non-BYOK) Copilot routing.
+
+    Sets :data:`COPILOT_NATIVE_API_URL_ENV` to the local proxy and clears every
+    BYOK variable so the CLI keeps its own GitHub auth and model routing.
+    """
+    env = dict(environ if environ is not None else os.environ)
+    base_url = with_project_prefix(f"http://127.0.0.1:{port}", project)
+    env[COPILOT_NATIVE_API_URL_ENV] = base_url
+    for var in COPILOT_BYOK_ENV_VARS:
+        env.pop(var, None)
+    return env, [
+        f"{COPILOT_NATIVE_API_URL_ENV}={base_url}",
+        "COPILOT_AUTH_MODE=github-native (Copilot's own model routing)",
+    ]
+
+
 def provider_key_source(provider_type: str) -> str:
     """Return the preferred provider key variable for the selected provider type."""
     return "ANTHROPIC_API_KEY" if provider_type == "anthropic" else "OPENAI_API_KEY"

--- a/headroom/providers/openai_responses.py
+++ b/headroom/providers/openai_responses.py
@@ -32,9 +32,19 @@ OPENAI_RESPONSES_ROOT_PATHS: tuple[str, ...] = (
     "/v1/codex/responses",
     "/backend-api/responses",
     "/backend-api/codex/responses",
+    # Unprefixed form used by Copilot CLI native mode (`wrap copilot --native`).
+    "/responses",
 )
 
-OPENAI_RESPONSES_WEBSOCKET_PATHS: tuple[str, ...] = OPENAI_RESPONSES_ROOT_PATHS
+#: Deliberately not an alias of the HTTP paths above. The websocket relay is the
+#: Codex ``/responses`` transport; Copilot's native WS frames are a different
+#: shape and unverified against it.
+OPENAI_RESPONSES_WEBSOCKET_PATHS: tuple[str, ...] = (
+    "/v1/responses",
+    "/v1/codex/responses",
+    "/backend-api/responses",
+    "/backend-api/codex/responses",
+)
 
 OPENAI_RESPONSES_SUBPATH_ROUTES: tuple[OpenAIResponsesSubpathRoute, ...] = (
     OpenAIResponsesSubpathRoute("/v1/responses/{sub_path:path}", ("GET", "POST", "DELETE")),

--- a/headroom/providers/route_specs.py
+++ b/headroom/providers/route_specs.py
@@ -105,6 +105,10 @@ ANTHROPIC_BATCH_ROUTES: tuple[ProviderHandlerRoute, ...] = (
 
 OPENAI_HANDLER_ROUTES: tuple[ProviderHandlerRoute, ...] = (
     ProviderHandlerRoute("POST", "/v1/chat/completions", "handle_openai_chat"),
+    # Unprefixed form used by Copilot CLI native mode (`wrap copilot --native`).
+    # Without this, native OpenAI-family traffic falls through to passthrough
+    # and is forwarded without compression.
+    ProviderHandlerRoute("POST", "/chat/completions", "handle_openai_chat"),
 )
 
 

--- a/tests/test_copilot_native_mode.py
+++ b/tests/test_copilot_native_mode.py
@@ -1,0 +1,272 @@
+"""`wrap copilot --native`: route Copilot's own API through Headroom.
+
+BYOK replaces Copilot's model routing and rejects Enterprise aliases like
+``claude-sonnet-5``. Native mode redirects the CLI's GitHub-authenticated API
+surface instead (via ``COPILOT_API_URL``), leaving Copilot's routing intact.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from headroom.providers.copilot.wrap import (
+    COPILOT_BYOK_ENV_VARS,
+    COPILOT_NATIVE_API_URL_ENV,
+    build_launch_env,
+    build_native_launch_env,
+    native_api_url_supported,
+)
+
+
+def test_native_env_redirects_the_cli_api_surface() -> None:
+    env, display = build_native_launch_env(port=8890, environ={}, project=None)
+    assert env[COPILOT_NATIVE_API_URL_ENV] == "http://127.0.0.1:8890"
+    assert any(COPILOT_NATIVE_API_URL_ENV in line for line in display)
+
+
+def test_native_env_clears_every_byok_variable() -> None:
+    seeded = dict.fromkeys(COPILOT_BYOK_ENV_VARS, "leftover")
+    env, _ = build_native_launch_env(port=8890, environ=seeded, project=None)
+    still_set = [v for v in COPILOT_BYOK_ENV_VARS if v in env]
+    assert not still_set, f"BYOK vars survived into native mode: {still_set}"
+
+
+def test_native_env_keeps_the_project_prefix() -> None:
+    env, _ = build_native_launch_env(port=8890, environ={}, project="myproj")
+    assert env[COPILOT_NATIVE_API_URL_ENV] == "http://127.0.0.1:8890/p/myproj"
+
+
+def test_native_env_preserves_unrelated_environment() -> None:
+    env, _ = build_native_launch_env(
+        port=8890, environ={"PATH": "/usr/bin", "MY_VAR": "keep"}, project=None
+    )
+    assert env["PATH"] == "/usr/bin"
+    assert env["MY_VAR"] == "keep"
+
+
+def test_native_support_probe_is_tri_state(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    empty = {"LOCALAPPDATA": str(tmp_path / "none")}
+    assert native_api_url_supported(environ=empty, home=str(tmp_path / "none")) is None
+
+    pkg = tmp_path / "copilot" / "pkg" / "win32-x64" / "1.0.0"
+    pkg.mkdir(parents=True)
+    (pkg / "app.js").write_text("var x = 1;  // no override support\n", encoding="utf-8")
+    assert (
+        native_api_url_supported(
+            environ={"LOCALAPPDATA": str(tmp_path)}, home=str(tmp_path / "none")
+        )
+        is False
+    )
+
+    (pkg / "app.js").write_text(
+        "function qc(){return process.env.COPILOT_API_URL?1:2}\n", encoding="utf-8"
+    )
+    assert (
+        native_api_url_supported(
+            environ={"LOCALAPPDATA": str(tmp_path)}, home=str(tmp_path / "none")
+        )
+        is True
+    )
+
+
+def test_byok_env_builder_is_unchanged_by_native_mode() -> None:
+    env, display = build_launch_env(
+        port=8787, provider_type="openai", wire_api="responses", environ={}, project=None
+    )
+    assert env["COPILOT_PROVIDER_TYPE"] == "openai"
+    assert env["COPILOT_PROVIDER_BASE_URL"] == "http://127.0.0.1:8787/v1"
+    assert env["COPILOT_PROVIDER_WIRE_API"] == "responses"
+    assert COPILOT_NATIVE_API_URL_ENV not in env
+    assert any("COPILOT_PROVIDER_BASE_URL" in line for line in display)
+
+
+def test_byok_and_native_are_mutually_exclusive_shapes() -> None:
+    byok, _ = build_launch_env(
+        port=8787, provider_type="openai", wire_api=None, environ={}, project=None
+    )
+    native, _ = build_native_launch_env(port=8787, environ={}, project=None)
+    assert "COPILOT_PROVIDER_BASE_URL" in byok
+    assert COPILOT_NATIVE_API_URL_ENV not in byok
+    assert COPILOT_NATIVE_API_URL_ENV in native
+    assert "COPILOT_PROVIDER_BASE_URL" not in native
+
+
+def _invoke_copilot(monkeypatch: pytest.MonkeyPatch, args: list[str]):
+    """Run `wrap copilot` with the launch intercepted, returning what it would do."""
+    import shutil
+
+    from click.testing import CliRunner
+
+    from headroom.cli import wrap as wrap_mod
+    from headroom.cli.main import main
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(shutil, "which", lambda _n: "/usr/bin/copilot")
+    monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _p: False)
+
+    class _Res:
+        token = "gho_test"
+        api_url = "https://api.githubcopilot.com"
+        refresh_oauth_token = None
+        api_token_expires_at = None
+
+    monkeypatch.setattr(wrap_mod, "_require_copilot_subscription_resolution", lambda: _Res())
+    monkeypatch.setattr(wrap_mod, "resolve_client_bearer_token", lambda: "gho_test")
+    monkeypatch.setattr(wrap_mod, "_native_api_url_supported", lambda **_k: True)
+
+    def _fake_launch(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(wrap_mod, "_launch_tool", _fake_launch)
+    result = CliRunner().invoke(main, ["wrap", "copilot", *args])
+    return result, captured
+
+
+def test_native_flag_sets_the_override_and_no_byok_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, captured = _invoke_copilot(monkeypatch, ["--native", "--port", "8890"])
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env[COPILOT_NATIVE_API_URL_ENV].startswith("http://127.0.0.1:8890")
+    assert "COPILOT_PROVIDER_BASE_URL" not in env
+
+
+def test_native_points_the_anthropic_upstream_at_copilot(monkeypatch: pytest.MonkeyPatch) -> None:
+    _result, captured = _invoke_copilot(monkeypatch, ["--native", "--port", "8890"])
+    assert captured["anthropic_api_url"] == "https://api.githubcopilot.com"
+    assert captured["openai_api_url"] == "https://api.githubcopilot.com"
+
+
+def test_byok_launch_leaves_the_anthropic_upstream_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    _result, captured = _invoke_copilot(
+        monkeypatch, ["--subscription", "--port", "8890", "--", "--model", "gpt-5.4"]
+    )
+    assert captured["anthropic_api_url"] is None
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "COPILOT_PROVIDER_BASE_URL" in env
+    assert COPILOT_NATIVE_API_URL_ENV not in env
+
+
+def test_native_implies_subscription_so_no_model_is_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result, captured = _invoke_copilot(monkeypatch, ["--native", "--port", "8890"])
+    assert result.exit_code == 0, result.output
+    assert "requires a model" not in result.output
+    assert COPILOT_NATIVE_API_URL_ENV in captured["env"]
+
+
+def test_native_rejects_wire_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, _captured = _invoke_copilot(
+        monkeypatch, ["--native", "--wire-api", "responses", "--port", "8890"]
+    )
+    assert result.exit_code != 0
+    assert "--wire-api" in result.output
+
+
+def test_native_rejects_anthropic_provider_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, _captured = _invoke_copilot(
+        monkeypatch, ["--native", "--provider-type", "anthropic", "--port", "8890"]
+    )
+    assert result.exit_code != 0
+    assert "provider-type anthropic" in result.output
+
+
+def test_native_rejects_no_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    result, _captured = _invoke_copilot(monkeypatch, ["--native", "--no-proxy", "--port", "8890"])
+    assert result.exit_code != 0
+    assert "--no-proxy" in result.output
+
+
+def test_native_warns_when_cli_lacks_support(monkeypatch: pytest.MonkeyPatch) -> None:
+    import shutil
+
+    from click.testing import CliRunner
+
+    from headroom.cli import wrap as wrap_mod
+    from headroom.cli.main import main
+
+    class _Res:
+        token = "gho_test"
+        api_url = "https://api.githubcopilot.com"
+        refresh_oauth_token = None
+        api_token_expires_at = None
+
+    monkeypatch.setattr(shutil, "which", lambda _n: "/usr/bin/copilot")
+    monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _p: False)
+    monkeypatch.setattr(wrap_mod, "_require_copilot_subscription_resolution", lambda: _Res())
+    monkeypatch.setattr(wrap_mod, "_launch_tool", lambda **_k: None)
+    monkeypatch.setattr(wrap_mod, "_native_api_url_supported", lambda **_k: False)
+
+    result = CliRunner().invoke(main, ["wrap", "copilot", "--native", "--port", "8890"])
+    assert result.exit_code == 0, result.output
+    assert "COPILOT_API_URL" in result.output
+    assert "silently get no compression" in result.output
+    assert "without --native" in result.output
+
+
+def test_anthropic_upstream_mismatch_predicate() -> None:
+    from headroom.cli.wrap import _proxy_anthropic_upstream_mismatch
+
+    native_proxy = {"anthropic_api_url": "https://api.githubcopilot.com"}
+    assert _proxy_anthropic_upstream_mismatch(native_proxy, None) is True
+
+
+def test_plain_proxy_is_still_reusable_for_claude() -> None:
+    from headroom.cli.wrap import _proxy_anthropic_upstream_mismatch
+
+    plain_proxy = {"anthropic_api_url": None}
+    assert _proxy_anthropic_upstream_mismatch(plain_proxy, None) is False
+    assert _proxy_anthropic_upstream_mismatch({}, None) is False
+
+
+def test_native_proxy_is_reusable_for_the_same_native_upstream() -> None:
+    from headroom.cli.wrap import _proxy_anthropic_upstream_mismatch
+
+    native_proxy = {"anthropic_api_url": "https://api.githubcopilot.com"}
+    assert (
+        _proxy_anthropic_upstream_mismatch(native_proxy, "https://api.githubcopilot.com") is False
+    )
+    assert _proxy_anthropic_upstream_mismatch(native_proxy, "https://api.anthropic.com") is True
+
+
+def test_probe_finds_a_needle_split_across_a_read_boundary(tmp_path) -> None:
+    pkg = tmp_path / "copilot" / "pkg" / "win32-x64" / "1.0.77"
+    pkg.mkdir(parents=True)
+    (pkg / "app.js").write_text(
+        "x" * ((1 << 20) - 8) + COPILOT_NATIVE_API_URL_ENV + "y" * 40, encoding="utf-8"
+    )
+    assert (
+        native_api_url_supported(
+            environ={"LOCALAPPDATA": str(tmp_path)}, home=str(tmp_path / "none")
+        )
+        is True
+    )
+
+
+def test_probe_answers_from_the_newest_bundle_only(tmp_path) -> None:
+    root = tmp_path / "copilot" / "pkg" / "win32-x64"
+    (root / "1.0.39").mkdir(parents=True)
+    (root / "1.0.39" / "app.js").write_text(
+        f"var a = process.env.{COPILOT_NATIVE_API_URL_ENV};", encoding="utf-8"
+    )
+    (root / "1.0.78").mkdir(parents=True)
+    (root / "1.0.78" / "app.js").write_text("var a = 1; // variable removed", encoding="utf-8")
+    assert (
+        native_api_url_supported(
+            environ={"LOCALAPPDATA": str(tmp_path)}, home=str(tmp_path / "none")
+        )
+        is False
+    )
+
+
+def test_probe_returns_unknown_for_an_empty_root(tmp_path) -> None:
+    (tmp_path / "copilot" / "pkg").mkdir(parents=True)
+    assert (
+        native_api_url_supported(
+            environ={"LOCALAPPDATA": str(tmp_path)}, home=str(tmp_path / "none")
+        )
+        is None
+    )

--- a/tests/test_provider_openai_responses.py
+++ b/tests/test_provider_openai_responses.py
@@ -23,8 +23,14 @@ def test_openai_responses_route_aliases_are_explicit() -> None:
         "/v1/codex/responses",
         "/backend-api/responses",
         "/backend-api/codex/responses",
+        "/responses",
     )
-    assert OPENAI_RESPONSES_WEBSOCKET_PATHS == OPENAI_RESPONSES_ROOT_PATHS
+    assert OPENAI_RESPONSES_WEBSOCKET_PATHS == (
+        "/v1/responses",
+        "/v1/codex/responses",
+        "/backend-api/responses",
+        "/backend-api/codex/responses",
+    )
     assert OPENAI_RESPONSES_SUBPATH_ROUTES == (
         OpenAIResponsesSubpathRoute("/v1/responses/{sub_path:path}", ("GET", "POST", "DELETE")),
         OpenAIResponsesSubpathRoute(


### PR DESCRIPTION
## Summary
- Add opt-in `headroom wrap copilot --native` that redirects Copilot CLI via `COPILOT_API_URL` instead of BYOK, so Copilot keeps its own model routing (needed for Enterprise/Business aliases like `claude-sonnet-5`; refs #1910).
- Point both OpenAI and Anthropic proxy upstreams at the Copilot host in native mode, register bare `/chat/completions` and `/responses` handlers for compression, and isolate/restart when a native-pinned proxy would be reused by `wrap claude`.
- Leave the existing BYOK / `--subscription` paths unchanged unless `--native` is set.

## Test plan
- [x] `pytest tests/test_copilot_native_mode.py tests/test_provider_openai_responses.py` (27 passed)
- [x] `pytest tests/test_cli/test_wrap_persistent.py tests/test_copilot_auth.py tests/test_copilot_subscription_smoke.py` (148 passed)
- [ ] On a GitHub Enterprise / Copilot Business account without BYOK keys: `headroom wrap copilot --native --verbose -- --model claude-sonnet-5 -p "say hi"`
- [ ] Confirm dashboard shows traffic (compression active) and BYOK path still works: `headroom wrap copilot --subscription -- --model gpt-4o`
- [ ] After `--native`, run `wrap claude` and confirm it does not silently reuse the Copilot-pinned proxy

## Notes
Focused alternative to the broader catalog work in #2643. Enterprise hosts can still be pinned with `GITHUB_COPILOT_API_URL` when needed.
