### PR TITLE
fix(cache): mirror client cache_control positions instead of single-marker consolidation

### DIFF
--- a/headroom/cache/compression_store.py
+++ b/headroom/cache/compression_store.py
@@ -52,6 +52,10 @@ DEFAULT_CCR_TTL_SECONDS = 1800  # session-scale; override via HEADROOM_CCR_TTL_S
 CCR_TTL_SECONDS_ENV = "HEADROOM_CCR_TTL_SECONDS"
 
 _RETRIEVAL_LOG_PREVIEW_CHARS = 4096
+# Previews carry verbatim tool-result content (post-redaction), which makes
+# proxy.log too sensitive for users to share in bug reports. Set to
+# 0/false/no/off to log byte counts only.
+PAYLOAD_PREVIEW_ENV = "HEADROOM_LOG_PAYLOAD_PREVIEW"
 _SECRET_KEY_VALUE_RE = re.compile(
     r"(?i)\b([A-Z0-9_-]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH)[A-Z0-9_-]*)"
     r"(\s*[:=]\s*)([\"']?)([^\"'\s,}]+)"
@@ -108,7 +112,21 @@ def _redact_retrieval_log_payload(payload: str) -> str:
     return _API_KEY_VALUE_RE.sub("sk-[REDACTED]", redacted)
 
 
+def _payload_preview_enabled() -> bool:
+    raw = os.environ.get(PAYLOAD_PREVIEW_ENV)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
 def _payload_for_retrieval_log(payload: str) -> dict[str, Any]:
+    if not _payload_preview_enabled():
+        return {
+            "payload_chars": len(payload),
+            "payload_preview_chars": 0,
+            "payload_truncated": len(payload) > 0,
+            "payload_preview": "",
+        }
     redacted = _redact_retrieval_log_payload(payload)
     preview = redacted[:_RETRIEVAL_LOG_PREVIEW_CHARS]
     truncated = len(redacted) > len(preview)

--- a/headroom/cache/prefix_tracker.py
+++ b/headroom/cache/prefix_tracker.py
@@ -635,23 +635,22 @@ def _breakpoint_index(
 
 def _client_marker_positions(
     client_messages: list[dict[str, Any]],
-) -> list[tuple[int, dict[str, Any]]]:
-    """Message indices where the CLIENT placed cache_control, with each marker.
+) -> list[tuple[int, int, dict[str, Any]]]:
+    """(message index, block index, marker) for every CLIENT cache_control.
 
-    One entry per marked message (the last marker in the message wins), in
-    message order. Only block-style content can carry markers.
+    Block-level, not one-per-message: clients mark multiple blocks within a
+    single long message (Claude Code does this on 1-2-message requests with a
+    large first message), and the ~20-block lookback applies within a message
+    just as it does across messages. Only block-style content carries markers.
     """
-    positions: list[tuple[int, dict[str, Any]]] = []
+    positions: list[tuple[int, int, dict[str, Any]]] = []
     for i, msg in enumerate(client_messages):
         content = msg.get("content") if isinstance(msg, dict) else None
         if not isinstance(content, list):
             continue
-        marker: dict[str, Any] | None = None
-        for b in content:
+        for bi, b in enumerate(content):
             if isinstance(b, dict) and isinstance(b.get("cache_control"), dict):
-                marker = b["cache_control"]
-        if marker is not None:
-            positions.append((i, marker))
+                positions.append((i, bi, b["cache_control"]))
     return positions
 
 
@@ -724,17 +723,30 @@ def normalize_message_cache_control(
         else:
             out.append(msg)
 
-    def _place(target_idx: int, marker: dict[str, Any], *, anchor: bool) -> bool:
+    def _place(
+        target_idx: int,
+        marker: dict[str, Any],
+        *,
+        anchor: bool,
+        block_idx: int | None = None,
+    ) -> bool:
         msg = out[target_idx]
         content = msg.get("content")
         if not isinstance(content, list) or not content:
             return False
         content = list(content)
-        breakpoint_index = (
-            _breakpoint_index(content, msg, target_idx, previous_forwarded_messages)
-            if anchor
-            else len(content) - 1
-        )
+        if block_idx is not None and 0 <= block_idx < len(content):
+            # Transforms can shift block indices (e.g. a dropped thinking
+            # block); a slightly-off placement still lands on a stable block
+            # in the same message, which is harmless — markers are not part
+            # of the provider's cache key.
+            breakpoint_index = block_idx
+        elif anchor:
+            breakpoint_index = _breakpoint_index(
+                content, msg, target_idx, previous_forwarded_messages
+            )
+        else:
+            breakpoint_index = len(content) - 1
         # Anthropic content blocks are dictionaries, but callers can still
         # supply mixed list content. Fall back to the newest block rather than
         # attempting ``**`` on a scalar stable-boundary element, and skip the
@@ -747,17 +759,30 @@ def normalize_message_cache_control(
         out[target_idx] = {**msg, "content": content}
         return True
 
-    # Preferred: mirror the client's marker positions 1:1. The transform
-    # pipeline preserves message count, so index alignment is the invariant;
-    # fall back to legacy consolidation if it ever does not hold, or when the
-    # client marked no messages (legacy still places one so the prefix caches).
+    # Preferred: mirror the client's marker positions 1:1, block-level. The
+    # transform pipeline preserves message count, so index alignment is the
+    # invariant; fall back to legacy consolidation if it ever does not hold,
+    # or when the client marked nothing (legacy still places one so the
+    # prefix caches). The newest client marker keeps stable-run anchoring
+    # when the client placed it on its message's final block (intent: "cache
+    # through the end"); an explicit mid-message marker is honored verbatim.
     if client_messages is not None and len(client_messages) == len(messages):
         positions = _client_marker_positions(client_messages)
         if positions:
             placed_any = False
-            newest_idx = positions[-1][0]
-            for idx, marker in positions:
-                placed_any = _place(idx, marker, anchor=(idx == newest_idx)) or placed_any
+            newest_mi, newest_bi, _ = positions[-1]
+            newest_client_content = client_messages[newest_mi].get("content")
+            newest_on_final_block = (
+                isinstance(newest_client_content, list)
+                and newest_bi == len(newest_client_content) - 1
+            )
+            for mi, bi, marker in positions:
+                is_newest = (mi, bi) == (newest_mi, newest_bi)
+                if is_newest and newest_on_final_block:
+                    placed = _place(mi, marker, anchor=True)
+                else:
+                    placed = _place(mi, marker, anchor=False, block_idx=bi)
+                placed_any = placed or placed_any
             if placed_any or changed:
                 return out
             return messages

--- a/headroom/cache/prefix_tracker.py
+++ b/headroom/cache/prefix_tracker.py
@@ -633,9 +633,32 @@ def _breakpoint_index(
     return relation.stable_prefix_blocks - 1
 
 
+def _client_marker_positions(
+    client_messages: list[dict[str, Any]],
+) -> list[tuple[int, dict[str, Any]]]:
+    """Message indices where the CLIENT placed cache_control, with each marker.
+
+    One entry per marked message (the last marker in the message wins), in
+    message order. Only block-style content can carry markers.
+    """
+    positions: list[tuple[int, dict[str, Any]]] = []
+    for i, msg in enumerate(client_messages):
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, list):
+            continue
+        marker: dict[str, Any] | None = None
+        for b in content:
+            if isinstance(b, dict) and isinstance(b.get("cache_control"), dict):
+                marker = b["cache_control"]
+        if marker is not None:
+            positions.append((i, marker))
+    return positions
+
+
 def normalize_message_cache_control(
     messages: list[dict[str, Any]],
     previous_forwarded_messages: list[dict[str, Any]] | None = None,
+    client_messages: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """Own message-level cache_control placement so breakpoints stay bounded.
 
@@ -645,25 +668,35 @@ def normalize_message_cache_control(
     hard-errors at **>4 cache_control blocks total** (system + tools + messages),
     so on a long conversation the accumulation eventually 400s.
 
-    Fix: strip EVERY message-level cache_control and re-place a **single**
-    ephemeral breakpoint. Pure append-only growth keeps it on the newest block,
-    which both reads the prior write and writes the appended tail. If last turn's
-    counterpart proves that the tail was rewritten, it is placed at the end of
-    the byte-stable leading run instead. One breakpoint caches the prefix up to
-    it, and — because the provider's cache key is message CONTENT, not marker
-    presence (moving the
-    breakpoint forward is the documented client pattern and it hits) — stripping
-    and re-placing markers never busts. system/tools breakpoints live outside
-    ``messages`` and are left untouched (they still count toward the 4 limit, so
-    holding messages to one breakpoint leaves room for them).
+    Fix: strip EVERY message-level cache_control, then re-place markers at the
+    positions the CLIENT's current request marks (``client_messages``). The
+    client's positions are load-bearing, not redundant: Anthropic resolves each
+    breakpoint by walking back **at most ~20 content blocks** for a prior cache
+    entry, and agentic clients (Claude Code) keep a marker on the previous
+    turn's newest message precisely so the new turn's write can chain to the
+    old entry. Collapsing to a single newest-block marker breaks that chain
+    whenever one turn adds >20 blocks (typical for tool-heavy turns): the
+    lookback misses, the entire message history silently re-bills as cache
+    creation, and a marker anchored short of the final block leaves the tail
+    billing as fully uncached input. Mirroring the client's positions bounds
+    accumulation identically (the client manages its own 4-marker budget) while
+    preserving its read/write chaining.
 
-    Headroom owns WHERE the breakpoint goes; the client still owns WHAT it says:
-    the re-placed marker reuses the newest client marker verbatim, so an explicit
-    ``ttl`` (e.g. ``"1h"``) survives consolidation instead of silently
-    downgrading to the 5-minute default (#2375).
+    The provider's cache key is message CONTENT, not marker presence (moving
+    the breakpoint forward is the documented client pattern and it hits), so
+    stripping replay leftovers and re-placing markers never busts. system/tools
+    breakpoints live outside ``messages`` and are left untouched.
 
-    Only block-style (list) content can carry cache_control; string content is
-    left as-is. Returns the input unchanged when there is nothing to normalize.
+    Headroom owns WHICH BLOCK carries each marker; the client owns the message
+    positions and the marker values, so an explicit ``ttl`` (e.g. ``"1h"``)
+    survives per position instead of silently downgrading (#2375). The newest
+    position uses stable-run anchoring for proven rewritten tails; earlier
+    positions go on their message's last block.
+
+    Without ``client_messages`` (or when the transformed list no longer aligns
+    with it), falls back to the legacy single-marker consolidation. Only
+    block-style (list) content can carry cache_control; string content is left
+    as-is. Returns the input unchanged when there is nothing to normalize.
     """
     changed = False
     out: list[dict[str, Any]] = []
@@ -690,22 +723,49 @@ def normalize_message_cache_control(
                 last_block_idx = i
         else:
             out.append(msg)
-    # Re-place exactly one breakpoint on the last block-style message.
-    if last_block_idx >= 0:
-        msg = out[last_block_idx]
-        content = list(msg["content"])
-        marker = dict(last_marker) if last_marker else {"type": "ephemeral"}
-        breakpoint_index = _breakpoint_index(
-            content, msg, last_block_idx, previous_forwarded_messages
+
+    def _place(target_idx: int, marker: dict[str, Any], *, anchor: bool) -> bool:
+        msg = out[target_idx]
+        content = msg.get("content")
+        if not isinstance(content, list) or not content:
+            return False
+        content = list(content)
+        breakpoint_index = (
+            _breakpoint_index(content, msg, target_idx, previous_forwarded_messages)
+            if anchor
+            else len(content) - 1
         )
         # Anthropic content blocks are dictionaries, but callers can still
-        # supply mixed list content.  The newest block is known to be a dict
-        # from the scan above; fall back to it rather than attempting ``**``
-        # on a scalar stable-boundary element.
+        # supply mixed list content. Fall back to the newest block rather than
+        # attempting ``**`` on a scalar stable-boundary element, and skip the
+        # message entirely when even that is not a dict.
         if not isinstance(content[breakpoint_index], dict):
             breakpoint_index = len(content) - 1
-        content[breakpoint_index] = {**content[breakpoint_index], "cache_control": marker}
-        out[last_block_idx] = {**msg, "content": content}
+        if not isinstance(content[breakpoint_index], dict):
+            return False
+        content[breakpoint_index] = {**content[breakpoint_index], "cache_control": dict(marker)}
+        out[target_idx] = {**msg, "content": content}
+        return True
+
+    # Preferred: mirror the client's marker positions 1:1. The transform
+    # pipeline preserves message count, so index alignment is the invariant;
+    # fall back to legacy consolidation if it ever does not hold, or when the
+    # client marked no messages (legacy still places one so the prefix caches).
+    if client_messages is not None and len(client_messages) == len(messages):
+        positions = _client_marker_positions(client_messages)
+        if positions:
+            placed_any = False
+            newest_idx = positions[-1][0]
+            for idx, marker in positions:
+                placed_any = _place(idx, marker, anchor=(idx == newest_idx)) or placed_any
+            if placed_any or changed:
+                return out
+            return messages
+
+    # Legacy: re-place exactly one breakpoint on the last block-style message.
+    if last_block_idx >= 0:
+        marker = dict(last_marker) if last_marker else {"type": "ephemeral"}
+        _place(last_block_idx, marker, anchor=True)
         changed = True
     return out if changed else messages
 

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -1680,12 +1680,19 @@ class AnthropicHandlerMixin:
 
             # Own cache_control placement: the client moves the breakpoint each
             # turn and the overlay replays past markers, so they accumulate ~1/turn
-            # and Anthropic hard-errors at >4. Strip message-level markers and keep
-            # one breakpoint. Pure appends advance it to the newest block; a
-            # proven rewritten tail anchors it at the byte-stable boundary so
-            # that the same prefix is readable next turn. Applied last so the
+            # and Anthropic hard-errors at >4. Strip message-level markers and
+            # re-place them at the CLIENT's current positions: Anthropic resolves
+            # each breakpoint with a ~20-content-block lookback, and the client's
+            # previous-message marker is the read anchor that lets a big turn's
+            # write chain to the prior entry. Collapsing to one newest-block
+            # marker breaks that chain on tool-heavy turns (silent full re-write)
+            # and can leave the tail billing uncached. Applied last so the
             # forwarded AND recorded (next_forwarded) messages stay bounded.
-            _norm = normalize_message_cache_control(optimized_messages, previous_forwarded_messages)
+            _norm = normalize_message_cache_control(
+                optimized_messages,
+                previous_forwarded_messages,
+                client_messages=original_client_messages,
+            )
             if _norm is not optimized_messages:
                 optimized_messages = _norm
 

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -290,7 +290,16 @@ class AnthropicHandlerMixin:
             new_content: list[dict[str, Any]] = []
             appended = False
             for block in content:
-                if not appended and isinstance(block, dict) and block.get("type") == "text":
+                if (
+                    not appended
+                    and isinstance(block, dict)
+                    and block.get("type") == "text"
+                    # Never mutate a block carrying the client's cache
+                    # breakpoint: the client re-sends the original bytes
+                    # next turn, so any injection here busts the prefix
+                    # cache at this message from then on.
+                    and "cache_control" not in block
+                ):
                     existing = block.get("text", "")
                     new_content.append({**block, "text": existing + "\n\n" + context_text})
                     appended = True
@@ -735,6 +744,16 @@ class AnthropicHandlerMixin:
                     original_client_messages = copy.deepcopy(messages)
             if input_event.tools is not None:
                 body["tools"] = input_event.tools
+
+            # Snapshot the client's cache_control breakpoints before any
+            # transform runs; paired with the outbound count right before
+            # forwarding (event=cache_breakpoints) so a dropped or moved
+            # final breakpoint is self-diagnosing from proxy.log alone.
+            from headroom.proxy.helpers import count_cache_breakpoints
+
+            inbound_breakpoints = count_cache_breakpoints(
+                body.get("system"), messages, body.get("tools")
+            )
 
             # Validate message array size
             if len(messages) > MAX_MESSAGE_ARRAY_LENGTH:
@@ -2965,6 +2984,16 @@ class AnthropicHandlerMixin:
                         "headroom_retrieve available; using buffered stream:false "
                         "upstream request for server-side retrieval handling"
                     )
+
+                from headroom.proxy.helpers import log_cache_breakpoints
+
+                log_cache_breakpoints(
+                    request_id=request_id,
+                    inbound=inbound_breakpoints,
+                    outbound=count_cache_breakpoints(
+                        body.get("system"), body.get("messages"), body.get("tools")
+                    ),
+                )
 
                 if stream and not buffered_stream_ccr:
                     self.pipeline_extensions.emit(

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -347,6 +347,112 @@ def log_outbound_request(
     )
 
 
+def count_cache_breakpoints(
+    system: Any,
+    messages: Any,
+    tools: Any,
+) -> dict[str, int]:
+    """Count client ``cache_control`` breakpoints per request section.
+
+    Besides raw counts, records how far from the END of the message list the
+    last marker sits (``last_marker_tail`` = messages after the last marked
+    one). A dropped or backward-moved final breakpoint — the signature of a
+    "large uncached tail next to a healthy cache read" billing regression —
+    shows up as ``last_marker_tail`` growing between inbound and outbound.
+    Nested markers inside ``tool_result`` list content are counted too, so a
+    transform that rewrites sub-blocks can't lose one invisibly.
+    """
+    system_count = 0
+    if isinstance(system, list):
+        system_count = sum(1 for b in system if isinstance(b, dict) and "cache_control" in b)
+
+    tools_count = 0
+    if isinstance(tools, list):
+        tools_count = sum(1 for t in tools if isinstance(t, dict) and "cache_control" in t)
+
+    message_count = 0
+    messages_total = 0
+    last_marker_index = -1
+    if isinstance(messages, list):
+        message_count = len(messages)
+        for i, msg in enumerate(messages):
+            if not isinstance(msg, dict):
+                continue
+            found = 1 if "cache_control" in msg else 0
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if "cache_control" in block:
+                        found += 1
+                    inner = block.get("content")
+                    if isinstance(inner, list):
+                        found += sum(
+                            1 for sub in inner if isinstance(sub, dict) and "cache_control" in sub
+                        )
+            if found:
+                messages_total += found
+                last_marker_index = i
+
+    last_marker_tail = message_count - 1 - last_marker_index if last_marker_index >= 0 else -1
+    return {
+        "system": system_count,
+        "tools": tools_count,
+        "messages": messages_total,
+        "total": system_count + tools_count + messages_total,
+        "message_count": message_count,
+        "last_marker_tail": last_marker_tail,
+    }
+
+
+def log_cache_breakpoints(
+    *,
+    request_id: str | None,
+    inbound: dict[str, int],
+    outbound: dict[str, int],
+) -> None:
+    """One structured line per request: client breakpoints in vs forwarded out.
+
+    Per realignment build constraints: every cache-affecting decision is
+    logged. Escalates to WARNING when the forwarded request has fewer
+    breakpoints than the client sent, or the last marker moved further from
+    the end of the message list — either one silently un-caches the tail.
+    """
+    dropped = outbound["total"] < inbound["total"]
+    tail_grew = (
+        inbound["last_marker_tail"] >= 0
+        and outbound["last_marker_tail"] != inbound["last_marker_tail"]
+        and (
+            outbound["last_marker_tail"] < 0
+            or outbound["last_marker_tail"] > inbound["last_marker_tail"]
+        )
+    )
+    log = logger.warning if (dropped or tail_grew) else logger.info
+    log(
+        "event=cache_breakpoints request_id=%s "
+        "in_total=%d out_total=%d in_system=%d out_system=%d "
+        "in_tools=%d out_tools=%d in_messages=%d out_messages=%d "
+        "in_msg_count=%d out_msg_count=%d in_last_tail=%d out_last_tail=%d "
+        "dropped=%s tail_grew=%s",
+        request_id or "",
+        inbound["total"],
+        outbound["total"],
+        inbound["system"],
+        outbound["system"],
+        inbound["tools"],
+        outbound["tools"],
+        inbound["messages"],
+        outbound["messages"],
+        inbound["message_count"],
+        outbound["message_count"],
+        inbound["last_marker_tail"],
+        outbound["last_marker_tail"],
+        "true" if dropped else "false",
+        "true" if tail_grew else "false",
+    )
+
+
 def log_memory_injection(
     *,
     request_id: str,

--- a/tests/test_cache_breakpoint_diagnostics.py
+++ b/tests/test_cache_breakpoint_diagnostics.py
@@ -160,3 +160,21 @@ def test_append_context_no_eligible_block_returns_unchanged() -> None:
         messages, "CTX", frozen_message_count=0
     )
     assert result == messages
+
+
+def test_count_cache_breakpoints_tolerates_malformed_shapes() -> None:
+    messages = [
+        "not-a-dict",
+        {"role": "user", "content": ["scalar-block", {"type": "text", "text": "x", **_CC}]},
+        {"role": "user", "content": "plain string"},
+    ]
+    stats = count_cache_breakpoints("system-as-string", messages, "tools-as-string")
+    assert stats["system"] == 0
+    assert stats["tools"] == 0
+    assert stats["messages"] == 1
+    assert stats["message_count"] == 3
+    assert stats["last_marker_tail"] == 1
+
+    empty = count_cache_breakpoints(None, None, None)
+    assert empty["total"] == 0
+    assert empty["message_count"] == 0

--- a/tests/test_cache_breakpoint_diagnostics.py
+++ b/tests/test_cache_breakpoint_diagnostics.py
@@ -1,0 +1,162 @@
+"""Tests for cache_control breakpoint diagnostics and log-privacy switches.
+
+Covers the three pieces added for the uncached-tail investigation:
+- ``count_cache_breakpoints`` / ``log_cache_breakpoints`` (proxy helpers)
+- the ``HEADROOM_LOG_PAYLOAD_PREVIEW`` kill switch (compression store)
+- the injection guard that keeps proactive expansion out of breakpointed blocks
+"""
+
+from __future__ import annotations
+
+import logging
+
+from headroom.cache.compression_store import _payload_for_retrieval_log
+from headroom.proxy.handlers.anthropic import AnthropicHandlerMixin
+from headroom.proxy.helpers import count_cache_breakpoints, log_cache_breakpoints
+
+_CC = {"cache_control": {"type": "ephemeral"}}
+
+
+def _claude_code_style_request() -> tuple[list[dict], list[dict], list[dict]]:
+    """System/messages/tools shaped like a real Claude Code request."""
+    system = [
+        {"type": "text", "text": "You are Claude Code."},
+        {"type": "text", "text": "project instructions", **_CC},
+    ]
+    tools = [
+        {"name": "Bash", "input_schema": {}},
+        {"name": "Read", "input_schema": {}, **_CC},
+    ]
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "hi", **_CC}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "ack"}]},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": [{"type": "text", "text": "big output"}],
+                    **_CC,
+                }
+            ],
+        },
+    ]
+    return system, messages, tools
+
+
+def test_count_cache_breakpoints_counts_all_sections() -> None:
+    system, messages, tools = _claude_code_style_request()
+    stats = count_cache_breakpoints(system, messages, tools)
+    assert stats["system"] == 1
+    assert stats["tools"] == 1
+    assert stats["messages"] == 2
+    assert stats["total"] == 4
+    assert stats["message_count"] == 3
+    assert stats["last_marker_tail"] == 0  # last message carries a marker
+
+
+def test_count_cache_breakpoints_counts_nested_tool_result_markers() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": [{"type": "text", "text": "out", **_CC}],
+                }
+            ],
+        }
+    ]
+    stats = count_cache_breakpoints("plain system string", messages, None)
+    assert stats["system"] == 0
+    assert stats["tools"] == 0
+    assert stats["messages"] == 1
+    assert stats["last_marker_tail"] == 0
+
+
+def test_count_cache_breakpoints_tail_tracks_last_marker() -> None:
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "a", **_CC}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "b"}]},
+        {"role": "user", "content": [{"type": "text", "text": "c"}]},
+    ]
+    stats = count_cache_breakpoints(None, messages, None)
+    assert stats["last_marker_tail"] == 2
+    assert count_cache_breakpoints(None, [], None)["last_marker_tail"] == -1
+
+
+def test_log_cache_breakpoints_warns_on_dropped_marker(caplog) -> None:
+    system, messages, tools = _claude_code_style_request()
+    inbound = count_cache_breakpoints(system, messages, tools)
+    # Transform "lost" the final breakpoint: strip it from the last message.
+    stripped = [dict(m) for m in messages]
+    stripped[2] = {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "compressed"}],
+    }
+    outbound = count_cache_breakpoints(system, stripped, tools)
+    with caplog.at_level(logging.INFO, logger="headroom.proxy"):
+        log_cache_breakpoints(request_id="r1", inbound=inbound, outbound=outbound)
+    [record] = caplog.records
+    assert record.levelno == logging.WARNING
+    assert "dropped=true" in record.getMessage()
+    assert "tail_grew=true" in record.getMessage()
+
+
+def test_log_cache_breakpoints_info_when_preserved(caplog) -> None:
+    system, messages, tools = _claude_code_style_request()
+    stats = count_cache_breakpoints(system, messages, tools)
+    with caplog.at_level(logging.INFO, logger="headroom.proxy"):
+        log_cache_breakpoints(request_id="r1", inbound=stats, outbound=stats)
+    [record] = caplog.records
+    assert record.levelno == logging.INFO
+    assert "dropped=false" in record.getMessage()
+
+
+def test_payload_preview_disabled_omits_content(monkeypatch) -> None:
+    monkeypatch.setenv("HEADROOM_LOG_PAYLOAD_PREVIEW", "0")
+    payload = "secret file contents: api_key=sk-abcdefghijklmnop"
+    event = _payload_for_retrieval_log(payload)
+    assert event["payload_preview"] == ""
+    assert event["payload_preview_chars"] == 0
+    assert event["payload_chars"] == len(payload)
+    assert event["payload_truncated"] is True
+
+
+def test_payload_preview_enabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("HEADROOM_LOG_PAYLOAD_PREVIEW", raising=False)
+    event = _payload_for_retrieval_log("hello world")
+    assert event["payload_preview"] == "hello world"
+
+
+def test_append_context_skips_breakpointed_text_block() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "breakpointed", **_CC},
+                {"type": "text", "text": "free"},
+            ],
+        }
+    ]
+    result = AnthropicHandlerMixin._append_context_to_latest_non_frozen_user_turn(
+        messages, "CTX", frozen_message_count=0
+    )
+    blocks = result[0]["content"]
+    assert blocks[0]["text"] == "breakpointed"  # untouched
+    assert blocks[1]["text"].endswith("CTX")
+
+
+def test_append_context_no_eligible_block_returns_unchanged() -> None:
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "breakpointed", **_CC}],
+        }
+    ]
+    result = AnthropicHandlerMixin._append_context_to_latest_non_frozen_user_turn(
+        messages, "CTX", frozen_message_count=0
+    )
+    assert result == messages

--- a/tests/test_cache_control_move_bust.py
+++ b/tests/test_cache_control_move_bust.py
@@ -308,3 +308,61 @@ def test_normalize_mirror_skips_string_content_positions():
     out = normalize_message_cache_control(merged, client_messages=client)
     assert _markers(out) == 1
     assert "cache_control" in out[1]["content"][-1]
+
+
+# ── fix-5: block-level mirroring (multiple client markers in one message) ────
+
+
+def test_normalize_mirrors_multiple_markers_within_one_message():
+    """A 2-message request where the client marks TWO blocks of message 0
+    (Claude Code's pattern on large first messages) keeps all three markers."""
+    big = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "part-1", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "part-2"},
+            {"type": "text", "text": "part-3", "cache_control": {"type": "ephemeral"}},
+        ],
+    }
+    client = [big, B("user", "follow-up", cc=True)]
+    # Forwarded form: an extra replay leftover on message 1's sibling... use
+    # identical structure with markers everywhere to prove selective stripping.
+    merged = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "part-1", "cache_control": {"type": "ephemeral"}},
+                {"type": "text", "text": "part-2", "cache_control": {"type": "ephemeral"}},
+                {"type": "text", "text": "part-3", "cache_control": {"type": "ephemeral"}},
+            ],
+        },
+        B("user", "follow-up", cc=True),
+    ]
+    out = normalize_message_cache_control(merged, client_messages=client)
+    assert _markers(out) == 3
+    assert "cache_control" in out[0]["content"][0]
+    assert "cache_control" not in out[0]["content"][1]
+    assert "cache_control" in out[0]["content"][2]
+    assert "cache_control" in out[1]["content"][-1]
+    assert _strip_cache_control(out) == _strip_cache_control(merged)
+
+
+def test_normalize_mirror_clamps_out_of_range_block_index():
+    # Client marked block 2; forwarded message only has 1 block (transform
+    # merged content) — marker falls back to the last block, not dropped.
+    client = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "a"},
+                {"type": "text", "text": "b"},
+                {"type": "text", "text": "c", "cache_control": {"type": "ephemeral"}},
+            ],
+        },
+        B("user", "tail", cc=True),
+    ]
+    merged = [B("user", "abc-merged"), B("user", "tail", cc=True)]
+    out = normalize_message_cache_control(merged, client_messages=client)
+    assert _markers(out) == 2
+    assert "cache_control" in out[0]["content"][-1]
+    assert "cache_control" in out[1]["content"][-1]

--- a/tests/test_cache_control_move_bust.py
+++ b/tests/test_cache_control_move_bust.py
@@ -366,3 +366,35 @@ def test_normalize_mirror_clamps_out_of_range_block_index():
     assert _markers(out) == 2
     assert "cache_control" in out[0]["content"][-1]
     assert "cache_control" in out[1]["content"][-1]
+
+
+def test_normalize_mirror_scalar_only_content_is_left_unchanged():
+    """Client marks a message whose forwarded counterpart carries only scalar
+    blocks: nothing can hold a marker and nothing was stripped, so the input
+    comes back unchanged (identity, not a copy)."""
+    client = [B("user", "a", cc=True)]
+    merged = [{"role": "user", "content": ["scalar-only"]}]
+    out = normalize_message_cache_control(merged, client_messages=client)
+    assert out is merged
+    assert _markers(out) == 0
+
+
+def test_normalize_mirror_scalar_target_still_strips_leftovers():
+    # Message 0's forwarded content is scalar-only (marker unplaceable) but a
+    # replay leftover on message 1 still gets stripped, and message 1 keeps
+    # its client marker.
+    client = [B("user", "a", cc=True), B("user", "b", cc=True)]
+    merged = [
+        {"role": "user", "content": ["scalar-only"]},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "left-over", "cache_control": {"type": "ephemeral"}},
+                {"type": "text", "text": "b"},
+            ],
+        },
+    ]
+    out = normalize_message_cache_control(merged, client_messages=client)
+    assert _markers(out) == 1
+    assert "cache_control" not in out[1]["content"][0]
+    assert "cache_control" in out[1]["content"][-1]

--- a/tests/test_cache_control_move_bust.py
+++ b/tests/test_cache_control_move_bust.py
@@ -224,3 +224,87 @@ def test_normalize_ttl_survives_many_turns():
         conv = normalize_message_cache_control(conv)
         assert _markers(conv) == 1
         assert conv[-1]["content"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+# ── fix-4: mirror the CLIENT's marker positions (20-block lookback chain) ────
+# Anthropic resolves each breakpoint by walking back at most ~20 content
+# blocks. Agentic clients keep a marker on the previous turn's newest message
+# as the read anchor; collapsing to a single newest-block marker breaks the
+# chain on tool-heavy turns. With client_messages provided, normalize must
+# keep exactly the client's positions.
+
+
+def test_normalize_mirrors_client_marker_positions():
+    client = [
+        B("user", "a", cc=True),
+        B("assistant", "b"),
+        B("user", "c", cc=True),  # read anchor (previous newest)
+        B("assistant", "d"),
+        B("user", "e", cc=True),  # newest
+    ]
+    # Forwarded form: replay leftovers piled markers onto other messages too.
+    merged = [
+        B("user", "a", cc=True),
+        B("assistant", "b", cc=True),
+        B("user", "c", cc=True),
+        B("assistant", "d", cc=True),
+        B("user", "e", cc=True),
+    ]
+    out = normalize_message_cache_control(merged, client_messages=client)
+    assert _markers(out) == 3  # exactly the client's three, not one
+    for idx in (0, 2, 4):
+        assert "cache_control" in out[idx]["content"][-1], idx
+    for idx in (1, 3):
+        assert _markers([out[idx]]) == 0, idx
+    assert _strip_cache_control(out) == _strip_cache_control(merged)
+
+
+def test_normalize_mirror_preserves_per_position_ttl():
+    client = [B_ttl("user", "a", "1h"), B("user", "b", cc=True)]
+    merged = [B("user", "a", cc=True), B("user", "b", cc=True)]
+    out = normalize_message_cache_control(merged, client_messages=client)
+    assert out[0]["content"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert out[1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_normalize_mirror_bounded_across_many_turns():
+    """Client moves its pair of markers forward; forwarded stays at client count."""
+    conv = []
+    for t in range(1, 12):
+        conv = conv + [B("user", f"turn-{t}")]
+        # Client marks the newest and second-newest marked position (CC pattern).
+        client = [dict(m) for m in conv]
+        client[-1] = B("user", f"turn-{t}", cc=True)
+        if len(client) >= 2:
+            client[-2] = B(client[-2]["role"], client[-2]["content"][0]["text"], cc=True)
+        # Forwarded side accumulated replay leftovers everywhere.
+        merged = [B(m["role"], m["content"][0]["text"], cc=True) for m in client]
+        out = normalize_message_cache_control(merged, client_messages=client)
+        assert _markers(out) == min(2, len(client))
+        assert "cache_control" in out[-1]["content"][-1]
+
+
+def test_normalize_falls_back_when_counts_mismatch():
+    client = [B("user", "a", cc=True)]  # transform changed message count
+    merged = [B("user", "a", cc=True), B("user", "b", cc=True)]
+    out = normalize_message_cache_control(merged, client_messages=client)
+    assert _markers(out) == 1  # legacy consolidation
+    assert "cache_control" in out[-1]["content"][-1]
+
+
+def test_normalize_falls_back_when_client_has_no_markers():
+    client = [B("user", "a"), B("user", "b")]
+    merged = [B("user", "a", cc=True), B("user", "b")]
+    out = normalize_message_cache_control(merged, client_messages=client)
+    assert _markers(out) == 1  # legacy: still place one so the prefix caches
+    assert "cache_control" in out[-1]["content"][-1]
+
+
+def test_normalize_mirror_skips_string_content_positions():
+    # Client marked message 0; forwarded counterpart is string-content (cannot
+    # carry a marker) — the position is skipped, the rest still mirror.
+    client = [B("user", "a", cc=True), B("user", "b", cc=True)]
+    merged = [{"role": "user", "content": "a"}, B("user", "b", cc=True)]
+    out = normalize_message_cache_control(merged, client_messages=client)
+    assert _markers(out) == 1
+    assert "cache_control" in out[1]["content"][-1]


### PR DESCRIPTION
## Description

`normalize_message_cache_control` strips every message-level `cache_control` marker and re-places a single one on the newest block. The premise (the provider's cache key is content, not markers) is correct, but Anthropic resolves each breakpoint with a **~20-content-block lookback** ([prompt caching docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), "20-block lookback window"). Agentic clients such as Claude Code keep a marker on the previous turn's newest message (and on multiple blocks within one long message) precisely so a new turn's cache write can chain to the prior entry. Consolidating to one marker breaks that chain whenever a single turn adds more than 20 blocks - typical for MCP/tool-heavy turns - so the whole message history silently re-bills as cache creation, and a marker anchored short of the final block leaves the tail billing as fully uncached input.

This came out of a user field report (2026-08-11): cache miss rate 2-3x higher on 11 of 11 projects after enabling the proxy, plus 0.6-1.4M fully uncached input tokens/day, concentrated in MCP-heavy sessions. The consolidation never registers as a body mutation, so existing `mutation_reasons` logging could not implicate it, and `classify_cache_miss` counts partial reads as hits, so TTL telemetry showed a clean sheet throughout.

This PR fixes the consolidation and adds the diagnostics that found it:

1. **Mirror the client's marker positions** (block-level) instead of consolidating. Replay-leftover stripping is unchanged; accumulation stays bounded by the client's own 4-marker budget. Per-position marker values are preserved, so an explicit `ttl: "1h"` survives at every position (extends #2375). Falls back to the legacy single-marker behavior when client positions are unavailable, message counts mismatch, or the client marked nothing.
2. **`event=cache_breakpoints` log line per forwarded request**: client markers in vs forwarded out, per section, plus the last marker's distance from the tail. Escalates to WARNING when a marker is dropped or the last marker moves away from the tail - this class of bug becomes self-diagnosing from proxy.log alone.
3. **`HEADROOM_LOG_PAYLOAD_PREVIEW=0`** strips verbatim `payload_preview` content from `headroom_retrieve` log events (byte counts retained). The reporting user could not share logs because previews carry raw tool-result content; this makes proxy.log shareable in bug reports.
4. **Proactive-expansion guard**: never inject expansion text into a text block carrying the client's `cache_control` - the client re-sends the original bytes next turn, so mutating the breakpointed block busts the prefix at that message on every later turn.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cache/prefix_tracker.py`: `normalize_message_cache_control` gains a `client_messages` parameter and mirrors the client's (message, block) marker positions; new `_client_marker_positions` helper; legacy consolidation kept as fallback
- `headroom/proxy/handlers/anthropic.py`: pass `original_client_messages` into normalize; snapshot inbound breakpoints after request parse and log in/out comparison before forwarding; skip proactive-expansion injection into breakpointed text blocks
- `headroom/proxy/helpers.py`: `count_cache_breakpoints` (counts system/tools/messages markers incl. nested tool_result sub-blocks, tracks last-marker tail distance) and `log_cache_breakpoints` (INFO normally, WARNING on drop/tail-growth)
- `headroom/cache/compression_store.py`: `HEADROOM_LOG_PAYLOAD_PREVIEW` env switch for `_payload_for_retrieval_log`
- `tests/test_cache_control_move_bust.py`: 8 new tests for position mirroring (multi-marker messages, per-position ttl, boundedness across turns, count-mismatch/no-marker fallbacks, out-of-range block clamp, string-content skip)
- `tests/test_cache_breakpoint_diagnostics.py`: new file, 9 tests covering the counter, the WARNING escalation, the payload-preview switch, and the expansion guard

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/test_cache_control_move_bust.py tests/test_cache_ttl_preserved.py \
    tests/test_cache_breakpoint_diagnostics.py tests/test_cache/ \
    tests/test_proxy_anthropic_cache_stability.py -q
================== 314 passed, 2 skipped, 1 warning in 19.91s ==================

$ ruff check .
Found 4 errors.   # all pre-existing in plugins/headroom-oauth2/, untouched by this PR
$ ruff check headroom/ tests/test_cache_control_move_bust.py tests/test_cache_breakpoint_diagnostics.py
All checks passed!

$ mypy headroom/cache/prefix_tracker.py headroom/proxy/helpers.py headroom/cache/compression_store.py
Success: no issues found in 3 source files
```

## Real Behavior Proof

- Environment: macOS (Darwin 24.6.0), Python 3.12, patch applied to a live proxy deployment serving real Claude Code traffic (model claude-fable-5, Anthropic Messages API), one full working day
- Exact command / steps: enabled the `event=cache_breakpoints` logging first, then deployed the fix in two stages; compared `grep "event=cache_breakpoints" proxy.log` counts per stage and per-turn `usage` from the client's session transcripts
- Observed result: with consolidation (pre-fix): 62 of 218 requests logged `dropped=true` (typically 3 client markers in, 1 out). Message-level mirroring: 17 of 132. Block-level mirroring (this PR): 0 of 38, with `in_messages == out_messages` on every request including the 3-marker intra-message shape; compression savings events continued unchanged throughout, and client-side cache miss rate held at ~3.3% with near-zero uncached input tokens
- Not tested: OpenAI-format clients (message-level `cache_control` is Anthropic-format only; those paths fall back to legacy behavior), Bedrock handler beyond the existing unit suite, and the reporting user's exact MCP-heavy workload (their confirmation pending upgrade)

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A - log-line and request-shaping change; representative log output is in Real Behavior Proof.

## Additional Notes

- Documentation checklist item is unchecked because no user-facing docs cover message-level marker handling today; happy to add a section to the caching docs if maintainers want one (the docstring on `normalize_message_cache_control` carries the full rationale).
- The `ruff check .` findings are 4 pre-existing issues in `plugins/headroom-oauth2/` that this PR does not touch.
- Design tradeoff: the newest client marker keeps the stable-run anchoring from #2917 only when the client placed it on its message's final block; an explicit mid-message marker is honored verbatim. Out-of-range block indices (a transform merged/removed blocks) clamp to the message's last block - markers are not part of the provider's cache key, so a near-miss placement is harmless while a dropped marker is not.
