### PR TITLE
feat(learn): support Grok CLI in verbosity learning

### DIFF
--- a/headroom/cli/learn.py
+++ b/headroom/cli/learn.py
@@ -426,6 +426,19 @@ def _activate_output_shaper(port: int | None = None) -> tuple[str, int]:
         return "error", resolved_port
 
 
+# Agents whose transcript formats are supported by verbosity signal mining.
+_VERBOSITY_AGENTS = frozenset({"claude", "grok"})
+
+
+def _verbosity_session_paths(plugin_name: str, data_path: Path) -> list[Path]:
+    """Return transcript paths for verbosity mining for a given agent plugin."""
+    if plugin_name == "grok":
+        # ~/.grok/sessions/<workspace>/<session-id>/updates.jsonl
+        return sorted(data_path.glob("*/updates.jsonl"))
+    # Claude Code: flat *.jsonl under the project data dir.
+    return sorted(data_path.glob("*.jsonl"))
+
+
 def _run_verbosity(
     *,
     project: Path | None,
@@ -441,39 +454,47 @@ def _run_verbosity(
     from ..paths import ensure_workspace_dir
     from ..proxy.output_savings import BaselineModel, SavingsLedger
 
-    # Verbosity mining reads Claude Code transcripts; restrict to that plugin.
+    # Verbosity mining supports Claude Code and Grok CLI transcripts.
     if agent == "auto":
-        plugins = [p for p in auto_detect_plugins() if p.name == "claude"]
+        plugins = [p for p in auto_detect_plugins() if p.name in _VERBOSITY_AGENTS]
         if not plugins:
-            click.echo("Verbosity learning currently supports Claude Code transcripts only.")
+            click.echo(
+                "Verbosity learning currently supports Claude Code and Grok CLI "
+                "transcripts only (none detected)."
+            )
             return
-        plugin = plugins[0]
     else:
         plugin = get_plugin(agent)
-        if plugin.name != "claude":
-            click.echo("Verbosity learning currently supports Claude Code transcripts only.")
+        if plugin.name not in _VERBOSITY_AGENTS:
+            click.echo(
+                "Verbosity learning currently supports Claude Code and Grok CLI "
+                f"transcripts only (got agent={plugin.name!r})."
+            )
             return
+        plugins = [plugin]
 
-    all_projects = plugin.discover_projects()
-    if not all_projects:
-        click.echo("No Claude Code project data found.")
-        return
+    # Collect (plugin, project) targets so multi-agent auto can merge baselines.
+    targets = []
+    for plugin in plugins:
+        all_projects = plugin.discover_projects()
+        if analyze_all:
+            selected = all_projects
+        elif project:
+            resolved = project.resolve()
+            selected = [p for p in all_projects if p.project_path == resolved]
+        else:
+            cwd = Path.cwd().resolve()
+            selected = [p for p in all_projects if p.project_path == cwd]
+            if not selected:
+                for parent in cwd.parents:
+                    selected = [p for p in all_projects if p.project_path == parent]
+                    if selected:
+                        break
+        targets.extend((plugin, proj) for proj in selected)
 
-    if analyze_all:
-        targets = all_projects
-    elif project:
-        resolved = project.resolve()
-        targets = [p for p in all_projects if p.project_path == resolved]
-    else:
-        cwd = Path.cwd().resolve()
-        targets = [p for p in all_projects if p.project_path == cwd]
-        if not targets:
-            for parent in cwd.parents:
-                targets = [p for p in all_projects if p.project_path == parent]
-                if targets:
-                    break
     if not targets:
-        click.echo("No matching project. Try --all or --project <path>.")
+        names = ", ".join(p.display_name for p in plugins)
+        click.echo(f"No matching project for {names}. Try --all or --project <path>.")
         return
 
     judge = _make_llm_judge(model or "claude-sonnet-4-6") if llm_judge else None
@@ -487,8 +508,8 @@ def _run_verbosity(
     best_profile_samples = -1
     analyzed_count = 0
 
-    for proj in targets:
-        session_paths = sorted(proj.data_path.glob("*.jsonl"))
+    for plugin, proj in targets:
+        session_paths = _verbosity_session_paths(plugin.name, proj.data_path)
         if not session_paths:
             continue
         profile, baseline = analyze(session_paths, str(proj.project_path), llm_judge=judge)
@@ -500,7 +521,7 @@ def _run_verbosity(
             best_profile = profile
 
         click.echo(f"\n{'=' * 60}")
-        click.echo(f"Verbosity — {proj.name}")
+        click.echo(f"Verbosity — {proj.name} [{plugin.display_name}]")
         click.echo(f"Path: {proj.project_path}")
         click.echo(f"{'=' * 60}")
         click.echo(

--- a/headroom/learn/verbosity.py
+++ b/headroom/learn/verbosity.py
@@ -4,7 +4,7 @@ The premise (validated on real transcripts): users almost never *say* how terse
 they want answers — explicit "be brief" feedback is near-zero — but they *show*
 it behaviorally. They interrupt long answers, and they reply faster than a long
 answer could possibly have been read. Those signals are mechanical to extract
-from Claude Code's JSONL transcripts.
+from coding-agent transcripts (Claude Code JSONL and Grok CLI ``updates.jsonl``).
 
 This module:
 
@@ -162,15 +162,26 @@ class VerbosityProfile:
         path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
 
 
-def _parse_ts(s: str | None) -> float | None:
-    if not s:
+def _parse_ts(s: str | float | int | None) -> float | None:
+    if s is None or s == "":
         return None
+    if isinstance(s, (int, float)):
+        # Grok CLI writes unix seconds (sometimes ms). Normalize ms → seconds.
+        ts = float(s)
+        if ts > 1e12:  # clearly milliseconds
+            ts /= 1000.0
+        return ts
     try:
         from datetime import datetime
 
-        return datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+        return datetime.fromisoformat(str(s).replace("Z", "+00:00")).timestamp()
     except (ValueError, TypeError):
         return None
+
+
+def _is_grok_session(path: Path) -> bool:
+    """True for Grok CLI session files (``.../<session-id>/updates.jsonl``)."""
+    return path.name == "updates.jsonl"
 
 
 def _assistant_words_and_text(content: Any) -> tuple[int, str]:
@@ -201,6 +212,13 @@ def _human_text(content: Any) -> str | None:
 
 def _parse_session(path: Path) -> tuple[list[_Response], list[_HumanMsg], bool]:
     """Parse one transcript into responses + human messages + has_tools flag."""
+    if _is_grok_session(path):
+        return _parse_session_grok(path)
+    return _parse_session_claude(path)
+
+
+def _parse_session_claude(path: Path) -> tuple[list[_Response], list[_HumanMsg], bool]:
+    """Parse a Claude Code JSONL transcript."""
     responses: list[_Response] = []
     humans: list[_HumanMsg] = []
     has_tools = False
@@ -276,16 +294,186 @@ def _parse_session(path: Path) -> tuple[list[_Response], list[_HumanMsg], bool]:
     return responses, humans, has_tools
 
 
+def _grok_chunk_text(update: dict[str, Any]) -> str:
+    content = update.get("content")
+    if isinstance(content, dict):
+        text = content.get("text")
+        return text if isinstance(text, str) else ""
+    if isinstance(content, str):
+        return content
+    return ""
+
+
+def _grok_model_from_update(update: dict[str, Any], fallback: str = "") -> str:
+    meta = update.get("_meta")
+    if isinstance(meta, dict):
+        mid = meta.get("modelId")
+        if isinstance(mid, str) and mid:
+            return mid
+    usage = update.get("usage")
+    if isinstance(usage, dict):
+        model_usage = usage.get("modelUsage")
+        if isinstance(model_usage, dict) and model_usage:
+            # Prefer the model that spent the most output tokens in the turn.
+            best_model = ""
+            best_out = -1
+            for name, stats in model_usage.items():
+                if not isinstance(stats, dict):
+                    continue
+                out = int(stats.get("outputTokens") or 0)
+                if out >= best_out:
+                    best_out = out
+                    best_model = str(name)
+            if best_model:
+                return best_model
+    return fallback
+
+
+def _parse_session_grok(path: Path) -> tuple[list[_Response], list[_HumanMsg], bool]:
+    """Parse a Grok CLI ``updates.jsonl`` transcript.
+
+    Grok streams assistant text as many ``agent_message_chunk`` events and often
+    reports token usage only on ``turn_completed`` (whole-turn, not per message).
+    We coalesce consecutive agent chunks into one response, flushed on the next
+    user message, turn completion, or EOF.
+    """
+    responses: list[_Response] = []
+    humans: list[_HumanMsg] = []
+    has_tools = False
+    prior_messages: list[dict[str, Any]] = []
+    recent_context: list[str] = []
+    current_model = ""
+
+    # Streaming agent buffer for the open turn.
+    agent_parts: list[str] = []
+    agent_ts: float | None = None
+
+    def flush_agent(
+        *,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        model: str | None = None,
+    ) -> None:
+        nonlocal agent_parts, agent_ts
+        text = "".join(agent_parts)
+        words = len(text.split()) if text.strip() else 0
+        agent_parts = []
+        ts = agent_ts
+        agent_ts = None
+        if words <= 0 and output_tokens <= 0:
+            return
+        ctx = " ".join(recent_context[-_ECHO_CONTEXT_LOOKBACK:])
+        responses.append(
+            _Response(
+                words=words,
+                output_tokens=output_tokens,
+                input_tokens=input_tokens,
+                model=model or current_model or "unknown",
+                turn_kind=classify_turn(prior_messages).value,
+                has_tools=False,  # backfilled below
+                ts=ts,
+                echo=echo_ratio(text, ctx) if text and ctx else 0.0,
+            )
+        )
+        prior_messages.append({"role": "assistant", "content": text})
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return [], [], False
+
+    for line in lines:
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        params = d.get("params")
+        if not isinstance(params, dict):
+            continue
+        update = params.get("update")
+        if not isinstance(update, dict):
+            continue
+        su = update.get("sessionUpdate")
+        ts = _parse_ts(d.get("timestamp"))
+
+        if su == "user_message_chunk":
+            # New human turn ends any open assistant stream (usage may be unknown).
+            flush_agent(model=current_model)
+            text = _grok_chunk_text(update)
+            current_model = _grok_model_from_update(update, current_model)
+            if not text.strip():
+                continue
+            prior_messages.append({"role": "user", "content": text})
+            # Grok has no Claude-style interrupt marker; treat explicit cancel text
+            # as interrupt when present so the signal isn't always zero.
+            is_interrupt = (
+                _INTERRUPT_MARKER in text
+                or "request interrupted" in text.lower()
+                or text.strip().lower() in {"cancel", "cancelled", "canceled", "stop"}
+            )
+            humans.append(_HumanMsg(ts=ts, is_interrupt=is_interrupt))
+            if not is_interrupt:
+                recent_context.append(text)
+            continue
+
+        if su == "agent_message_chunk":
+            chunk = _grok_chunk_text(update)
+            if not chunk:
+                continue
+            if not agent_parts:
+                agent_ts = ts
+            agent_parts.append(chunk)
+            continue
+
+        if su == "tool_call":
+            has_tools = True
+            continue
+
+        if su == "tool_call_update":
+            has_tools = True
+            # Feed tool output into echo context (best-effort).
+            raw_output = update.get("rawOutput")
+            if isinstance(raw_output, dict):
+                for key in ("output_for_prompt", "output", "FileContent"):
+                    value = raw_output.get(key)
+                    if isinstance(value, str) and value.strip():
+                        recent_context.append(value[:2000])
+                        break
+            continue
+
+        if su == "turn_completed":
+            usage = update.get("usage") if isinstance(update.get("usage"), dict) else {}
+            in_tok = int(usage.get("inputTokens") or 0) + int(usage.get("cachedReadTokens") or 0)
+            out_tok = int(usage.get("outputTokens") or 0)
+            model = _grok_model_from_update(update, current_model)
+            if model:
+                current_model = model
+            flush_agent(input_tokens=in_tok, output_tokens=out_tok, model=model)
+            continue
+
+    flush_agent(model=current_model)
+
+    for r in responses:
+        r.has_tools = has_tools
+    return responses, humans, has_tools
+
+
 def _ordered_events(path: Path) -> list[tuple[float | None, str, _Response | _HumanMsg]]:
     """Re-read interleaving order so fast-skip can pair a human reply to the
     assistant response immediately before it. Kept simple: re-parse with a tag.
     """
+    if _is_grok_session(path):
+        return _ordered_events_grok(path)
+    return _ordered_events_claude(path)
+
+
+def _ordered_events_claude(path: Path) -> list[tuple[float | None, str, _Response | _HumanMsg]]:
     out: list[tuple[float | None, str, Any]] = []
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeDecodeError):
         return out
-    responses, humans, _ = _parse_session(path)
+    responses, humans, _ = _parse_session_claude(path)
     # The two lists are already in file order; interleave by re-walking lines.
     ri = hi = 0
     for line in lines:
@@ -317,6 +505,61 @@ def _ordered_events(path: Path) -> list[tuple[float | None, str, _Response | _Hu
             if hi < len(humans):
                 out.append((humans[hi].ts, "human", humans[hi]))
                 hi += 1
+    return out
+
+
+def _ordered_events_grok(path: Path) -> list[tuple[float | None, str, _Response | _HumanMsg]]:
+    """Interleave Grok human / assistant events for fast-skip pairing.
+
+    Assistant responses are emitted when a stream is flushed (turn_completed,
+    next user message, or EOF). Human events align with ``user_message_chunk``.
+    """
+    out: list[tuple[float | None, str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return out
+    responses, humans, _ = _parse_session_grok(path)
+    ri = hi = 0
+    agent_open = False
+    agent_has_text = False
+
+    def emit_assistant() -> None:
+        nonlocal ri, agent_open, agent_has_text
+        if agent_open and agent_has_text and ri < len(responses):
+            out.append((responses[ri].ts, "assistant", responses[ri]))
+            ri += 1
+        agent_open = False
+        agent_has_text = False
+
+    for line in lines:
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        params = d.get("params")
+        if not isinstance(params, dict):
+            continue
+        update = params.get("update")
+        if not isinstance(update, dict):
+            continue
+        su = update.get("sessionUpdate")
+        if su == "user_message_chunk":
+            # Flush open agent stream before the human (mirrors parse order).
+            emit_assistant()
+            text = _grok_chunk_text(update)
+            if not text.strip():
+                continue
+            if hi < len(humans):
+                out.append((humans[hi].ts, "human", humans[hi]))
+                hi += 1
+        elif su == "agent_message_chunk":
+            if _grok_chunk_text(update):
+                agent_open = True
+                agent_has_text = True
+        elif su == "turn_completed":
+            emit_assistant()
+    emit_assistant()
     return out
 
 

--- a/headroom/learn/verbosity.py
+++ b/headroom/learn/verbosity.py
@@ -296,91 +296,83 @@ def _parse_session_claude(path: Path) -> tuple[list[_Response], list[_HumanMsg],
 
 def _grok_chunk_text(update: dict[str, Any]) -> str:
     content = update.get("content")
-    if isinstance(content, dict):
-        text = content.get("text")
-        return text if isinstance(text, str) else ""
-    if isinstance(content, str):
-        return content
-    return ""
+    if isinstance(content, dict) and isinstance(content.get("text"), str):
+        return content["text"]
+    return content if isinstance(content, str) else ""
 
 
-def _grok_model_from_update(update: dict[str, Any], fallback: str = "") -> str:
+def _grok_model(update: dict[str, Any], fallback: str = "") -> str:
+    """Best-effort model id from user ``_meta.modelId`` or ``usage.modelUsage``."""
     meta = update.get("_meta")
-    if isinstance(meta, dict):
-        mid = meta.get("modelId")
-        if isinstance(mid, str) and mid:
-            return mid
+    if isinstance(meta, dict) and isinstance(meta.get("modelId"), str) and meta["modelId"]:
+        return meta["modelId"]
     usage = update.get("usage")
     if isinstance(usage, dict):
         model_usage = usage.get("modelUsage")
         if isinstance(model_usage, dict) and model_usage:
-            # Prefer the model that spent the most output tokens in the turn.
-            best_model = ""
-            best_out = -1
+            best, best_out = "", -1
             for name, stats in model_usage.items():
-                if not isinstance(stats, dict):
-                    continue
-                out = int(stats.get("outputTokens") or 0)
+                out = int(stats.get("outputTokens") or 0) if isinstance(stats, dict) else 0
                 if out >= best_out:
-                    best_out = out
-                    best_model = str(name)
-            if best_model:
-                return best_model
+                    best, best_out = str(name), out
+            if best:
+                return best
     return fallback
 
 
-def _parse_session_grok(path: Path) -> tuple[list[_Response], list[_HumanMsg], bool]:
-    """Parse a Grok CLI ``updates.jsonl`` transcript.
+def _scan_session_grok(
+    path: Path,
+) -> tuple[
+    list[_Response],
+    list[_HumanMsg],
+    bool,
+    list[tuple[float | None, str, _Response | _HumanMsg]],
+]:
+    """Single-pass Grok ``updates.jsonl`` scan.
 
-    Grok streams assistant text as many ``agent_message_chunk`` events and often
-    reports token usage only on ``turn_completed`` (whole-turn, not per message).
-    We coalesce consecutive agent chunks into one response, flushed on the next
-    user message, turn completion, or EOF.
+    Coalesces ``agent_message_chunk`` streams into one response (flushed on
+    user message, ``turn_completed``, or EOF). Builds ordered events in the
+    same pass so fast-skip pairing cannot desync from a second walk.
     """
     responses: list[_Response] = []
     humans: list[_HumanMsg] = []
+    events: list[tuple[float | None, str, _Response | _HumanMsg]] = []
     has_tools = False
     prior_messages: list[dict[str, Any]] = []
     recent_context: list[str] = []
     current_model = ""
-
-    # Streaming agent buffer for the open turn.
     agent_parts: list[str] = []
     agent_ts: float | None = None
 
-    def flush_agent(
-        *,
-        input_tokens: int = 0,
-        output_tokens: int = 0,
-        model: str | None = None,
-    ) -> None:
+    def flush_agent(*, input_tokens: int = 0, output_tokens: int = 0, model: str = "") -> None:
         nonlocal agent_parts, agent_ts
         text = "".join(agent_parts)
         words = len(text.split()) if text.strip() else 0
         agent_parts = []
         ts = agent_ts
         agent_ts = None
-        if words <= 0 and output_tokens <= 0:
+        # Token-only flushes (no visible text) are noise for verbosity signals.
+        if words <= 0:
             return
         ctx = " ".join(recent_context[-_ECHO_CONTEXT_LOOKBACK:])
-        responses.append(
-            _Response(
-                words=words,
-                output_tokens=output_tokens,
-                input_tokens=input_tokens,
-                model=model or current_model or "unknown",
-                turn_kind=classify_turn(prior_messages).value,
-                has_tools=False,  # backfilled below
-                ts=ts,
-                echo=echo_ratio(text, ctx) if text and ctx else 0.0,
-            )
+        resp = _Response(
+            words=words,
+            output_tokens=output_tokens,
+            input_tokens=input_tokens,
+            model=model or current_model or "unknown",
+            turn_kind=classify_turn(prior_messages).value,
+            has_tools=False,
+            ts=ts,
+            echo=echo_ratio(text, ctx) if text and ctx else 0.0,
         )
+        responses.append(resp)
+        events.append((ts, "assistant", resp))
         prior_messages.append({"role": "assistant", "content": text})
 
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeDecodeError):
-        return [], [], False
+        return [], [], False, []
 
     for line in lines:
         try:
@@ -397,23 +389,16 @@ def _parse_session_grok(path: Path) -> tuple[list[_Response], list[_HumanMsg], b
         ts = _parse_ts(d.get("timestamp"))
 
         if su == "user_message_chunk":
-            # New human turn ends any open assistant stream (usage may be unknown).
             flush_agent(model=current_model)
             text = _grok_chunk_text(update)
-            current_model = _grok_model_from_update(update, current_model)
+            current_model = _grok_model(update, current_model)
             if not text.strip():
                 continue
             prior_messages.append({"role": "user", "content": text})
-            # Grok has no Claude-style interrupt marker; treat explicit cancel text
-            # as interrupt when present so the signal isn't always zero.
-            is_interrupt = (
-                _INTERRUPT_MARKER in text
-                or "request interrupted" in text.lower()
-                or text.strip().lower() in {"cancel", "cancelled", "canceled", "stop"}
-            )
-            humans.append(_HumanMsg(ts=ts, is_interrupt=is_interrupt))
-            if not is_interrupt:
-                recent_context.append(text)
+            human = _HumanMsg(ts=ts, is_interrupt=False)
+            humans.append(human)
+            events.append((ts, "human", human))
+            recent_context.append(text)
             continue
 
         if su == "agent_message_chunk":
@@ -425,36 +410,34 @@ def _parse_session_grok(path: Path) -> tuple[list[_Response], list[_HumanMsg], b
             agent_parts.append(chunk)
             continue
 
-        if su == "tool_call":
+        if su in ("tool_call", "tool_call_update"):
             has_tools = True
-            continue
-
-        if su == "tool_call_update":
-            has_tools = True
-            # Feed tool output into echo context (best-effort).
-            raw_output = update.get("rawOutput")
-            if isinstance(raw_output, dict):
-                for key in ("output_for_prompt", "output", "FileContent"):
-                    value = raw_output.get(key)
-                    if isinstance(value, str) and value.strip():
-                        recent_context.append(value[:2000])
-                        break
             continue
 
         if su == "turn_completed":
             usage = update.get("usage") if isinstance(update.get("usage"), dict) else {}
             in_tok = int(usage.get("inputTokens") or 0) + int(usage.get("cachedReadTokens") or 0)
             out_tok = int(usage.get("outputTokens") or 0)
-            model = _grok_model_from_update(update, current_model)
-            if model:
-                current_model = model
-            flush_agent(input_tokens=in_tok, output_tokens=out_tok, model=model)
+            current_model = _grok_model(update, current_model)
+            if agent_parts:
+                flush_agent(input_tokens=in_tok, output_tokens=out_tok, model=current_model)
+            elif responses and out_tok > 0 and responses[-1].output_tokens == 0:
+                # Usage arrived after a user-boundary flush of the same text.
+                responses[-1].output_tokens = out_tok
+                if in_tok:
+                    responses[-1].input_tokens = in_tok
+                if current_model:
+                    responses[-1].model = current_model
             continue
 
     flush_agent(model=current_model)
-
     for r in responses:
         r.has_tools = has_tools
+    return responses, humans, has_tools, events
+
+
+def _parse_session_grok(path: Path) -> tuple[list[_Response], list[_HumanMsg], bool]:
+    responses, humans, has_tools, _ = _scan_session_grok(path)
     return responses, humans, has_tools
 
 
@@ -463,7 +446,7 @@ def _ordered_events(path: Path) -> list[tuple[float | None, str, _Response | _Hu
     assistant response immediately before it. Kept simple: re-parse with a tag.
     """
     if _is_grok_session(path):
-        return _ordered_events_grok(path)
+        return _scan_session_grok(path)[3]
     return _ordered_events_claude(path)
 
 
@@ -505,61 +488,6 @@ def _ordered_events_claude(path: Path) -> list[tuple[float | None, str, _Respons
             if hi < len(humans):
                 out.append((humans[hi].ts, "human", humans[hi]))
                 hi += 1
-    return out
-
-
-def _ordered_events_grok(path: Path) -> list[tuple[float | None, str, _Response | _HumanMsg]]:
-    """Interleave Grok human / assistant events for fast-skip pairing.
-
-    Assistant responses are emitted when a stream is flushed (turn_completed,
-    next user message, or EOF). Human events align with ``user_message_chunk``.
-    """
-    out: list[tuple[float | None, str, Any]] = []
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except (OSError, UnicodeDecodeError):
-        return out
-    responses, humans, _ = _parse_session_grok(path)
-    ri = hi = 0
-    agent_open = False
-    agent_has_text = False
-
-    def emit_assistant() -> None:
-        nonlocal ri, agent_open, agent_has_text
-        if agent_open and agent_has_text and ri < len(responses):
-            out.append((responses[ri].ts, "assistant", responses[ri]))
-            ri += 1
-        agent_open = False
-        agent_has_text = False
-
-    for line in lines:
-        try:
-            d = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        params = d.get("params")
-        if not isinstance(params, dict):
-            continue
-        update = params.get("update")
-        if not isinstance(update, dict):
-            continue
-        su = update.get("sessionUpdate")
-        if su == "user_message_chunk":
-            # Flush open agent stream before the human (mirrors parse order).
-            emit_assistant()
-            text = _grok_chunk_text(update)
-            if not text.strip():
-                continue
-            if hi < len(humans):
-                out.append((humans[hi].ts, "human", humans[hi]))
-                hi += 1
-        elif su == "agent_message_chunk":
-            if _grok_chunk_text(update):
-                agent_open = True
-                agent_has_text = True
-        elif su == "turn_completed":
-            emit_assistant()
-    emit_assistant()
     return out
 
 

--- a/headroom/proxy/output_savings_policy.py
+++ b/headroom/proxy/output_savings_policy.py
@@ -33,7 +33,21 @@ def model_family(model: str) -> str:
     so we bucket (e.g.) every ``claude-opus-*`` together.
     """
     m = model.lower()
-    for fam in ("opus", "sonnet", "haiku", "fable", "mythos", "gpt", "gemini"):
+    # Order matters for overlapping substrings (e.g. "claude-opus" vs bare names).
+    # deepseek / composer / grok cover common Grok CLI / multi-provider ids that
+    # otherwise collapse to the uninformative "other" bucket.
+    for fam in (
+        "opus",
+        "sonnet",
+        "haiku",
+        "fable",
+        "mythos",
+        "gpt",
+        "gemini",
+        "deepseek",
+        "composer",
+        "grok",
+    ):
         if fam in m:
             return fam
     return "other"

--- a/headroom/proxy/output_savings_policy.py
+++ b/headroom/proxy/output_savings_policy.py
@@ -33,9 +33,6 @@ def model_family(model: str) -> str:
     so we bucket (e.g.) every ``claude-opus-*`` together.
     """
     m = model.lower()
-    # Order matters for overlapping substrings (e.g. "claude-opus" vs bare names).
-    # deepseek / composer / grok cover common Grok CLI / multi-provider ids that
-    # otherwise collapse to the uninformative "other" bucket.
     for fam in (
         "opus",
         "sonnet",

--- a/tests/test_output_savings_policy.py
+++ b/tests/test_output_savings_policy.py
@@ -34,6 +34,9 @@ def test_input_bucket_and_model_family_are_coarse() -> None:
     ]
     assert model_family("claude-sonnet-4-6") == "sonnet"
     assert model_family("unknown-model") == "other"
+    assert model_family("deepseek/deepseek-v4-flash") == "deepseek"
+    assert model_family("grok-composer-2.5-fast") == "composer"
+    assert model_family("grok-2-vision-1212") == "grok"
 
 
 def test_assign_arm_is_stable_and_respects_extreme_holdouts() -> None:

--- a/tests/test_verbosity_learn.py
+++ b/tests/test_verbosity_learn.py
@@ -472,3 +472,40 @@ class TestGrokSignalExtraction:
         assert len(responses) == 1
         assert responses[0].has_tools is True
         assert responses[0].model == "grok-composer-2.5-fast"
+
+
+    def test_turn_completed_backfills_tokens_after_user_flush(self, tmp_path):
+        """If usage lands after the next user turn started, still attach tokens."""
+        long = " ".join(["word"] * 50)
+        p = _write_grok_session(
+            tmp_path,
+            "sess3",
+            [
+                _grok_update(
+                    "user_message_chunk",
+                    ts=1.0,
+                    content={"type": "text", "text": "ask"},
+                    _meta={"modelId": "deepseek/deepseek-v4-flash"},
+                ),
+                _grok_update(
+                    "agent_message_chunk",
+                    ts=2.0,
+                    content={"type": "text", "text": long},
+                ),
+                # Next user arrives before turn_completed (unusual but possible).
+                _grok_update(
+                    "user_message_chunk",
+                    ts=3.0,
+                    content={"type": "text", "text": "next"},
+                ),
+                _grok_update(
+                    "turn_completed",
+                    ts=4.0,
+                    usage={"inputTokens": 1000, "outputTokens": 42},
+                ),
+            ],
+        )
+        responses, _, _ = _parse_session(p)
+        assert len(responses) == 1
+        assert responses[0].output_tokens == 42
+        assert responses[0].input_tokens == 1000

--- a/tests/test_verbosity_learn.py
+++ b/tests/test_verbosity_learn.py
@@ -356,3 +356,119 @@ class TestWindowsEncoding:
         assert loaded is not None
         assert loaded.rationale == prof.rationale
         assert loaded.project_path == prof.project_path
+
+
+def _grok_update(session_update: str, *, ts: float, **update_fields: object) -> dict:
+    update = {"sessionUpdate": session_update, **update_fields}
+    return {
+        "timestamp": ts,
+        "method": "session/update",
+        "params": {"sessionId": "test", "update": update},
+    }
+
+
+def _write_grok_session(tmp_path: Path, name: str, lines: list[dict]) -> Path:
+    session_dir = tmp_path / name
+    session_dir.mkdir(parents=True, exist_ok=True)
+    p = session_dir / "updates.jsonl"
+    p.write_text("\n".join(json.dumps(line) for line in lines))
+    return p
+
+
+class TestGrokSignalExtraction:
+    def test_coalesces_agent_chunks_and_fast_skip(self, tmp_path):
+        # 400-word answer needs ~96s to read; reply after 5s = fast skip.
+        long = " ".join(["word"] * 400)
+        # Stream as three chunks to prove coalescing.
+        n = len(long) // 3
+        p = _write_grok_session(
+            tmp_path,
+            "sess1",
+            [
+                _grok_update(
+                    "user_message_chunk",
+                    ts=1_700_000_000,
+                    content={"type": "text", "text": "explain"},
+                    _meta={"modelId": "deepseek/deepseek-v4-flash"},
+                ),
+                _grok_update(
+                    "agent_message_chunk",
+                    ts=1_700_000_001,
+                    content={"type": "text", "text": long[:n]},
+                ),
+                _grok_update(
+                    "agent_message_chunk",
+                    ts=1_700_000_002,
+                    content={"type": "text", "text": long[n : 2 * n]},
+                ),
+                _grok_update(
+                    "agent_message_chunk",
+                    ts=1_700_000_003,
+                    content={"type": "text", "text": long[2 * n :]},
+                ),
+                _grok_update(
+                    "turn_completed",
+                    ts=1_700_000_004,
+                    usage={
+                        "inputTokens": 5000,
+                        "outputTokens": 800,
+                        "modelUsage": {
+                            "deepseek/deepseek-v4-flash": {
+                                "inputTokens": 5000,
+                                "outputTokens": 800,
+                            }
+                        },
+                    },
+                ),
+                _grok_update(
+                    "user_message_chunk",
+                    ts=1_700_000_009,  # +5s after first agent chunk start
+                    content={"type": "text", "text": "ok next"},
+                ),
+            ],
+        )
+        responses, humans, has_tools = _parse_session(p)
+        assert has_tools is False
+        assert len(humans) == 2
+        assert len(responses) == 1
+        assert responses[0].words == 400
+        assert responses[0].output_tokens == 800
+        assert responses[0].model == "deepseek/deepseek-v4-flash"
+
+        sig, baseline = extract_signals([p])
+        assert sig.sessions == 1
+        assert sig.asst_responses == 1
+        assert sig.skip_eligible == 1
+        assert sig.fast_skips == 1
+        # Baseline stratified under deepseek, not "other"
+        assert any(k.startswith("deepseek|") for k in baseline.strata)
+
+    def test_tool_calls_set_has_tools(self, tmp_path):
+        p = _write_grok_session(
+            tmp_path,
+            "sess2",
+            [
+                _grok_update(
+                    "user_message_chunk",
+                    ts=100.0,
+                    content={"type": "text", "text": "run it"},
+                    _meta={"modelId": "grok-composer-2.5-fast"},
+                ),
+                _grok_update("tool_call", ts=101.0, toolCallId="c1", title="Bash"),
+                _grok_update(
+                    "agent_message_chunk",
+                    ts=102.0,
+                    content={"type": "text", "text": " ".join(["done"] * 20)},
+                ),
+                _grok_update(
+                    "turn_completed",
+                    ts=103.0,
+                    usage={"inputTokens": 100, "outputTokens": 20},
+                ),
+            ],
+        )
+        responses, _, has_tools = _parse_session(p)
+        assert has_tools is True
+        assert len(responses) == 1
+        assert responses[0].has_tools is True
+        assert responses[0].model == "grok-composer-2.5-fast"


### PR DESCRIPTION
## Description

Extends `headroom learn --verbosity` beyond Claude Code to **Grok CLI** transcripts (`~/.grok/sessions/**/updates.jsonl`). `--agent grok` no longer hard-errors; `--agent auto` mines Claude **and** Grok when both are present and merges baselines. Extends `model_family()` with `deepseek`, `composer`, and `grok` so multi-provider Grok Build traffic is stratified instead of collapsing to `other`.

Users who primarily work in Grok Build (often DeepSeek / Composer via Headroom) previously hit: `Verbosity learning currently supports Claude Code transcripts only.`

Closes #2841

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `learn/verbosity.py`: detect `updates.jsonl`; coalesce `agent_message_chunk`; map user/tool/`turn_completed.usage` into shared `_Response` / `_HumanMsg`
- `cli/learn.py`: allow `claude` + `grok`; Grok session glob `*/updates.jsonl`; multi-agent auto merge of baselines
- `proxy/output_savings_policy.py`: `model_family` adds deepseek / composer / grok
- tests: Grok coalesce + fast-skip + tools; family assertions in `test_verbosity_learn.py` and `test_output_savings_policy.py`

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run pytest tests/test_verbosity_learn.py tests/test_output_savings_policy.py
26 passed

$ ruff check headroom/cli/learn.py headroom/learn/verbosity.py headroom/proxy/output_savings_policy.py tests/test_verbosity_learn.py tests/test_output_savings_policy.py
All checks passed!
```

## Real Behavior Proof

- Environment: macOS arm64, Python 3.13, branch `feat/verbosity-grok`, real `~/.grok/sessions/` data for `/Users/pranav.j/Documents/memory`
- Exact command / steps: `headroom learn --verbosity --agent grok` (before on 0.34.0 installed tool, then after from this branch with `.venv/bin/headroom`)
- Observed result: Before: "Verbosity learning currently supports Claude Code transcripts only." After: mines 183 sessions / 1447 human turns / 1345 responses; recommends verbosity level 1 (high confidence); sample stratum family is `deepseek` (not `other`)
- Not tested: `--apply` against a live proxy hot-enable path; multi-project `--all` with both agents in one run; Codex/Gemini (still unsupported for verbosity by design)

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

Known limitations (documented in #2841):
- Grok has no Claude-style interrupt marker so interrupt rate is often ~0; fast-skip and length signals still work.
- Token usage is often per-turn on `turn_completed`, not per assistant message.

Happy to split `model_family` into a tiny follow-up if preferred.
