### PR TITLE
feat(config): add none tool profile to skip compression

### DIFF
--- a/headroom/config.py
+++ b/headroom/config.py
@@ -435,7 +435,10 @@ class CompressionProfile:
 
 
 # Named presets for convenience
+# "none" uses bias=inf as a sentinel: ContentRouter detects isinf(bias) and
+# skips compression entirely, returning the tool output verbatim.
 PROFILE_PRESETS: dict[str, CompressionProfile] = {
+    "none": CompressionProfile(bias=float("inf"), min_k=0),
     "conservative": CompressionProfile(bias=1.5, min_k=5),
     "moderate": CompressionProfile(bias=1.0, min_k=3),
     "aggressive": CompressionProfile(bias=0.7, min_k=3),

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -5271,7 +5271,7 @@ def _parse_tool_profiles(cli_profiles: list[str]) -> dict[str, Any]:
             profiles[tool_name] = PROFILE_PRESETS[level]
         else:
             logger.warning(
-                "Unknown profile level '%s' for tool '%s'. Use: conservative, moderate, aggressive",
+                "Unknown profile level '%s' for tool '%s'. Use: none, conservative, moderate, aggressive",
                 level,
                 tool_name,
             )

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -5034,6 +5034,13 @@ class ContentRouter(Transform):
                 # Look up tool-specific compression bias for OpenAI tool messages
                 tool_name = tool_name_map.get(tool_call_id, "")
                 bias = self._get_tool_bias(tool_name) if tool_name else 1.0
+                # "none" profile: bias=inf sentinel → skip compression for this tool
+                if math.isinf(bias):
+                    result_slots[i] = message
+                    transforms_applied.append("router:protected:tool_profile_none")
+                    route_counts.setdefault("tool_profile_none", 0)
+                    route_counts["tool_profile_none"] += 1
+                    continue
 
                 # Bash-search lossless pre-empt: a read-only search (grep/rg/git
                 # grep) run via a shell tool yields byte-losslessly foldable
@@ -5971,6 +5978,14 @@ class ContentRouter(Transform):
                 # Look up tool-specific compression bias
                 tool_name = (tool_name_map or {}).get(tool_use_id, "")
                 bias = self._get_tool_bias(tool_name) if tool_name else 1.0
+                # "none" profile: bias=inf sentinel → skip compression for this tool
+                if math.isinf(bias):
+                    new_blocks.append(block)
+                    transforms_applied.append("router:protected:tool_profile_none")
+                    if route_counts is not None:
+                        route_counts.setdefault("tool_profile_none", 0)
+                        route_counts["tool_profile_none"] += 1
+                    continue
 
                 # Enrich the relevance query with the triggering tool call's
                 # args (grep pattern, read path, …) — the sharpest, per-output

--- a/tests/test_cli_proxy_env.py
+++ b/tests/test_cli_proxy_env.py
@@ -1284,7 +1284,6 @@ class TestCLIProxyExcludeToolsEnvVar:
         assert result.exit_code == 0, result.output
         assert captured_config["config"].tool_profiles is None
 
-
 class TestCLIProxyRpmTpm:
     """--rpm/--tpm flags and HEADROOM_RPM/HEADROOM_TPM env vars must reach ProxyConfig."""
 
@@ -1431,3 +1430,27 @@ class TestSettingsFileToEnv:
 
         assert result.exit_code == 0, result.output
         assert captured_config["config"].port == 7777
+
+
+def test_tool_profiles_none_level_accepted(runner):
+    """HEADROOM_TOOL_PROFILES=Bash:none is accepted and yields an inf bias."""
+    import math
+
+    captured_config = {}
+
+    def mock_run_server(config, **kwargs):
+        captured_config["config"] = config
+
+    with patch("headroom.proxy.server.run_server", mock_run_server):
+        result = runner.invoke(
+            main,
+            ["proxy"],
+            env={"HEADROOM_TOOL_PROFILES": "Bash:none"},
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    cfg = captured_config["config"]
+    assert cfg.tool_profiles is not None
+    assert "Bash" in cfg.tool_profiles
+    assert math.isinf(cfg.tool_profiles["Bash"].bias)

--- a/tests/test_cli_proxy_env.py
+++ b/tests/test_cli_proxy_env.py
@@ -1284,6 +1284,7 @@ class TestCLIProxyExcludeToolsEnvVar:
         assert result.exit_code == 0, result.output
         assert captured_config["config"].tool_profiles is None
 
+
 class TestCLIProxyRpmTpm:
     """--rpm/--tpm flags and HEADROOM_RPM/HEADROOM_TPM env vars must reach ProxyConfig."""
 

--- a/tests/test_transforms_content_router.py
+++ b/tests/test_transforms_content_router.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 import headroom.transforms.content_router as content_router_module
+from headroom.config import CompressionProfile
 from headroom.transforms.content_detector import ContentType, DetectionResult
 from headroom.transforms.content_router import (
     CompressionCache,
@@ -35,6 +36,14 @@ def _reset_detect_module_state(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(content_router_module, "_detect_native_unhealthy", False)
     monkeypatch.setattr(content_router_module, "_detect_backend_warned", False)
     monkeypatch.setattr(content_router_module, "_detect_panic_warned", False)
+
+
+class _TinyTokenizer:
+    def count_text(self, text: str) -> int:
+        return max(1, len(text) // 4)
+
+    def count_messages(self, messages: list[dict]) -> int:
+        return sum(self.count_text(str(message.get("content", ""))) for message in messages)
 
 
 def test_compression_cache_handles_hits_skips_evictions_and_clear(
@@ -228,6 +237,67 @@ def test_short_instruction_with_embedded_json_compresses_without_kompress() -> N
     assert any(
         decision.strategy is CompressionStrategy.SMART_CRUSHER for decision in result.routing_log
     )
+
+
+def test_tool_profile_none_skips_openai_tool_message() -> None:
+    tool_output = "important exact output\n" * 200
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "Bash", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": tool_output},
+    ]
+    router = ContentRouter(
+        ContentRouterConfig(tool_profiles={"Bash": CompressionProfile(bias=float("inf"), min_k=0)})
+    )
+
+    result = router.apply(messages, _TinyTokenizer(), read_protection_window=0)
+
+    assert result.messages == messages
+    assert "router:protected:tool_profile_none" in result.transforms_applied
+
+
+def test_tool_profile_none_skips_anthropic_tool_result_block() -> None:
+    tool_output = "important exact output\n" * 200
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "Bash",
+                    "input": {},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": tool_output,
+                }
+            ],
+        },
+    ]
+    router = ContentRouter(
+        ContentRouterConfig(tool_profiles={"Bash": CompressionProfile(bias=float("inf"), min_k=0)})
+    )
+
+    result = router.apply(messages, _TinyTokenizer(), read_protection_window=0)
+
+    assert result.messages == messages
+    assert "router:protected:tool_profile_none" in result.transforms_applied
 
 
 def test_extract_json_block_ignores_brackets_inside_strings() -> None:


### PR DESCRIPTION
## Description

Replays the focused intent of #1389 onto current `main`: add a `none` per-tool compression profile so selected tool outputs bypass lossy routing. The original contributor branch contains a large historical merge and cannot be updated from this repository.

Closes #1307
Supersedes #1389

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add `PROFILE_PRESETS["none"]` using an infinite bias sentinel.
- Short-circuit OpenAI tool messages and Anthropic tool-result blocks before lossy compression when that profile is selected.
- Accept `ToolName:none` in CLI/environment profile parsing.
- Preserve and adapt the original contributor tests on current main.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ uv run --frozen pytest -q tests/test_cli_proxy_env.py tests/test_transforms_content_router.py
132 passed, 1 skipped in 5.17s

$ uv run ruff check headroom/config.py headroom/proxy/server.py headroom/transforms/content_router.py tests/test_cli_proxy_env.py tests/test_transforms_content_router.py
All checks passed!
```

## Real Behavior Proof

- Environment: macOS, Python 3.12, current main.
- Exact command / steps: parse `HEADROOM_TOOL_PROFILES=Bash:none`, then route both OpenAI-style and Anthropic-style Bash tool output through `ContentRouter.apply`.
- Observed result: content remains byte-for-byte unchanged and `router:protected:tool_profile_none` is recorded.
- Not tested: live proxy session or Windows.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — configuration and backend routing only; no UI changes.

## Additional Notes

The documentation and manual-test checklist items are N/A for this narrow conflict-resolution replay. Commit authorship from #1389 is preserved on the feature commit; the regression-test follow-up preserves its original author as well.