### PR TITLE
test(ccr): cross SQLite max lifetime boundary

### DIFF
--- a/crates/headroom-core/tests/ccr_backends.rs
+++ b/crates/headroom-core/tests/ccr_backends.rs
@@ -267,8 +267,10 @@ fn sqlite_max_lifetime_caps_sliding_window() {
     // the idle window or the entry dies of idleness and the assertion below
     // passes without ever exercising the ceiling — the thing under test.
     // 0.7s gaps read as at most 1s apparent, comfortably under the 2s idle
-    // window, while the 4 of them carry total age past 3s.
-    for _ in 0..4 {
+    // window. Five gaps carry total age to at least 4s, which is strictly
+    // beyond the 3s ceiling even after unix-second truncation. Four gaps
+    // only reach 3.3s and can land exactly on the now-valid 3s boundary.
+    for _ in 0..5 {
         std::thread::sleep(Duration::from_millis(700));
         let _ = store.get(&hash);
     }


### PR DESCRIPTION
## Description

Fixes the failing Rust test on `main` after #2669 made SQLite CCR entries valid at the exact TTL boundary. The integration test waited only 3.3 seconds for a three-second ceiling; unix-second truncation can represent that as exactly three seconds, so the entry is correctly still valid. The test now crosses a guaranteed four-second elapsed boundary.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Extend the max-lifetime test's access loop from four to five 700 ms gaps.
- Document why four gaps can land on the valid equality boundary and why five are deterministic.
- Leave production SQLite TTL behavior and defaults unchanged.

## Testing

- [x] Unit tests pass (`cargo test -p headroom-core --test ccr_backends`)
- [x] Formatting passes (`cargo fmt --all -- --check`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
cargo test -p headroom-core --test ccr_backends
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

5 consecutive repetitions of the previously failing test:
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out
```

## Real Behavior Proof

- Environment: macOS, Rust workspace at `d0a86d409fab377f9c642d1f3680b6ece7f97b8a`
- Exact command / steps: `for iteration in 1 2 3 4 5; do cargo test -q -p headroom-core --test ccr_backends sqlite_max_lifetime_caps_sliding_window || exit; done`
- Observed result: all five repetitions passed; the complete 12-test CCR backend suite also passed.
- Not tested: Redis integration, which is unrelated to this SQLite timing-only test change.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — test-only timing correction with no UI changes.

## Additional Notes

`cargo clippy -p headroom-core --all-targets -- -D warnings` reaches two pre-existing warnings in unrelated `code_compressor.rs` and `log_compressor.rs`; this PR changes neither file and introduces no Rust code warnings.
