### PR TITLE
fix(proxy): close the upstream stream when a streaming body is never consumed

### DIFF
--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -1098,6 +1098,7 @@ class StreamingMixin:
     ) -> Response | StreamingResponse:
         """Actual streaming implementation, guarded by _stream_response's cleanup wrapper."""
         from fastapi.responses import Response, StreamingResponse
+        from starlette.background import BackgroundTask
 
         from headroom.proxy.helpers import MAX_SSE_BUFFER_SIZE
 
@@ -1656,10 +1657,29 @@ class StreamingMixin:
                     )
                     yield f"event: headroom_pending_messages\ndata: {pending_event}\n\n".encode()
 
+        async def _release_upstream_stream() -> None:
+            # Guarantee the upstream HTTP/2 stream is released even when the
+            # body generator above is never iterated — the client disconnected
+            # before Starlette started sending the response body (routine when a
+            # harness like Claude Code cancels or supersedes an in-flight turn),
+            # so ``generate()`` never entered its own ``aclosing`` and nothing
+            # else closes ``upstream_response``. Each such request otherwise
+            # leaks one open h2 stream; they accumulate on the pooled upstream
+            # connection until it reaches SETTINGS_MAX_CONCURRENT_STREAMS (100)
+            # and no new stream can open ("Max outbound streams is 100, 100
+            # open"), and the proxy goes unhealthy until restart (#2797).
+            # Starlette runs a response's ``background`` task after the body
+            # finishes *and* after an early client disconnect, so this fires in
+            # both cases. ``aclose()`` is idempotent, so on the normal path —
+            # where the generator already closed the stream — this is a no-op.
+            with contextlib.suppress(Exception):
+                await upstream_response.aclose()
+
         return StreamingResponse(
             generate(),
             media_type="text/event-stream",
             headers=forwarded_headers,
+            background=BackgroundTask(_release_upstream_stream),
         )
 
     async def _stream_response_bedrock(

--- a/tests/test_proxy_copilot_auth_hooks.py
+++ b/tests/test_proxy_copilot_auth_hooks.py
@@ -52,11 +52,22 @@ def _load_handler_module(monkeypatch: pytest.MonkeyPatch, module_name: str, rela
     responses_mod = types.ModuleType("fastapi.responses")
 
     class Response:
-        def __init__(self, content=None, status_code: int = 200, headers=None, media_type=None):
+        def __init__(
+            self,
+            content=None,
+            status_code: int = 200,
+            headers=None,
+            media_type=None,
+            background=None,
+        ):
             self.content = content
             self.status_code = status_code
             self.headers = headers or {}
             self.media_type = media_type
+            # The streaming forwarder attaches a background task that releases the
+            # upstream stream when the body is never consumed (#2882); the double
+            # must accept and store it so the real StreamingResponse call works.
+            self.background = background
 
     class StreamingResponse(Response):
         pass
@@ -228,6 +239,9 @@ def test_streaming_response_applies_copilot_auth(monkeypatch: pytest.MonkeyPatch
     assert sent_headers["Authorization"] == "Bearer upstream-token"
     assert sent_headers["content-type"] == "application/json"
     assert response.status_code == 200
+    # The Copilot auth hook and the #2882 upstream-stream cleanup coexist: the
+    # streaming response still carries its background release task.
+    assert response.background is not None
 
 
 def test_openai_chat_routes_copilot_requests_per_model(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_proxy_streaming_ratelimit_headers.py
+++ b/tests/test_proxy_streaming_ratelimit_headers.py
@@ -513,6 +513,56 @@ class TestStreamingRatelimitHeaderForwarding:
         mock_response.aclose.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_upstream_stream_released_over_asgi_lifecycle_on_disconnect(self):
+        """Driving the real ASGI response through an early disconnect releases the stream.
+
+        Rather than calling ``result.background()`` directly, this exercises the
+        Starlette response lifecycle with a client that disconnects immediately,
+        and asserts the upstream stream is closed by the end of it -- proving the
+        cleanup this PR attaches is actually invoked by Starlette, not merely
+        present on the response object.
+        """
+        import asyncio
+
+        proxy = self._create_mock_proxy()
+        mock_response = self._create_mock_upstream_response()
+        proxy.http_client.build_request = MagicMock(return_value=MagicMock())
+        proxy.http_client.send = AsyncMock(return_value=mock_response)
+
+        result = await proxy._stream_response(
+            url="https://api.anthropic.com/v1/messages",
+            headers={"x-api-key": "sk-test"},
+            body={
+                "model": "claude-sonnet-4-20250514",
+                "max_tokens": 100,
+                "stream": True,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+            provider="anthropic",
+            model="claude-sonnet-4-20250514",
+            request_id="test-asgi-lifecycle",
+            original_tokens=10,
+            optimized_tokens=10,
+            tokens_saved=0,
+            transforms_applied=[],
+            tags={},
+            optimization_latency=0.0,
+        )
+
+        async def receive():
+            # The client is already gone before the body is streamed.
+            return {"type": "http.disconnect"}
+
+        async def send(_message):
+            return None
+
+        scope = {"type": "http", "method": "POST", "headers": []}
+        await asyncio.wait_for(result(scope, receive, send), timeout=5.0)
+
+        # By the end of the response lifecycle the upstream stream is released.
+        mock_response.aclose.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_codex_rate_limit_headers_captured_and_forwarded_in_streaming(self):
         """Codex x-codex-* headers must refresh /stats state AND reach the client.
 

--- a/tests/test_proxy_streaming_ratelimit_headers.py
+++ b/tests/test_proxy_streaming_ratelimit_headers.py
@@ -464,6 +464,55 @@ class TestStreamingRatelimitHeaderForwarding:
         assert chunks
 
     @pytest.mark.asyncio
+    async def test_upstream_stream_closed_when_body_never_consumed(self):
+        """A never-iterated streaming body must still release the upstream stream (#2797).
+
+        The upstream stream is opened before the body generator, and the
+        generator's own ``aclosing`` only runs if the body is iterated. When a
+        client disconnects before Starlette starts sending the body the
+        generator never runs, so the close must come from the response's
+        ``background`` task instead — otherwise every such request leaks an open
+        HTTP/2 stream and the pooled upstream connection eventually exhausts its
+        100 concurrent streams ("Max outbound streams is 100, 100 open").
+        """
+        proxy = self._create_mock_proxy()
+        mock_response = self._create_mock_upstream_response()
+
+        mock_request = MagicMock()
+        proxy.http_client.build_request = MagicMock(return_value=mock_request)
+        proxy.http_client.send = AsyncMock(return_value=mock_response)
+
+        result = await proxy._stream_response(
+            url="https://api.anthropic.com/v1/messages",
+            headers={"x-api-key": "sk-test"},
+            body={
+                "model": "claude-sonnet-4-20250514",
+                "max_tokens": 100,
+                "stream": True,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+            provider="anthropic",
+            model="claude-sonnet-4-20250514",
+            request_id="test-abandoned-stream",
+            original_tokens=10,
+            optimized_tokens=10,
+            tokens_saved=0,
+            transforms_applied=[],
+            tags={},
+            optimization_latency=0.0,
+        )
+
+        # Simulate the client disconnecting before the body is consumed: the
+        # generator is never iterated, so its aclosing never runs.
+        mock_response.aclose.assert_not_awaited()
+
+        # Starlette runs the response's background task in exactly this case.
+        assert result.background is not None, "streaming response must carry a cleanup task"
+        await result.background()
+
+        mock_response.aclose.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_codex_rate_limit_headers_captured_and_forwarded_in_streaming(self):
         """Codex x-codex-* headers must refresh /stats state AND reach the client.
 


### PR DESCRIPTION
## Description

A long-lived proxy serving Claude Code eventually goes unhealthy with:

```json
"upstream": {"status": "unhealthy", "error": "Max outbound streams is 100, 100 open"}
```

and clients start getting `502`s until the service is restarted (#2797).

Root cause is a leaked upstream HTTP/2 stream on the streaming path. In `_stream_response_inner` the upstream response is opened *before* the body generator, so its headers are available to build the `StreamingResponse` (ratelimit forwarding):

```python
upstream_response = await self.http_client.send(_upstream_req, stream=True)
...
return StreamingResponse(generate(), media_type="text/event-stream", headers=forwarded_headers)
```

The only thing that closes `upstream_response` on the success path is the generator's own `contextlib.aclosing`:

```python
async def generate():
    ...
    async with contextlib.aclosing(upstream_response) as response:
        async for chunk in response.aiter_bytes():
            ...
```

That cleanup runs only if the body is iterated. When a client disconnects before Starlette starts sending the body, the generator is never started, its `aclosing` never runs, and nothing else closes the stream. This is routine with Claude Code, which cancels or supersedes in-flight turns (ESC, a newer request, `/compact` side-requests). Each abandoned request leaks one open h2 stream.

Leaked streams accumulate on the pooled upstream connection until it reaches the server's `SETTINGS_MAX_CONCURRENT_STREAMS` (100 for Anthropic). After that httpcore cannot open a new stream on it, the upstream health probe surfaces `Max outbound streams is 100, 100 open`, and the proxy stays unhealthy until restart. It builds up slowly, which matches the "after prolonged use" reports.

The outer `_stream_response` already anticipates exactly this disconnect-mid-setup case for the session key:

```python
# any exception here - including asyncio.CancelledError from a client disconnect
# mid-setup - must still release session_key ...
except (Exception, asyncio.CancelledError):
    self._cleanup_mid_turn_stream(session_key)
    raise
```

The opened upstream stream never got the same guarantee.

## Fix

Attach an idempotent close as the `StreamingResponse` `background` task. Starlette runs a response's background task after the body finishes *and* after an early client disconnect, so the stream is released in both cases. On the normal path the generator has already closed it, so `aclose()` is a no-op (`httpx.Response.aclose()` is idempotent).

```python
async def _release_upstream_stream() -> None:
    with contextlib.suppress(Exception):
        await upstream_response.aclose()

return StreamingResponse(
    generate(),
    media_type="text/event-stream",
    headers=forwarded_headers,
    background=BackgroundTask(_release_upstream_stream),
)
```

The already-correct paths are untouched: the `>= 400` error path and the retry path close the stream explicitly, and the transport-error path returns before a stream is held.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `headroom/proxy/handlers/streaming.py` (`_stream_response_inner`): attach `background=BackgroundTask(_release_upstream_stream)` to the success `StreamingResponse` so the upstream stream is closed even when the body generator is never iterated. Imports `starlette.background.BackgroundTask`.
- `tests/test_proxy_streaming_ratelimit_headers.py`: add `test_upstream_stream_closed_when_body_never_consumed` - builds the streaming response, does not consume the body (asserts `aclose` not yet called), then runs the response's background task and asserts the upstream `aclose` is awaited.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] New test added

### Test Output

```text
# Fail-before (background= line removed, new test kept):
tests/test_proxy_streaming_ratelimit_headers.py::...::test_upstream_stream_closed_when_body_never_consumed FAILED
  assert result.background is not None -> AssertionError: streaming response must carry a cleanup task

# Pass-after (fix in place):
tests/test_proxy_streaming_ratelimit_headers.py  12 passed
tests/test_proxy_streaming_ratelimit_headers.py tests/test_h2_stream_reset_retry.py
tests/test_proxy_streaming_request_logger.py
tests/test_proxy/test_anthropic_streaming_ccr_retrieve.py   34 passed

# uvx ruff@0.15.17 check  -> All checks passed!
# uvx mypy@1.20.2 headroom/proxy/handlers/streaming.py -> Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.15.17 and mypy 1.20.2 via uvx.
- Steps: traced the streaming forwarder from `send(stream=True)` to the `StreamingResponse` return and confirmed the only close on the success path is the body generator's `contextlib.aclosing`, which does not run if the body is never iterated. Reproduced that condition in the existing streaming unit harness (mock upstream whose `aclose` is an `AsyncMock`), built the response, left the body unconsumed, and observed `aclose` was never awaited before the fix; the response also carried no `background` task. With the fix, the response carries a background task that awaits the upstream `aclose`.
- Observed result: an abandoned streaming request now releases its upstream stream instead of leaking it, so streams no longer accumulate toward the 100-stream ceiling on the pooled connection.
- Not tested: an end-to-end multi-hour Claude Code session reproducing the 100-open exhaustion against a live Anthropic connection (no live long-running proxy here). The leak condition and its release are verified directly at the streaming handler with the same plumbing the proxy uses.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`: it is generated by release-please from my Conventional Commit PR title

## Additional Notes

`aclose()` is idempotent, so the background close is safe alongside the generator's own cleanup on the normal path - it simply becomes the sole closer when the generator never runs. The background task runs only after the response lifecycle completes, so it never races an in-flight stream.
