### PR TITLE
fix(wrap/claude): keep --1m effective when an explicit --model is passed through

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -303,6 +303,33 @@ def _resolve_1m_model(current: str | None) -> str:
     return base if base.endswith(_CONTEXT_1M_SUFFIX) else f"{base}{_CONTEXT_1M_SUFFIX}"
 
 
+def _apply_1m_to_claude_args(args: tuple[str, ...]) -> tuple[tuple[str, ...], str | None]:
+    """Add the ``[1m]`` suffix to an explicit ``--model`` in pass-through args.
+
+    Claude Code gives the ``--model`` CLI flag precedence over the
+    ``ANTHROPIC_MODEL`` env var, so when a user passes both ``--1m`` and
+    ``--model X`` the env-var suffix is silently shadowed and the session caps at
+    200k (#2915). Rewriting the flag's value the same way ``_resolve_1m_model``
+    rewrites the env var keeps ``--1m`` effective on the higher-precedence flag.
+
+    Handles ``--model VALUE`` and ``--model=VALUE`` (the first occurrence only, as
+    Claude Code honours the first). Idempotent via ``_resolve_1m_model``. Returns
+    ``(new_args, rewritten_value)``; ``rewritten_value`` is ``None`` when no
+    ``--model`` was present (the env-var path already covers that case).
+    """
+    out = list(args)
+    for i, arg in enumerate(out):
+        if arg == "--model" and i + 1 < len(out):
+            rewritten = _resolve_1m_model(out[i + 1])
+            out[i + 1] = rewritten
+            return tuple(out), rewritten
+        if arg.startswith("--model="):
+            rewritten = _resolve_1m_model(arg.split("=", 1)[1])
+            out[i] = f"--model={rewritten}"
+            return tuple(out), rewritten
+    return tuple(out), None
+
+
 def _normalize_tool_search_mode(value: str) -> str:
     """Validate an ``ENABLE_TOOL_SEARCH`` value and return it normalized.
 
@@ -4728,10 +4755,18 @@ def claude(
         # force it via ANTHROPIC_MODEL on the launched process.
         if context_1m:
             env[_ANTHROPIC_MODEL_ENV] = _resolve_1m_model(env.get(_ANTHROPIC_MODEL_ENV))
-            click.echo(
-                f"  {_ANTHROPIC_MODEL_ENV}={env[_ANTHROPIC_MODEL_ENV]} "
-                "(1M context window; issue #1158)"
-            )
+            # An explicit pass-through --model outranks ANTHROPIC_MODEL in Claude
+            # Code, so add the suffix there too or the env var is silently
+            # shadowed and the window stays 200k (#2915). Report what will
+            # actually take effect rather than the shadowed env value.
+            claude_args, _model_flag_1m = _apply_1m_to_claude_args(claude_args)
+            if _model_flag_1m is not None:
+                click.echo(f"  --model {_model_flag_1m} (1M context window; issue #1158)")
+            else:
+                click.echo(
+                    f"  {_ANTHROPIC_MODEL_ENV}={env[_ANTHROPIC_MODEL_ENV]} "
+                    "(1M context window; issue #1158)"
+                )
 
         result = subprocess.run([claude_bin, *claude_args], env=env)
         raise SystemExit(result.returncode)

--- a/tests/test_cli/test_wrap_claude_vertex_proxy_env.py
+++ b/tests/test_cli/test_wrap_claude_vertex_proxy_env.py
@@ -160,6 +160,46 @@ def test_wrap_claude_sibling_note_accurate_under_1m_and_tool_search_optouts(
     assert "kept on" not in output
 
 
+def test_wrap_claude_1m_adds_suffix_to_passthrough_model_flag(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # #2915: Claude Code's --model CLI flag outranks ANTHROPIC_MODEL, so with
+    # both --1m and an explicit --model the env-var [1m] suffix is shadowed and
+    # the window silently caps at 200k. The wrapper must add the suffix to the
+    # pass-through flag so the 1M window actually activates.
+    captured, output = _invoke_wrap_claude(
+        runner,
+        monkeypatch,
+        env={},
+        extra_args=("--1m", "--model", "opusplan"),
+    )
+    assert captured["child_cmd"] == ["/usr/bin/claude", "--model", "opusplan[1m]"]
+    # The banner reports what actually takes effect, not the shadowed env value.
+    assert "--model opusplan[1m]" in output
+
+
+def test_wrap_claude_1m_adds_suffix_to_equals_model_flag(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured, _output = _invoke_wrap_claude(
+        runner,
+        monkeypatch,
+        env={},
+        extra_args=("--1m", "--model=opusplan"),
+    )
+    assert captured["child_cmd"] == ["/usr/bin/claude", "--model=opusplan[1m]"]
+
+
+def test_wrap_claude_1m_without_model_flag_still_uses_env(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No pass-through --model: ANTHROPIC_MODEL carries the suffix as before, and
+    # the launched command is untouched.
+    captured, _output = _invoke_wrap_claude(runner, monkeypatch, env={}, extra_args=("--1m",))
+    assert captured["child_cmd"] == ["/usr/bin/claude"]
+    assert captured["child_env"]["ANTHROPIC_MODEL"].endswith("[1m]")
+
+
 def test_wrap_claude_tool_search_banner_line_still_accurate_when_active(
     runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli/test_wrap_helpers.py
+++ b/tests/test_cli/test_wrap_helpers.py
@@ -110,6 +110,35 @@ def test_wrap_claude_allows_claude_print_short_flag_in_passthrough_args() -> Non
 
 
 # ---------------------------------------------------------------------------
+# _apply_1m_to_claude_args — add the [1m] suffix to an explicit pass-through
+# --model so it survives Claude Code's CLI-over-env precedence (#2915).
+# ---------------------------------------------------------------------------
+def test_apply_1m_rewrites_model_flag_value() -> None:
+    args, rewritten = wrap_mod._apply_1m_to_claude_args(("--model", "opusplan"))
+    assert args == ("--model", "opusplan[1m]")
+    assert rewritten == "opusplan[1m]"
+
+
+def test_apply_1m_rewrites_equals_model_flag() -> None:
+    args, rewritten = wrap_mod._apply_1m_to_claude_args(("--model=opusplan",))
+    assert args == ("--model=opusplan[1m]",)
+    assert rewritten == "opusplan[1m]"
+
+
+def test_apply_1m_is_idempotent_on_already_suffixed_model() -> None:
+    args, rewritten = wrap_mod._apply_1m_to_claude_args(("--model", "opusplan[1m]"))
+    assert args == ("--model", "opusplan[1m]")
+    assert rewritten == "opusplan[1m]"
+
+
+def test_apply_1m_noop_without_model_flag() -> None:
+    original = ("--permission-mode", "auto", "--resume")
+    args, rewritten = wrap_mod._apply_1m_to_claude_args(original)
+    assert args == original
+    assert rewritten is None
+
+
+# ---------------------------------------------------------------------------
 # _run_proxy_only_watcher — must print banner, call setup callback, install
 # signal handlers, and clean up. Heavily mocked since the real watcher
 # blocks on `time.sleep` indefinitely.


### PR DESCRIPTION
## Description

`headroom wrap claude --1m --model opusplan` silently launches a **200k** session instead of the 1M window it advertises.

`--1m` sets `ANTHROPIC_MODEL=<model>[1m]` on the child environment (`_resolve_1m_model`), and Claude Code only sends the `context-1m` beta header when the resolved model id carries the `[1m]` suffix. But Claude Code gives its **`--model` CLI flag precedence over the `ANTHROPIC_MODEL` env var**. So when a user passes both `--1m` and a pass-through `--model X`, the env-var suffix is shadowed, no `[1m]` reaches Claude Code, the beta header is never sent, and the session stays capped at 200k -- while the success banner still prints `ANTHROPIC_MODEL=<opus>[1m] (1M context window)`, which is actively misleading (#2915).

Repro:

```bash
headroom wrap claude --1m --model opusplan
# banner: ANTHROPIC_MODEL=claude-opus-4-8[1m] (1M context window; issue #1158)
# actually launches: claude --model opusplan   (no [1m], 200k window)
```

## Fix

When `--1m` is set and the pass-through args carry an explicit `--model VALUE` / `--model=VALUE`, add the `[1m]` suffix to that flag's value with the same `_resolve_1m_model` logic already used for `ANTHROPIC_MODEL`. The higher-precedence CLI flag then carries the suffix, so 1M activates whether or not the user also passes `--model`. The banner now reports the value that actually takes effect.

This is symmetric with the existing behaviour: `_resolve_1m_model` already appends `[1m]` to *whatever* `ANTHROPIC_MODEL` holds (including an alias like `opusplan`, when a user sets that env var), so `opusplan[1m]` on the flag is a shape the wrapper already trusts -- Claude Code strips the `[1m]` marker and resolves the base model + beta header the same way on either path.

Scope note: this handles the long-form `--model` (the flag named in the issue). It does not special-case the dual-model alias concern the issue raises as a secondary point (whether a single `[1m]` on `opusplan` propagates to both underlying models is Claude Code's internal behaviour, unchanged by where the suffix is applied), and it does not touch the separate Opus-5 default request.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cli/wrap.py`: add `_apply_1m_to_claude_args()` and call it in the `wrap claude` launch path when `--1m` is set; the banner reports the effective `--model` when one was rewritten, else the `ANTHROPIC_MODEL` value as before.
- `tests/test_cli/test_wrap_claude_vertex_proxy_env.py`: end-to-end tests that drive `wrap claude` and assert the launched command -- `--1m --model opusplan` launches `claude --model opusplan[1m]`, `--model=opusplan` likewise, and `--1m` alone leaves the command untouched while `ANTHROPIC_MODEL` keeps the suffix.
- `tests/test_cli/test_wrap_helpers.py`: focused unit tests for `_apply_1m_to_claude_args` (rewrite, `=` form, idempotency, no-op without `--model`).

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] New tests added

### Test Output

```text
# Fail-before (launch-path wiring reverted, tests kept):
test_wrap_claude_1m_adds_suffix_to_passthrough_model_flag  -> child_cmd was
  ['/usr/bin/claude', '--model', 'opusplan']  != [..., 'opusplan[1m]']  (FAIL)
test_wrap_claude_1m_adds_suffix_to_equals_model_flag        -> FAIL
test_wrap_claude_1m_without_model_flag_still_uses_env        -> PASS (unchanged path)

# Pass-after:
tests/test_cli/test_wrap_helpers.py tests/test_cli/test_wrap_claude_vertex_proxy_env.py  72 passed

# uvx ruff@0.15.22 check  -> All checks passed!
# uvx mypy@1.20.2 headroom/cli/wrap.py -> Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.15.22 and mypy 1.20.2 via uvx.
- Steps: drove the real `wrap claude` Click command via `CliRunner` with `subprocess.run` mocked to capture the launched argv/env. With `--1m --model opusplan` the captured child command is `['/usr/bin/claude', '--model', 'opusplan[1m]']` (was `opusplan` before the fix); with `--1m` alone it stays `['/usr/bin/claude']` and `ANTHROPIC_MODEL` ends in `[1m]`.
- Observed result: a pass-through `--model` no longer shadows `--1m`; the launched Claude Code process receives a `[1m]`-suffixed model on the flag it actually honours, so the 1M window is requested. The banner reflects the effective value.
- Not tested: a live Claude Code subscription session confirming the 1M window server-side (no entitled account here). The wrapper's contract -- getting the `[1m]` suffix onto the model id Claude Code resolves -- is verified at the launch boundary.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`: it is generated by release-please from my Conventional Commit PR title

## Additional Notes

Fixes #2915 (the primary precedence bug and the misleading banner). The issue's secondary points -- the dual-model `opusplan` alias semantics and the Opus-5 default request -- are intentionally left out of scope so this stays a focused, low-risk fix.
