### PR TITLE
fix(deps): enforce audited transitive dependency floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -363,6 +363,10 @@ constraint-dependencies = [
     "transformers>=5.5.0",
     # PYSEC-2026-3447 — transitive dependency; fix at 83.0.0
     "setuptools>=83.0.0",
+    # PYSEC-2026-3545/3546/3547 — transitive HTTP/WebSocket parser fixes
+    "aiohttp>=3.14.3",
+    # PYSEC-2026-3552/3553/3554 — PKCS#7 and certificate verification fixes
+    "cryptography>=50.0.0",
 ]
 
 # Pin the project's package index to public PyPI. Without this, `uv lock`

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,8 @@ resolution-markers = [
 
 [manifest]
 constraints = [
+    { name = "aiohttp", specifier = ">=3.14.3" },
+    { name = "cryptography", specifier = ">=50.0.0" },
     { name = "gitpython", specifier = ">=3.1.50" },
     { name = "langsmith", specifier = ">=0.9.0" },
     { name = "lxml-html-clean", specifier = ">=0.4.5" },
@@ -1678,7 +1680,7 @@ wheels = [
 
 [[package]]
 name = "headroom-ai"
-version = "0.33.0"
+version = "0.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "ast-grep-cli" },


### PR DESCRIPTION
## Description

Enforces patched minimum versions for the vulnerable transitive `aiohttp` and `cryptography` dependencies so future lockfile refreshes cannot reintroduce the pip-audit failures affecting open pull requests.

Related to the shared Security / pip-audit failures across open PRs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Enforces `aiohttp>=3.14.3` for PYSEC-2026-3545/3546/3547.
- Enforces `cryptography>=50.0.0` for PYSEC-2026-3552/3553/3554.
- Synchronizes the project version recorded in `uv.lock` with `pyproject.toml`.

## Testing

- [x] Dependency audit passes (`pip-audit`)
- [x] Lockfile validation passes (`uv lock --check`)
- [ ] Unit tests pass (`pytest`)
- [ ] Type checking passes (`mypy headroom`)
- [x] Manual verification performed

### Test Output

```text
$ uv lock --check
Resolved 269 packages

$ uv export --frozen --no-dev --no-emit-project --no-hashes --extra all --format requirements-txt | uvx --python 3.12 pip-audit -r /dev/stdin
No known vulnerabilities found
```

## Real Behavior Proof

- Environment: Local macOS worktree using CPython 3.12.13 and the frozen production dependency export.
- Exact command / steps: Validated the lockfile, exported every production dependency with the `all` extra, and audited that exact export with pip-audit.
- Observed result: The lockfile resolved successfully and pip-audit reported no known vulnerabilities.
- Not tested: Publishing or deployment; the refreshed GitHub CI suite covers builds, wheels, containers, security scans, and platform tests.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my changes
- [x] No explanatory code comments are required beyond the PYSEC constraint annotations
- [x] Documentation changes are not required for transitive security floors
- [x] My changes generate no new local warnings
- [x] The dependency audit proves the security fix is effective
- [ ] Full repository tests are delegated to GitHub CI
- [x] I did not edit `CHANGELOG.md`; release-please owns it

## Screenshots (if applicable)

N/A — dependency metadata only.

## Additional Notes

The earlier Docker-native failure was a transient Docker Hub HTTP 502 while resolving `python:3.13-slim`; the build did not reach project code. A fresh CI suite is running on the current head.
