### PR TITLE
fix(image): cap the technique-router ONNX intra-op thread pool

### DIFF
--- a/headroom/image/onnx_router.py
+++ b/headroom/image/onnx_router.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import io
 import logging
 import math
+import os
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,18 @@ logger = logging.getLogger(__name__)
 
 _TECHNIQUE_ROUTER_REPO = "chopratejas/technique-router-onnx"
 _SIGLIP_ENCODER_REPO = "chopratejas/siglip-image-encoder-onnx"
+
+# The query classifier is a MiniLM INT8 graph over a fixed [1, 64] input (the
+# tokenizer pads to exactly 64 below), so it saturates after a handful of
+# threads. Left at ORT's default the pool scales with the core count and the
+# per-call cost grows without buying latency -- on a 20-core box that measured
+# 10.07 ms / 33.65 CPU-ms versus 8.57 ms / 20.76 CPU-ms at 4 threads.
+# Capped rather than fixed so smaller hosts keep ORT's own choice.
+_CLASSIFIER_MAX_INTRA_OP_THREADS = 4
+
+
+def _classifier_intra_op_threads() -> int:
+    return max(1, min(_CLASSIFIER_MAX_INTRA_OP_THREADS, os.cpu_count() or 1))
 
 
 # ImageSignals, RouteDecision, Technique imported from trained_router
@@ -64,7 +77,11 @@ class OnnxTechniqueRouter:
         model_path = hf_hub_download_local_first(_TECHNIQUE_ROUTER_REPO, "model_quantized.onnx")
         self._classifier_session = ort.InferenceSession(
             model_path,
-            create_cpu_session_options(ort),
+            create_cpu_session_options(
+                ort,
+                intra_op_num_threads=_classifier_intra_op_threads(),
+                inter_op_num_threads=1,
+            ),
             providers=["CPUExecutionProvider"],
         )
 

--- a/headroom/image/onnx_router.py
+++ b/headroom/image/onnx_router.py
@@ -37,8 +37,30 @@ _SIGLIP_ENCODER_REPO = "chopratejas/siglip-image-encoder-onnx"
 _CLASSIFIER_MAX_INTRA_OP_THREADS = 4
 
 
+def _available_cpu_count() -> int:
+    """CPUs this process may actually run on.
+
+    ``os.cpu_count()`` reports the host's cores even when a cgroup cpuset pins
+    the process to a subset, so a two-CPU container on a 64-core box would be
+    handed the full four-thread cap -- exactly the oversubscription the cap
+    exists to avoid. Prefer the affinity-aware counts where the platform has
+    them.
+    """
+    sched_getaffinity = getattr(os, "sched_getaffinity", None)
+    if sched_getaffinity is not None:
+        return max(1, len(sched_getaffinity(0)))
+
+    process_cpu_count = getattr(os, "process_cpu_count", None)  # Python 3.13+
+    if process_cpu_count is not None:
+        usable: int | None = process_cpu_count()
+        if usable:
+            return usable
+
+    return max(1, os.cpu_count() or 1)
+
+
 def _classifier_intra_op_threads() -> int:
-    return max(1, min(_CLASSIFIER_MAX_INTRA_OP_THREADS, os.cpu_count() or 1))
+    return min(_CLASSIFIER_MAX_INTRA_OP_THREADS, _available_cpu_count())
 
 
 # ImageSignals, RouteDecision, Technique imported from trained_router

--- a/tests/test_onnx_router_threads.py
+++ b/tests/test_onnx_router_threads.py
@@ -19,6 +19,7 @@ import pytest
 from headroom.image.onnx_router import (
     _CLASSIFIER_MAX_INTRA_OP_THREADS,
     OnnxTechniqueRouter,
+    _available_cpu_count,
     _classifier_intra_op_threads,
 )
 
@@ -71,8 +72,7 @@ def _install_fake_tokenizers(monkeypatch) -> None:
     monkeypatch.setitem(sys.modules, "tokenizers", types.SimpleNamespace(Tokenizer=_Tokenizer))
 
 
-@pytest.fixture
-def loaded_classifier(monkeypatch, tmp_path):
+def _load_classifier(monkeypatch, tmp_path):
     created = _install_fake_ort(monkeypatch)
     _install_fake_tokenizers(monkeypatch)
 
@@ -93,6 +93,11 @@ def loaded_classifier(monkeypatch, tmp_path):
     return created
 
 
+@pytest.fixture
+def loaded_classifier(monkeypatch, tmp_path):
+    return _load_classifier(monkeypatch, tmp_path)
+
+
 def test_classifier_session_caps_intra_op_threads(loaded_classifier):
     assert len(loaded_classifier) == 1
     options = loaded_classifier[0].sess_options
@@ -102,16 +107,77 @@ def test_classifier_session_caps_intra_op_threads(loaded_classifier):
     assert options.inter_op_num_threads == 1
 
 
+def _fake_cpu_topology(monkeypatch, *, host, affinity=None, process="absent"):
+    """Model a host/container CPU topology for the count helpers.
+
+    ``affinity`` is the CPU set ``sched_getaffinity`` reports (``None`` removes
+    the call, as on macOS/Windows); ``process`` is what ``process_cpu_count``
+    returns, or ``"absent"`` for pre-3.13 interpreters.
+    """
+    monkeypatch.setattr("headroom.image.onnx_router.os.cpu_count", lambda: host)
+
+    if affinity is None:
+        monkeypatch.delattr("os.sched_getaffinity", raising=False)
+    else:
+        monkeypatch.setattr("os.sched_getaffinity", lambda _pid: set(affinity), raising=False)
+
+    if process == "absent":
+        monkeypatch.delattr("os.process_cpu_count", raising=False)
+    else:
+        monkeypatch.setattr("os.process_cpu_count", lambda: process, raising=False)
+
+
 def test_classifier_thread_cap_never_exceeds_available_cores(monkeypatch):
     """A 2-core host must not be told to run 4 intra-op threads."""
-    monkeypatch.setattr("headroom.image.onnx_router.os.cpu_count", lambda: 2)
+    _fake_cpu_topology(monkeypatch, host=2)
     assert _classifier_intra_op_threads() == 2
 
-    monkeypatch.setattr("headroom.image.onnx_router.os.cpu_count", lambda: 64)
+    _fake_cpu_topology(monkeypatch, host=64)
     assert _classifier_intra_op_threads() == _CLASSIFIER_MAX_INTRA_OP_THREADS
 
-    monkeypatch.setattr("headroom.image.onnx_router.os.cpu_count", lambda: None)
+    _fake_cpu_topology(monkeypatch, host=None)
     assert _classifier_intra_op_threads() == 1
+
+
+def test_thread_cap_follows_process_affinity_not_host_cores(monkeypatch):
+    """A cpuset-restricted container on a big host must not get 4 threads.
+
+    ``os.cpu_count()`` still reports the host's 64 cores inside such a cgroup,
+    so counting cores that way would reintroduce the oversubscription the cap
+    is meant to prevent.
+    """
+    _fake_cpu_topology(monkeypatch, host=64, affinity={3, 11})
+
+    assert _available_cpu_count() == 2
+    assert _classifier_intra_op_threads() == 2
+
+
+def test_thread_cap_uses_process_cpu_count_without_affinity_api(monkeypatch):
+    """Without ``sched_getaffinity`` the 3.13 process count still wins."""
+    _fake_cpu_topology(monkeypatch, host=64, affinity=None, process=2)
+
+    assert _available_cpu_count() == 2
+    assert _classifier_intra_op_threads() == 2
+
+
+def test_thread_cap_falls_back_to_host_cores(monkeypatch):
+    """With no usable affinity-aware answer, the host count is all we have."""
+    _fake_cpu_topology(monkeypatch, host=2, affinity=None)
+    assert _available_cpu_count() == 2
+
+    # ``process_cpu_count()`` returns None when it cannot determine the count.
+    _fake_cpu_topology(monkeypatch, host=2, affinity=None, process=None)
+    assert _available_cpu_count() == 2
+    assert _classifier_intra_op_threads() == 2
+
+
+def test_classifier_session_honors_affinity_on_many_core_host(monkeypatch, tmp_path):
+    """The session itself, not just the helper, respects the process affinity."""
+    _fake_cpu_topology(monkeypatch, host=64, affinity={0, 5})
+
+    created = _load_classifier(monkeypatch, tmp_path)
+
+    assert created[0].sess_options.intra_op_num_threads == 2
 
 
 def test_classifier_session_keeps_retention_defaults(loaded_classifier):

--- a/tests/test_onnx_router_threads.py
+++ b/tests/test_onnx_router_threads.py
@@ -1,0 +1,122 @@
+"""The technique-router session must cap its ONNX intra-op thread pool.
+
+The classifier runs a MiniLM INT8 graph over a fixed [1, 64] input, so its
+thread pool saturates almost immediately. Built with a bare
+``create_cpu_session_options(ort)`` the pool instead scales with the host core
+count, which costs CPU without buying latency on a many-core box.
+
+``headroom/memory/adapters/embedders.py`` already pins its own session, so this
+keeps the two ONNX call sites consistent.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from headroom.image.onnx_router import (
+    _CLASSIFIER_MAX_INTRA_OP_THREADS,
+    OnnxTechniqueRouter,
+    _classifier_intra_op_threads,
+)
+
+
+class _FakeSessionOptions:
+    def __init__(self) -> None:
+        self.intra_op_num_threads: int | None = None
+        self.inter_op_num_threads: int | None = None
+        self.enable_cpu_mem_arena = True
+        self.enable_mem_pattern = True
+        self.config_entries: dict[str, str] = {}
+
+    def add_session_config_entry(self, key: str, value: str) -> None:
+        self.config_entries[key] = value
+
+
+class _FakeInferenceSession:
+    def __init__(self, model_path, sess_options, providers=None):
+        self.model_path = model_path
+        self.sess_options = sess_options
+        self.providers = providers
+
+
+def _install_fake_ort(monkeypatch) -> list[_FakeInferenceSession]:
+    """Stand in for onnxruntime, which onnx_router imports inside the method."""
+    created: list[_FakeInferenceSession] = []
+
+    def _make(model_path, sess_options, providers=None):
+        session = _FakeInferenceSession(model_path, sess_options, providers)
+        created.append(session)
+        return session
+
+    fake_ort = types.SimpleNamespace(
+        SessionOptions=_FakeSessionOptions,
+        InferenceSession=_make,
+    )
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+    return created
+
+
+def _install_fake_tokenizers(monkeypatch) -> None:
+    class _Tokenizer:
+        @staticmethod
+        def from_file(path):
+            return types.SimpleNamespace(
+                enable_truncation=lambda **_: None,
+                enable_padding=lambda **_: None,
+            )
+
+    monkeypatch.setitem(sys.modules, "tokenizers", types.SimpleNamespace(Tokenizer=_Tokenizer))
+
+
+@pytest.fixture
+def loaded_classifier(monkeypatch, tmp_path):
+    created = _install_fake_ort(monkeypatch)
+    _install_fake_tokenizers(monkeypatch)
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"id2label": {"0": "preserve"}}')
+    model_path = tmp_path / "model_quantized.onnx"
+    model_path.write_bytes(b"")
+    tokenizer_path = tmp_path / "tokenizer.json"
+    tokenizer_path.write_text("{}")
+
+    def _download(repo, filename):
+        return str(tmp_path / filename)
+
+    monkeypatch.setattr("headroom.image.onnx_router.hf_hub_download_local_first", _download)
+
+    router = OnnxTechniqueRouter()
+    router._load_classifier()
+    return created
+
+
+def test_classifier_session_caps_intra_op_threads(loaded_classifier):
+    assert len(loaded_classifier) == 1
+    options = loaded_classifier[0].sess_options
+
+    assert options.intra_op_num_threads == _classifier_intra_op_threads()
+    assert options.intra_op_num_threads <= _CLASSIFIER_MAX_INTRA_OP_THREADS
+    assert options.inter_op_num_threads == 1
+
+
+def test_classifier_thread_cap_never_exceeds_available_cores(monkeypatch):
+    """A 2-core host must not be told to run 4 intra-op threads."""
+    monkeypatch.setattr("headroom.image.onnx_router.os.cpu_count", lambda: 2)
+    assert _classifier_intra_op_threads() == 2
+
+    monkeypatch.setattr("headroom.image.onnx_router.os.cpu_count", lambda: 64)
+    assert _classifier_intra_op_threads() == _CLASSIFIER_MAX_INTRA_OP_THREADS
+
+    monkeypatch.setattr("headroom.image.onnx_router.os.cpu_count", lambda: None)
+    assert _classifier_intra_op_threads() == 1
+
+
+def test_classifier_session_keeps_retention_defaults(loaded_classifier):
+    """The cap must not bypass create_cpu_session_options' other settings."""
+    options = loaded_classifier[0].sess_options
+
+    assert options.config_entries.get("session.intra_op.allow_spinning") == "0"
+    assert options.config_entries.get("session.inter_op.allow_spinning") == "0"


### PR DESCRIPTION
## Description

`OnnxTechniqueRouter._load_classifier` builds its session with a bare `create_cpu_session_options(ort)`, so ORT sizes the intra-op thread pool from the host core count:

```python
self._classifier_session = ort.InferenceSession(
    model_path,
    create_cpu_session_options(ort),
    providers=["CPUExecutionProvider"],
)
```

The classifier is a MiniLM INT8 graph over a fixed `[1, 64]` input — the tokenizer two lines below pins it with `enable_truncation(max_length=64)` / `enable_padding(length=64)`. A graph that small saturates after a handful of threads, so on a many-core host the extra threads cost CPU without buying latency.

`headroom/memory/adapters/embedders.py` already pins its own ONNX session (`intra_op_num_threads=1, inter_op_num_threads=1`) with a comment about keeping the pool small. This brings the two call sites in line.

Follow-up to @JerrettDavis' review: the cap is now sized from the CPUs this
process may run on, not from the host's core count.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/image/onnx_router.py`: build the classifier session with
  `create_cpu_session_options(ort, intra_op_num_threads=..., inter_op_num_threads=1)`
  instead of the bare call, capped at `_CLASSIFIER_MAX_INTRA_OP_THREADS = 4`.
- `headroom/image/onnx_router.py`: add `_available_cpu_count()`, which prefers
  `len(os.sched_getaffinity(0))`, falls back to `os.process_cpu_count()`
  (Python 3.13+) and only then to `os.cpu_count()`. `os.cpu_count()` reports the
  host's cores inside a cgroup-restricted cpuset, so a container pinned to two
  CPUs on a 64-core box would have been handed the full four threads — the exact
  oversubscription this PR exists to remove.
- `tests/test_onnx_router_threads.py`: 7 tests covering the session options, the
  container case (host cores > process affinity), both fallback layers, and the
  untouched retention defaults.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run pytest tests/test_onnx_router_threads.py tests/test_onnx_runtime.py -q
21 passed in 1.18s

$ uv run ruff check headroom/image/onnx_router.py tests/test_onnx_router_threads.py
All checks passed!

$ uv run ruff format --check headroom/image/onnx_router.py tests/test_onnx_router_threads.py
2 files already formatted

$ uv run mypy headroom/image/onnx_router.py
Success: no issues found in 1 source file
```

Before this follow-up, `test_thread_cap_follows_process_affinity_not_host_cores`
fails on the old helper:

```text
E   assert 4 == 2
E    +  where 4 = _classifier_intra_op_threads()
```

## Real Behavior Proof

- Environment: macOS 27.0 arm64 (20 cores), Python 3.12.13, onnxruntime
  1.23.2, headroom @ `main` (2f2950a) + this branch.
- Exact command / steps: ran the focused ONNX router/runtime tests and the CPU-affinity probe shown below.

```text
$ uv run python -c "
import os
from headroom.image import onnx_router as r
print('host cpu_count      :', os.cpu_count())
print('available (real)    :', r._available_cpu_count())
print('intra-op (real)     :', r._classifier_intra_op_threads())
os.sched_getaffinity = lambda pid: {3, 11}   # emulate a 2-CPU cpuset
os.cpu_count = lambda: 64
print('available (cpuset 2):', r._available_cpu_count())
print('intra-op (cpuset 2) :', r._classifier_intra_op_threads())
"
```

- Observed result: the real process selects four intra-op threads, while an emulated two-CPU cpuset selects two; focused tests and static checks pass.

```text
host cpu_count      : 20
available (real)    : 20
intra-op (real)     : 4
available (cpuset 2): 2
intra-op (cpuset 2) : 2
```

- Not tested: no run inside a real Docker cgroup, and cgroup CPU quota
  (`--cpus=1.5`, `cpu.max`) is still invisible to both `sched_getaffinity` and
  `os.cpu_count()` — that is a separate gap from the cpuset case raised in
  review, and nothing else in the repo reads cgroup limits today.

### Thread-count benchmark (unchanged from the original submission)

Environment: macOS 27.0 arm64 (20 physical cores, 16P + 4E), Python 3.13, onnxruntime 1.26.0, headroom @ `main` (2f2950a).

Sessions were built through `create_cpu_session_options`, not a bare `ort.SessionOptions()`, so the arena and `allow_spinning` entries from #2540 are in effect and the numbers reflect what the proxy actually runs. Median of 60 calls after 5 warmup calls, `[1, 64]` int64 inputs.

### technique router (`model_quantized.onnx`)

| intra-op threads | median ms | p90 ms | CPU ms/call |
| --- | --- | --- | --- |
| 1 | 12.72 | 13.08 | 12.65 |
| 2 | 9.96 | 10.55 | 16.34 |
| 4 | 8.57 | 9.29 | 20.76 |
| 8 | 9.56 | 10.10 | 27.17 |
| 20 | 15.45 | 19.55 | 69.87 |
| ORT default (today) | 10.07 | 10.57 | 33.65 |

4 threads is 15% faster and 38% cheaper in CPU than the current default. It is strictly dominant here — there is no latency/CPU tradeoff to argue about.

### SigLIP encoder — measured, deliberately unchanged

| intra-op threads | median ms | CPU ms/call |
| --- | --- | --- |
| 4 | 56.48 | 180.28 |
| 8 | 42.55 | 209.63 |
| 20 | 50.86 | 370.17 |
| ORT default (today) | 41.82 | 242.42 |

ORT's default is already the encoder's best latency point, so this PR leaves the SigLIP session alone. Capping it to 8 would trade 2% latency for 14% CPU, which is a judgement call rather than a bug fix; say the word and I will add it.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit `CHANGELOG.md`

## Additional Notes

Documentation is unchanged: the cap is an internal ONNX session detail with no
user-facing knob. The SigLIP session is still left at ORT's default on purpose
(see the benchmark above).

