### PR TITLE
docs(readme): surface the Serena opt-out in the wrap quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ headroom dashboard                      # live savings dashboard (proxy must be 
 
 To use headroom, it is recommended you launch a wrapped agent session each time so that all necessary setup is completed. When wrapping a coding agent, headroom starts a local proxy, installs **Serena** for semantic code navigation, and launches a coding agent session configured to proxy requests through headroom.
 
+Serena is registered at **user scope** (for Claude Code, in `~/.claude.json`), so it stays available in your other projects until you run `headroom unwrap`. To skip it entirely, wrap with `--code-memory none`.
+
 The `headroom` CLI ships **only** via the PyPI package. The npm `headroom-ai` is the TypeScript SDK — a library you import (`import { compress } from 'headroom-ai'`), not a CLI, so it provides no `headroom` command.
 
 Granular extras: `[proxy]`, `[mcp]`, `[ml]`, `[code]`, `[memory]`, `[vector]` (optional HNSW backend — needs a C++ toolchain, not in `[all]`), `[relevance]`, `[image]`, `[agno]`, `[langchain]`, `[evals]`, `[pytorch-mps]` (Apple-GPU memory-embedder offload — set `HEADROOM_EMBEDDER_RUNTIME=pytorch_mps`). Requires **Python 3.10+**.


### PR DESCRIPTION
## Description

The README quickstart announces that `headroom wrap` installs Serena, then stops — it offers no way to decline. The opt-out exists (`--code-memory none`) but was documented only on the docs site at `docs/content/docs/proxy.mdx:78`, which a README reader never reaches.

In #2783 a user followed the quickstart verbatim, hit a Serena startup failure, and found the flag via `headroom wrap claude --help` only afterwards, while recovering the machine. Their words: *"a first-time user following the documented `headroom wrap claude` command has no signal that this failure mode exists or how to avoid it."*

One line at the point where the install is announced closes that gap.

Closes #2788

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `README.md` — one sentence after the existing wrap paragraph:

  > Serena is registered at **user scope** (for Claude Code, in `~/.claude.json`), so it stays available in your other projects until you run `headroom unwrap`. To skip it entirely, wrap with `--code-memory none`.

Two facts, both of which the #2783 reporter needed and could not find: the registration is user-scoped (so Serena shows up in projects that were never wrapped, until `unwrap`), and there is a flag to skip it.

`docs/content/docs/quickstart.mdx` was checked for the same gap and has no equivalent wrap section — its only `wrap` mention is `vscode-claude` — so there is nothing to mirror. `proxy.mdx` already covers the flag and is unchanged.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

A two-line Markdown addition to `README.md`. No Python, no config, no build inputs — pytest / ruff / mypy have nothing to cover. What was worth checking is that the sentence is *true*, so I verified both claims against the CLI on `main` rather than against the issue text.

### Test Output

```text
$ grep -n '"--code-memory"' -A 2 headroom/cli/wrap.py
924:    "--code-memory",
925-    type=click.Choice([_CODE_MEMORY_SERENA, _CODE_MEMORY_NONE]),
926-    default=None,

$ headroom wrap claude --help | grep -A3 code-memory
      headroom wrap claude --code-memory none # No code-memory MCP
...
  --code-memory [serena|none]  Code-memory MCP to register: 'serena' (default)
                               or 'none'. Also set by HEADROOM_CODE_MEMORY.
                               Replaces --serena/--no-serena.
```

## Real Behavior Proof

- **Environment:** macOS (darwin 25.4.0), repo `.venv`, branch cut from `upstream/main` @ `6b63b623`.
- **Exact command / steps:** ran `headroom wrap claude --help` against the branch to confirm `none` is a real `click.Choice` value on the `claude` subcommand (not just on `wrap` generally, and not renamed since #2499 retired `--serena`/`--no-serena`). Read `headroom/mcp_registry/claude.py:128` to confirm the scope wording — registration is `claude mcp add <name> -s user`, with a file fallback writing top-level `mcpServers` in `~/.claude.json`, so "user scope" is accurate for Claude Code specifically. Grepped `docs/content/docs/quickstart.mdx` for wrap coverage to decide whether a mirror was needed.
- **Observed result:** flag present and spelled as documented; `HEADROOM_CODE_MEMORY` is an equivalent env var (mentioned in `--help`, deliberately left out of the README line to keep it to one sentence); `quickstart.mdx` has no wrap-install paragraph to mirror into.
- **Not tested:** did not run a real `headroom wrap claude` — the sentence describes existing behavior this PR does not change, and the registration scope is read from the code path above. Rendering not previewed on github.com; it is plain prose with two inline code spans and one bold span, matching the surrounding paragraphs.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

- N/A on the test-related checklist items: prose-only change, nothing to assert.
- Deliberately one sentence, not a Serena section. The quickstart should not become a Serena tutorial; it just needs the opt-out to be discoverable at the moment the install happens.
- Related, not addressed here: **#2787** asks whether user scope should stay the default at all, since it is what let one failing MCP server degrade every Claude Code session in #2783. If that lands with project scope, this README line needs a one-word update — worth noting so the two do not drift.
- The crash that prompted #2783 is already fixed on `main` by #2676 and ships in 0.34.0; this PR only closes the documentation half.
