### PR TITLE
fix(wrap/opencode): verify the opencode binary before mutating config

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -6947,6 +6947,20 @@ def opencode(
             )
         subscription_resolution = _require_copilot_subscription_resolution()
 
+    # Verify the opencode binary exists BEFORE mutating any config. Otherwise a
+    # missing binary leaves headroom MCP/Serena/memory entries in the user's
+    # opencode config and an injected AGENTS.md, then errors with no cleanup --
+    # the config-before-verify anti-pattern (#1614). Siblings (claude, codex,
+    # goose, omp) already check first. `--prepare-only` intentionally writes
+    # config without launching, so it is exempt.
+    opencode_bin: str | None = None
+    if not prepare_only:
+        opencode_bin = shutil.which("opencode")
+        if not opencode_bin:
+            click.echo("Error: 'opencode' not found in PATH.")
+            click.echo("Install OpenCode: https://opencode.ai")
+            raise SystemExit(1)
+
     # Snapshot OpenCode config.json BEFORE any wrap-time mutation so
     # `headroom unwrap opencode` can restore the user's pre-wrap state.
     _opencode_config_file, _opencode_backup_file = opencode_config_paths()
@@ -6987,11 +7001,9 @@ def opencode(
         inject_opencode_provider_config(port)
         return
 
-    opencode_bin = shutil.which("opencode")
-    if not opencode_bin:
-        click.echo("Error: 'opencode' not found in PATH.")
-        click.echo("Install OpenCode: https://opencode.ai")
-        raise SystemExit(1)
+    # Past the prepare-only return the launch path always ran the binary check
+    # above, so opencode_bin is resolved.
+    assert opencode_bin is not None
 
     # Register our proxy client marker BEFORE _ensure_proxy so that another
     # wrapper's cleanup sees us as an active client and doesn't terminate a

--- a/tests/test_cli/test_wrap_opencode.py
+++ b/tests/test_cli/test_wrap_opencode.py
@@ -364,6 +364,35 @@ def test_wrap_opencode_missing_binary_errors_clearly(
     assert "'opencode' not found in PATH" in result.output
 
 
+def test_wrap_opencode_missing_binary_does_not_mutate_config(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing opencode binary must not leave memory side-effects behind (#1614 class).
+
+    The MCP/Serena registrations are already gated on ``registrar.detect()``, but
+    the ``--memory`` injections (AGENTS.md, the .headroom dir, the memory MCP
+    config) are not -- they ran unconditionally before the binary check. Verify
+    the binary first, like claude/codex/goose/omp, so an absent tool cannot write
+    those and then error with nothing launched.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    _set_test_home(monkeypatch, tmp_path)
+
+    agents_md = tmp_path / "AGENTS.md"
+    headroom_dir = tmp_path / ".headroom"
+
+    with patch.object(wrap_mod.shutil, "which", return_value=None):
+        result = runner.invoke(main, ["wrap", "opencode", "--memory"])
+
+    assert result.exit_code == 1
+    assert "'opencode' not found in PATH" in result.output
+    assert not agents_md.exists(), "AGENTS.md was created before the missing-binary check"
+    assert not headroom_dir.exists(), ".headroom dir was created before the missing-binary check"
+
+
 def test_wrap_opencode_prepare_only_injects_config(
     runner: CliRunner,
     tmp_path: Path,


### PR DESCRIPTION
## Description

`headroom wrap opencode --memory` mutates state before it verifies the `opencode` binary exists. In the `--memory` path the command:

- creates `.headroom/` in the cwd,
- injects the memory MCP config, and
- writes `AGENTS.md` into the cwd (`_inject_memory_agents_md` creates the file),

and only *after* that runs `shutil.which("opencode")` and errors if the tool is missing. So a user who runs it without opencode installed is left with an `AGENTS.md`, a `.headroom` dir, and a mutated memory MCP config, then sees `Error: 'opencode' not found in PATH` with nothing launched. This is the config-before-verify anti-pattern called out in #1614.

opencode is the outlier here -- `wrap claude`, `wrap codex`, `wrap goose`, and `wrap omp` all resolve and check their binary *before* touching config. (The MCP/Serena registrations in opencode were already safe: `_setup_headroom_mcp` / `_setup_serena_mcp` both early-return on `registrar.detect()`. The `--memory` injections had no such guard.)

## Fix

Hoist the `shutil.which("opencode")` check above the config-mutating steps, gated on `not prepare_only` (`--prepare-only` intentionally writes config without a launch, matching codex/omp). The later duplicate check is removed; a narrowing `assert` documents that the launch path always resolved the binary.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cli/wrap.py` (`opencode`): resolve + verify the `opencode` binary before the snapshot/MCP/Serena/memory steps (skipped for `--prepare-only`); drop the redundant later check.
- `tests/test_cli/test_wrap_opencode.py`: `test_wrap_opencode_missing_binary_does_not_mutate_config` -- with the binary missing, `wrap opencode --memory` must not create `AGENTS.md` or `.headroom/`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] New test added

### Test Output

```text
# Fail-before (original wrap.py, new test kept):
test_wrap_opencode_missing_binary_does_not_mutate_config
  -> AssertionError: AGENTS.md was created before the missing-binary check  (FAIL)

# Pass-after:
tests/test_cli/test_wrap_opencode.py  (full file) passes

# uvx ruff@0.15.22 check  -> All checks passed!
# uvx mypy@1.20.2 headroom/cli/wrap.py -> Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.15.22 and mypy 1.20.2 via uvx.
- Steps: drove the real `wrap opencode` Click command via `CliRunner` with `shutil.which` patched to `None` (opencode absent) and `HOME` redirected to a tmp dir. Before the fix, `wrap opencode --memory` created `AGENTS.md` and `.headroom/` in the cwd before failing; after the fix it fails immediately with `'opencode' not found in PATH` and writes nothing.
- Observed result: an absent opencode binary no longer leaves memory side effects behind, matching the other wrap subcommands.
- Not tested: a real opencode launch (no opencode CLI here). The mutation ordering is verified at the Click-command boundary.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`: it is generated by release-please from my Conventional Commit PR title

## Additional Notes

Scope is deliberately narrow: only the check is hoisted. The MCP/Serena paths were already `detect()`-gated, so the only observable behaviour change is that `--memory` no longer writes `AGENTS.md`/`.headroom`/memory-MCP config when opencode is absent.
