### PR TITLE
fix(opencode): send x-headroom-project so per-project savings can attribute traffic

### DIFF
--- a/headroom/providers/opencode/_dist/entry.opencode.js
+++ b/headroom/providers/opencode/_dist/entry.opencode.js
@@ -12487,6 +12487,7 @@ var childProcess = nodeRequire("node:child_process");
 var fs = nodeRequire("node:fs");
 var BASE_URL_HEADER = "x-headroom-base-url";
 var ORIGINAL_PATH_HEADER = "x-headroom-original-path";
+var PROJECT_HEADER = "x-headroom-project";
 var PROXY_ENV = "HEADROOM_OPENCODE_TRANSPORT_PROXY_URL";
 var STATE_KEY = /* @__PURE__ */ Symbol.for("headroom.opencode.transport");
 function getState() {
@@ -12642,6 +12643,10 @@ function mergeFetchHeaders(input, init, upstream, originalPath = void 0) {
   }
   if (upstream) {
     headers.set(BASE_URL_HEADER, upstream.origin);
+    const project = getState()?.project;
+    if (project) {
+      headers.set(PROJECT_HEADER, project);
+    }
     headers.delete("host");
   }
   if (originalPath) {
@@ -12706,6 +12711,10 @@ function urlFromRequestOptions(options) {
 function headersForNodeRequest(options, upstream, originalPath) {
   const headers = new Headers(options.headers);
   headers.set(BASE_URL_HEADER, upstream.origin);
+  const project = getState()?.project;
+  if (project) {
+    headers.set(PROJECT_HEADER, project);
+  }
   if (originalPath) {
     headers.set(ORIGINAL_PATH_HEADER, originalPath);
   }
@@ -12795,6 +12804,7 @@ function installHeadroomTransport(options) {
     existing.refs += 1;
     existing.proxyUrl = options.proxyUrl;
     existing.debug = Boolean(options.debug);
+    existing.project = options.project ?? existing.project;
     installProcessEnv(options.proxyUrl);
     return () => uninstallHeadroomTransport();
   }
@@ -12802,6 +12812,7 @@ function installHeadroomTransport(options) {
     refs: 1,
     proxyUrl: options.proxyUrl,
     debug: Boolean(options.debug),
+    project: options.project,
     originalFetch: globalThis.fetch,
     originalHttpRequest: http.request,
     originalHttpGet: http.get,
@@ -12868,13 +12879,18 @@ function resolveProxyUrl(options) {
     options?.proxyUrl ?? process.env.HEADROOM_PROXY_URL ?? process.env.HEADROOM_BASE_URL ?? getDefaultProxyUrl()
   );
 }
+function resolveProject(options, input) {
+  return options.project ?? input.project?.id ?? input.directory;
+}
 var HeadroomPlugin = async (input, options = {}) => {
   const pluginOptions = options;
   const proxyUrl = resolveProxyUrl(pluginOptions);
+  const project = resolveProject(pluginOptions, input);
   const retrieveTool = createHeadroomRetrieveTool({ proxyBaseUrl: proxyUrl });
   const uninstallTransport = installHeadroomTransport({
     proxyUrl,
-    debug: pluginOptions.debug
+    debug: pluginOptions.debug,
+    project
   });
   return {
     dispose: async () => {
@@ -12894,7 +12910,9 @@ var HeadroomPlugin = async (input, options = {}) => {
     "shell.env": async (_input, output) => {
       output.env.HEADROOM_ACTIVE = "1";
       output.env.HEADROOM_PROXY_URL = proxyUrl;
-      output.env.HEADROOM_PROJECT = pluginOptions.project ?? input.project.id ?? input.directory;
+      if (project) {
+        output.env.HEADROOM_PROJECT = project;
+      }
       if (pluginOptions.backend) {
         output.env.HEADROOM_BACKEND = pluginOptions.backend;
       }

--- a/plugins/opencode/src/plugin.ts
+++ b/plugins/opencode/src/plugin.ts
@@ -25,13 +25,29 @@ function resolveProxyUrl(options?: HeadroomOpenCodePluginOptions): string {
   );
 }
 
+function resolveProject(
+  options: HeadroomOpenCodePluginOptions,
+  input: { project?: unknown; directory?: string },
+): string | undefined {
+  return (
+    options.project ??
+    (input.project as { id?: string } | undefined)?.id ??
+    input.directory
+  );
+}
+
 export const HeadroomPlugin: Plugin = async (input, options = {}) => {
   const pluginOptions = options as HeadroomOpenCodePluginOptions;
   const proxyUrl = resolveProxyUrl(pluginOptions);
+  // Resolve the project once so the transport header and the spawned-subprocess
+  // env var agree, and per-project savings attribution works for the proxied
+  // HTTP requests too, not just child processes (#2847).
+  const project = resolveProject(pluginOptions, input);
   const retrieveTool = createHeadroomRetrieveTool({ proxyBaseUrl: proxyUrl });
   const uninstallTransport = installHeadroomTransport({
     proxyUrl,
     debug: pluginOptions.debug,
+    project,
   });
 
   return {
@@ -54,10 +70,9 @@ export const HeadroomPlugin: Plugin = async (input, options = {}) => {
     "shell.env": async (_input, output) => {
       output.env.HEADROOM_ACTIVE = "1";
       output.env.HEADROOM_PROXY_URL = proxyUrl;
-      output.env.HEADROOM_PROJECT =
-        pluginOptions.project ??
-        (input.project as { id?: string }).id ??
-        input.directory;
+      if (project) {
+        output.env.HEADROOM_PROJECT = project;
+      }
       if (pluginOptions.backend) {
         output.env.HEADROOM_BACKEND = pluginOptions.backend;
       }

--- a/plugins/opencode/src/transport.test.ts
+++ b/plugins/opencode/src/transport.test.ts
@@ -193,6 +193,58 @@ describe("Headroom OpenCode transport", () => {
     await proxy.close();
   });
 
+  it("sets x-headroom-project on routed fetch when a project is configured (#2847)", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(async (..._args: FetchCall) => new Response("ok"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    installHeadroomTransport({ proxyUrl: "http://127.0.0.1:8787/v1", project: "acme-web" });
+
+    await fetch("https://api.deepseek.com/v1/chat/completions", { method: "POST" });
+
+    const headers = new Headers(fetchMock.mock.calls[0][1]?.headers);
+    expect(headers.get("x-headroom-project")).toBe("acme-web");
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it("omits x-headroom-project when no project is configured", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(async (..._args: FetchCall) => new Response("ok"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    installHeadroomTransport({ proxyUrl: "http://127.0.0.1:8787/v1" });
+
+    await fetch("https://api.deepseek.com/v1/chat/completions", { method: "POST" });
+
+    const headers = new Headers(fetchMock.mock.calls[0][1]?.headers);
+    expect(headers.get("x-headroom-project")).toBeNull();
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it("sets x-headroom-project on routed Node https.request when a project is configured (#2847)", async () => {
+    const proxy = await proxyServer();
+    installHeadroomTransport({ proxyUrl: proxy.url, project: "acme-web" });
+
+    await new Promise<void>((resolve, reject) => {
+      const req = https.request(
+        "https://api.anthropic.com/v1/messages",
+        { method: "POST" },
+        (res) => {
+          res.resume();
+          res.on("end", resolve);
+        },
+      );
+      req.on("error", reject);
+      req.end("{}");
+    });
+
+    expect(proxy.seen[0].headers["x-headroom-project"]).toBe("acme-web");
+
+    await proxy.close();
+  });
+
   it("normalizes Node HTTP(S) requests for /chat/completions and /responses", async () => {
     const proxy = await proxyServer("");
     installHeadroomTransport({ proxyUrl: proxy.url });

--- a/plugins/opencode/src/transport.ts
+++ b/plugins/opencode/src/transport.ts
@@ -9,6 +9,12 @@ const fs = nodeRequire("node:fs") as typeof import("node:fs");
 
 const BASE_URL_HEADER = "x-headroom-base-url";
 const ORIGINAL_PATH_HEADER = "x-headroom-original-path";
+// Per-project savings attribution: the server (`project_policy.classify_project`)
+// attributes routed traffic via this header or a `/p/<name>` path prefix. Without
+// it every OpenCode request is unattributed and the dashboard shows 0 projects
+// (#2847). The child-process `HEADROOM_PROJECT` env var only reaches spawned
+// subprocesses, not the proxied HTTP requests, so it has to ride on the header too.
+const PROJECT_HEADER = "x-headroom-project";
 const PROXY_ENV = "HEADROOM_OPENCODE_TRANSPORT_PROXY_URL";
 const STATE_KEY = Symbol.for("headroom.opencode.transport");
 
@@ -26,12 +32,14 @@ type ChildFork = typeof childProcess.fork;
 interface InstallOptions {
   proxyUrl: string;
   debug?: boolean;
+  project?: string;
 }
 
 interface TransportState {
   refs: number;
   proxyUrl: string;
   debug: boolean;
+  project?: string;
   originalFetch: typeof fetch;
   originalHttpRequest: HttpRequest;
   originalHttpGet: HttpGet;
@@ -240,6 +248,10 @@ function mergeFetchHeaders(
   }
   if (upstream) {
     headers.set(BASE_URL_HEADER, upstream.origin);
+    const project = getState()?.project;
+    if (project) {
+      headers.set(PROJECT_HEADER, project);
+    }
     headers.delete("host");
   }
   if (originalPath) {
@@ -317,6 +329,10 @@ function headersForNodeRequest(
 ): Record<string, string> {
   const headers = new Headers(options.headers as HeadersInit | undefined);
   headers.set(BASE_URL_HEADER, upstream.origin);
+  const project = getState()?.project;
+  if (project) {
+    headers.set(PROJECT_HEADER, project);
+  }
   if (originalPath) {
     headers.set(ORIGINAL_PATH_HEADER, originalPath);
   }
@@ -421,6 +437,7 @@ export function installHeadroomTransport(options: InstallOptions): () => void {
     existing.refs += 1;
     existing.proxyUrl = options.proxyUrl;
     existing.debug = Boolean(options.debug);
+    existing.project = options.project ?? existing.project;
     installProcessEnv(options.proxyUrl);
     return () => uninstallHeadroomTransport();
   }
@@ -429,6 +446,7 @@ export function installHeadroomTransport(options: InstallOptions): () => void {
     refs: 1,
     proxyUrl: options.proxyUrl,
     debug: Boolean(options.debug),
+    project: options.project,
     originalFetch: globalThis.fetch,
     originalHttpRequest: http.request,
     originalHttpGet: http.get,


### PR DESCRIPTION
## Description

The OpenCode transport plugin sets `HEADROOM_PROJECT` only as a spawned-subprocess env var (the `shell.env` hook, derived from `input.project.id`), but the `fetch` / `http` / `https` wrapping that `installHeadroomTransport` installs only ever sets `x-headroom-base-url` and `x-headroom-original-path` on routed requests. It never sets `x-headroom-project`.

Server-side, `headroom/proxy/project_policy.py` (`classify_project`) attributes savings only via the `x-headroom-project` header or a `/p/<name>` URL-path prefix. Since the OpenCode plugin sends neither on the actual proxied HTTP requests, every OpenCode request is unattributed and the dashboard's "Per-Project Savings" panel permanently shows `0 project(s)`, even with per-project memory storage running (that path is cwd-based and only feeds the memory DB, not cost/savings attribution).

The fix resolves the project once at plugin init (`project` option -> `input.project.id` -> `input.directory`), threads it into the transport state, and sets `x-headroom-project` alongside `x-headroom-base-url` in both header-construction seams:

- `mergeFetchHeaders` (used by the wrapped `fetch`)
- `headersForNodeRequest` (used by the wrapped `http.request` / `https.request`)

The same resolved value now backs the `shell.env` `HEADROOM_PROJECT` export, so the header and the child-process env agree. When no project resolves, the header is simply omitted (behavior unchanged for that case).

Fixes #2847

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `plugins/opencode/src/transport.ts`: added a `PROJECT_HEADER` constant, a `project` field on `InstallOptions`/`TransportState`, and set `x-headroom-project` in `mergeFetchHeaders` and `headersForNodeRequest` when a project is configured.
- `plugins/opencode/src/plugin.ts`: resolve the project once via `resolveProject(...)`, pass it to `installHeadroomTransport`, and reuse it for the `shell.env` `HEADROOM_PROJECT` export.
- `plugins/opencode/src/transport.test.ts`: added three tests: the header is present on a routed `fetch` and on a routed Node `https.request` when a project is configured, and absent when it is not.
- `headroom/providers/opencode/_dist/entry.opencode.js`: rebuilt the committed wheel bundle via `npm run build:standalone` (the CI `opencode-plugin.yml` guard byte-compares this against the source build).

## Testing

- [x] Unit tests pass (`npm test` / vitest)
- [x] Type checking passes (`npm run typecheck` / `tsc --noEmit`)
- [x] New tests added for new functionality
- [x] Committed wheel bundle rebuilt and byte-matches the standalone build
- [ ] Manual testing performed

### Test Output

```text
# Fail-before (transport.ts source stashed, new tests kept):
src/transport.test.ts (15 tests | 2 failed)
  × sets x-headroom-project on routed fetch when a project is configured (#2847)
  × sets x-headroom-project on routed Node https.request when a project is configured (#2847)

# Pass-after (fix applied):
npm run typecheck  -> tsc --noEmit (clean)
npm test           -> Test Files 2 passed (2), Tests 17 passed (17)

# Committed wheel bundle rebuilt + CI guard reproduced:
npm run build:standalone
cmp dist-standalone/entry.opencode.js ../../headroom/providers/opencode/_dist/entry.opencode.js  -> match
# committed blob is LF-only (0 CR), so the Linux CI byte-compare matches
```

## Real Behavior Proof

- Environment: Windows 11, Node v24.11.0, npm 11.5.2, vitest 4.1.10, tsup 8.5.1 / esbuild 0.28.1 (matching the committed `package-lock.json`).
- Exact command / steps: traced the gap (transport wrapping sets `x-headroom-base-url`/`x-headroom-original-path` but never `x-headroom-project`, while `classify_project` reads only `x-headroom-project` or `/p/<name>`), added the header in both seams sourced from transport state, resolved the project once in the plugin. Fail-before with `git stash push plugins/opencode/src/transport.ts` and `npm test` (the two project-header tests fail: header not set), pass-after with `git stash pop` and rerunning (`17 passed`), then `npm run build:standalone` and `cmp` against the committed bundle (match).
- Observed result: a routed `fetch` and a routed Node `https.request` now carry `x-headroom-project: <project>` when the plugin resolved a project, so `classify_project` can attribute the traffic and the Per-Project Savings panel populates for OpenCode. With no project resolved the header is omitted, unchanged.
- Not tested: a live OpenCode session against a running proxy dashboard (no OpenCode client in this environment). The header emission is verified at both transport seams with the real wrapped `fetch` and a real loopback Node `https.request` captured by an in-test HTTP server.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`: it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

Scoped to project attribution on the routed HTTP requests, which is the reported gap. The child-process `HEADROOM_PROJECT` env var (which reaches spawned subprocesses but not the proxied requests) is preserved and now shares the single resolved value. The `package-lock.json` was left untouched: this change adds no dependencies, and the only local churn was Windows dropping optional non-Windows `@emnapi/*` entries during `npm install`, which I reverted.
