### PR TITLE
fix(proxy): include tool_search_deferral savings in the savings ledger

### DIFF
--- a/headroom/proxy/prometheus_metrics.py
+++ b/headroom/proxy/prometheus_metrics.py
@@ -845,14 +845,23 @@ class PrometheusMetrics:
         # would hold the lock for the whole write instead of just the syscall.
         # ponytail: default thread pool, not a dedicated executor -- give it one
         # if a profile ever shows writers parked on flock saturating the pool.
-        if tokens_saved > 0 and not self._stateless:
+        # tool_search_deferral saves tool-SCHEMA tokens that never move the
+        # message-level tok_before/after, so a tool-heavy turn can have
+        # tokens_saved=0 while genuinely deferring thousands of tokens. Fold that
+        # component into the ledger delta the same way the PERF headline and
+        # perf/analyzer do (`headline_before = before + tool_saved`); otherwise
+        # `headroom savings` understates real compression 7-10x on tool-search
+        # sessions and drops deferral-only turns from the ledger entirely (#2795).
+        deferral_saved = max(0, int(tool_search_saved))
+        ledger_saved = tokens_saved + deferral_saved
+        if ledger_saved > 0 and not self._stateless:
             # `input_tokens` here is the optimized (post-compression) count
             # that was actually forwarded — see emit_request_outcome, which
             # passes `input_tokens=outcome.optimized_tokens`. The ledger's
             # `before` is the pre-compression original and `after` is what we
             # forwarded, and `headroom savings` derives the reduction percent
             # as saved / before. Passing the forwarded count as `before`
-            # understated the original by `tokens_saved`, inflating that
+            # understated the original by `ledger_saved`, inflating that
             # percentage (e.g. a real 40% reduction was reported as ~67%).
             # Reconstruct the original as forwarded + saved.
             await asyncio.to_thread(
@@ -863,7 +872,7 @@ class PrometheusMetrics:
                 # `tokens_saved` yields a mixed-ruler before/after (local 10->6
                 # with the provider reporting 8 would record 12->8). Use the
                 # caller's local count when supplied.
-                tokens_before=ledger_input_tokens + tokens_saved,
+                tokens_before=ledger_input_tokens + ledger_saved,
                 tokens_after=ledger_input_tokens,
                 model=model,
                 client=client or "proxy",

--- a/tests/test_savings_ledger_before_forwarded.py
+++ b/tests/test_savings_ledger_before_forwarded.py
@@ -63,3 +63,69 @@ async def test_record_savings_event_uses_original_input_as_before(
             "source": "proxy",
         }
     ]
+
+
+def _capture_ledger(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        prometheus_metrics.savings_ledger,
+        "record_savings_event",
+        lambda **kwargs: calls.append(kwargs),
+    )
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_record_savings_event_includes_tool_search_deferral(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """tool_search_deferral savings must ride into the ledger delta so
+    `headroom savings` does not undercount tool-search sessions ~7-10x (#2795)."""
+    calls = _capture_ledger(monkeypatch)
+    metrics = prometheus_metrics.PrometheusMetrics(
+        savings_tracker=_FakeSavingsTracker(),
+        otel_metrics=_FakeOtelMetrics(),
+    )
+    await metrics.record_request(
+        provider="anthropic",
+        model="claude-opus-4-6",
+        input_tokens=109844,  # forwarded (post-compression) message count
+        output_tokens=25,
+        tokens_saved=1896,
+        tool_search_saved=13182,  # deferred tool schemas never sent
+        latency_ms=10.0,
+        client="claude-code",
+    )
+
+    assert len(calls) == 1
+    # saved = tokens_saved + tool_search_saved; before = forwarded + saved.
+    assert calls[0]["tokens_after"] == 109844
+    assert calls[0]["tokens_before"] == 109844 + 1896 + 13182  # == 124922
+
+
+@pytest.mark.asyncio
+async def test_record_savings_event_written_for_deferral_only_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool-heavy turn can defer thousands of tool-schema tokens while
+    tokens_saved is 0 (deferral does not move the message-level count). It must
+    still be recorded, not dropped from the ledger (#2795)."""
+    calls = _capture_ledger(monkeypatch)
+    metrics = prometheus_metrics.PrometheusMetrics(
+        savings_tracker=_FakeSavingsTracker(),
+        otel_metrics=_FakeOtelMetrics(),
+    )
+    await metrics.record_request(
+        provider="anthropic",
+        model="claude-opus-4-6",
+        input_tokens=50000,
+        output_tokens=25,
+        tokens_saved=0,
+        tool_search_saved=13182,
+        latency_ms=10.0,
+        client="claude-code",
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["tokens_before"] == 50000 + 13182
+    assert calls[0]["tokens_after"] == 50000


### PR DESCRIPTION
## Description

`headroom savings` reports a percentage far below what the proxy log shows per call. The durable savings ledger (`~/.headroom/savings_events.jsonl`) records only `before`/`after`/`saved`, which trace back to the message-level `tok_saved`:

```json
{"before":111740,"after":109844,"saved":1896,"cost_usd":0.00948,"model":"claude-opus-5"}
```

The matching PERF line for the same call carries a `tool_saved` that never reaches the ledger:

```text
PERF ... tok_before=111740 tok_after=109844 tok_saved=1896 tool_saved=13182 ... transforms=... router:tool_search_deferral:10tools:13182tok
```

`tool_saved=13182` (tokens saved by `tool_search_deferral` -- deferred tool schemas never sent) is 7x the `tok_saved=1896` actually persisted. Including it, the real reduction is `(1896+13182)/111740 ~ 13.5%`, not the ~1.7% the ledger implied. On any session using on-demand tool loading (`ENABLE_TOOL_SEARCH=true`), `tool_search_deferral` is one of the largest per-call savings sources, so `headroom savings` systematically understated compression ~7-10x. Worse, a tool-heavy turn that saves only tool schemas has `tok_saved=0`, and the ledger write was gated on `tokens_saved > 0`, so those turns were dropped from the ledger entirely.

`record_request` already receives `tool_search_saved` (the same value the PERF line and `perf/analyzer` use -- `tool_schema_saved_from_tags(outcome.tags)`), but the ledger write ignored it. This folds it into the ledger delta exactly the way the headline does (`perf/analyzer`'s `headline_before = before + tool_saved`, `total_headline_saved = total_saved + total_tool_saved`): record `saved = tokens_saved + tool_search_saved` with `before = forwarded + that sum`, and gate on the total so deferral-only turns are recorded. The event `cost_usd` is then computed on the full saving.

Fixes #2795

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/prometheus_metrics.py` (`record_request`): compute `ledger_saved = tokens_saved + max(0, tool_search_saved)`, gate the ledger append on `ledger_saved > 0`, and pass `tokens_before = ledger_input_tokens + ledger_saved` (unchanged `tokens_after`).
- `tests/test_savings_ledger_before_forwarded.py`: added `test_record_savings_event_includes_tool_search_deferral` (deferral folded into the delta) and `test_record_savings_event_written_for_deferral_only_turn` (a `tokens_saved=0` deferral-only turn is still recorded).

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy`)
- [x] New tests added for new functionality

### Test Output

```text
# Fail-before (source fix stashed, new tests kept):
tests/test_savings_ledger_before_forwarded.py::test_record_savings_event_includes_tool_search_deferral FAILED
tests/test_savings_ledger_before_forwarded.py::test_record_savings_event_written_for_deferral_only_turn FAILED

# Pass-after:
tests/test_savings_ledger_before_forwarded.py tests/test_savings_ledger.py
tests/test_savings_tool_search_aggregation.py                              25 passed
tests/test_outcome_dual_ruler_funnel.py tests/test_request_outcome.py      (green)

# uvx ruff@0.15.17 check  -> All checks passed!
# uvx mypy@1.20.2 headroom/proxy/prometheus_metrics.py -> Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.15.17 and mypy 1.20.2 via uvx.
- Exact command / steps: traced the ledger write from the outcome funnel (`emit_request_outcome` -> `metrics.record_request(tool_search_saved=...)`) into `prometheus_metrics.record_request`, and confirmed the append recorded `before = forwarded + tokens_saved` and was gated on `tokens_saved > 0`, dropping the `tool_search_saved` component. Folded it in, then fail-before by stashing the source (the two new tests fail: the deferral is excluded and the deferral-only turn is dropped) and pass-after by restoring it (25 savings-suite tests pass, including the existing `before_forwarded` expectation which is unchanged because `tool_search_saved` defaults to 0).
- Observed result: on the issue's example call the ledger now records `before=124922`, `after=109844`, `saved=15078` (the 1896 message reduction plus the 13182 deferred tool tokens), and a `tokens_saved=0` deferral-only turn is written instead of skipped, so `headroom savings` reflects tool-search compression instead of understating it ~7-10x.
- Not tested: an end-to-end `headroom savings` run over a live ledger from a real `ENABLE_TOOL_SEARCH=true` Claude Code session (no live proxy here). The ledger write is verified directly with the exact plumbing (`record_request` -> `savings_ledger.record_savings_event`) the proxy uses, and the fold matches the already-shipped PERF/analyzer headline convention.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`: it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

I deliberately matched `perf/analyzer`'s existing convention (`headline_before = before + tool_saved`) so `headroom savings` and the PERF headline agree on the same reduction figure, rather than inventing a third accounting. `tool_search_saved` is clamped to `>= 0` before folding. One unrelated test, `test_savings_ledger_offload.py::test_concurrent_requests_all_land_their_events`, is flaky on my machine ("a concurrent append was lost") and fails identically on pristine `main` with this diff stashed, so it is a pre-existing concurrency-race flake, not a regression here.
