### PR TITLE
test(proxy): assert bounded concurrency structurally in the pre-upstream gate

### DIFF
--- a/tests/test_anthropic_pre_upstream_backpressure.py
+++ b/tests/test_anthropic_pre_upstream_backpressure.py
@@ -431,14 +431,21 @@ async def _await_entered(handler: _DummyAnthropicHandler, count: int) -> None:
         await handler.upstream_entered.wait_for(lambda: len(handler.upstream_enter_times) >= count)
 
 
-async def _drain_scheduler(iterations: int = 100) -> None:
-    """Give every runnable task ample opportunity to progress.
+def _queued_waiters(sem: asyncio.Semaphore) -> int:
+    """Number of tasks parked inside ``sem.acquire()``."""
+    return sum(1 for waiter in (sem._waiters or ()) if not waiter.cancelled())
 
-    A bounded number of event-loop turns, not a duration: a request that is
-    *able* to enter the upstream section will have done so long before this
-    returns, no matter how slow or how loaded the machine is.
+
+async def _await_queued_waiters(sem: asyncio.Semaphore, count: int) -> None:
+    """Block until ``count`` tasks are queued on ``sem``.
+
+    This is the handshake that makes the "has not entered yet" assertion
+    meaningful: it establishes *where* the (N+1)th request is parked rather
+    than merely giving it chances to run. Yielding until the waiter appears
+    has no iteration budget to get wrong; the enclosing ``anyio.fail_after``
+    turns a genuine deadlock into a failure.
     """
-    for _ in range(iterations):
+    while _queued_waiters(sem) < count:
         await asyncio.sleep(0)
 
 
@@ -448,8 +455,10 @@ def test_n_plus_one_contention_blocks_until_slot_frees(_iteration, stage_log_cap
 
     Contention is driven by coordination primitives, never by sleeps or
     millisecond thresholds: the two admitted requests are pinned inside the
-    upstream section until the test hands out a permit. Every assertion is
-    therefore structural (occupancy, ordering, semaphore state) and stays
+    upstream section until the test hands out a permit, and the third is
+    observed queued on the gate before its non-entry is asserted. Every
+    assertion is therefore structural (occupancy, ordering, semaphore
+    queue depth and final value) and stays
     valid under arbitrary scheduling pauses on a loaded CI runner. Do not
     reintroduce wall-clock bounds here, absolute *or* relative to another
     request's measured wait -- both fail when the loop delays all three
@@ -482,8 +491,12 @@ def test_n_plus_one_contention_blocks_until_slot_frees(_iteration, stage_log_cap
                 assert sem._value == 0
 
                 # The third request cannot enter while both slots are held.
+                # Wait until it is provably parked *inside* the gate before
+                # asserting non-entry, so the assertion cannot pass merely
+                # because the task had not reached ``acquire()`` yet.
                 tg.start_soon(handler.handle_anthropic_messages, reqs[2])
-                await _drain_scheduler()
+                await _await_queued_waiters(sem, 1)
+                assert _queued_waiters(sem) == 1
                 assert len(handler.upstream_enter_times) == 2, handler.upstream_enter_times
                 assert len(handler.upstream_exit_times) == 0, handler.upstream_exit_times
 

--- a/tests/test_anthropic_pre_upstream_backpressure.py
+++ b/tests/test_anthropic_pre_upstream_backpressure.py
@@ -119,6 +119,7 @@ class _DummyAnthropicHandler(AnthropicHandlerMixin):
         *,
         anthropic_pre_upstream_sem: asyncio.Semaphore | None = None,
         upstream_delay_s: float = 0.0,
+        upstream_release: asyncio.Semaphore | None = None,
         raise_during_critical: bool = False,
         security: Any = None,
         upstream_status: int = 200,
@@ -206,6 +207,13 @@ class _DummyAnthropicHandler(AnthropicHandlerMixin):
         self._raise_during_critical = raise_during_critical
         self.upstream_enter_times: list[float] = []
         self.upstream_exit_times: list[float] = []
+        # Deterministic hold: when set, a request inside the upstream section
+        # blocks until the test hands it a permit, instead of sleeping for
+        # ``upstream_delay_s``. One ``release()`` frees exactly one holder, so
+        # a test can prove that the (N+1)th request enters only once a slot is
+        # actually returned -- no wall-clock thresholds involved.
+        self._upstream_release = upstream_release
+        self.upstream_entered = asyncio.Condition()
 
     async def _run_compression_in_executor(self, fn, *, timeout):  # noqa: ANN001
         # Mirror of ``HeadroomProxy._run_compression_in_executor`` for the
@@ -271,7 +279,11 @@ class _DummyAnthropicHandler(AnthropicHandlerMixin):
             raise RuntimeError("synthetic pre-upstream failure")
         enter = time.perf_counter()
         self.upstream_enter_times.append(enter)
-        if self._upstream_delay_s > 0:
+        async with self.upstream_entered:
+            self.upstream_entered.notify_all()
+        if self._upstream_release is not None:
+            await self._upstream_release.acquire()
+        elif self._upstream_delay_s > 0:
             await asyncio.sleep(self._upstream_delay_s)
         self.upstream_exit_times.append(time.perf_counter())
         return _ResponseStub(status_code=self._upstream_status)
@@ -413,51 +425,99 @@ def _max_concurrent(enter_times: list[float], exit_times: list[float]) -> int:
     return peak
 
 
-def test_n_plus_one_contention_only_waiter_has_nonzero_wait(stage_log_capture):
+async def _await_entered(handler: _DummyAnthropicHandler, count: int) -> None:
+    """Block until ``count`` requests have entered the upstream section."""
+    async with handler.upstream_entered:
+        await handler.upstream_entered.wait_for(lambda: len(handler.upstream_enter_times) >= count)
+
+
+async def _drain_scheduler(iterations: int = 100) -> None:
+    """Give every runnable task ample opportunity to progress.
+
+    A bounded number of event-loop turns, not a duration: a request that is
+    *able* to enter the upstream section will have done so long before this
+    returns, no matter how slow or how loaded the machine is.
+    """
+    for _ in range(iterations):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.parametrize("_iteration", range(10))
+def test_n_plus_one_contention_blocks_until_slot_frees(_iteration, stage_log_capture):
+    """The (N+1)th request enters the upstream section only when a slot frees.
+
+    Contention is driven by coordination primitives, never by sleeps or
+    millisecond thresholds: the two admitted requests are pinned inside the
+    upstream section until the test hands out a permit. Every assertion is
+    therefore structural (occupancy, ordering, semaphore state) and stays
+    valid under arbitrary scheduling pauses on a loaded CI runner. Do not
+    reintroduce wall-clock bounds here, absolute *or* relative to another
+    request's measured wait -- both fail when the loop delays all three
+    coroutines around acquisition while the gate itself behaves correctly.
+    """
     sem = asyncio.Semaphore(2)
-    # Each request hogs the semaphore for ~150 ms. With concurrency=2, at
-    # least one of 3 concurrent requests has to queue behind the others.
-    handler = _DummyAnthropicHandler(anthropic_pre_upstream_sem=sem, upstream_delay_s=0.15)
+    release = asyncio.Semaphore(0)
+    handler = _DummyAnthropicHandler(anthropic_pre_upstream_sem=sem, upstream_release=release)
+    reqs = [
+        _build_request(
+            {
+                "model": "claude-3-5-sonnet-latest",
+                "messages": [{"role": "user", "content": f"hello {i}"}],
+            },
+            {"authorization": "Bearer sk-ant-api-test"},
+        )
+        for i in range(3)
+    ]
 
     async def _run() -> None:
-        reqs = [
-            _build_request(
-                {
-                    "model": "claude-3-5-sonnet-latest",
-                    "messages": [{"role": "user", "content": f"hello {i}"}],
-                },
-                {"authorization": "Bearer sk-ant-api-test"},
-            )
-            for i in range(3)
-        ]
-        await asyncio.gather(*(handler.handle_anthropic_messages(r) for r in reqs))
-        assert sem._value == 2  # semaphore fully released
+        # Below the 15 s pre-upstream acquire timeout, so a genuine deadlock
+        # surfaces as a test failure rather than as the fail-open path.
+        with anyio.fail_after(10):
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(handler.handle_anthropic_messages, reqs[0])
+                tg.start_soon(handler.handle_anthropic_messages, reqs[1])
+
+                # Both slots provably occupied.
+                await _await_entered(handler, 2)
+                assert sem._value == 0
+
+                # The third request cannot enter while both slots are held.
+                tg.start_soon(handler.handle_anthropic_messages, reqs[2])
+                await _drain_scheduler()
+                assert len(handler.upstream_enter_times) == 2, handler.upstream_enter_times
+                assert len(handler.upstream_exit_times) == 0, handler.upstream_exit_times
+
+                # Free exactly one holder: now -- and only now -- it enters.
+                release.release()
+                await _await_entered(handler, 3)
+                assert len(handler.upstream_exit_times) == 1, handler.upstream_exit_times
+
+                release.release()
+                release.release()
 
     with _tokenizer_patch():
         anyio.run(_run)
 
-    # The gate is structural: never more than ``concurrency`` requests in the
-    # upstream section at once. Asserting that directly — instead of pinning
-    # each request's ``pre_upstream_wait`` to a wall-clock threshold — keeps
-    # the test meaningful on a loaded CI runner, where scheduling jitter under
-    # ``pytest --cov`` can inflate a non-waiter's measured wait past any fixed
-    # millisecond bound. Do not reintroduce absolute upper bounds here.
     assert len(handler.upstream_enter_times) == 3
     assert len(handler.upstream_exit_times) == 3
+    # Never more than ``concurrency`` requests inside the upstream section.
     assert _max_concurrent(handler.upstream_enter_times, handler.upstream_exit_times) <= 2, (
         handler.upstream_enter_times,
         handler.upstream_exit_times,
     )
+    # The waiter entered after a slot was handed back, not alongside the holders.
+    assert handler.upstream_enter_times[2] >= handler.upstream_exit_times[0], (
+        handler.upstream_enter_times,
+        handler.upstream_exit_times,
+    )
+    # Semaphore fully released.
+    assert sem._value == 2
 
     payloads = _parse_all_stage_logs(stage_log_capture)
     assert len(payloads) == 3
-    waits = sorted(p["stages"]["pre_upstream_wait"] for p in payloads)
-    # Contention was really exercised: at least one request queued for
-    # roughly the upstream-delay budget behind an earlier holder.
-    assert waits[2] > 75.0, waits
-    # ...and at least one acquired without queueing, so the semaphore is not
-    # serializing everything. Relative to the waiter, not an absolute bound.
-    assert waits[0] < waits[2] / 2.0, waits
+    waits = [p["stages"]["pre_upstream_wait"] for p in payloads]
+    # Contention was recorded at all -- no upper bound, no ratio.
+    assert max(waits) > 0.0, waits
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_anthropic_pre_upstream_backpressure.py
+++ b/tests/test_anthropic_pre_upstream_backpressure.py
@@ -394,17 +394,32 @@ def test_happy_path_single_request_negligible_wait(stage_log_capture):
 
 
 # --------------------------------------------------------------------------- #
-# N+1 contention: with concurrency=2 and 3 concurrent requests,               #
-# exactly one of them must observe a non-trivial ``pre_upstream_wait``.       #
+# N+1 contention: with concurrency=2 and 3 concurrent requests, no more than  #
+# 2 may sit in the upstream section at once and at least one must wait.       #
 # --------------------------------------------------------------------------- #
 
 
+def _max_concurrent(enter_times: list[float], exit_times: list[float]) -> int:
+    """Peak number of requests simultaneously inside the upstream section."""
+    events = [(t, 1) for t in enter_times] + [(t, -1) for t in exit_times]
+    # Exits sort before enters at an identical timestamp so a slot handed
+    # straight over is not double-counted.
+    events.sort(key=lambda e: (e[0], e[1]))
+    current = 0
+    peak = 0
+    for _, delta in events:
+        current += delta
+        peak = max(peak, current)
+    return peak
+
+
 def test_n_plus_one_contention_only_waiter_has_nonzero_wait(stage_log_capture):
+    sem = asyncio.Semaphore(2)
+    # Each request hogs the semaphore for ~150 ms. With concurrency=2, at
+    # least one of 3 concurrent requests has to queue behind the others.
+    handler = _DummyAnthropicHandler(anthropic_pre_upstream_sem=sem, upstream_delay_s=0.15)
+
     async def _run() -> None:
-        sem = asyncio.Semaphore(2)
-        # Each request hogs the semaphore for ~150 ms. With concurrency=2,
-        # 3 concurrent requests mean exactly one waits ~150 ms.
-        handler = _DummyAnthropicHandler(anthropic_pre_upstream_sem=sem, upstream_delay_s=0.15)
         reqs = [
             _build_request(
                 {
@@ -421,15 +436,28 @@ def test_n_plus_one_contention_only_waiter_has_nonzero_wait(stage_log_capture):
     with _tokenizer_patch():
         anyio.run(_run)
 
+    # The gate is structural: never more than ``concurrency`` requests in the
+    # upstream section at once. Asserting that directly — instead of pinning
+    # each request's ``pre_upstream_wait`` to a wall-clock threshold — keeps
+    # the test meaningful on a loaded CI runner, where scheduling jitter under
+    # ``pytest --cov`` can inflate a non-waiter's measured wait past any fixed
+    # millisecond bound. Do not reintroduce absolute upper bounds here.
+    assert len(handler.upstream_enter_times) == 3
+    assert len(handler.upstream_exit_times) == 3
+    assert _max_concurrent(handler.upstream_enter_times, handler.upstream_exit_times) <= 2, (
+        handler.upstream_enter_times,
+        handler.upstream_exit_times,
+    )
+
     payloads = _parse_all_stage_logs(stage_log_capture)
     assert len(payloads) == 3
     waits = sorted(p["stages"]["pre_upstream_wait"] for p in payloads)
-    # Exactly one request must have waited noticeably; the first two should
-    # be near zero (they acquired the sem immediately).
-    assert waits[0] < 25.0, waits
-    assert waits[1] < 25.0, waits
-    # The waiter should have waited roughly the upstream-delay budget.
+    # Contention was really exercised: at least one request queued for
+    # roughly the upstream-delay budget behind an earlier holder.
     assert waits[2] > 75.0, waits
+    # ...and at least one acquired without queueing, so the semaphore is not
+    # serializing everything. Relative to the waiter, not an absolute bound.
+    assert waits[0] < waits[2] / 2.0, waits
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Description

`tests/test_anthropic_pre_upstream_backpressure.py::test_n_plus_one_contention_only_waiter_has_nonzero_wait` is timing-flaky and fails CI shards on unrelated PRs (seen on #2607, run 31056617633, job `test (1)`):

```
FAILED tests/test_anthropic_pre_upstream_backpressure.py::test_n_plus_one_contention_only_waiter_has_nonzero_wait - AssertionError: [0.020465000005742695, 156.20862800000168, 353.85536299997966]
assert 156.20862800000168 < 25.0
```

The test drove 3 concurrent requests through the Unit 4 pre-upstream semaphore with `Semaphore(2)` and a 150 ms fake upstream, then asserted the two non-waiters each measured `pre_upstream_wait < 25 ms`. That is a wall-clock proxy for the property, not the property. The shard runs sequentially under `pytest --cov` on a shared runner; when the loop schedules the three coroutines serially, a request that acquired the semaphore with no queueing still records a 156 ms wait, and the assertion fails even though `headroom/proxy/handlers/anthropic.py` behaved correctly.

Per review feedback, the test no longer contains any millisecond threshold, absolute or relative. Contention is now produced deterministically with coordination primitives, so the assertions hold under arbitrary scheduling pauses on a loaded runner.

Closes # <!-- no issue; flake found while reviewing CI on #2607 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `_DummyAnthropicHandler` gains an optional `upstream_release: asyncio.Semaphore`. When set, a request inside the upstream section blocks on a permit instead of sleeping for `upstream_delay_s`, so one `release()` frees exactly one holder. The existing sleep path is untouched for the other tests that use it
- The handler also exposes an `upstream_entered` condition, notified on each entry, so a test can await "N requests are inside the upstream section" without polling a duration
- `test_n_plus_one_contention_only_waiter_has_nonzero_wait` is replaced by `test_n_plus_one_contention_blocks_until_slot_frees`, which: pins two requests inside the upstream section, asserts both slots are held (`sem._value == 0`), starts the third, drains a bounded number of event-loop turns and asserts it has **not** entered, frees exactly one holder and asserts it enters only then
- Post-run assertions are structural: 3 enters / 3 exits, peak occupancy `<= 2` via the `_max_concurrent` event sweep (exits sort before enters at equal timestamps so a handed-over slot is not double-counted), the waiter's entry ordered after the first exit, and `sem._value == 2` for clean release
- The only timing-derived assertion left is `max(pre_upstream_wait) > 0` — no upper bound, no ratio. A comment records that wall-clock bounds must not come back in either form
- The test is parametrized `range(10)` as a stress invocation; it stays fast because every wait is event-driven rather than sleep-driven
- No production code touched; `test_happy_path_single_request_negligible_wait` and `test_concurrency_one_serializes_requests` are unchanged
- The scenario is wrapped in `anyio.fail_after(10)`, below the 15 s `anthropic_pre_upstream_acquire_timeout_seconds`, so a genuine deadlock fails the test rather than silently exercising the fail-open path

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`) — N/A, tests-only change
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_anthropic_pre_upstream_backpressure.py -q
34 passed in 2.98s

$ python -m ruff check tests/test_anthropic_pre_upstream_backpressure.py
All checks passed!

$ python -m ruff format --check tests/test_anthropic_pre_upstream_backpressure.py
1 file already formatted
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.13.11, pytest 9.1.1, local checkout branched from upstream/main 7940c05e
- Exact command / steps: ran the full file (34 tests, including the 10 parametrized repeats of the rewritten test), then ran two mutation checks against the rewritten test — (1) widened the gate to `asyncio.Semaphore(3)` in the test, (2) removed `pre_upstream_sem.release()` from `_release_pre_upstream_sem` in `headroom/proxy/handlers/anthropic.py`. Both mutations were reverted afterwards. Separately verified the `_max_concurrent` sweep returns 3 for three overlapping intervals and 1 for a direct hand-over
- Observed result: 34 passed in 2.98s on the unmodified tree. With the gate widened to 3, all 10 repeats failed on the "third request has not entered" assertion. With the semaphore release removed, all 10 repeats failed. The helper sweep returned 3 and 1 as expected. So the test rejects unbounded concurrency, a leaked semaphore, and double-counted hand-overs, while containing no millisecond threshold at all
- Not tested: reproducing the original failure on a GitHub runner; the fix changes what is asserted, not proxy behaviour

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

Unblocks #2607, whose only red check is this flake. Screenshots N/A.
