### PR TITLE
fix(proxy): honor HEADROOM_MODEL_ROUTER_ENABLED/ROUTES on the CLI proxy path (#2764)

### DIFF
--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -1019,6 +1019,7 @@ def proxy(
     """
     # Import here to avoid slow startup
     try:
+        from headroom.proxy.model_router import ModelRouterConfig
         from headroom.proxy.server import (
             ProxyConfig,
             _parse_csv_tools,
@@ -1195,6 +1196,10 @@ def proxy(
         tool_profiles=_parse_tool_profiles([]) or None,
         smart_crusher_with_compaction=_get_env_bool_optional("HEADROOM_SMART_CRUSHER_COMPACTION"),
         savings_profile=os.environ.get("HEADROOM_SAVINGS_PROFILE") or "coding",
+        model_router=ModelRouterConfig.from_env(
+            os.environ.get("HEADROOM_MODEL_ROUTER_ENABLED"),
+            os.environ.get("HEADROOM_MODEL_ROUTES"),
+        ),
         target_ratio=target_ratio,
         compress_system_messages=_get_env_bool_optional("HEADROOM_COMPRESS_SYSTEM_MESSAGES"),
         protect_recent=_get_env_int_optional("HEADROOM_PROTECT_RECENT"),

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -147,7 +147,7 @@ from headroom.proxy.loopback_guard import is_loopback_host
 from headroom.proxy.memory_handler import MemoryConfig, MemoryHandler
 
 # Data models (extracted to headroom/proxy/models.py for maintainability)
-from headroom.proxy.model_router import ModelRouter, ModelRouterConfig
+from headroom.proxy.model_router import ModelRoute, ModelRouter, ModelRouterConfig
 from headroom.proxy.models import CacheEntry, ProxyConfig, RateLimitState, RequestLog  # noqa: F401
 from headroom.proxy.modes import (
     PROXY_MODE_CACHE,
@@ -4894,7 +4894,17 @@ def _proxy_config_from_env() -> ProxyConfig:
     raw_config = os.environ.get(_MULTI_WORKER_CONFIG_ENV)
     if raw_config:
         try:
-            return ProxyConfig(**json.loads(raw_config))
+            parsed = json.loads(raw_config)
+            mr = parsed.get("model_router")
+            if isinstance(mr, dict):
+                parsed["model_router"] = ModelRouterConfig(
+                    enabled=bool(mr.get("enabled", False)),
+                    routes=tuple(
+                        ModelRoute(**{**route, "from_models": tuple(route.get("from_models", ()))})
+                        for route in mr.get("routes", ())
+                    ),
+                )
+            return ProxyConfig(**parsed)
         except (TypeError, ValueError, json.JSONDecodeError):
             logger.warning(
                 "Invalid %s; falling back to HEADROOM_* env vars", _MULTI_WORKER_CONFIG_ENV

--- a/tests/test_proxy/test_model_router_wiring.py
+++ b/tests/test_proxy/test_model_router_wiring.py
@@ -264,3 +264,82 @@ def test_vertex_raw_predict_model_is_not_rewritten_in_body() -> None:
         )
     assert resp.status_code == 200
     assert "model" not in _forwarded_body(http)
+
+
+def test_cli_proxy_wires_model_router_from_env(monkeypatch) -> None:
+    """The default `headroom proxy` (single-worker) path must honor the
+
+    HEADROOM_MODEL_ROUTER_ENABLED / HEADROOM_MODEL_ROUTES env vars, like the
+    multi-worker `_proxy_config_from_env` path does. Regression for #2764.
+    """
+    from click.testing import CliRunner
+
+    import headroom.proxy.server as server_mod
+    from headroom.cli.main import main
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        server_mod, "run_server", lambda config, **kwargs: captured.__setitem__("config", config)
+    )
+    monkeypatch.setenv("HEADROOM_MODEL_ROUTER_ENABLED", "true")
+    monkeypatch.setenv(
+        "HEADROOM_MODEL_ROUTES",
+        '[{"name":"small","max_input_tokens":4000,"require_no_tools":true,'
+        '"to_model":"claude-haiku-4-5"}]',
+    )
+
+    result = CliRunner().invoke(main, ["proxy"])
+
+    assert result.exit_code == 0, result.output
+    config = captured.get("config")
+    assert config is not None, "run_server was not reached"
+    assert config.model_router is not None and config.model_router.enabled
+    assert config.model_router.routes[0].to_model == "claude-haiku-4-5"
+
+
+def test_cli_proxy_model_router_disabled_when_unset(monkeypatch) -> None:
+    """With the env vars unset, the CLI path leaves the router disabled."""
+    from click.testing import CliRunner
+
+    import headroom.proxy.server as server_mod
+    from headroom.cli.main import main
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        server_mod, "run_server", lambda config, **kwargs: captured.__setitem__("config", config)
+    )
+    monkeypatch.delenv("HEADROOM_MODEL_ROUTER_ENABLED", raising=False)
+    monkeypatch.delenv("HEADROOM_MODEL_ROUTES", raising=False)
+
+    result = CliRunner().invoke(main, ["proxy"])
+
+    assert result.exit_code == 0, result.output
+    config = captured.get("config")
+    assert config is not None, "run_server was not reached"
+    assert config.model_router is None or not config.model_router.enabled
+
+
+def test_multi_worker_json_roundtrip_reconstructs_model_router(monkeypatch) -> None:
+    """The workers>1 JSON round-trip must rebuild model_router as a dataclass,
+
+    not leave it a raw dict (which crashes `ModelRouter(...).enabled`). #2764.
+    """
+    from headroom.proxy.model_router import ModelRouter
+    from headroom.proxy.server import (
+        _MULTI_WORKER_CONFIG_ENV,
+        ProxyConfig,
+        _proxy_config_from_env,
+        _proxy_config_payload,
+    )
+
+    source = ProxyConfig(model_router=_router_config())
+    payload = _proxy_config_payload(source)
+    monkeypatch.setenv(_MULTI_WORKER_CONFIG_ENV, json.dumps(payload))
+
+    rebuilt = _proxy_config_from_env()
+
+    assert isinstance(rebuilt.model_router, ModelRouterConfig)
+    assert rebuilt.model_router.enabled
+    assert rebuilt.model_router.routes[0].to_model == "claude-haiku-4-5"
+    # The crash surface: constructing a ModelRouter and reading .enabled must not raise.
+    assert ModelRouter(rebuilt.model_router).enabled is True


### PR DESCRIPTION
## Description

The cost-aware model router (issue #1706) is configured by two documented env vars, `HEADROOM_MODEL_ROUTER_ENABLED` and `HEADROOM_MODEL_ROUTES`, but they were **silently ignored on the default `headroom proxy` invocation**.

Two `ProxyConfig` construction paths exist:

- **Multi-worker path** — `headroom/proxy/server.py`'s `_proxy_config_from_env` wires `model_router=ModelRouterConfig.from_env(os.environ.get("HEADROOM_MODEL_ROUTER_ENABLED"), os.environ.get("HEADROOM_MODEL_ROUTES"))` (server.py:4947). Correct.
- **Single-worker path (the default)** — `headroom/cli/proxy.py` builds its own inline `ProxyConfig(...)` and never set `model_router`, so it stayed `None` (`ProxyConfig.model_router` default) and the router was disabled regardless of the env vars.

Since `headroom proxy` defaults to `workers=1`, the common case never routed. This wires the router into the CLI path, mirroring the server path.

Closes #2764

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- **`headroom/cli/proxy.py`** — add `model_router=ModelRouterConfig.from_env(...)` to the CLI's `ProxyConfig(...)`, plus a lazy import of `ModelRouterConfig` (matching the file's "import here to avoid slow startup" pattern). Byte-for-byte identical call to `server.py:4947-4949`. `from_env` fails open to disabled when the vars are unset/malformed, so behavior is unchanged when the feature isn't used.
- **`headroom/proxy/server.py`** — follow-up needed by the above: with the CLI path now producing a real `ModelRouterConfig`, the `headroom proxy --workers N` (N>1) path exposed a latent crash. `run_server` JSON-serializes the config to worker subprocesses (`_proxy_config_payload` flattens the nested `ModelRouterConfig` dataclass to a dict), but `_proxy_config_from_env`'s worker-rebuild did `ProxyConfig(**json.loads(...))` without reconstructing the nested dataclass — leaving `model_router` a raw `dict`, so `ModelRouter(dict).enabled` raised `AttributeError` on every request. Fixed by reconstructing `model_router` (dict → `ModelRouterConfig` with `ModelRoute` routes, `from_models` list→tuple for frozen-dataclass hashability) before `ProxyConfig(**parsed)`, inside the existing fail-open `try/except`.
- **`tests/test_proxy/test_model_router_wiring.py`** — 3 regression tests: CLI path enabled (fails pre-fix), CLI path disabled-when-unset, and the multi-worker JSON round-trip reconstructs the router instead of a dict.

Scope kept minimal: no refactor to unify the CLI and server config construction (they legitimately differ — CLI merges click options + env, server is env-only). No new env var.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run pytest tests/test_proxy/test_model_router_wiring.py -q
16 passed

# broader sweep of everything that consumes _proxy_config_from_env / the multi-worker payload:
$ uv run pytest tests/test_proxy/ -k "multi_worker or config_from_env or proxy_config or model_router" -q
45 passed
# other consumers (test_cli_proxy_env, scalability, telemetry_env, bedrock_passthrough, ...): 205 passed, 1 skipped (pre-existing)

$ uv run ruff check headroom/cli/proxy.py headroom/proxy/server.py tests/test_proxy/test_model_router_wiring.py
All checks passed!
```

Pre-fix, `test_cli_proxy_wires_model_router_from_env` fails with `AssertionError: assert (None is not None)` (the CLI-built config's `model_router` is `None` even with the env vars set), and `test_multi_worker_json_roundtrip_reconstructs_model_router` fails because the round-trip leaves `model_router` a raw `dict`. Both pass after the fix.

## Real Behavior Proof

- **Environment:** Windows 11, Python 3.13.5, headroom from this branch (editable, via `uv`).
- **Exact command / steps:** The tests drive the real code paths — `test_cli_proxy_wires_model_router_from_env` invokes the actual `proxy` CLI command (`CliRunner().invoke(main, ["proxy"])`) with the env vars set, patching `run_server` to capture the constructed `ProxyConfig`; `test_multi_worker_json_roundtrip_reconstructs_model_router` runs the real `_proxy_config_payload` → env → `_proxy_config_from_env` round-trip and asserts `ModelRouter(rebuilt.model_router).enabled` does not raise.
- **Observed result:** With the fix, the single-worker CLI config has an enabled `ModelRouterConfig` with the parsed route, and the multi-worker round-trip yields a `ModelRouterConfig` (not a dict), so the `--workers N` + router path no longer crashes. The router's request-rewriting behavior itself is already covered by the existing `test_messages_request_gets_model_rewritten_when_enabled`; this change only makes the CLI/worker paths reach that already-tested code.
- **Not tested:** A live end-to-end run against a real upstream provider (no live account here). The routing selection is exercised by existing tests; this PR fixes whether the config plumbing reaches it.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Screenshots (if applicable)

N/A

## Additional Notes

- CHANGELOG left untouched — the repo enforces a `no-manual-changelog` CI check (release-please owns `CHANGELOG.md`); the conventional-commit `fix(...)` message drives the entry.
- `mypy` not run as part of this verification; the change adds one kwarg and a small deserialization block, no new type-level surface.
- The `server.py` reconstruction was not in the original one-line plan — it's a follow-up caught in review: making `config.model_router` non-None on the CLI path first exposed the pre-existing incomplete deserialization of the one nested-dataclass `ProxyConfig` field on the `--workers N` path. Fixing it here keeps this change from introducing a crash and makes multi-worker routing actually work.
