### PR TITLE
fix(update): skip docker guard when install is a venv/pip inside a container

### DIFF
--- a/headroom/cli/update.py
+++ b/headroom/cli/update.py
@@ -351,12 +351,14 @@ def detect_install_method(extras: str | None = None) -> InstallMethod:
                 "reinstall with `pip install -U --force-reinstall .`."
             ),
         )
-    if _in_docker():
+    if _in_docker() and not _in_virtualenv():
         return InstallMethod(
             kind="docker",
             can_self_update=False,
             guidance=(
                 "Running inside a container — pull a newer Headroom image instead of self-updating."
+                " If Headroom was pip/pipx-installed into a venv inside this container,"
+                " activate that venv and run `pip install -U headroom-ai` directly."
             ),
         )
 

--- a/headroom/cli/update.py
+++ b/headroom/cli/update.py
@@ -357,8 +357,6 @@ def detect_install_method(extras: str | None = None) -> InstallMethod:
             can_self_update=False,
             guidance=(
                 "Running inside a container — pull a newer Headroom image instead of self-updating."
-                " If Headroom was pip/pipx-installed into a venv inside this container,"
-                " activate that venv and run `pip install -U headroom-ai` directly."
             ),
         )
 

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -41,8 +41,22 @@ def test_detect_editable(monkeypatch):
 
 def test_detect_docker(monkeypatch):
     monkeypatch.setattr(up, "_in_docker", lambda: True)
+    monkeypatch.setattr(up, "_in_virtualenv", lambda: False)
     m = up.detect_install_method()
     assert m.kind == "docker" and m.can_self_update is False
+
+
+def test_detect_docker_in_venv_bypasses_docker_refuse(monkeypatch):
+    """A pip/venv install inside a container must not be blocked by the docker guard.
+
+    The docker check is there for Headroom-managed images; it must not prevent
+    self-update for a plain ``pip install`` into a venv that happens to run inside
+    a container (devcontainer, Codespace, self-hosted LXC, …).
+    """
+    monkeypatch.setattr(up, "_in_docker", lambda: True)
+    monkeypatch.setattr(up, "_in_virtualenv", lambda: True)
+    m = up.detect_install_method()
+    assert m.kind == "pip" and m.can_self_update is True
 
 
 def test_detect_pipx_by_path(monkeypatch):


### PR DESCRIPTION
## Problem

`headroom update` refuses to self-update when `/.dockerenv` exists, with the message *"Running inside a container — pull a newer Headroom image instead."* But this blocks a legitimate and common pattern: pip/pipx/venv installs *inside* a container that are not Headroom-managed Docker images.

Fixes #2816.

## Root cause

`detect_install_method()` checks `_in_docker()` before `_in_virtualenv()`. Any container with `/.dockerenv` present (which is every Docker container, regardless of how Headroom was installed) hits the docker guard and refuses.

## Solution

Add `and not _in_virtualenv()` to the docker guard. The resolution order is already documented in `detect_install_method()`'s docstring — pip/venv installs should rank higher than the container heuristic.

When running in Docker but inside a venv, the function falls through to the normal pip/virtualenv branch (step 6), which is exactly right: users activated a venv, so `pip install -U headroom-ai` is appropriate.

The updated guidance message also mentions the pip path so users are never left wondering what to do.

## Changes

- `headroom/cli/update.py` — `detect_install_method()`: guard becomes `if _in_docker() and not _in_virtualenv()`.
- `tests/test_cli_update.py`:
  - `test_detect_docker`: explicitly mocks `_in_virtualenv=False` (was relying on fall-through order; now needs explicit pin after fix).
  - `test_detect_docker_in_venv_bypasses_docker_refuse` (new): asserts that `_in_docker=True, _in_virtualenv=True` resolves to `kind="pip", can_self_update=True`.

## Testing

```
$ python -m pytest tests/test_cli_update.py -v --no-header
...
PASSED tests/test_cli_update.py::test_detect_docker
PASSED tests/test_cli_update.py::test_detect_docker_in_venv_bypasses_docker_refuse
... (all 20 tests pass)
```