### PR TITLE
fix(backends/anyllm): convert Anthropic tools and tool_choice to OpenAI shape

### DIFF
--- a/headroom/backends/anyllm.py
+++ b/headroom/backends/anyllm.py
@@ -25,6 +25,44 @@ except ImportError:
     AnyLLM = None  # type: ignore
 
 
+def _convert_anthropic_tool(tool: dict[str, Any]) -> dict[str, Any]:
+    """Convert an Anthropic tool definition to the OpenAI function shape.
+
+    any-llm speaks OpenAI, so an Anthropic ``{name, description, input_schema}``
+    tool must become ``{type: function, function: {name, description,
+    parameters}}`` before it is forwarded, or the provider ignores/rejects the
+    tools array and the model never calls a tool. Mirrors the LiteLLM backend's
+    converter so both OpenAI-compatible backends send the same shape.
+    """
+    func: dict[str, Any] = {"name": tool.get("name", "")}
+    if "description" in tool:
+        func["description"] = tool["description"]
+    if "input_schema" in tool:
+        func["parameters"] = tool["input_schema"]
+    return {"type": "function", "function": func}
+
+
+def _convert_tool_choice(choice: Any) -> Any:
+    """Convert an Anthropic ``tool_choice`` to the OpenAI shape (mirrors LiteLLM).
+
+    Anthropic: ``{"type": "auto"}``, ``{"type": "any"}``, ``{"type": "tool",
+    "name": ...}``. OpenAI: ``"auto"``, ``"required"``, ``{"type": "function",
+    "function": {"name": ...}}``. Passing the raw Anthropic dict through makes
+    the provider reject or ignore it.
+    """
+    if isinstance(choice, str):
+        return choice
+    if isinstance(choice, dict):
+        choice_type = choice.get("type", "auto")
+        if choice_type == "auto":
+            return "auto"
+        if choice_type == "any":
+            return "required"
+        if choice_type == "tool":
+            return {"type": "function", "function": {"name": choice.get("name", "")}}
+    return "auto"
+
+
 class AnyLLMBackend(Backend):
     """Backend using any-llm for multi-provider support."""
 
@@ -251,9 +289,9 @@ class AnyLLMBackend(Backend):
             if "stop_sequences" in body:
                 kwargs["stop"] = body["stop_sequences"]
             if "tools" in body:
-                kwargs["tools"] = body["tools"]
+                kwargs["tools"] = [_convert_anthropic_tool(t) for t in body["tools"]]
             if "tool_choice" in body:
-                kwargs["tool_choice"] = body["tool_choice"]
+                kwargs["tool_choice"] = _convert_tool_choice(body["tool_choice"])
 
             logger.debug(f"any-llm request: provider={self.provider}, model={original_model}")
 
@@ -301,9 +339,9 @@ class AnyLLMBackend(Backend):
             if "stop_sequences" in body:
                 kwargs["stop"] = body["stop_sequences"]
             if "tools" in body:
-                kwargs["tools"] = body["tools"]
+                kwargs["tools"] = [_convert_anthropic_tool(t) for t in body["tools"]]
             if "tool_choice" in body:
-                kwargs["tool_choice"] = body["tool_choice"]
+                kwargs["tool_choice"] = _convert_tool_choice(body["tool_choice"])
 
             msg_id = f"msg_{uuid.uuid4().hex[:24]}"
 

--- a/tests/test_backend_anyllm.py
+++ b/tests/test_backend_anyllm.py
@@ -294,6 +294,81 @@ async def test_send_message_builds_anthropic_response(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.asyncio
+async def test_send_message_converts_anthropic_tools_and_tool_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anthropic tools/tool_choice must reach any-llm in the OpenAI shape.
+
+    any-llm speaks OpenAI; forwarding the raw Anthropic ``input_schema`` tool and
+    the ``{"type": ...}`` tool_choice makes the provider ignore or reject them,
+    so the model never calls a tool. Regression for tool use silently not
+    working on the any-llm backend.
+    """
+    backend, instance = make_backend(monkeypatch)
+    instance.response = make_response(make_choice("ok", "stop"))
+
+    await backend.send_message(
+        {
+            "model": "claude",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "description": "look up weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                }
+            ],
+            "tool_choice": {"type": "any"},
+        },
+        {},
+    )
+
+    sent = instance.calls[0]
+    assert sent["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "look up weather",
+                "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+            },
+        }
+    ]
+    assert sent["tool_choice"] == "required"
+
+
+@pytest.mark.asyncio
+async def test_stream_message_converts_anthropic_tools_and_tool_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The streaming request path converts tools/tool_choice the same way."""
+    backend, instance = make_backend(monkeypatch)
+    instance.response = FakeAsyncStream([])
+
+    _events = [
+        event
+        async for event in backend.stream_message(
+            {
+                "model": "claude",
+                "messages": [],
+                "tools": [{"name": "t", "input_schema": {"type": "object"}}],
+                "tool_choice": {"type": "tool", "name": "t"},
+            },
+            {},
+        )
+    ]
+
+    sent = instance.calls[0]
+    assert sent["tools"] == [
+        {"type": "function", "function": {"name": "t", "parameters": {"type": "object"}}}
+    ]
+    assert sent["tool_choice"] == {"type": "function", "function": {"name": "t"}}
+
+
+@pytest.mark.asyncio
 async def test_send_message_returns_error_response(monkeypatch: pytest.MonkeyPatch) -> None:
     backend, instance = make_backend(monkeypatch)
     instance.raise_error = RuntimeError("authentication api_key missing")


### PR DESCRIPTION
## Description

On the any-llm backend, the Anthropic-shaped request path (`send_message` / `stream_message`, taken when an Anthropic client such as Claude Code runs with `--backend anyllm`) forwards `tools` and `tool_choice` to the provider unchanged:

```python
if "tools" in body:
    kwargs["tools"] = body["tools"]              # {name, description, input_schema}
if "tool_choice" in body:
    kwargs["tool_choice"] = body["tool_choice"]  # {"type": "auto"}
```

any-llm speaks OpenAI. OpenAI expects function tools shaped as `{"type": "function", "function": {name, description, parameters}}` and a `tool_choice` of `"auto"` / `"required"` / `{"type": "function", "function": {"name": ...}}`. The raw Anthropic `input_schema` tool and `{"type": ...}` tool_choice are ignored or rejected by the provider, so the model is never actually offered the tools and **tool calling silently does not work on this backend**.

The LiteLLM backend already converts both (`_convert_anthropic_tool` / `_convert_tool_choice`); any-llm was missing the request-side conversion entirely.

## Fix

Convert Anthropic tools to OpenAI function tools and map `tool_choice` (`auto`->`auto`, `any`->`required`, `tool`->`function`) in both the buffered (`send_message`) and streaming (`stream_message`) request paths, mirroring the LiteLLM backend's converters. The OpenAI-shaped passthrough methods (`send_openai_message` / `stream_openai_message`) already receive OpenAI format and are left unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/backends/anyllm.py`: add module-level `_convert_anthropic_tool` and `_convert_tool_choice` (mirroring the LiteLLM backend) and apply them in `send_message` and `stream_message` when building the any-llm request.
- `tests/test_backend_anyllm.py`: added `test_send_message_converts_anthropic_tools_and_tool_choice` and `test_stream_message_converts_anthropic_tools_and_tool_choice`, asserting the kwargs handed to `acompletion` carry OpenAI-shaped tools and tool_choice.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] New tests added for the conversion on both request paths

### Test Output

```text
# Fail-before (raw passthrough restored, new tests kept):
test_send_message_converts_anthropic_tools_and_tool_choice
  -> tools stay {name, input_schema, ...} != {type: function, function: {...}}  (FAIL)
test_stream_message_converts_anthropic_tools_and_tool_choice
  -> same (FAIL)

# Pass-after (fix in place):
tests/test_backend_anyllm.py  18 passed

# uvx ruff@0.15.17 check  -> All checks passed!
# uvx mypy@1.20.2 headroom/backends/anyllm.py -> Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.15.17 and mypy 1.20.2 via uvx.
- Steps: drove `send_message` and `stream_message` with a fake any-llm instance that records the kwargs passed to `acompletion`, sending an Anthropic tool (`{name, description, input_schema}`) and Anthropic `tool_choice` variants (`any`, `tool`). Before the fix the recorded `tools`/`tool_choice` were the raw Anthropic shapes; after the fix they are the OpenAI shapes (`{type: function, function: {name, description, parameters}}`, and `required` / `{type: function, function: {name}}`).
- Observed result: an Anthropic client using `--backend anyllm` now actually offers its tools to the provider, so the model can call them, instead of the tools being dropped.
- Not tested: a live any-llm provider round-trip (no third-party keys here). The conversion is verified at the exact call boundary (`acompletion` kwargs) any-llm consumes.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`: it is generated by release-please from my Conventional Commit PR title

## Additional Notes

This is the request-side companion to the any-llm streaming tool-call handling. The two converters are duplicated from the LiteLLM backend rather than shared, to keep the any-llm backend decoupled from the (optional) litellm module; folding both backends onto one shared converter would be a reasonable follow-up refactor.
