### PR TITLE
fix(backends/anyllm): stream tool_use blocks and map finish_reason on the streaming path

### DIFF
--- a/headroom/backends/anyllm.py
+++ b/headroom/backends/anyllm.py
@@ -326,16 +326,22 @@ class AnyLLMBackend(Backend):
 
             stream_response = await self.llm.acompletion(**kwargs)
             output_tokens = 0
-            # Open content blocks lazily as deltas arrive so a response can carry
-            # tool_use blocks (not just text). The previous version pre-opened a
-            # single text block at index 0 and only inspected ``delta.content``,
-            # so a tool call streamed back over any-llm was silently dropped even
-            # though ``tools``/``tool_choice`` are forwarded above — the client
-            # saw an empty turn and the agent loop stalled. Mirrors the
-            # non-streaming ``_to_anthropic_response`` and the LiteLLM streamer.
+            # Stream text immediately in a single text block, but BUFFER tool
+            # calls and emit them as complete blocks at the end. OpenAI streams
+            # parallel tool calls interleaved by index (index 0 and 1 introduced
+            # together, then a fragment for 0, then for 1), while Anthropic
+            # requires each content block to be fully emitted — start, deltas,
+            # stop — before the next opens. Reassembling per index and flushing
+            # complete blocks keeps every delta inside its own block's start/stop
+            # for any interleaving. (The previous version pre-opened one text
+            # block and dropped tool calls entirely; a naive open-on-new-index
+            # instead mis-sequenced parallel calls, emitting a fragment for an
+            # already-stopped block.)
             current_block_index = -1
-            active_block_type: str | None = None  # "text" or "tool_use"
-            tool_block_map: dict[int, int] = {}  # provider tc.index -> SSE block index
+            text_block_open = False
+            # provider tool index -> {"id", "name", "arguments"}, first-seen order
+            tool_calls: dict[int, dict[str, Any]] = {}
+            tool_order: list[int] = []
             stop_reason = "end_turn"
 
             async for chunk in cast(AsyncIterator[Any], stream_response):
@@ -357,61 +363,24 @@ class AnyLLMBackend(Backend):
                 if getattr(delta, "tool_calls", None):
                     for tc in delta.tool_calls:
                         idx = tc.index if getattr(tc, "index", None) is not None else 0
-                        if idx not in tool_block_map:
-                            if active_block_type is not None:
-                                yield StreamEvent(
-                                    event_type="content_block_stop",
-                                    data={
-                                        "type": "content_block_stop",
-                                        "index": current_block_index,
-                                    },
-                                )
-                            current_block_index += 1
-                            tool_block_map[idx] = current_block_index
-                            active_block_type = "tool_use"
-                            tool_id = getattr(tc, "id", None) or f"toolu_{uuid.uuid4().hex[:24]}"
-                            func = getattr(tc, "function", None)
-                            tool_name = func.name if func and func.name else ""
-                            yield StreamEvent(
-                                event_type="content_block_start",
-                                data={
-                                    "type": "content_block_start",
-                                    "index": current_block_index,
-                                    "content_block": {
-                                        "type": "tool_use",
-                                        "id": tool_id,
-                                        "name": tool_name,
-                                        "input": {},
-                                    },
-                                },
-                            )
+                        buf = tool_calls.get(idx)
+                        if buf is None:
+                            buf = {"id": None, "name": "", "arguments": ""}
+                            tool_calls[idx] = buf
+                            tool_order.append(idx)
+                        if getattr(tc, "id", None):
+                            buf["id"] = tc.id
                         func = getattr(tc, "function", None)
-                        if func and func.arguments:
-                            yield StreamEvent(
-                                event_type="content_block_delta",
-                                data={
-                                    "type": "content_block_delta",
-                                    "index": tool_block_map[idx],
-                                    "delta": {
-                                        "type": "input_json_delta",
-                                        "partial_json": func.arguments,
-                                    },
-                                },
-                            )
-                            output_tokens += 1
+                        if func is not None:
+                            if getattr(func, "name", None):
+                                buf["name"] = func.name
+                            if getattr(func, "arguments", None):
+                                buf["arguments"] += func.arguments
 
                 elif getattr(delta, "content", None):
-                    if active_block_type != "text":
-                        if active_block_type is not None:
-                            yield StreamEvent(
-                                event_type="content_block_stop",
-                                data={
-                                    "type": "content_block_stop",
-                                    "index": current_block_index,
-                                },
-                            )
+                    if not text_block_open:
                         current_block_index += 1
-                        active_block_type = "text"
+                        text_block_open = True
                         yield StreamEvent(
                             event_type="content_block_start",
                             data={
@@ -430,8 +399,46 @@ class AnyLLMBackend(Backend):
                     )
                     output_tokens += 1
 
-            # Close the last open block, if any content or tool call arrived.
-            if active_block_type is not None:
+            # Close the text block before any tool blocks (Anthropic orders
+            # content blocks sequentially, text then tool_use).
+            if text_block_open:
+                yield StreamEvent(
+                    event_type="content_block_stop",
+                    data={"type": "content_block_stop", "index": current_block_index},
+                )
+
+            # Flush each buffered tool call as a complete, self-contained block:
+            # start, one input_json_delta with the reassembled arguments, stop.
+            for idx in tool_order:
+                buf = tool_calls[idx]
+                current_block_index += 1
+                tool_id = buf["id"] or f"toolu_{uuid.uuid4().hex[:24]}"
+                yield StreamEvent(
+                    event_type="content_block_start",
+                    data={
+                        "type": "content_block_start",
+                        "index": current_block_index,
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": tool_id,
+                            "name": buf["name"],
+                            "input": {},
+                        },
+                    },
+                )
+                if buf["arguments"]:
+                    yield StreamEvent(
+                        event_type="content_block_delta",
+                        data={
+                            "type": "content_block_delta",
+                            "index": current_block_index,
+                            "delta": {
+                                "type": "input_json_delta",
+                                "partial_json": buf["arguments"],
+                            },
+                        },
+                    )
+                    output_tokens += 1
                 yield StreamEvent(
                     event_type="content_block_stop",
                     data={"type": "content_block_stop", "index": current_block_index},

--- a/headroom/backends/anyllm.py
+++ b/headroom/backends/anyllm.py
@@ -324,42 +324,124 @@ class AnyLLMBackend(Backend):
                 },
             )
 
-            yield StreamEvent(
-                event_type="content_block_start",
-                data={
-                    "type": "content_block_start",
-                    "index": 0,
-                    "content_block": {"type": "text", "text": ""},
-                },
-            )
-
             stream_response = await self.llm.acompletion(**kwargs)
             output_tokens = 0
+            # Open content blocks lazily as deltas arrive so a response can carry
+            # tool_use blocks (not just text). The previous version pre-opened a
+            # single text block at index 0 and only inspected ``delta.content``,
+            # so a tool call streamed back over any-llm was silently dropped even
+            # though ``tools``/``tool_choice`` are forwarded above — the client
+            # saw an empty turn and the agent loop stalled. Mirrors the
+            # non-streaming ``_to_anthropic_response`` and the LiteLLM streamer.
+            current_block_index = -1
+            active_block_type: str | None = None  # "text" or "tool_use"
+            tool_block_map: dict[int, int] = {}  # provider tc.index -> SSE block index
+            stop_reason = "end_turn"
 
             async for chunk in cast(AsyncIterator[Any], stream_response):
-                if hasattr(chunk, "choices") and chunk.choices:
-                    delta = chunk.choices[0].delta
-                    if hasattr(delta, "content") and delta.content:
+                if not (hasattr(chunk, "choices") and chunk.choices):
+                    continue
+                choice = chunk.choices[0]
+                delta = choice.delta
+
+                # Map OpenAI finish_reason to the Anthropic stop_reason so a tool
+                # call or a length truncation is not reported as end_turn.
+                finish_reason = getattr(choice, "finish_reason", None)
+                if finish_reason == "tool_calls":
+                    stop_reason = "tool_use"
+                elif finish_reason == "length":
+                    stop_reason = "max_tokens"
+                elif finish_reason == "stop":
+                    stop_reason = "end_turn"
+
+                if getattr(delta, "tool_calls", None):
+                    for tc in delta.tool_calls:
+                        idx = tc.index if getattr(tc, "index", None) is not None else 0
+                        if idx not in tool_block_map:
+                            if active_block_type is not None:
+                                yield StreamEvent(
+                                    event_type="content_block_stop",
+                                    data={
+                                        "type": "content_block_stop",
+                                        "index": current_block_index,
+                                    },
+                                )
+                            current_block_index += 1
+                            tool_block_map[idx] = current_block_index
+                            active_block_type = "tool_use"
+                            tool_id = getattr(tc, "id", None) or f"toolu_{uuid.uuid4().hex[:24]}"
+                            func = getattr(tc, "function", None)
+                            tool_name = func.name if func and func.name else ""
+                            yield StreamEvent(
+                                event_type="content_block_start",
+                                data={
+                                    "type": "content_block_start",
+                                    "index": current_block_index,
+                                    "content_block": {
+                                        "type": "tool_use",
+                                        "id": tool_id,
+                                        "name": tool_name,
+                                        "input": {},
+                                    },
+                                },
+                            )
+                        func = getattr(tc, "function", None)
+                        if func and func.arguments:
+                            yield StreamEvent(
+                                event_type="content_block_delta",
+                                data={
+                                    "type": "content_block_delta",
+                                    "index": tool_block_map[idx],
+                                    "delta": {
+                                        "type": "input_json_delta",
+                                        "partial_json": func.arguments,
+                                    },
+                                },
+                            )
+                            output_tokens += 1
+
+                elif getattr(delta, "content", None):
+                    if active_block_type != "text":
+                        if active_block_type is not None:
+                            yield StreamEvent(
+                                event_type="content_block_stop",
+                                data={
+                                    "type": "content_block_stop",
+                                    "index": current_block_index,
+                                },
+                            )
+                        current_block_index += 1
+                        active_block_type = "text"
                         yield StreamEvent(
-                            event_type="content_block_delta",
+                            event_type="content_block_start",
                             data={
-                                "type": "content_block_delta",
-                                "index": 0,
-                                "delta": {"type": "text_delta", "text": delta.content},
+                                "type": "content_block_start",
+                                "index": current_block_index,
+                                "content_block": {"type": "text", "text": ""},
                             },
                         )
-                        output_tokens += 1
+                    yield StreamEvent(
+                        event_type="content_block_delta",
+                        data={
+                            "type": "content_block_delta",
+                            "index": current_block_index,
+                            "delta": {"type": "text_delta", "text": delta.content},
+                        },
+                    )
+                    output_tokens += 1
 
-            yield StreamEvent(
-                event_type="content_block_stop",
-                data={"type": "content_block_stop", "index": 0},
-            )
+            # Close the last open block, if any content or tool call arrived.
+            if active_block_type is not None:
+                yield StreamEvent(
+                    event_type="content_block_stop",
+                    data={"type": "content_block_stop", "index": current_block_index},
+                )
 
             yield StreamEvent(
                 event_type="message_delta",
                 data={
                     "type": "message_delta",
-                    "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                    "delta": {"stop_reason": stop_reason, "stop_sequence": None},
                     "usage": {"output_tokens": output_tokens},
                 },
             )

--- a/tests/test_backend_anyllm.py
+++ b/tests/test_backend_anyllm.py
@@ -379,10 +379,11 @@ async def test_stream_message_emits_tool_use_blocks(monkeypatch: pytest.MonkeyPa
     ]
     types = [e.event_type for e in events]
 
+    # The tool call is buffered and flushed as one complete block: start, a
+    # single input_json_delta with the reassembled arguments, then stop.
     assert types == [
         "message_start",
         "content_block_start",
-        "content_block_delta",
         "content_block_delta",
         "content_block_stop",
         "message_delta",
@@ -395,12 +396,97 @@ async def test_stream_message_emits_tool_use_blocks(monkeypatch: pytest.MonkeyPa
     assert start.data["content_block"]["name"] == "get_weather"
 
     arg_deltas = [e for e in events if e.event_type == "content_block_delta"]
-    assert [d.data["delta"]["type"] for d in arg_deltas] == ["input_json_delta", "input_json_delta"]
+    assert [d.data["delta"]["type"] for d in arg_deltas] == ["input_json_delta"]
     joined = "".join(d.data["delta"]["partial_json"] for d in arg_deltas)
     assert joined == '{"city":"paris"}'
 
     message_delta = next(e for e in events if e.event_type == "message_delta")
     assert message_delta.data["delta"]["stop_reason"] == "tool_use"
+
+
+@pytest.mark.asyncio
+async def test_stream_message_handles_parallel_tool_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interleaved parallel tool calls must produce valid, disjoint Anthropic blocks.
+
+    OpenAI can introduce two tool indices in one chunk and then stream argument
+    fragments for each across later chunks. Each Anthropic tool_use block must be
+    fully framed (exactly one start and stop, arguments reassembled) with no
+    delta emitted after that block's stop.
+    """
+    backend, instance = make_backend(monkeypatch)
+    instance.response = FakeAsyncStream(
+        [
+            # One chunk introduces BOTH tool indices at once.
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            tool_calls=[
+                                SimpleNamespace(
+                                    index=0,
+                                    id="call_0",
+                                    function=SimpleNamespace(name="alpha", arguments='{"a":'),
+                                ),
+                                SimpleNamespace(
+                                    index=1,
+                                    id="call_1",
+                                    function=SimpleNamespace(name="beta", arguments='{"b":'),
+                                ),
+                            ]
+                        ),
+                        finish_reason=None,
+                    )
+                ]
+            ),
+            # Interleaved argument fragments: index 0, then index 1.
+            _tool_call_delta(index=0, arguments="1}"),
+            _tool_call_delta(index=1, arguments="2}"),
+            SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(), finish_reason="tool_calls")]
+            ),
+        ]
+    )
+
+    events = [
+        event async for event in backend.stream_message({"model": "claude", "messages": []}, {})
+    ]
+
+    # Each tool block index must have exactly one start and one stop, and no
+    # delta may appear after that index's stop.
+    stopped: set[int] = set()
+    starts: dict[int, int] = {}
+    stops: dict[int, int] = {}
+    args: dict[int, str] = {}
+    for e in events:
+        if e.event_type == "content_block_start":
+            idx = e.data["index"]
+            starts[idx] = starts.get(idx, 0) + 1
+            assert e.data["content_block"]["type"] == "tool_use"
+        elif e.event_type == "content_block_delta":
+            idx = e.data["index"]
+            assert idx not in stopped, f"delta for block {idx} after its stop"
+            args[idx] = args.get(idx, "") + e.data["delta"]["partial_json"]
+        elif e.event_type == "content_block_stop":
+            idx = e.data["index"]
+            stops[idx] = stops.get(idx, 0) + 1
+            stopped.add(idx)
+
+    assert starts == {0: 1, 1: 1}
+    assert stops == {0: 1, 1: 1}
+    assert args == {0: '{"a":1}', 1: '{"b":2}'}
+
+    block0 = next(
+        e for e in events if e.event_type == "content_block_start" and e.data["index"] == 0
+    )
+    block1 = next(
+        e for e in events if e.event_type == "content_block_start" and e.data["index"] == 1
+    )
+    assert block0.data["content_block"]["name"] == "alpha"
+    assert block0.data["content_block"]["id"] == "call_0"
+    assert block1.data["content_block"]["name"] == "beta"
+    assert block1.data["content_block"]["id"] == "call_1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_backend_anyllm.py
+++ b/tests/test_backend_anyllm.py
@@ -344,6 +344,87 @@ async def test_stream_message_yields_events_and_error(monkeypatch: pytest.Monkey
     assert error_events[-1].data["error"]["message"] == "stream broke"
 
 
+def _tool_call_delta(*, index, tc_id=None, name=None, arguments=None):  # noqa: ANN001, ANN202
+    """Build an OpenAI-style streaming tool_call delta chunk."""
+    func = SimpleNamespace(name=name, arguments=arguments)
+    tc = SimpleNamespace(index=index, id=tc_id, function=func)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=SimpleNamespace(tool_calls=[tc]), finish_reason=None)]
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_message_emits_tool_use_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tool call streamed over any-llm must surface as an Anthropic tool_use block.
+
+    Regression: the streamer only handled text deltas, so ``tools`` were
+    forwarded upstream but any tool call the model streamed back was dropped and
+    the client saw an empty turn with stop_reason=end_turn. The block must open,
+    stream its arguments as input_json_delta, and the turn must end tool_use.
+    """
+    backend, instance = make_backend(monkeypatch)
+    instance.response = FakeAsyncStream(
+        [
+            _tool_call_delta(index=0, tc_id="call_abc", name="get_weather"),
+            _tool_call_delta(index=0, arguments='{"city":'),
+            _tool_call_delta(index=0, arguments='"paris"}'),
+            SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(), finish_reason="tool_calls")]
+            ),
+        ]
+    )
+
+    events = [
+        event async for event in backend.stream_message({"model": "claude", "messages": []}, {})
+    ]
+    types = [e.event_type for e in events]
+
+    assert types == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+
+    start = next(e for e in events if e.event_type == "content_block_start")
+    assert start.data["content_block"]["type"] == "tool_use"
+    assert start.data["content_block"]["id"] == "call_abc"
+    assert start.data["content_block"]["name"] == "get_weather"
+
+    arg_deltas = [e for e in events if e.event_type == "content_block_delta"]
+    assert [d.data["delta"]["type"] for d in arg_deltas] == ["input_json_delta", "input_json_delta"]
+    joined = "".join(d.data["delta"]["partial_json"] for d in arg_deltas)
+    assert joined == '{"city":"paris"}'
+
+    message_delta = next(e for e in events if e.event_type == "message_delta")
+    assert message_delta.data["delta"]["stop_reason"] == "tool_use"
+
+
+@pytest.mark.asyncio
+async def test_stream_message_maps_length_finish_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A truncated (length) text stream must report stop_reason=max_tokens."""
+    backend, instance = make_backend(monkeypatch)
+    instance.response = FakeAsyncStream(
+        [
+            SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content="hi"), finish_reason=None)]
+            ),
+            SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(), finish_reason="length")]
+            ),
+        ]
+    )
+
+    events = [
+        event async for event in backend.stream_message({"model": "claude", "messages": []}, {})
+    ]
+    message_delta = next(e for e in events if e.event_type == "message_delta")
+    assert message_delta.data["delta"]["stop_reason"] == "max_tokens"
+
+
 @pytest.mark.asyncio
 async def test_send_openai_message_maps_choices_and_tool_calls(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Description

On the any-llm backend (`--backend anyllm`), the streaming path drops tool calls entirely.

`stream_message` forwards `tools` / `tool_choice` upstream:

```python
if "tools" in body:
    kwargs["tools"] = body["tools"]
if "tool_choice" in body:
    kwargs["tool_choice"] = body["tool_choice"]
```

but its event loop only ever inspected `delta.content`. It pre-opened a single text block at index 0 and never looked at `delta.tool_calls`:

```python
yield StreamEvent(event_type="content_block_start", data={... "index": 0, "content_block": {"type": "text", ...}})
...
async for chunk in stream_response:
    if hasattr(chunk, "choices") and chunk.choices:
        delta = chunk.choices[0].delta
        if hasattr(delta, "content") and delta.content:
            ...  # text only
```

So when the model streamed a tool call back, the client (Claude Code and other agent harnesses) saw an empty assistant turn -- no `tool_use` block -- and, because `stop_reason` was hardcoded to `end_turn`, no signal that a tool was even called. The agent loop stalls with nothing to execute. `stop_reason` being hardcoded also mislabels a `length` truncation as `end_turn`.

The non-streaming path on this same backend (`_to_anthropic_response`) already handles tool calls and maps `finish_reason` correctly; only the streaming path was missing it.

## Fix

Open content blocks lazily as deltas arrive (so a response can carry `tool_use` blocks, not just one pre-opened text block) and handle `delta.tool_calls`:

- Emit a `tool_use` `content_block_start` per provider tool index, carrying the tool `id`/`name`.
- Stream the arguments as `input_json_delta` deltas.
- Derive `stop_reason` from the OpenAI `finish_reason` (`tool_calls` -> `tool_use`, `length` -> `max_tokens`, `stop` -> `end_turn`).

This mirrors the non-streaming `_to_anthropic_response` on the same backend and the LiteLLM streamer, so the transports agree. The text-only path is unchanged in output: the first text delta opens the block lazily at index 0, producing the same event sequence as before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/backends/anyllm.py` (`stream_message`): lazy block opening + `tool_calls` handling (tool_use `content_block_start` / `input_json_delta`) + `finish_reason` -> `stop_reason` mapping. Removes the unconditional pre-opened text block.
- `tests/test_backend_anyllm.py`: added `test_stream_message_emits_tool_use_blocks` (a streamed tool call surfaces as a tool_use block with reassembled arguments and `stop_reason=tool_use`) and `test_stream_message_maps_length_finish_reason` (`length` -> `max_tokens`). The existing text-only streaming test is unchanged and still passes.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] New tests added for the tool-call and finish_reason behaviour

### Test Output

```text
# Fail-before (original source, new tests kept):
test_stream_message_emits_tool_use_blocks
  -> event sequence diff at index 2: 'content_block_stop' != 'content_block_delta'  (tool call dropped)
test_stream_message_maps_length_finish_reason
  -> assert 'end_turn' == 'max_tokens'  (hardcoded stop_reason)

# Pass-after (fix in place):
tests/test_backend_anyllm.py  18 passed

# uvx ruff@0.15.17 check  -> All checks passed!
# uvx mypy@1.20.2 headroom/backends/anyllm.py -> Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.15.17 and mypy 1.20.2 via uvx.
- Steps: drove `stream_message` with a fake any-llm async stream yielding OpenAI-style `delta.tool_calls` chunks (id + name, then two argument fragments) followed by a `finish_reason=tool_calls` chunk, and collected the emitted `StreamEvent`s. Before the fix the tool call produced no `tool_use` block and the turn ended `end_turn`; after the fix it emits `content_block_start{type:tool_use,id,name}`, two `input_json_delta` deltas that reassemble to `{"city":"paris"}`, a `content_block_stop`, and `message_delta` with `stop_reason=tool_use`. A separate text stream with `finish_reason=length` now reports `stop_reason=max_tokens`.
- Observed result: an any-llm streaming turn that calls a tool now reaches the client as a valid Anthropic `tool_use` block instead of an empty turn, so agent loops using this backend can execute the tool.
- Not tested: a live any-llm provider call (no third-party keys here). The conversion is exercised directly against the streaming shape any-llm normalizes to (OpenAI-compatible `choices[0].delta.tool_calls`).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`: it is generated by release-please from my Conventional Commit PR title

## Additional Notes

Output-token accounting on this path is still the per-delta chunk count (unchanged here); that is a separate concern from the dropped tool calls and is left as-is to keep this fix focused.
