### PR TITLE
fix(proxy): run the consistency token re-count off the event loop

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -2561,9 +2561,17 @@ class AnthropicHandlerMixin:
             # the handler tokenizer so the delta is meaningful. This also captures any
             # turn-hook fold (optimized_messages is post-hook). Runs unconditionally.
             try:
+                from headroom.proxy.token_counting import recount_messages_offloaded
+
                 _orig_snapshot = original_client_messages  # noqa: F821 (bound at request start)
-                original_tokens = tokenizer.count_messages(_orig_snapshot)
-                optimized_tokens = tokenizer.count_messages(optimized_messages)
+                # Off the event loop: with a real BPE tokenizer these two counts
+                # can block the loop for ~1s on a multi-MB body and stall every
+                # other in-flight request on a shared proxy (#2810). Both counts
+                # share the one handler tokenizer so the delta stays on a single
+                # scale; fails open to an inline count.
+                original_tokens, optimized_tokens = await recount_messages_offloaded(
+                    self, tokenizer, _orig_snapshot, optimized_messages
+                )
                 # Fold the tool-schema/desc compaction delta into BOTH endpoints so
                 # tok_before - tok_after == tok_saved stays coherent in the PERF line
                 # (count_messages never sees tool bytes). Same shape as the OpenAI chat

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -3720,9 +3720,15 @@ class OpenAIHandlerMixin:
         # branch may have left original_tokens in the pipeline's char-estimator scale
         # (result.tokens_before), which mismatches optimized_tokens (provider tokenizer)
         # and yields impossible tok_after>tok_before. Recount original from the
-        # pre-compression snapshot so the message delta is on one scale.
-        original_tokens = tokenizer.count_messages(original_client_messages)
-        optimized_tokens = tokenizer.count_messages(body["messages"])
+        # pre-compression snapshot so the message delta is on one scale. Off the event
+        # loop: with a real BPE tokenizer these counts can block the loop for ~1s on a
+        # multi-MB body and stall every other in-flight request (#2810); both share the
+        # one tokenizer so the delta stays on a single scale, and it fails open inline.
+        from headroom.proxy.token_counting import recount_messages_offloaded
+
+        original_tokens, optimized_tokens = await recount_messages_offloaded(
+            self, tokenizer, original_client_messages, body["messages"]
+        )
         if tool_tokens_before_compaction > 0:
             try:
                 tool_tokens_after_compaction = tokenizer.count_text(_json_debug_dumps(tools))

--- a/headroom/proxy/token_counting.py
+++ b/headroom/proxy/token_counting.py
@@ -79,6 +79,39 @@ async def count_texts_offloaded(owner: Any, model: Any, texts: Any) -> tuple[Any
     )
 
 
+async def recount_messages_offloaded(
+    owner: Any, tokenizer: Any, *message_lists: Any
+) -> tuple[int, ...]:
+    """Count several message lists on an ALREADY-resolved tokenizer, off the loop.
+
+    Unlike :func:`count_tokens_offloaded`, this reuses a caller-provided
+    tokenizer instead of resolving a new one, so several counts stay on one
+    scale for a consistency delta (tok_before vs tok_after). All counts run in a
+    single executor hop. With a real BPE tokenizer, counting a multi-MB body is
+    CPU-bound and blocks the event loop for up to ~1s -- stalling every other
+    in-flight request on a shared proxy (GH #2810) -- so it must not run inline.
+
+    Fails open to a synchronous count when the owner exposes no compression
+    executor, or on timeout/error, matching :func:`_count_offloaded`.
+    """
+
+    def _count_all() -> tuple[int, ...]:
+        return tuple(tokenizer.count_messages(messages) for messages in message_lists)
+
+    runner = getattr(owner, "_run_compression_in_executor", None)
+    if runner is None:
+        return _count_all()
+
+    from headroom.proxy.helpers import COMPRESSION_TIMEOUT_SECONDS
+
+    try:
+        result = await runner(_count_all, timeout=float(COMPRESSION_TIMEOUT_SECONDS))
+        return cast("tuple[int, ...]", result)
+    except Exception as e:  # fail open — includes asyncio.TimeoutError
+        logger.debug("Offloaded re-count failed (%s); counting inline", e.__class__.__name__)
+        return _count_all()
+
+
 def gemini_output_tokens(usage_meta: dict[str, Any]) -> int:
     """Output-token count for a Gemini ``usageMetadata``, including thinking tokens.
 

--- a/tests/test_recount_messages_offloaded.py
+++ b/tests/test_recount_messages_offloaded.py
@@ -1,0 +1,81 @@
+"""``recount_messages_offloaded`` keeps the consistency re-count off the loop (#2810)."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from headroom.proxy.token_counting import recount_messages_offloaded
+
+
+class _SumTokenizer:
+    """Deterministic tokenizer: token count == total content length."""
+
+    def count_messages(self, messages) -> int:  # noqa: ANN001
+        return sum(len(m.get("content", "")) for m in messages)
+
+
+class _OwnerWithExecutor:
+    """Owner whose executor runs the work off the event-loop thread."""
+
+    async def _run_compression_in_executor(self, fn, timeout):  # noqa: ANN001, ANN201
+        return await asyncio.to_thread(fn)
+
+
+class _OwnerNoExecutor:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_recount_runs_off_the_event_loop_thread() -> None:
+    loop_thread = threading.get_ident()
+    seen: dict[str, int] = {}
+
+    class _ThreadRecordingTokenizer:
+        def count_messages(self, messages) -> int:  # noqa: ANN001
+            seen["thread"] = threading.get_ident()
+            return len(messages)
+
+    result = await recount_messages_offloaded(
+        _OwnerWithExecutor(), _ThreadRecordingTokenizer(), [{}, {}], [{}]
+    )
+
+    assert result == (2, 1)  # per-list counts, in order
+    assert "thread" in seen, "the count never ran"
+    assert seen["thread"] != loop_thread, "the count ran on the event-loop thread"
+
+
+@pytest.mark.asyncio
+async def test_recount_shares_one_tokenizer_across_lists() -> None:
+    # Both endpoints must be counted with the SAME tokenizer so the delta is on
+    # one scale; the helper counts every list with the tokenizer it is given.
+    tok = _SumTokenizer()
+    before, after = await recount_messages_offloaded(
+        _OwnerWithExecutor(), tok, [{"content": "aaaa"}], [{"content": "bb"}]
+    )
+    assert (before, after) == (4, 2)
+
+
+@pytest.mark.asyncio
+async def test_recount_fails_open_without_executor() -> None:
+    # No compression executor: count inline rather than raising.
+    result = await recount_messages_offloaded(
+        _OwnerNoExecutor(), _SumTokenizer(), [{"content": "ab"}], [{"content": "c"}]
+    )
+    assert result == (2, 1)
+
+
+@pytest.mark.asyncio
+async def test_recount_fails_open_on_executor_error() -> None:
+    class _BoomOwner:
+        async def _run_compression_in_executor(self, fn, timeout):  # noqa: ANN001, ANN201
+            raise RuntimeError("executor down")
+
+    # A failing/timed-out offload must fall back to an inline count, not surface
+    # the error to the request handler.
+    result = await recount_messages_offloaded(
+        _BoomOwner(), _SumTokenizer(), [{"content": "xyz"}], []
+    )
+    assert result == (3, 0)


### PR DESCRIPTION
## Description

In v0.33.0 the proxy's "consistency re-count" runs `tokenizer.count_messages()` twice **directly on the event loop**, unconditionally, for every request. Since Claude token counting moved from a character estimate to a real BPE tokenizer (#2543), this blocks the event loop for a measurable time on large bodies -- up to roughly **1 second on a 2.3 MB request body** in the reporter's measurements. For a shared deployment, every other in-flight request on the process is stalled while one request is re-counted.

Both sites are `async def` and both call the tokenizer synchronously:

- `headroom/proxy/handlers/anthropic.py`, `handle_anthropic_messages`:
  ```python
  original_tokens = tokenizer.count_messages(_orig_snapshot)
  optimized_tokens = tokenizer.count_messages(optimized_messages)
  ```
- `headroom/proxy/handlers/openai.py`, `handle_openai_chat`:
  ```python
  original_tokens = tokenizer.count_messages(original_client_messages)
  optimized_tokens = tokenizer.count_messages(body["messages"])
  ```

The class already offloads the *other* tokenizer counting (`_count_tokens_offloaded`, added for #2498 / GH #1701); these two re-count sites were simply missed.

Fixes #2810

## Fix

The existing `count_tokens_offloaded` resolves a *new* tokenizer, which is wrong here: the consistency re-count must count both endpoints with the **same** tokenizer so `tok_before`/`tok_after` stay on one scale. Add a sibling that reuses a caller-provided tokenizer:

```python
async def recount_messages_offloaded(owner, tokenizer, *message_lists) -> tuple[int, ...]:
    def _count_all():
        return tuple(tokenizer.count_messages(m) for m in message_lists)
    runner = getattr(owner, "_run_compression_in_executor", None)
    if runner is None:
        return _count_all()
    try:
        return await runner(_count_all, timeout=float(COMPRESSION_TIMEOUT_SECONDS))
    except Exception:
        return _count_all()
```

It runs both counts in a single executor hop off the event loop and fails open to an inline count when there is no executor or the offload errors/times out, matching `_count_offloaded`. Both handler sites now call it instead of counting inline.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/token_counting.py`: add `recount_messages_offloaded(owner, tokenizer, *message_lists)`.
- `headroom/proxy/handlers/anthropic.py` (`handle_anthropic_messages`): offload the consistency re-count.
- `headroom/proxy/handlers/openai.py` (`handle_openai_chat`): offload the consistency re-count.
- `tests/test_recount_messages_offloaded.py`: new tests for the helper -- runs off the event-loop thread, counts every list with the one tokenizer, and fails open (no executor, and executor error) to an inline count.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] New tests added for the offload helper

### Test Output

```text
tests/test_recount_messages_offloaded.py  4 passed
tests/test_backend_nonstreaming_cache_metrics.py tests/test_proxy_streaming_ratelimit_headers.py  15 passed
# uvx ruff@0.15.17 check  -> All checks passed!
# uvx mypy@1.20.2 headroom/proxy/token_counting.py -> Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.15.17 and mypy 1.20.2 via uvx.
- Steps: exercised `recount_messages_offloaded` directly. With an owner whose `_run_compression_in_executor` dispatches to a worker thread, a thread-recording tokenizer reports a thread id different from the event-loop thread -- proving the counts run off the loop. Fail-open paths (no executor; executor raises) return the same per-list counts computed inline. The two handler sites now `await recount_messages_offloaded(self, tokenizer, ...)` in place of the inline `tokenizer.count_messages(...)` calls.
- Observed result: the two consistency-recount `count_messages` calls no longer run on the event loop, so a large body's BPE count cannot stall other in-flight requests; the reported `tok_before`/`tok_after` are unchanged (same tokenizer, same inputs).
- Not tested: the multi-MB event-loop-stall reproduction from the issue (needs a live proxy under concurrent load). The off-loop dispatch and fail-open behavior are verified directly at the helper the handlers now call.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`: it is generated by release-please from my Conventional Commit PR title

## Additional Notes

The re-count semantics are unchanged -- same tokenizer, same two inputs, same tool-token fold afterwards -- only the execution moves off the loop. `_run_compression_in_executor` bounds the work by `COMPRESSION_TIMEOUT_SECONDS` and the helper fails open, so a slow/absent executor degrades to today's inline behavior rather than erroring.
