### PR TITLE
fix(toin): address patterns by signature hash

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -179,7 +179,7 @@ from headroom.subscription.tracker import (
 )
 from headroom.telemetry import get_telemetry_collector
 from headroom.telemetry.beacon import is_telemetry_enabled
-from headroom.telemetry.toin import get_toin
+from headroom.telemetry.toin import _deserialize_pattern_key, get_toin
 from headroom.transforms import (
     CacheAligner,
     CodeAwareCompressor,
@@ -4712,7 +4712,12 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
 
         # Convert to list and sort by sample_size
         patterns_list = []
-        for sig_hash, pattern_dict in patterns_data.items():
+        for serialized_key, pattern_dict in patterns_data.items():
+            # TOIN v2 persists the tenant/model slice as
+            # ``auth|model|signature_hash``. The public identifier is the
+            # signature component, not the first 12 characters of that
+            # composite key.
+            signature_hash = _deserialize_pattern_key(serialized_key)[2]
             sample_size = pattern_dict.get("sample_size", 0)
             total_compressions = pattern_dict.get("total_compressions", 0)
             total_retrievals = pattern_dict.get("total_retrievals", 0)
@@ -4722,7 +4727,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
 
             patterns_list.append(
                 {
-                    "hash": sig_hash[:12],
+                    "hash": signature_hash[:12],
                     "compressions": total_compressions,
                     "retrievals": total_retrievals,
                     "retrieval_rate": f"{retrieval_rate:.1%}",
@@ -4759,8 +4764,9 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         patterns_data = exported.get("patterns", {})
 
         # Search for pattern with matching hash prefix
-        for sig_hash, pattern_dict in patterns_data.items():
-            if sig_hash.startswith(hash_prefix):
+        for serialized_key, pattern_dict in patterns_data.items():
+            signature_hash = _deserialize_pattern_key(serialized_key)[2]
+            if signature_hash.startswith(hash_prefix):
                 # Keep this response aligned with /v1/toin/patterns while
                 # excluding query text, field semantics, and other internal
                 # learning state from the detail endpoint.

--- a/tests/test_proxy_loopback_gating.py
+++ b/tests/test_proxy_loopback_gating.py
@@ -106,7 +106,7 @@ def test_toin_pattern_detail_whitelists_learned_payload(monkeypatch: pytest.Monk
             }
 
     monkeypatch.setattr("headroom.proxy.server.get_toin", lambda: FakeTOIN())
-    response = _loopback_client().get("/v1/toin/pattern/unknown")
+    response = _loopback_client().get("/v1/toin/pattern/abc123")
 
     assert response.status_code == 200
     assert response.json() == {

--- a/tests/test_proxy_toin_identifiers.py
+++ b/tests/test_proxy_toin_identifiers.py
@@ -1,0 +1,58 @@
+"""Regression tests for TOIN composite-key identifiers (#2928)."""
+
+from fastapi.testclient import TestClient
+
+from headroom.proxy.server import ProxyConfig, create_app
+
+
+class _FakeTOIN:
+    def export_patterns(self):
+        return {
+            "patterns": {
+                "unknown|unknown|abcdef1234567890": {
+                    "sample_size": 10,
+                    "total_compressions": 8,
+                    "total_retrievals": 2,
+                    "confidence": 0.4,
+                    "skip_compression_recommended": False,
+                    "optimal_max_items": 20,
+                },
+                "oauth|gpt-4o|1234567890abcdef": {
+                    "sample_size": 5,
+                    "total_compressions": 4,
+                    "total_retrievals": 1,
+                    "confidence": 0.2,
+                    "skip_compression_recommended": True,
+                    "optimal_max_items": 12,
+                },
+            }
+        }
+
+
+def test_toin_list_uses_signature_component(monkeypatch) -> None:
+    monkeypatch.setattr("headroom.proxy.server.get_toin", lambda: _FakeTOIN())
+    app = create_app(ProxyConfig(optimize=False, cache_enabled=False, rate_limit_enabled=False))
+
+    response = TestClient(
+        app,
+        base_url="http://127.0.0.1",
+        client=("127.0.0.1", 12345),
+    ).get("/v1/toin/patterns")
+
+    assert response.status_code == 200
+    assert {row["hash"] for row in response.json()} == {"abcdef123456", "1234567890ab"}
+
+
+def test_toin_detail_round_trips_list_identifier(monkeypatch) -> None:
+    monkeypatch.setattr("headroom.proxy.server.get_toin", lambda: _FakeTOIN())
+    app = create_app(ProxyConfig(optimize=False, cache_enabled=False, rate_limit_enabled=False))
+    client = TestClient(
+        app,
+        base_url="http://127.0.0.1",
+        client=("127.0.0.1", 12345),
+    )
+
+    response = client.get("/v1/toin/pattern/abcdef123456")
+
+    assert response.status_code == 200
+    assert response.json()["compressions"] == 8


### PR DESCRIPTION
## Summary

Fixes #2928.

TOIN v2 serializes pattern keys as `auth|model|signature_hash`, but the API took the first 12 characters of that composite key. Patterns commonly appeared as `unknown|unknown`, making all identifiers collide and detail lookup arbitrary.

## Changes

- extract the signature-hash component from v2 composite keys before exposing `hash`
- make detail lookup match against that same signature component
- preserve legacy bare-hash export compatibility through the existing deserializer

## Validation

- added list/detail round-trip tests with multiple tenant/model slices
- 78 focused proxy/TOIN tests passed (6 skipped)
- Ruff check/format and `git diff --check` passed

## Review notes

The documented 12-character display-prefix contract is preserved. As with any prefix API, two hashes sharing the same first 12 characters remain theoretically ambiguous; the fix removes the total collision caused by the composite-key prefix and keeps the endpoint backward compatible.
