### PR TITLE
docs(configuration): document LiteLLM as the source for limits and prices

### DIFF
--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -425,8 +425,11 @@ Configure context limits and pricing for new or custom models:
   },
   "openai": {
     "context_limits": {
-      "gpt-5": 256000,
-      "ft:gpt-4o:my-org": 128000
+      "ft:gpt-4o:my-org": 128000,
+      "my-private-deployment": 200000
+    },
+    "pricing": {
+      "my-private-deployment": [5.00, 15.00]
     }
   }
 }
@@ -437,18 +440,61 @@ Save as `${HEADROOM_CONFIG_DIR}/models.json` (defaults to
 JSON string or file path. Installs that still have
 `~/.headroom/models.json` (the legacy location) continue to work.
 
-Settings are resolved in this order (later overrides earlier):
+<Callout type="info">
+  Configure **models Headroom can't already look up** — fine-tunes, private
+  deployments, gateway aliases. Public models are resolved from LiteLLM (see
+  below), so pinning one here means maintaining a number yourself that would
+  otherwise stay current on its own.
+</Callout>
 
-1. Built-in defaults
-2. `${HEADROOM_CONFIG_DIR}/models.json` (new canonical location); falls
-   back to `~/.headroom/models.json` (legacy) when the canonical file
-   is absent
-3. `HEADROOM_MODEL_LIMITS` environment variable
-4. SDK constructor arguments
+### Where limits and prices come from
+
+Headroom consults the **installed LiteLLM model database** (`litellm.model_cost`)
+for public model metadata. That data ships with the LiteLLM package rather than
+being fetched at runtime, so it is as current as your installed LiteLLM version
+and refreshes when you upgrade it. Nothing here makes a network call.
+
+Limits and prices do **not** use the same precedence. Both are first-match-wins:
+
+**Context limits**
+
+1. **Explicit configuration and the built-in table**, checked together — they are
+   merged into one mapping, so an exact match in either returns immediately, then
+   partial/prefix matches.
+2. **LiteLLM** (`max_input_tokens`) — reached only for models the previous step
+   didn't match.
+3. **Pattern inference**, then a generic default.
+
+**Pricing**
+
+1. **Explicit configuration** — a value you configured is a decision, so it beats
+   everything below.
+2. **LiteLLM.**
+3. **Built-in table**, then pattern inference, then a generic default.
+
+<Callout type="warn">
+  The asymmetry is deliberate, not an oversight. For limits, a built-in entry
+  outranks LiteLLM because LiteLLM reports a model's maximum *capability* while
+  Headroom needs its *effective default*. `claude-sonnet-4-20250514` is the
+  concrete case: LiteLLM reports 1,000,000, but that window is an opt-in beta, so
+  the built-in 200,000 is the safe assumption for a client that has not enabled
+  it. Pricing has no equivalent capability-vs-default split, so there LiteLLM
+  wins outright.
+</Callout>
+
+Limits are an **input** budget (`max_input_tokens`), not the total window: `gpt-5`
+resolves to 272K input, not the 400K total (272K in + 128K out).
+
+LiteLLM also resolves gateway-routed names — `azure/...`, `bedrock/...`,
+`vertex_ai/...`, `groq/...` — which the built-in tables never covered.
+
+The built-in tables additionally cover installs where LiteLLM is unavailable: the
+dependency is gated `python_version < '3.14'`.
 
 ### Pattern-Based Inference
 
-Unknown models are automatically inferred from naming patterns:
+Models that reach step 3 and match no table entry are inferred from naming
+patterns:
 
 | Pattern | Inferred Settings |
 |---------|-------------------|
@@ -456,7 +502,12 @@ Unknown models are automatically inferred from naming patterns:
 | `*sonnet*` | 200K context, Sonnet-tier pricing |
 | `*haiku*` | 200K context, Haiku-tier pricing |
 | `gpt-4o*` | 128K context, GPT-4o pricing |
-| `o1*`, `o3*` | 200K context, reasoning model pricing |
+| `gpt-4.1*` | ~1M context, GPT-4.1 pricing |
+| `gpt-5*` | 272K input, GPT-5 pricing |
+| `o1*`, `o3*`, `o4*` | 200K context, reasoning model pricing |
+
+Matching prefers the **most specific** prefix, so `gpt-4.1` is not treated as
+`gpt-4` (which would give it an 8K limit and legacy `gpt-4` pricing).
 
 ## Provider-Specific Settings
 

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -289,13 +289,55 @@ Configure context limits and pricing for new or custom models. Useful when:
 
 ### Configuration Methods
 
-Settings are resolved in this order (later overrides earlier):
-1. Built-in defaults
-2. `${HEADROOM_CONFIG_DIR}/models.json` (defaults to
+Headroom reads public model metadata from the **installed LiteLLM model database**
+(`litellm.model_cost`). That data ships with the LiteLLM package rather than being
+fetched at runtime, so it is as current as your installed LiteLLM version and
+refreshes when you upgrade it. No network call is made.
+
+Explicit configuration comes from three places, later overriding earlier:
+
+1. `${HEADROOM_CONFIG_DIR}/models.json` (defaults to
    `~/.headroom/config/models.json`); falls back to the legacy location
    `~/.headroom/models.json` when the canonical file is absent
-3. `HEADROOM_MODEL_LIMITS` environment variable
-4. SDK constructor arguments
+2. `HEADROOM_MODEL_LIMITS` environment variable
+3. SDK constructor arguments
+
+Limits and prices then resolve with **different** precedence. Both are
+first-match-wins:
+
+**Context limits**
+
+1. **Explicit configuration and the built-in table, checked together** — they are
+   merged into one mapping, so an exact match in either returns immediately,
+   followed by partial/prefix matches.
+2. **LiteLLM** (`max_input_tokens`) — reached only for models step 1 didn't match.
+3. **Pattern inference**, then a generic default.
+
+**Pricing**
+
+1. **Explicit configuration** — a configured value is a decision, so it beats
+   everything below.
+2. **LiteLLM.**
+3. **Built-in table**, then pattern inference, then a generic default.
+
+The asymmetry is deliberate. For limits a built-in entry outranks LiteLLM because
+LiteLLM reports a model's maximum *capability* while Headroom needs its *effective
+default*: LiteLLM gives `claude-sonnet-4-20250514` 1,000,000, but that window is
+an opt-in beta, so the built-in 200,000 is the safe assumption for a client that
+has not enabled it. Pricing has no capability-vs-default split, so there LiteLLM
+wins outright.
+
+Limits are an **input** budget (`max_input_tokens`), not the total window: `gpt-5`
+resolves to 272K input, not the 400K total (272K in + 128K out).
+
+LiteLLM also resolves gateway-routed names (`azure/...`, `bedrock/...`,
+`vertex_ai/...`, `groq/...`) that the built-in tables never covered, and the
+built-in tables additionally cover installs where LiteLLM is unavailable (the
+dependency is gated `python_version < '3.14'`).
+
+Configure only models Headroom can't already look up — fine-tunes, private
+deployments, gateway aliases. Pinning a public model's *price* here means
+maintaining a number yourself that would otherwise stay current.
 
 ### Config File Format
 
@@ -318,11 +360,11 @@ Create `~/.headroom/models.json`:
   },
   "openai": {
     "context_limits": {
-      "gpt-5": 256000,
-      "ft:gpt-4o:my-org": 128000
+      "ft:gpt-4o:my-org": 128000,
+      "my-private-deployment": 200000
     },
     "pricing": {
-      "gpt-5": [5.00, 15.00]
+      "my-private-deployment": [5.00, 15.00]
     }
   }
 }


### PR DESCRIPTION
## Description

The ten token/pricing fixes merged this session changed documented behaviour, and `configuration.mdx` / `wiki/configuration.md` were left describing the old model. This is docs-only.

**The main problem:** both trees documented resolution as

```
1. Built-in defaults
2. models.json
3. HEADROOM_MODEL_LIMITS
4. SDK constructor arguments
```

with **no mention of LiteLLM at all**. That is misleading in a way that costs users real work: it reads as though editing `models.json` is the only way to correct a wrong limit or price. In fact public models resolve from LiteLLM and stay current on their own — pinning one in config means signing up to maintain a number by hand forever.

Restated as an explicit first-match-wins list covering **both** limits and pricing:

```
1. explicit config (models.json / env / SDK args)   <- a decision, beats everything
2. LiteLLM                                          <- live source for public models
3. built-in tables -> pattern -> generic default    <- fallback only
```

…and noted that step 3 exists for installs where LiteLLM is unavailable (the dependency is gated `python_version < '3.14'`) and for models LiteLLM doesn't know.

## Changes Made

- **Fixed the example overrides.** Both trees used `"gpt-5": 256000` and `"gpt-5": [5.00, 15.00]`. Both numbers are wrong (272K input; $1.25/$10.00), and gpt-5 is now a *known* model — so the example was teaching readers to override a correct, self-updating value with a stale hand-written one. Swapped for `ft:gpt-4o:my-org` and `my-private-deployment`, which are what custom configuration is actually for, plus a callout saying so.
- **Documented that limits are an INPUT budget.** They come from LiteLLM's `max_input_tokens`, so `gpt-5` is 272K of prompt room, not 400K — the total window is 272K in + 128K out. I conflated these myself while writing #2762 and had to correct it, so it's worth stating for anyone configuring a limit.
- **Updated pattern inference** with `gpt-4.1*`, `gpt-5*`, `o4*`, and stated that matching prefers the **most specific** prefix — so `gpt-4.1` isn't treated as `gpt-4` (which is exactly the bug #2762 fixed: an 8K limit and legacy `gpt-4` pricing).

Kept in sync across both doc trees, since they carried identical stale text.

## Type of Change

- [x] Documentation update

## Checked and deliberately left alone

- `savings.mdx:50` — already correct: it says cost-avoided uses LiteLLM list pricing for proxy traffic. That path (`savings_ledger`) was always LiteLLM-backed; it was the *provider* tables that weren't.
- `opencode.mdx:62` — "GPT-4.1, 1M context, 32K output" is right. Worth noting the docs had the correct figure all along while the code resolved 8192.
- `wiki/metrics.md` — uses `tokens_input_before/after`, a different surface from the beacon's `tokens.input` that #2756 touched. No change needed.

## Testing

- [x] Documentation update

No code changed, so no unit tests. `<Callout type="info">` matches existing un-imported usage in `savings.mdx`, `ccr.mdx` and `benchmarks.mdx`; the docs workflow runs `validate-mkdocs` and `validate-nextjs` (`npm run build`) on any `docs/**` / `wiki/**` PR, which is the real check for both trees here.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My changes are documentation-only
- [x] I have kept both documentation trees in sync
- [x] I did **not** edit `CHANGELOG.md`

