### PR TITLE
fix(proxy): warm deferred kompress model so /health stops reporting backend=null

### DIFF
--- a/headroom/proxy/kompress_health_detail_policy.py
+++ b/headroom/proxy/kompress_health_detail_policy.py
@@ -1,0 +1,70 @@
+"""Policy for the public ``detail`` field on the kompress health check.
+
+``/health`` and ``/readyz`` are auth-exempt, so everything they serialize is
+unauthenticated public data. The kompress check reports ``detail`` because
+``ready=false`` on its own is ambiguous — the model may be warming in the
+background, missing from the local cache, or the ML extras may not be installed
+at all (#2730).
+
+That diagnostic value must not come at the cost of leaking internals. Native
+loader, model and cache failures routinely embed absolute filesystem paths,
+model identifiers, endpoint URLs and configuration values in their exception
+text, and a warmup slot's ``error`` string is populated from exactly those
+failures. So the public field draws from a closed vocabulary: anything not in
+it degrades to ``unavailable`` rather than being echoed.
+
+The precise cause is not lost — it stays in the proxy log and in the warmup
+slot, which ``/debug/warmup`` serializes behind authentication.
+"""
+
+from __future__ import annotations
+
+# The model is loaded and serving.
+KOMPRESS_DETAIL_LOADED = "loaded"
+# The background warm thread is still running.
+KOMPRESS_DETAIL_WARMING = "warming"
+# Cache-only warm found no local artifacts; no network call was made.
+KOMPRESS_DETAIL_NOT_CACHED = "model not cached"
+# The warm attempt raised. The cause is in the log, not here.
+KOMPRESS_DETAIL_WARM_FAILED = "warm failed"
+# The ML extras are absent, or no compressor was ever constructed.
+KOMPRESS_DETAIL_NOT_INSTALLED = "not installed"
+
+# ``ContentRouter.eager_load_compressors()`` source statuses. These are fixed
+# literals in the router, never interpolated, so they are safe to surface.
+KOMPRESS_DETAIL_ENABLED = "enabled"
+KOMPRESS_DETAIL_DEFERRED = "deferred"
+KOMPRESS_DETAIL_UNAVAILABLE = "unavailable"
+
+#: Every value ``/health`` and ``/readyz`` may report for ``kompress.detail``.
+KOMPRESS_HEALTH_DETAILS = frozenset(
+    {
+        KOMPRESS_DETAIL_LOADED,
+        KOMPRESS_DETAIL_WARMING,
+        KOMPRESS_DETAIL_NOT_CACHED,
+        KOMPRESS_DETAIL_WARM_FAILED,
+        KOMPRESS_DETAIL_NOT_INSTALLED,
+        KOMPRESS_DETAIL_ENABLED,
+        KOMPRESS_DETAIL_DEFERRED,
+        KOMPRESS_DETAIL_UNAVAILABLE,
+    }
+)
+
+#: What an out-of-vocabulary value collapses to.
+DEFAULT_KOMPRESS_HEALTH_DETAIL = KOMPRESS_DETAIL_UNAVAILABLE
+
+
+def public_detail(value: str | None) -> str:
+    """Return ``value`` if it is a known detail, else the bounded fallback.
+
+    This is the single choke point for the field. Route *every* candidate
+    through it — including strings that look safe at the call site, such as a
+    warmup slot's ``source_status`` — so a future code path cannot introduce a
+    leak by writing free-form text into the slot.
+    """
+    if not isinstance(value, str):
+        return DEFAULT_KOMPRESS_HEALTH_DETAIL
+    normalized = value.strip().lower()
+    if normalized in KOMPRESS_HEALTH_DETAILS:
+        return normalized
+    return DEFAULT_KOMPRESS_HEALTH_DETAIL

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -142,6 +142,14 @@ from headroom.proxy.helpers import (
     resolve_display_provider,
     retry_after_ms,
 )
+from headroom.proxy.kompress_health_detail_policy import (
+    KOMPRESS_DETAIL_LOADED,
+    KOMPRESS_DETAIL_NOT_CACHED,
+    KOMPRESS_DETAIL_NOT_INSTALLED,
+    KOMPRESS_DETAIL_WARM_FAILED,
+    KOMPRESS_DETAIL_WARMING,
+    public_detail,
+)
 from headroom.proxy.loop_callback_failure_policy import is_known_websocket_callback_failure
 from headroom.proxy.loopback_guard import is_loopback_host
 from headroom.proxy.memory_handler import MemoryConfig, MemoryHandler
@@ -1751,11 +1759,14 @@ class HeadroomProxy(
                 try:
                     backend = compressor.preload(allow_download=False)
                 except not_cached:
-                    slot.info["detail"] = "model not cached"
+                    slot.info["detail"] = KOMPRESS_DETAIL_NOT_CACHED
                     continue
-                except Exception as exc:
-                    slot.info["detail"] = f"warm failed: {exc}"
-                    logger.debug("Kompress background warm failed: %s", exc)
+                except Exception:
+                    # The detail lands on the auth-exempt /health payload, so it
+                    # stays a bounded token; loader failures embed paths, model
+                    # ids and URLs. The real cause goes to the log only.
+                    slot.info["detail"] = KOMPRESS_DETAIL_WARM_FAILED
+                    logger.warning("Kompress background warm failed", exc_info=True)
                     continue
                 if not backend:
                     continue
@@ -2895,22 +2906,28 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         ``ready=false`` on its own is ambiguous — the model may be warming in
         the background, missing from the local cache, or the extras may not be
         installed at all (GH #2730).
+
+        This value is served by the auth-exempt ``/health`` and ``/readyz``, so
+        every candidate goes through :func:`public_detail` and anything outside
+        ``KOMPRESS_HEALTH_DETAILS`` collapses to ``unavailable``. That matters
+        most for ``slot.error``, which carries raw loader exception text.
+        ``/debug/warmup`` and the proxy log still hold the precise cause.
         """
         slot = proxy.warmup.kompress
         if slot.status == "loaded":
-            return "loaded"
+            return KOMPRESS_DETAIL_LOADED
         detail = slot.info.get("detail")
         if isinstance(detail, str) and detail:
-            return detail
+            return public_detail(detail)
         if slot.error:
-            return slot.error
+            return public_detail(slot.error)
         warm_thread = getattr(proxy, "_kompress_warm_thread", None)
         if warm_thread is not None and warm_thread.is_alive():
-            return "warming"
+            return KOMPRESS_DETAIL_WARMING
         source_status = slot.info.get("source_status")
         if isinstance(source_status, str) and source_status:
-            return source_status
-        return "not installed"
+            return public_detail(source_status)
+        return KOMPRESS_DETAIL_NOT_INSTALLED
 
     def _health_checks() -> dict[str, dict[str, Any]]:
         kompress_enabled = _reconcile_kompress_health()

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -1170,6 +1170,9 @@ class HeadroomProxy(
         )
         self._compression_quarantine_releases: int = 0
         self._compression_metrics_lock = threading.Lock()
+        # Daemon thread that warms the Kompress model after startup when the
+        # eager preload deferred the native load (GH #2730). None until started.
+        self._kompress_warm_thread: threading.Thread | None = None
 
         # Backend for Anthropic API (direct, LiteLLM, or any-llm)
         # Supports: "anthropic" (direct), "bedrock", "vertex", "litellm-<provider>", or "anyllm"
@@ -1703,6 +1706,68 @@ class HeadroomProxy(
 
         return eager_status, transform_statuses
 
+    def _start_kompress_background_warm(self) -> None:
+        """Warm the deferred Kompress model on a daemon thread.
+
+        The eager preload deliberately skips ``preload()`` so a native model
+        load can never block the port bind (GH #790). Without this thread the
+        warmup slot stays ``null`` and /health reports
+        ``kompress: unhealthy, backend: null`` until some request happens to
+        route to kompress (GH #2730).
+
+        ``allow_download=False`` keeps startup off the network: a cold cache
+        raises :class:`KompressModelNotCached` and the component simply stays
+        deferred, exactly as it behaves today.
+        """
+        if os.environ.get("HEADROOM_KOMPRESS_BACKGROUND_WARM", "1").strip() == "0":
+            logger.debug("Kompress background warm disabled via env")
+            return
+        if self._kompress_warm_thread is not None and self._kompress_warm_thread.is_alive():
+            return
+        compressors = _kompress_compressors(self)
+        for router in _kompress_routers(self):
+            try:
+                compressor = router._get_kompress()
+            except Exception:  # pragma: no cover - defensive
+                continue
+            if compressor is not None and all(compressor is not item for item in compressors):
+                compressors.append(compressor)
+        compressors = [c for c in compressors if hasattr(c, "preload")]
+        if not compressors:
+            return
+
+        slot = self.warmup.kompress
+
+        def _warm() -> None:
+            not_cached: tuple[type[BaseException], ...]
+            try:
+                from headroom.transforms.kompress_compressor import KompressModelNotCached
+
+                not_cached = (KompressModelNotCached,)
+            except Exception:  # pragma: no cover - ML extras absent
+                not_cached = ()
+
+            for compressor in compressors:
+                try:
+                    backend = compressor.preload(allow_download=False)
+                except not_cached:
+                    slot.info["detail"] = "model not cached"
+                    continue
+                except Exception as exc:
+                    slot.info["detail"] = f"warm failed: {exc}"
+                    logger.debug("Kompress background warm failed: %s", exc)
+                    continue
+                if not backend:
+                    continue
+                slot.info.pop("detail", None)
+                slot.mark_loaded(handle=compressor, backend=backend)
+                logger.info("Kompress: model warm (backend=%s)", backend)
+                return
+
+        thread = threading.Thread(target=_warm, name="kompress-startup-warm", daemon=True)
+        self._kompress_warm_thread = thread
+        thread.start()
+
     async def startup(self):
         """Initialize async resources."""
         self._get_shutdown_event().clear()
@@ -1804,6 +1869,12 @@ class HeadroomProxy(
         # Update internal status from eager loading results
         if eager_status.get("kompress") in {"enabled", "deferred"}:
             self._kompress_status = eager_status["kompress"]
+            if self._kompress_status == "deferred":
+                # The transform IS wired into the pipeline; only the native
+                # model load was deferred so a cold cache cannot block the port
+                # bind (GH #790). Warm it in the background instead of leaving
+                # the health slot empty forever (GH #2730).
+                self._start_kompress_background_warm()
         if eager_status.get("code_aware") == "enabled":
             self._code_aware_status = "enabled"
 
@@ -1811,7 +1882,7 @@ class HeadroomProxy(
         if self._kompress_status == "enabled":
             logger.info("Kompress: ENABLED (ModernBERT token compressor)")
         elif self._kompress_status == "deferred":
-            logger.info("Kompress: DEFERRED (model loads on first request)")
+            logger.info("Kompress: DEFERRED (wired into pipeline; model loads in background)")
         elif self.config.optimize:
             logger.info("Kompress: not installed (pip install headroom-ai[ml] for ML compression)")
 
@@ -2455,6 +2526,31 @@ class WebSocketProjectPrefixMiddleware:
         await self.app(scope, receive, send)
 
 
+def _kompress_routers(proxy: HeadroomProxy) -> list[ContentRouter]:
+    """Kompress-enabled ContentRouters across both pipelines, deduped by identity."""
+    routers: list[ContentRouter] = []
+    for pipeline in (proxy.anthropic_pipeline, proxy.openai_pipeline):
+        for transform in getattr(pipeline, "transforms", ()):
+            if (
+                isinstance(transform, ContentRouter)
+                and transform.config.enable_kompress
+                and all(transform is not item for item in routers)
+            ):
+                routers.append(transform)
+    return routers
+
+
+def _kompress_compressors(proxy: HeadroomProxy) -> list[Any]:
+    """Compressor instances held by the kompress-enabled routers, deduped."""
+    compressors: list[Any] = []
+    for router in _kompress_routers(proxy):
+        for name in ("_kompress", "_kompress_remote"):
+            compressor = getattr(router, name, None)
+            if compressor is not None and all(compressor is not item for item in compressors):
+                compressors.append(compressor)
+    return compressors
+
+
 def create_app(config: ProxyConfig | None = None) -> FastAPI:
     """Create FastAPI application."""
     if not FASTAPI_AVAILABLE:
@@ -2753,30 +2849,13 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         return result
 
     def _kompress_health_routers() -> list[ContentRouter]:
-        routers: list[ContentRouter] = []
-        for pipeline in (proxy.anthropic_pipeline, proxy.openai_pipeline):
-            for transform in getattr(pipeline, "transforms", ()):
-                if (
-                    isinstance(transform, ContentRouter)
-                    and transform.config.enable_kompress
-                    and all(transform is not item for item in routers)
-                ):
-                    routers.append(transform)
-        return routers
+        return _kompress_routers(proxy)
 
     def _reconcile_kompress_health() -> bool:
-        routers = _kompress_health_routers()
-        if not routers:
+        if not _kompress_health_routers():
             return False
 
-        compressors: list[Any] = []
-        for router in routers:
-            for name in ("_kompress", "_kompress_remote"):
-                compressor = getattr(router, name, None)
-                if compressor is not None and all(compressor is not item for item in compressors):
-                    compressors.append(compressor)
-
-        for compressor in compressors:
+        for compressor in _kompress_compressors(proxy):
             try:
                 if not compressor.is_ready():
                     continue
@@ -2809,6 +2888,29 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                         handle=model, backend=backend, source_status="runtime"
                     )
         return True
+
+    def _kompress_detail() -> str:
+        """Human-readable reason behind the kompress readiness bit.
+
+        ``ready=false`` on its own is ambiguous — the model may be warming in
+        the background, missing from the local cache, or the extras may not be
+        installed at all (GH #2730).
+        """
+        slot = proxy.warmup.kompress
+        if slot.status == "loaded":
+            return "loaded"
+        detail = slot.info.get("detail")
+        if isinstance(detail, str) and detail:
+            return detail
+        if slot.error:
+            return slot.error
+        warm_thread = getattr(proxy, "_kompress_warm_thread", None)
+        if warm_thread is not None and warm_thread.is_alive():
+            return "warming"
+        source_status = slot.info.get("source_status")
+        if isinstance(source_status, str) and source_status:
+            return source_status
+        return "not installed"
 
     def _health_checks() -> dict[str, dict[str, Any]]:
         kompress_enabled = _reconcile_kompress_health()
@@ -2862,6 +2964,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                 ready=proxy.warmup.kompress.status == "loaded",
                 optional=True,
                 backend=proxy.warmup.kompress.info.get("backend", None),
+                detail=_kompress_detail(),
             ),
         }
 

--- a/tests/test_kompress_health_detail_policy.py
+++ b/tests/test_kompress_health_detail_policy.py
@@ -1,0 +1,38 @@
+"""The public kompress health detail must stay inside a closed vocabulary."""
+
+import pytest
+
+from headroom.proxy.kompress_health_detail_policy import (
+    DEFAULT_KOMPRESS_HEALTH_DETAIL,
+    KOMPRESS_HEALTH_DETAILS,
+    public_detail,
+)
+
+
+@pytest.mark.parametrize("value", sorted(KOMPRESS_HEALTH_DETAILS))
+def test_known_details_pass_through(value):
+    assert public_detail(value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "warm failed: /home/opt/models/modernbert.onnx not readable",
+        "OSError: cannot open shared object /usr/lib/libonnxruntime.so",
+        "HTTPError 401 for https://internal.example/models?token=abc123",
+        "",
+        "   ",
+        None,
+        123,
+    ],
+)
+def test_unknown_details_collapse(value):
+    assert public_detail(value) == DEFAULT_KOMPRESS_HEALTH_DETAIL
+
+
+def test_details_are_normalized():
+    assert public_detail("  Model Not Cached  ") == "model not cached"
+
+
+def test_default_is_itself_a_known_detail():
+    assert DEFAULT_KOMPRESS_HEALTH_DETAIL in KOMPRESS_HEALTH_DETAILS

--- a/tests/test_kompress_preload_deferral.py
+++ b/tests/test_kompress_preload_deferral.py
@@ -337,3 +337,31 @@ async def test_startup_background_warm_leaves_cold_cache_deferred(monkeypatch):
         assert proxy.warmup.kompress.info["detail"] == "model not cached"
     finally:
         await proxy.shutdown()
+
+
+class _LeakyPreloadCompressor(_StubCompressor):
+    """Fails with an exception carrying a path and a token, as loaders do."""
+
+    def preload(self, *, allow_download: bool = True) -> str:
+        self.preload_calls.append(allow_download)
+        raise RuntimeError("/opt/secret-path/model.onnx token=SENTINEL-LEAK-9f3a")
+
+
+@pytest.mark.asyncio
+async def test_startup_background_warm_failure_detail_is_bounded(monkeypatch):
+    """The warm failure reason must not reach the auth-exempt health payload."""
+    pytest.importorskip("httpx")
+
+    stub = _LeakyPreloadCompressor(cached=True)
+    proxy = _kompress_proxy(monkeypatch, stub)
+
+    await proxy.startup()
+    try:
+        thread = proxy._kompress_warm_thread
+        assert thread is not None
+        thread.join(timeout=10)
+        assert stub.preload_calls == [False]
+        assert proxy.warmup.kompress.status == "null"
+        assert proxy.warmup.kompress.info["detail"] == "warm failed"
+    finally:
+        await proxy.shutdown()

--- a/tests/test_kompress_preload_deferral.py
+++ b/tests/test_kompress_preload_deferral.py
@@ -260,6 +260,9 @@ async def test_proxy_startup_does_not_enter_cached_kompress_native_loader(monkey
             code_aware_enabled=False,
         )
     )
+    # The background warm thread (GH #2730) is allowed to preload; this test
+    # covers the *awaited* startup path only, so disable it for determinism.
+    monkeypatch.setenv("HEADROOM_KOMPRESS_BACKGROUND_WARM", "0")
     router = _router_kompress_only()
     stub = _FatalPreloadCompressor(cached=True)
     monkeypatch.setattr(router, "_get_kompress", lambda: stub)
@@ -270,5 +273,67 @@ async def test_proxy_startup_does_not_enter_cached_kompress_native_loader(monkey
     try:
         assert stub.preload_calls == []
         assert proxy.warmup.kompress.info["source_status"] == "deferred"
+        assert proxy._kompress_warm_thread is None
+    finally:
+        await proxy.shutdown()
+
+
+def _kompress_proxy(monkeypatch, stub):
+    from headroom.proxy.server import HeadroomProxy, ProxyConfig
+
+    proxy = HeadroomProxy(
+        ProxyConfig(
+            optimize=True,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=False,
+            code_aware_enabled=False,
+        )
+    )
+    router = _router_kompress_only()
+    monkeypatch.setattr(router, "_get_kompress", lambda: stub)
+    proxy.anthropic_pipeline.transforms = [router]
+    proxy.openai_pipeline.transforms = [router]
+    return proxy
+
+
+@pytest.mark.asyncio
+async def test_startup_background_warm_promotes_deferred_kompress(monkeypatch):
+    """A cached model must reach the warmup slot without any request (GH #2730)."""
+    pytest.importorskip("httpx")
+
+    stub = _StubCompressor(cached=True)
+    proxy = _kompress_proxy(monkeypatch, stub)
+
+    await proxy.startup()
+    try:
+        thread = proxy._kompress_warm_thread
+        assert thread is not None
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+        # Cache-only: the warm path must never hit the network.
+        assert stub.preload_calls == [False]
+        assert proxy.warmup.kompress.status == "loaded"
+        assert proxy.warmup.kompress.info["backend"] == "onnx"
+    finally:
+        await proxy.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_startup_background_warm_leaves_cold_cache_deferred(monkeypatch):
+    """An uncached model stays deferred and says why."""
+    pytest.importorskip("httpx")
+
+    stub = _StubCompressor(cached=False)
+    proxy = _kompress_proxy(monkeypatch, stub)
+
+    await proxy.startup()
+    try:
+        thread = proxy._kompress_warm_thread
+        assert thread is not None
+        thread.join(timeout=10)
+        assert stub.preload_calls == [False]
+        assert proxy.warmup.kompress.status == "null"
+        assert proxy.warmup.kompress.info["detail"] == "model not cached"
     finally:
         await proxy.shutdown()

--- a/tests/test_proxy_eager_preload_bind.py
+++ b/tests/test_proxy_eager_preload_bind.py
@@ -151,7 +151,9 @@ async def test_startup_reports_deferred_kompress(caplog):
             server_mod.logger.removeHandler(caplog.handler)
 
         assert proxy._kompress_status == "deferred"
-        assert "Kompress: DEFERRED (model loads on first request)" in caplog.messages
+        assert (
+            "Kompress: DEFERRED (wired into pipeline; model loads in background)" in caplog.messages
+        )
         assert not any("Kompress: not installed" in message for message in caplog.messages)
     finally:
         await proxy.shutdown()

--- a/tests/test_proxy_health.py
+++ b/tests/test_proxy_health.py
@@ -336,3 +336,33 @@ def test_readyz_kompress_state_matrix(monkeypatch, slot_status, compressor, disa
     payload = TestClient(app).get("/readyz").json()["checks"]["kompress"]
 
     assert payload == expected
+
+
+# /health and /readyz are auth-exempt, so nothing they serialize may carry raw
+# exception text: loader failures embed absolute paths, model ids and URLs.
+_SENTINEL_DETAIL = "/opt/secret-path/model.onnx token=SENTINEL-LEAK-9f3a"
+
+
+@pytest.mark.parametrize("endpoint", ["/health", "/readyz"])
+def test_public_health_does_not_leak_warm_failure_text(monkeypatch, endpoint):
+    app, proxy = _health_app(monkeypatch)
+    # What the background warm thread would have written pre-#2799 review.
+    proxy.warmup.kompress.info["detail"] = f"warm failed: {_SENTINEL_DETAIL}"
+
+    response = TestClient(app).get(endpoint)
+
+    assert response.json()["checks"]["kompress"]["detail"] == "unavailable"
+    assert "SENTINEL-LEAK-9f3a" not in response.text
+    assert "secret-path" not in response.text
+
+
+@pytest.mark.parametrize("endpoint", ["/health", "/readyz"])
+def test_public_health_does_not_leak_slot_error_text(monkeypatch, endpoint):
+    app, proxy = _health_app(monkeypatch)
+    proxy.warmup.kompress.mark_error(f"native load failed: {_SENTINEL_DETAIL}")
+
+    response = TestClient(app).get(endpoint)
+
+    assert response.json()["checks"]["kompress"]["detail"] == "unavailable"
+    assert "SENTINEL-LEAK-9f3a" not in response.text
+    assert "secret-path" not in response.text

--- a/tests/test_proxy_health.py
+++ b/tests/test_proxy_health.py
@@ -72,6 +72,7 @@ def test_readyz_excludes_kompress_from_aggregate_readiness(monkeypatch):
         "status": "degraded",
         "optional": True,
         "backend": None,
+        "detail": "model not cached",
     }
 
 
@@ -88,6 +89,7 @@ def test_readyz_promotes_deferred_kompress_after_runtime_load(monkeypatch):
         "status": "healthy",
         "optional": True,
         "backend": "onnx",
+        "detail": "loaded",
     }
     # The promotion must also clear the startup marker, otherwise the slot
     # serializes as loaded-but-deferred in /debug/warmup.
@@ -114,6 +116,7 @@ def test_readyz_promotes_kompress_from_module_cache(monkeypatch, attached):
         "status": "healthy",
         "optional": True,
         "backend": "onnx",
+        "detail": "loaded",
     }
     assert proxy.warmup.kompress.handle is model
     if compressor is not None:
@@ -147,6 +150,7 @@ def test_readyz_keeps_pending_kompress_unloaded(monkeypatch):
         "status": "degraded",
         "optional": True,
         "backend": None,
+        "detail": "not installed",
     }
     assert compressor.calls == ["is_ready"]
 
@@ -187,6 +191,7 @@ def test_readyz_disabled_kompress_skips_inspection(monkeypatch):
         "status": "disabled",
         "optional": True,
         "backend": None,
+        "detail": "not installed",
     }
     assert compressor.calls == []
 
@@ -209,6 +214,7 @@ def test_readyz_per_provider_kompress_override_reenables_health(monkeypatch):
         "status": "healthy",
         "optional": True,
         "backend": "onnx",
+        "detail": "loaded",
     }
     assert compressor.calls == ["is_ready", "ready_backend"]
 
@@ -231,6 +237,7 @@ def test_readyz_never_calls_lazy_kompress_getters(monkeypatch):
         "status": "degraded",
         "optional": True,
         "backend": None,
+        "detail": "not installed",
     }
 
 
@@ -247,6 +254,7 @@ def test_readyz_never_calls_lazy_kompress_getters(monkeypatch):
                 "status": "degraded",
                 "optional": True,
                 "backend": None,
+                "detail": "not installed",
             },
         ),
         (
@@ -259,6 +267,7 @@ def test_readyz_never_calls_lazy_kompress_getters(monkeypatch):
                 "status": "healthy",
                 "optional": True,
                 "backend": "onnx",
+                "detail": "loaded",
             },
         ),
         (
@@ -271,6 +280,7 @@ def test_readyz_never_calls_lazy_kompress_getters(monkeypatch):
                 "status": "healthy",
                 "optional": True,
                 "backend": "remote",
+                "detail": "loaded",
             },
         ),
         (
@@ -283,6 +293,7 @@ def test_readyz_never_calls_lazy_kompress_getters(monkeypatch):
                 "status": "healthy",
                 "optional": True,
                 "backend": "onnx",
+                "detail": "loaded",
             },
         ),
         (
@@ -295,6 +306,7 @@ def test_readyz_never_calls_lazy_kompress_getters(monkeypatch):
                 "status": "healthy",
                 "optional": True,
                 "backend": "existing",
+                "detail": "loaded",
             },
         ),
         (
@@ -307,6 +319,7 @@ def test_readyz_never_calls_lazy_kompress_getters(monkeypatch):
                 "status": "disabled",
                 "optional": True,
                 "backend": None,
+                "detail": "not installed",
             },
         ),
     ],


### PR DESCRIPTION
## Description

On an idle proxy with the ML extras installed and the Kompress model cached, `/health` and `/readyz` reported `kompress: {"ready": false, "status": "unhealthy", "backend": null}` forever, and the startup banner logged `Kompress: not installed`.

The issue diagnosed this as "the kompress transform is not wired into the pipeline". That is not accurate — `enable_kompress` defaults to `True` and `ContentRouter` sits in both the Anthropic and OpenAI pipelines. The real chain is:

1. `ContentRouter.eager_load_compressors()` deliberately does not call `preload()`, so a native model load can never run before the port binds (#790 hang on Windows, #1908 segfault on RHEL/CentOS 7). It returns `kompress = "deferred"`.
2. `WarmupRegistry.merge_transform_status` only promotes `enabled` / `ready` / `loaded*`, so `"deferred"` leaves the slot at `status="null"`.
3. `/health` reads that slot, hence `ready=false, backend=null`.
4. `_reconcile_kompress_health()` can promote the slot, but only once a compressor reports `is_ready()`. Nothing warms the model after startup — the only loader kick, `ensure_background_load()`, lives in the compression request path. No kompress-routed request means unhealthy indefinitely.

Closes #2730

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `HeadroomProxy._start_kompress_background_warm()`: when startup reports `kompress = "deferred"`, a daemon thread (`kompress-startup-warm`) calls `compressor.preload(allow_download=False)` and promotes `warmup.kompress` with the returned backend. Cache-only means no network at startup, so a cold cache raises `KompressModelNotCached` and stays deferred exactly as today, and the port still binds immediately. Disable with `HEADROOM_KOMPRESS_BACKGROUND_WARM=0`.
- Router/compressor lookup lifted out of `create_app` into module-level `_kompress_routers()` / `_kompress_compressors()` so startup and the health endpoint share one implementation.
- Honest status reporting: the startup banner logs `Kompress: DEFERRED (wired into pipeline; model loads in background)`, and the kompress health check gains a `detail` field — `loaded` / `warming` / `model not cached` / `not installed` / the warm error. `enabled`, `ready` and `backend` semantics are unchanged, so the `/readyz` aggregate exclusion still holds.
- Tests: pinned the existing awaited-startup deferral test with the kill switch, added warm-cache promotion and cold-cache coverage, and updated the health/log expectations.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ uv run --no-sync pytest tests/test_proxy_health.py tests/test_proxy_warmup.py tests/test_kompress_preload_deferral.py tests/test_proxy_eager_preload_bind.py -q
45 passed, 1 failed in 9.4s

FAILED tests/test_kompress_preload_deferral.py::test_proxy_startup_does_not_enter_cached_kompress_native_loader
E     - deferred
E     + unavailable

$ uv run --no-sync ruff check headroom tests
All checks passed!

$ uv run --no-sync ruff format --check headroom/proxy/server.py tests/test_proxy_health.py tests/test_kompress_preload_deferral.py tests/test_proxy_eager_preload_bind.py
4 files already formatted

$ uv run --no-sync mypy headroom/proxy/server.py --ignore-missing-imports --python-version 3.13
(no errors reported for headroom/proxy/server.py)
```

The single local failure is pre-existing on `upstream/main` in my environment and is not caused by this change — verified by swapping in the unmodified `main` copies of `headroom/proxy/server.py` and `tests/test_kompress_preload_deferral.py`, which fail identically. It comes from a second ContentRouter in the pipelines whose real `_get_kompress()` returns `None` on this machine (ML extras not fully installed), so `merge_transform_status` overwrites `source_status` with `unavailable`. CI passes this test, so it is environment-specific; worth a separate look.

`ruff check .` also reports 4 pre-existing errors in `plugins/headroom-oauth2/`, untouched by this PR.

## Real Behavior Proof

- Environment: Windows 11, Python 3.13.11, pytest 9.1.1, branch rebased on `upstream/main` d0a86d4
- Exact command / steps: `uv run --no-sync pytest tests/test_kompress_preload_deferral.py tests/test_proxy_health.py tests/test_proxy_warmup.py tests/test_proxy_eager_preload_bind.py -q`, exercising the two new tests `test_startup_background_warm_promotes_deferred_kompress` (joins the warm thread, asserts `preload_calls == [False]`, slot `loaded`, backend `onnx`) and `test_startup_background_warm_leaves_cold_cache_deferred` (slot stays `null`, `detail == "model not cached"`)
- Observed result: the warm thread promotes the deferred slot with no request at all, and a cold cache stays deferred with zero network calls; the DEFERRED startup line replaces the misleading `not installed` line. Full CI on this branch is green.
- Not tested: a live proxy run against a real cached ModernBERT model on macOS arm64 (the reporter's platform). The ML extras are not fully installed in this environment, so the warm path is covered by stubs only.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — no user-facing UI change.

## Additional Notes

- "Manual testing performed" is unchecked: no live proxy run against a real cached model, for the reason under Not tested above.
- Documentation is unchanged; the new `HEADROOM_KOMPRESS_BACKGROUND_WARM` kill switch is an escape hatch rather than a documented knob. Happy to add it to the env-var reference if maintainers prefer.
