### PR TITLE
fix(content-router): protect custom-tag blocks before mixed-content section split

### DIFF
--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -2406,7 +2406,24 @@ class ContentRouter(Transform):
         Returns:
             RouterCompressionResult with reassembled content.
         """
-        sections = split_into_sections(content)
+        from .tag_protector import protect_tags, restore_tags
+
+        # Protect custom-tag blocks BEFORE splitting into sections. Section
+        # boundaries (code fences, blank lines) split a
+        # ``<system-reminder>...</system-reminder>`` pair across sections, so
+        # the per-section tag protection inside ``_try_ml_compressor`` never
+        # sees a matched pair (an unmatched tag protects nothing) and
+        # instruction blocks — Claude Code ships CLAUDE.md inside
+        # <system-reminder> — leak into lossy ML compression and arrive
+        # word-dropped. Protecting here keeps the whole block as one
+        # placeholder that spans sections intact.
+        cleaned, protected = protect_tags(
+            content,
+            compress_tagged_content=self.config.compress_tagged_content,
+        )
+        sections_source = cleaned if protected else content
+
+        sections = split_into_sections(sections_source)
         if logger.isEnabledFor(logging.DEBUG):
             _log_router_debug(
                 "content_router_mixed_sections",
@@ -2422,10 +2439,32 @@ class ContentRouter(Transform):
                 strategy_used=CompressionStrategy.PASSTHROUGH,
             )
 
+        # Placeholders must survive byte-exact: ``restore_tags`` DISCARDS a
+        # protected block whose placeholder was stripped or rewritten
+        # (Hotfix-A9), so a compressor eating a placeholder would silently
+        # drop the whole tag block — worse than the mangling this fixes.
+        # Any section carrying a placeholder is passed through verbatim
+        # instead of ever entering a compressor.
+        placeholders = [placeholder for placeholder, _ in protected]
+
         compressed_sections: list[str] = []
         routing_log: list[RoutingDecision] = []
 
         for i, section in enumerate(sections):
+            if placeholders and any(ph in section.content for ph in placeholders):
+                section_tokens = _estimate_tokens(section.content)
+                compressed_sections.append(section.content)
+                routing_log.append(
+                    RoutingDecision(
+                        content_type=section.content_type,
+                        strategy=CompressionStrategy.PASSTHROUGH,
+                        original_tokens=section_tokens,
+                        compressed_tokens=section_tokens,
+                        section_index=i,
+                    )
+                )
+                continue
+
             # Get strategy for this section
             strategy = self._strategy_from_detection_type(section.content_type)
 
@@ -2455,8 +2494,12 @@ class ContentRouter(Transform):
                 )
             )
 
+        compressed = "\n\n".join(compressed_sections)
+        if protected:
+            compressed = restore_tags(compressed, protected)
+
         return RouterCompressionResult(
-            compressed="\n\n".join(compressed_sections),
+            compressed=compressed,
             original=content,
             strategy_used=CompressionStrategy.MIXED,
             routing_log=routing_log,

--- a/tests/test_transforms/test_content_router.py
+++ b/tests/test_transforms/test_content_router.py
@@ -1699,3 +1699,70 @@ class TestCompressBlockContent:
         assert any("router:tool_result" in t for t in transforms_applied), (
             f"Expected router:tool_result:* in transforms, got: {transforms_applied}"
         )
+
+
+# =============================================================================
+# Mixed content: custom-tag protection (system-reminder mangling regression)
+# =============================================================================
+
+
+class TestMixedContentTagProtection:
+    """_compress_mixed must protect custom-tag blocks BEFORE section split.
+
+    Splitting first lands the open/close tags of a
+    ``<system-reminder>...</system-reminder>`` pair in different sections;
+    per-section protection then sees only unmatched tags (which protect
+    nothing) and the block's content — Claude Code ships CLAUDE.md this way —
+    is lossy-compressed and arrives word-dropped.
+    """
+
+    REMINDER = (
+        "<system-reminder>\n"
+        "Instruction prose that must survive byte-exact.\n\n"
+        "```bash\nrtk gain\n```\n\n"
+        "More instructions after the fence, also byte-exact.\n"
+        "</system-reminder>"
+    )
+
+    @staticmethod
+    def _mangling_router() -> ContentRouter:
+        """Router whose per-section compressor visibly mangles everything."""
+        router = ContentRouter(ContentRouterConfig(min_section_tokens=1))
+
+        def mangle(content, strategy, context, language=None, question=None, bias=1.0):
+            return "MANGLED", 1, None
+
+        router._apply_strategy_to_content = mangle  # type: ignore[method-assign]
+        return router
+
+    def test_reminder_block_survives_mixed_compression_verbatim(self):
+        router = self._mangling_router()
+        content = (
+            "Prose before the reminder that may compress.\n\n"
+            + self.REMINDER
+            + "\n\nProse after the reminder that may compress."
+        )
+
+        result = router._compress_mixed(content, context="")
+
+        # The tag block (fence and all) is byte-exact in the output...
+        assert self.REMINDER in result.compressed
+        # ...while content outside it still went through the compressor.
+        assert "MANGLED" in result.compressed
+
+    def test_reminder_only_content_passes_through(self):
+        router = self._mangling_router()
+
+        result = router._compress_mixed(self.REMINDER, context="")
+
+        assert self.REMINDER in result.compressed
+        assert "MANGLED" not in result.compressed
+
+    def test_untagged_mixed_content_still_compresses(self):
+        router = self._mangling_router()
+        content = "Plain prose section.\n\n```python\nprint('hi')\n```\n\nMore prose."
+
+        result = router._compress_mixed(content, context="")
+
+        assert "MANGLED" in result.compressed
+        assert result.strategy_used == CompressionStrategy.MIXED


### PR DESCRIPTION
## Description

Claude Code delivers CLAUDE.md user instructions inside `<system-reminder>` blocks in user turns. When user-message text compression is active (e.g. the `coding` savings persona sets `compress_user_messages=True` since 0.34.0), those instruction blocks arrive at the model **word-dropped and mangled**, with `[N items compressed to M ... Retrieve more: hash=...]` markers spliced into the middle of the user's own instructions. Observed in production; at least one paying Headroom Desktop user cancelled over it ("My CLAUDE.md files would be cut/mangled ... not worth saving on tokens").

Root cause: the tag protection in `_try_ml_compressor` (protect `<system-reminder>`, `<tool_call>`, `<thinking>` from lossy ML compression) is defeated on the MIXED path. CLAUDE.md content contains code fences, so it routes through `_compress_mixed`, which calls `split_into_sections` **before** any compressor runs. Section boundaries (fences, blank lines) land the reminder's open and close tags in different sections; per-section `protect_tags` then only ever sees an unmatched tag, and an unmatched tag protects nothing (`protect_tags("<system-reminder>only open tag", False)` → 0 protected blocks). The instruction prose flows into Kompress; only the tag markers survive.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/transforms/content_router.py` — `_compress_mixed` now runs `protect_tags` **before** `split_into_sections`, so a matched tag pair becomes a single placeholder spanning sections intact, and `restore_tags` after reassembly.
- Sections carrying a placeholder are passed through verbatim (logged as `PASSTHROUGH` in the routing log) instead of entering a compressor: `restore_tags` **discards** a protected block whose placeholder was stripped or rewritten (Hotfix-A9 behavior), so letting a compressor eat a placeholder would upgrade "mangled instructions" to "instructions silently deleted".
- `tests/test_transforms/test_content_router.py` — new `TestMixedContentTagProtection` regression class (3 tests).
- Behavior unchanged for mixed content without custom tags; `compress_tagged_content=True` still exposes tagged content for callers that opt in.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/test_transforms/ -q
380 passed, 67 skipped, 1 warning in 50.92s

$ ruff check headroom/transforms/content_router.py tests/test_transforms/test_content_router.py
All checks passed!
$ ruff format --check headroom/transforms/content_router.py tests/test_transforms/test_content_router.py
2 files already formatted
$ mypy headroom/transforms/content_router.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: macOS (Darwin 24.6.0), Python 3.12, `uv run --frozen --extra dev`, repo at upstream/main (2f2950a6) + this branch.
- Exact command / steps: swapped the unpatched router in and out under the new regression tests:
  `git checkout upstream/main -- headroom/transforms/content_router.py && pytest tests/test_transforms/test_content_router.py::TestMixedContentTagProtection -q`, then restored the branch version and re-ran.

  ```text
  === ON UNPATCHED upstream/main router ===
  FAILED ...::test_reminder_block_survives_mixed_compression_verbatim
  FAILED ...::test_reminder_only_content_passes_through
  2 failed, 1 passed in 0.25s
  === ON PATCHED branch ===
  3 passed in 0.16s
  ```

- Observed result: on unpatched main, a `<system-reminder>` block containing a code fence has its prose replaced by the section compressor while only the tag markers survive — the exact production mangling. On the branch the block is byte-exact in the output while content outside it still compresses. The split-defeats-protection mechanism was also confirmed directly against a deployed 0.34.0 runtime: `split_into_sections` puts `<system-reminder>` and `</system-reminder>` in different `PLAIN_TEXT` sections, and `protect_tags` on an unmatched tag returns 0 protected blocks.
- Not tested: end-to-end through a live proxy with the Kompress ML model loaded (the regression uses a deterministic stand-in for the section compressor — the bug is in the routing layer, not in Kompress itself); the OpenAI batch path (see Additional Notes).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — behavior is fully captured by the test output above.

## Additional Notes

- Documentation change: N/A — no user-facing docs describe the mixed-section internals.
- Related but out of scope: `compression_batches.py` passes `compress_tagged_content=True` on the OpenAI batch path, deliberately exposing tagged content there. It looks intentional (envelope validation), but may deserve the same instruction-block scrutiny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
