### PR TITLE
fix(proxy): report optional kompress component as degraded, not unhealthy

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2652,9 +2652,17 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         *,
         enabled: bool,
         ready: bool,
+        optional: bool = False,
         **details: Any,
     ) -> dict[str, Any]:
-        status = "disabled" if not enabled else ("healthy" if ready else "unhealthy")
+        if not enabled:
+            status = "disabled"
+        elif ready:
+            status = "healthy"
+        elif optional:
+            status = "degraded"
+        else:
+            status = "unhealthy"
         return {
             "enabled": enabled,
             "ready": (ready if enabled else True),
@@ -2770,6 +2778,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
             "kompress": _component_health(
                 enabled=kompress_enabled,
                 ready=proxy.warmup.kompress.status == "loaded",
+                optional=True,
                 backend=proxy.warmup.kompress.info.get("backend", None),
             ),
         }

--- a/tests/test_proxy_health.py
+++ b/tests/test_proxy_health.py
@@ -69,7 +69,7 @@ def test_readyz_excludes_kompress_from_aggregate_readiness(monkeypatch):
     assert payload["checks"]["kompress"] == {
         "enabled": True,
         "ready": False,
-        "status": "unhealthy",
+        "status": "degraded",
         "backend": None,
     }
 
@@ -141,7 +141,7 @@ def test_readyz_keeps_pending_kompress_unloaded(monkeypatch):
     assert payload["checks"]["kompress"] == {
         "enabled": True,
         "ready": False,
-        "status": "unhealthy",
+        "status": "degraded",
         "backend": None,
     }
     assert compressor.calls == ["is_ready"]
@@ -222,7 +222,7 @@ def test_readyz_never_calls_lazy_kompress_getters(monkeypatch):
     assert payload["checks"]["kompress"] == {
         "enabled": True,
         "ready": False,
-        "status": "unhealthy",
+        "status": "degraded",
         "backend": None,
     }
 
@@ -234,7 +234,7 @@ def test_readyz_never_calls_lazy_kompress_getters(monkeypatch):
             "null",
             None,
             False,
-            {"enabled": True, "ready": False, "status": "unhealthy", "backend": None},
+            {"enabled": True, "ready": False, "status": "degraded", "backend": None},
         ),
         (
             "null",


### PR DESCRIPTION
## Description

`/health` deliberately excludes the optional `kompress` component from the
aggregate readiness check (see the comment at `_health_payload()` in
`headroom/proxy/server.py`), but the per-component status for `kompress`
still reported `"unhealthy"` when it wasn't ready. That reads as a real
failure even though it's excluded from readiness by design.

Closes #2813

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `_component_health()` in `headroom/proxy/server.py` now accepts an `optional` flag; when set and the component isn't ready, it reports `"degraded"` instead of `"unhealthy"`.
- The `kompress` health check now passes `optional=True`.
- Updated the 4 pinned assertions in `tests/test_proxy_health.py` that expected `"unhealthy"` for a not-ready `kompress` to expect `"degraded"`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality (existing tests updated to cover the new status value)
- [ ] Manual testing performed

### Test Output

```text
$ uv run ruff check headroom/proxy/server.py tests/test_proxy_health.py
All checks passed!

$ uv run mypy headroom/proxy/server.py
Success: no issues found in 1 source file

$ uv run pytest tests/test_proxy_health.py -q
tests/test_proxy_health.py .................                             [100%]
17 passed, 1 warning in 1.74s
```

## Real Behavior Proof

- Environment: local dev checkout, Python 3.11.12, `uv run pytest`
- Exact command / steps: `uv run pytest tests/test_proxy_health.py -q`
- Observed result: all 17 tests pass, including the 4 updated assertions confirming `kompress` now reports `"status": "degraded"` (not `"unhealthy"`) when not ready but not blocking readiness
- Not tested: manual `curl /health` against a live proxy instance with kompress deferred

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — backend-only status string change.

## Additional Notes

No documentation changes needed since this only adjusts an internal health-check status label, not documented API behavior.
