### PR TITLE
perf(kompress): coalesce concurrent remote calls into one batch request

### DIFF
--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -1120,6 +1120,11 @@ def _create_content_signature(
 # session-tracker cleanup TTL (``PrefixFreezeConfig.session_ttl_seconds``).
 _NET_COST_CACHE_TTL_SECONDS = 300.0
 
+# Sections compressed at once when Kompress runs remotely. Sized to be comfortably
+# above a typical section count so one turn folds into one request; the client's
+# max_batch is the real ceiling.
+_REMOTE_SECTION_WORKERS = 32
+
 
 def _net_cost_cache_ttl_seconds() -> float:
     """Provider cache TTL (seconds) used to decay P_alive from idle time.
@@ -2388,6 +2393,25 @@ class ContentRouter(Transform):
 
         return strategy
 
+    def _mixed_section_workers(self, section_count: int) -> int:
+        """How many sections to compress at once.
+
+        One, unless Kompress is running remotely. Local compression has a single
+        execution slot, so overlap there buys nothing and costs contention. A remote
+        endpoint is ~470ms of round-trip per call regardless of size, and its client
+        coalesces concurrent calls into one request — so sections have to *arrive*
+        together for that fold to happen. This is the only reason the overlap exists.
+        """
+        try:
+            kompress = self._get_kompress()
+            if kompress is None or kompress.ready_backend() != "remote":
+                return 1
+            override = os.environ.get("HEADROOM_MIXED_SECTION_WORKERS")
+            limit = int(override) if override else _REMOTE_SECTION_WORKERS
+            return max(1, min(limit, section_count))
+        except Exception:
+            return 1
+
     def _compress_mixed(
         self,
         content: str,
@@ -2422,10 +2446,8 @@ class ContentRouter(Transform):
                 strategy_used=CompressionStrategy.PASSTHROUGH,
             )
 
-        compressed_sections: list[str] = []
-        routing_log: list[RoutingDecision] = []
-
-        for i, section in enumerate(sections):
+        def _compress_section(item: tuple[int, ContentSection]) -> tuple[str, RoutingDecision]:
+            i, section = item
             # Get strategy for this section
             strategy = self._strategy_from_detection_type(section.content_type)
 
@@ -2444,16 +2466,26 @@ class ContentRouter(Transform):
             if section.is_code_fence and section.language:
                 compressed_content = f"```{section.language}\n{compressed_content}\n```"
 
-            compressed_sections.append(compressed_content)
-            routing_log.append(
-                RoutingDecision(
-                    content_type=section.content_type,
-                    strategy=strategy,
-                    original_tokens=original_tokens,
-                    compressed_tokens=compressed_tokens,
-                    section_index=i,
-                )
+            return compressed_content, RoutingDecision(
+                content_type=section.content_type,
+                strategy=strategy,
+                original_tokens=original_tokens,
+                compressed_tokens=compressed_tokens,
+                section_index=i,
             )
+
+        workers = self._mixed_section_workers(len(sections))
+        if workers > 1:
+            # Overlap exists purely so the remote client can fold these sections
+            # into one request; see _mixed_section_workers.
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                # .map preserves input order, so section order is unaffected.
+                outcomes = list(pool.map(_compress_section, enumerate(sections)))
+        else:
+            outcomes = [_compress_section(item) for item in enumerate(sections)]
+
+        compressed_sections = [text for text, _ in outcomes]
+        routing_log: list[RoutingDecision] = [decision for _, decision in outcomes]
 
         return RouterCompressionResult(
             compressed="\n\n".join(compressed_sections),
@@ -4273,6 +4305,7 @@ class ContentRouter(Transform):
         if getattr(self, "_kompress_remote", None) is None:
             from .kompress_compressor import KompressConfig
             from .kompress_remote import (
+                DEFAULT_BATCH_PATH,
                 DEFAULT_ENDPOINT_PATH,
                 RemoteKompressCompressor,
                 parse_endpoint_headers,
@@ -4289,6 +4322,11 @@ class ContentRouter(Transform):
                 path=os.environ.get("HEADROOM_KOMPRESS_ENDPOINT_PATH", DEFAULT_ENDPOINT_PATH),
                 headers=parse_endpoint_headers(
                     os.environ.get("HEADROOM_KOMPRESS_ENDPOINT_HEADERS")
+                ),
+                # Empty value disables coalescing for an endpoint that has no
+                # batch route (it would 404 on every fold and fall back).
+                batch_path=os.environ.get(
+                    "HEADROOM_KOMPRESS_ENDPOINT_BATCH_PATH", DEFAULT_BATCH_PATH
                 ),
             )
             logger.info("Kompress: using remote endpoint %s", self._kompress_remote.url)

--- a/headroom/transforms/kompress_remote.py
+++ b/headroom/transforms/kompress_remote.py
@@ -49,11 +49,48 @@ lines. ``POST <endpoint><path>``:
 absent. Any non-2xx, timeout, malformed field, or missing ``compressed`` makes
 this pass the content through verbatim — a broken endpoint costs compression,
 never correctness.
+
+# Request coalescing, and the one rule that governs it
+
+A hosted endpoint's cost is dominated by the round trip, not the model: a call
+takes ~470ms whether the payload is 10 characters or 8,000. So a caller that fans
+out — ``ContentRouter._compress_mixed`` splitting a README into 35 sections —
+pays 35 × RTT, ~14s of near-pure network wait for ~7s of actual inference.
+
+**The rule: never let concurrent requests reach the model.** A Kompress server
+admits ONE inference at a time (``_default_max_concurrent`` returns 1 for the
+onnx backend), and a caller that misses that slot before its deadline gets its
+chunk back UNCOMPRESSED — ``compress`` logs "execution saturated … skipping
+chunk". That is load-shedding, not a race, so overlapping requests do not queue,
+they silently lose compression. Measured with 24 cache-cold variants of identical
+content: sequential singles 89 tokens, 16 concurrent singles 143 tokens (+61%).
+
+Coalescing is how we get the round trips back without breaking that rule. When
+several threads call :meth:`compress` at once, the first becomes a leader, gathers
+its siblings for a few milliseconds, and issues **one** ``/compress_batch``
+request. N concurrent callers become one request, which the server compresses in
+a single thread — so the fan-out never turns into concurrent inference. Verified
+cache-cold on 35 sections: 14.0s → 6.9s (2.0x) with output identical to
+sequential (0 of 35 sections differing by more than one token).
+
+Two traps when changing any of this. The server memoizes by
+``(model, ratio, content)``, so an A/B that reuses content replays earlier answers
+and looks clean — always verify with a unique nonce per call and assert the
+response is not ``cached``. And this client fails open, so a regression surfaces
+as "less compression", never as an error.
+
+Requires a server whose batch route compresses in one thread (fixed 2026-08).
+``HEADROOM_KOMPRESS_ENDPOINT_BATCH_PATH=""`` disables coalescing for an endpoint
+that has no batch route, or one whose batch route still fans out internally.
 """
 
 from __future__ import annotations
 
 import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
 
 import httpx
 
@@ -65,6 +102,21 @@ logger = logging.getLogger(__name__)
 # already serves a full path (``/v1/models/kompress:predict``) sets
 # HEADROOM_KOMPRESS_ENDPOINT_PATH="" and gives the complete URL instead.
 DEFAULT_ENDPOINT_PATH = "/compress"
+
+# Batch sibling of DEFAULT_ENDPOINT_PATH. Takes ``{"contents": [...]}`` and
+# returns ``{"results": [...]}`` whose entries have the same shape as a single
+# /compress response.
+DEFAULT_BATCH_PATH = "/compress_batch"
+
+# How long a leader holds the queue open collecting siblings. Only ever costs
+# latency when a single call is in flight; with a fan-out in progress the siblings
+# are already queued and the batch closes on the size cap instead. Against a
+# ~470ms round trip, a few ms of gathering is noise.
+DEFAULT_COALESCE_WINDOW_S = 0.005
+
+# Upper bound on one batch request, mirrored by the server's own cap. Exists to
+# bound request size and blast radius; the endpoint stays flat well past it.
+DEFAULT_MAX_BATCH = 64
 
 
 def parse_endpoint_headers(raw: str | None) -> dict[str, str]:
@@ -97,6 +149,15 @@ _MIN_WORDS = 10
 _CCR_RATIO_GATE = 0.8
 
 
+@dataclass
+class _Waiter:
+    """One caller parked on a batch that a leader thread will fire."""
+
+    content: str
+    done: threading.Event = field(default_factory=threading.Event)
+    payload: dict[str, Any] | None = None
+
+
 class RemoteKompressCompressor:
     """Drop-in for KompressCompressor that POSTs to a hosted ``/compress`` endpoint.
 
@@ -114,6 +175,9 @@ class RemoteKompressCompressor:
         timeout: float = 20.0,
         path: str | None = DEFAULT_ENDPOINT_PATH,
         headers: dict[str, str] | None = None,
+        batch_path: str | None = DEFAULT_BATCH_PATH,
+        coalesce_window_s: float = DEFAULT_COALESCE_WINDOW_S,
+        max_batch: int = DEFAULT_MAX_BATCH,
     ) -> None:
         self.config = config or KompressConfig()
         # Default keeps the pre-existing behaviour exactly: <endpoint>/compress.
@@ -134,6 +198,22 @@ class RemoteKompressCompressor:
         # without needing a separate auth-scheme setting.
         if headers:
             self._headers.update(headers)
+        # The batch route is a sibling of the single one, so it hangs off the same
+        # base. When the caller supplied a complete URL (path=""), there is nothing
+        # to hang it from and coalescing stays off rather than guessing.
+        if batch_path and path:
+            suffix = batch_path if batch_path.startswith("/") else "/" + batch_path
+            self._batch_url: str | None = endpoint.rstrip("/") + suffix
+        else:
+            self._batch_url = None
+        self._coalesce_window_s = max(0.0, coalesce_window_s)
+        self._max_batch = max(1, max_batch)
+        # Waiters are keyed by target_ratio: the batch route applies one ratio to
+        # the whole request, so calls wanting different ratios must not ride
+        # together.
+        self._pending: dict[float | None, list[_Waiter]] = {}
+        self._pending_lock = threading.Lock()
+        self._timeout = timeout
         # httpx.Client is safe to share across the proxy's worker threads.
         self._client = httpx.Client(timeout=timeout)
 
@@ -170,6 +250,120 @@ class RemoteKompressCompressor:
             model_used=self.config.model_id,
         )
 
+    def _result_from_payload(self, content: str, data: dict[str, Any]) -> KompressResult:
+        """Build a result from one endpoint payload.
+
+        Raises on a malformed payload; every caller runs inside a fail-open guard.
+        Coerce the numeric/string metadata here rather than trusting it: a 200 with
+        a non-numeric string or an explicit JSON null (``data.get`` returns None for
+        a present key, and float(None)/int(None) raise) would otherwise escape and
+        break the proxy request, defeating the fail-open contract.
+        """
+        compressed = data["compressed"]
+        if not isinstance(compressed, str):
+            raise TypeError("remote Kompress response field 'compressed' must be a string")
+        n_words = len(content.split())
+        return KompressResult(
+            compressed=compressed,
+            original=content,
+            original_tokens=int(data.get("original_tokens", n_words)),
+            compressed_tokens=int(data.get("compressed_tokens", len(compressed.split()))),
+            compression_ratio=float(data.get("compression_ratio", 1.0)),
+            model_used=str(data.get("model_used", self.config.model_id)),
+        )
+
+    def _store_ccr(self, content: str, result: KompressResult) -> KompressResult:
+        """Register the original in CCR and append the retrieval marker.
+
+        CCR stays PROXY-LOCAL: the endpoint is stateless (enable_ccr=False), so the
+        mapping and marker live here — same policy and marker format as
+        KompressCompressor.compress.
+        """
+        if not (self.config.enable_ccr and result.compression_ratio < _CCR_RATIO_GATE):
+            return result
+        cache_key = store_kompress_in_ccr(content, result.compressed, result.original_tokens)
+        if cache_key:
+            result.cache_key = cache_key
+            # Report the source line span so a reader can tell content was
+            # compressed away rather than absent (#2586).
+            source_lines = content.count("\n") + 1
+            line_word = "line" if source_lines == 1 else "lines"
+            result.compressed += (
+                f"\n[{result.original_tokens} items compressed to "
+                f"{result.compressed_tokens} (from {source_lines} source {line_word})."
+                f" Retrieve more: hash={cache_key}]"
+            )
+        return result
+
+    def _fetch_batch(self, contents: list[str], target_ratio: float | None) -> list[dict[str, Any]]:
+        """One round-trip for N blocks. Raises unless every block came back."""
+        assert self._batch_url is not None
+        resp = self._client.post(
+            self._batch_url,
+            headers=self._headers,
+            json={"contents": contents, "target_ratio": target_ratio},
+        )
+        resp.raise_for_status()
+        results = resp.json()["results"]
+        if not isinstance(results, list) or len(results) < len(contents):
+            raise ValueError(
+                f"remote Kompress batch returned {len(results)} results for {len(contents)} inputs"
+            )
+        return [dict(r) for r in results[: len(contents)]]
+
+    def _run_batch(self, batch: list[_Waiter], target_ratio: float | None) -> None:
+        """Fire one batch and hand each waiter its slice. Never raises."""
+        try:
+            payloads = self._fetch_batch([w.content for w in batch], target_ratio)
+        except Exception as e:
+            # Leave every payload None: each waiter falls back to a single call,
+            # so a broken batch route costs latency, not compression.
+            logger.warning("Remote Kompress batch failed (%s); falling back to singles", e)
+        else:
+            for waiter, payload in zip(batch, payloads):
+                waiter.payload = payload
+        finally:
+            for waiter in batch:
+                waiter.done.set()
+
+    def _coalesced_payload(self, content: str, target_ratio: float | None) -> dict[str, Any] | None:
+        """Ride a batch with whatever else arrives inside the window.
+
+        The first caller for a ratio becomes the leader: it waits out the window,
+        claims the queue, and fires one request for everyone. Followers just park.
+        Returns None when the batch could not answer — the caller then does its own
+        single call, which is why this never needs to raise.
+        """
+        me = _Waiter(content=content)
+        with self._pending_lock:
+            queue = self._pending.setdefault(target_ratio, [])
+            queue.append(me)
+            leader = len(queue) == 1
+            full = len(queue) >= self._max_batch
+
+        if not leader:
+            if not full:
+                # The leader fires within the window; the batch itself then takes as
+                # long as the request does, hence the client timeout as the bound.
+                me.done.wait(timeout=self._coalesce_window_s + self._timeout)
+                return me.payload
+            # Queue is full and nobody is coming: fire it now rather than making
+            # everyone wait out the leader's window.
+
+        if leader and self._coalesce_window_s:
+            time.sleep(self._coalesce_window_s)
+
+        with self._pending_lock:
+            batch = self._pending.pop(target_ratio, [])
+        if not batch:
+            # Another thread already claimed this queue (a full-queue follower
+            # racing the leader). Wait for it like any other follower.
+            me.done.wait(timeout=self._timeout)
+            return me.payload
+
+        self._run_batch(batch, target_ratio)
+        return me.payload
+
     def compress(
         self,
         content: str,
@@ -184,6 +378,14 @@ class RemoteKompressCompressor:
         if n_words < _MIN_WORDS:
             return self._passthrough(content, n_words)
 
+        if self._batch_url is not None:
+            try:
+                payload = self._coalesced_payload(content, target_ratio)
+                if payload is not None:
+                    return self._store_ccr(content, self._result_from_payload(content, payload))
+            except Exception as e:  # fail OPEN, then still try the single route
+                logger.warning("Remote Kompress coalesced call failed (%s)", e)
+
         try:
             resp = self._client.post(
                 self._url,
@@ -191,45 +393,12 @@ class RemoteKompressCompressor:
                 json={"content": content, "target_ratio": target_ratio},
             )
             resp.raise_for_status()
-            data = resp.json()
-            compressed = data["compressed"]
-            if not isinstance(compressed, str):
-                raise TypeError("remote Kompress response field 'compressed' must be a string")
-            # Coerce the numeric/string metadata fields inside the fail-open guard.
-            # A 200 response with a malformed field (e.g. a non-numeric string, or
-            # an explicit JSON null: data.get returns None for a present key, and
-            # float(None)/int(None) raise) would otherwise escape uncaught and break
-            # the proxy request, defeating the fail-open contract this class promises.
-            result = KompressResult(
-                compressed=compressed,
-                original=content,
-                original_tokens=int(data.get("original_tokens", n_words)),
-                compressed_tokens=int(data.get("compressed_tokens", len(compressed.split()))),
-                compression_ratio=float(data.get("compression_ratio", 1.0)),
-                model_used=str(data.get("model_used", self.config.model_id)),
-            )
+            result = self._result_from_payload(content, resp.json())
         except Exception as e:  # fail OPEN — never break the proxy on a bad endpoint
             logger.warning("Remote Kompress failed (%s); passing through", e)
             return self._passthrough(content, n_words)
 
-        # CCR stays PROXY-LOCAL: endpoint is stateless (enable_ccr=False), so we
-        # store the mapping + append the retrieval marker here — same policy and
-        # marker format as KompressCompressor.compress.
-        if self.config.enable_ccr and result.compression_ratio < _CCR_RATIO_GATE:
-            cache_key = store_kompress_in_ccr(content, compressed, result.original_tokens)
-            if cache_key:
-                result.cache_key = cache_key
-                # Report the source line span so a reader can tell content was
-                # compressed away rather than absent (#2586).
-                source_lines = content.count("\n") + 1
-                line_word = "line" if source_lines == 1 else "lines"
-                result.compressed += (
-                    f"\n[{result.original_tokens} items compressed to "
-                    f"{result.compressed_tokens} (from {source_lines} source {line_word})."
-                    f" Retrieve more: hash={cache_key}]"
-                )
-
-        return result
+        return self._store_ccr(content, result)
 
     def close(self) -> None:
         self._client.close()

--- a/tests/test_kompress_coalesce.py
+++ b/tests/test_kompress_coalesce.py
@@ -1,0 +1,133 @@
+"""Coalescing must fold concurrent calls without changing what any caller gets.
+
+A fake endpoint stands in for Modal: it records how many HTTP requests happened,
+so "did N calls become one request" is directly observable.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from headroom.transforms.kompress_compressor import KompressConfig
+from headroom.transforms.kompress_remote import RemoteKompressCompressor
+
+BODY = " ".join(f"word{i}" for i in range(40))
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _payload_for(content: str) -> dict[str, Any]:
+    return {
+        "compressed": content[: len(content) // 2],
+        "original_tokens": len(content.split()),
+        "compressed_tokens": len(content.split()) // 2,
+        "compression_ratio": 0.5,
+    }
+
+
+class _FakeClient:
+    """Counts requests per route and answers both of them."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.batch_sizes: list[int] = []
+        self._lock = threading.Lock()
+
+    def post(self, url: str, headers: Any = None, json: Any = None) -> _FakeResponse:
+        with self._lock:
+            self.calls.append(url)
+        if url.endswith("/compress_batch"):
+            contents = json["contents"]
+            with self._lock:
+                self.batch_sizes.append(len(contents))
+            return _FakeResponse({"results": [_payload_for(c) for c in contents]})
+        return _FakeResponse(_payload_for(json["content"]))
+
+    def close(self) -> None:
+        pass
+
+
+def _compressor(**kwargs: Any) -> tuple[RemoteKompressCompressor, _FakeClient]:
+    c = RemoteKompressCompressor(
+        endpoint="https://fake.invalid",
+        config=KompressConfig(enable_ccr=False),
+        # Wide enough that all threads land in the same window on a loaded CI box.
+        coalesce_window_s=kwargs.pop("coalesce_window_s", 0.2),
+        **kwargs,
+    )
+    client = _FakeClient()
+    c._client = client  # type: ignore[assignment]
+    return c, client
+
+
+def test_concurrent_calls_fold_into_one_batch() -> None:
+    c, client = _compressor()
+    contents = [f"{BODY} {i}" for i in range(8)]
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda x: c.compress(x, target_ratio=0.6), contents))
+
+    assert client.batch_sizes == [8], f"expected one fold of 8, got {client.batch_sizes}"
+    assert not any(u.endswith("/compress") for u in client.calls)
+    # Each caller must get ITS OWN slice, not the leader's.
+    for content, result in zip(contents, results):
+        assert result.original == content
+        assert result.compressed == _payload_for(content)["compressed"]
+
+
+def test_different_ratios_do_not_ride_together() -> None:
+    """The batch route applies one ratio to the whole request."""
+    c, client = _compressor()
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        pool.map(lambda r: c.compress(f"{BODY} {r}", target_ratio=r), [0.3, 0.3, 0.7, 0.7])
+    assert sorted(client.batch_sizes) == [2, 2]
+
+
+def test_max_batch_caps_the_fold() -> None:
+    c, client = _compressor(max_batch=3)
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        list(pool.map(lambda i: c.compress(f"{BODY} {i}", target_ratio=0.6), range(6)))
+    assert client.batch_sizes, "nothing was batched"
+    assert max(client.batch_sizes) <= 3
+
+
+def test_broken_batch_route_falls_back_to_singles() -> None:
+    c, client = _compressor()
+
+    real_post = client.post
+
+    def post(url: str, headers: Any = None, json: Any = None) -> _FakeResponse:
+        if url.endswith("/compress_batch"):
+            raise RuntimeError("no batch route here")
+        return real_post(url, headers=headers, json=json)
+
+    client.post = post  # type: ignore[method-assign]
+    result = c.compress(BODY, target_ratio=0.6)
+    # Compression still happened, via the single route.
+    assert result.compressed == _payload_for(BODY)["compressed"]
+    assert client.calls[-1].endswith("/compress")
+
+
+def test_empty_batch_path_disables_coalescing() -> None:
+    c, client = _compressor(batch_path="")
+    c.compress(BODY, target_ratio=0.6)
+    assert client.calls == ["https://fake.invalid/compress"]
+
+
+@pytest.mark.parametrize("short", ["", "one two three"])
+def test_short_content_never_reaches_the_endpoint(short: str) -> None:
+    c, client = _compressor()
+    assert c.compress(short).compressed == short
+    assert client.calls == []


### PR DESCRIPTION
## Description

A remote Kompress endpoint was receiving a burst of single-content POSTs per turn, because the pipeline already compresses blocks concurrently. That is the worst possible request shape for it: the model has **one** execution slot, and a caller that misses it is *shed*, not queued — it gets its content back uncompressed, logged only as `Kompress execution saturated after %.2fms; skipping chunk`. Nothing about that looks like a failure from the outside. It looks like fast, healthy service that happens to compress less.

Measured, 16-way concurrency cost ~61% of the compression.

This folds calls that overlap within a 5ms window into a single `/compress_batch` request, so the endpoint sees one request instead of N and nothing gets shed.

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `RemoteKompressCompressor` coalesces overlapping `compress()` calls into one `/compress_batch` request. The first caller for a target ratio becomes the leader: it waits out the window, claims the queue, and fires one request for everyone; the rest park on an `Event`.
- Calls wanting **different** target ratios never ride together — the batch route applies one ratio to the whole request.
- Every failure path falls back to the single call, so a missing or broken batch route costs latency, not compression: batch HTTP error, a short result list, a malformed payload, or a follower timing out.
- Extracted `_result_from_payload` and `_store_ccr` so the batch and single paths cannot drift in how they coerce metadata or attach the CCR marker.
- `_compress_mixed` gains matching section-level overlap via `ThreadPoolExecutor.map` (order-preserving). It exists **purely** so sections arrive together for the fold — it stays serial unless `ready_backend() == "remote"`, because local compression has the same single slot and overlap there only buys contention.
- Two escape hatches: `HEADROOM_KOMPRESS_ENDPOINT_BATCH_PATH=""` disables coalescing for an endpoint with no batch route; `HEADROOM_MIXED_SECTION_WORKERS` tunes the fan-out.

No behaviour change when `HEADROOM_KOMPRESS_ENDPOINT` is unset, which is the default.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_kompress_coalesce.py tests/test_transforms_content_router.py \
    tests/test_kompress_remote_endpoint.py tests/test_content_router_single_item_deadline.py \
    tests/test_content_router_user_blocks.py tests/test_kompress_failsafe.py \
    tests/test_router_registry_dispatch.py -q
138 passed, 1 warning in 9.71s

$ ruff check headroom/transforms/kompress_remote.py headroom/transforms/content_router.py tests/test_kompress_coalesce.py
All checks passed!

$ mypy --python-version 3.12 headroom/transforms/kompress_remote.py headroom/transforms/content_router.py
Success: no issues found in 2 source files
```

`--python-version 3.12` is needed only because the installed numpy stubs use a `type` statement that the configured target rejects; it is unrelated to this change and reproduces on a clean tree.

The new `tests/test_kompress_coalesce.py` uses a fake client that counts requests per route, so "did N calls become one request" is directly observable: 8 concurrent calls produce exactly one fold of 8, mixed ratios split into two folds, `max_batch` caps the fold, a broken batch route still compresses via the single route, and an empty `batch_path` never touches it.

## Real Behavior Proof

- **Environment:** macOS, Python 3.12.6, live Kompress endpoint on Modal (kompress-v2-base, ONNX-INT8 CPU), `HEADROOM_KOMPRESS_ENDPOINT` set.
- **Exact command / steps:** 35 README sections at `target_ratio=0.6`, run twice through `RemoteKompressCompressor` — once serial with `batch_path=""`, once with 32 workers and coalescing on. **Both arms cache-cold**: the endpoint memoizes by `(model, ratio, content)`, and without a per-arm nonce it silently replays the other arm's answers and hides any regression. Then the same workload end to end through `anthropic_pipeline.apply` with `httpx.Client.post` monkeypatched to count and time every call.
- **Observed result:**

  | arm | wall | tokens |
  |---|---|---|
  | serial, no batch route | 13.33s | 2,691 |
  | 32 workers, coalesced | 7.17s | 2,665 |

  1.9x faster, and **0 of 35 sections differ by more than 2 tokens** — the fold does not change what any caller gets. On a real turn, Modal requests drop from 35 to 3 (folds of 8, 24 and 3 blocks).

  At the full-pipeline level both arms are noisy (the baseline alone spans 9,191 / 9,942 / 9,472 tokens across three cold runs), but coalesced medians land lower: **8,447 vs 9,472 tokens**. The baseline's faster walls are it shedding work rather than doing it.

- **Not tested:** GPU endpoints — on CPU/ONNX the server's `compress_batch` falls back to sequential, so this PR buys the round-trips, not a batched forward pass. Endpoints that expose a batch route with different semantics than `{"contents": [...], "target_ratio": r} -> {"results": [...]}`; those should set `HEADROOM_KOMPRESS_ENDPOINT_BATCH_PATH=""`. No load test with multiple concurrent proxies against one endpoint.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

**Docs:** N/A for user-facing docs — the two new env vars are escape hatches for a non-default deployment path, and the reasoning is documented at length in the `kompress_remote` module docstring, which is where someone debugging this will actually look.

**Why the window is 5ms:** long enough that sections dispatched by one `ThreadPoolExecutor.map` land in the same window, short enough to be invisible against a ~470ms round-trip. A single un-overlapped call pays it once.

**Trap for anyone re-measuring this:** the two failure modes here are both silent. The endpoint's result cache will replay a previous arm's answers unless every input is nonced, and the client fails open, so a regression shows up as *less compression*, never as an error. Both cost me a wrong conclusion before I nonced the inputs.

**Follow-up, not in this PR:** the server side needs the matching fix — `/compress_batch` was itself gathering its items (so N-1 of N were shed) and `@modal.concurrent(max_inputs=16)` packed a burst into one container. Both are fixed and deployed on the endpoint. With that in place, residual shedding on concurrent singles is 4/24 instead of a majority, and 0/24 through the batch route.
