### PR TITLE
fix(cli): honor explicit Claude model with 1m

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -303,6 +303,66 @@ def _resolve_1m_model(current: str | None) -> str:
     return base if base.endswith(_CONTEXT_1M_SUFFIX) else f"{base}{_CONTEXT_1M_SUFFIX}"
 
 
+def _resolve_1m_model_selection(
+    claude_args: tuple[str, ...],
+    environment_model: str | None,
+) -> tuple[tuple[str, ...], str, bool]:
+    """Apply ``[1m]`` to the model Claude Code will actually resolve.
+
+    Claude Code gives an explicit ``--model``/``-m`` argument precedence over
+    ``ANTHROPIC_MODEL``. Rewrite that argument when present; otherwise retain
+    the existing environment-based behavior. Mode aliases such as
+    ``opusplan`` select multiple underlying models and cannot safely carry one
+    suffix, so fail before launching with a misleading success banner.
+    """
+    args = list(claude_args)
+    model_index: int | None = None
+    inline = False
+
+    index = 0
+    while index < len(args):
+        argument = args[index]
+        if argument in {"--model", "-m"}:
+            if index + 1 >= len(args) or not args[index + 1].strip():
+                raise ValueError(f"{argument} requires a model when used with --1m")
+            model_index = index + 1
+            inline = False
+            index += 2
+            continue
+        if argument.startswith("--model=") or argument.startswith("-m="):
+            value = argument.split("=", 1)[1].strip()
+            if not value:
+                raise ValueError(
+                    f"{argument.split('=', 1)[0]} requires a model when used with --1m"
+                )
+            model_index = index
+            inline = True
+        index += 1
+
+    if model_index is None:
+        return claude_args, _resolve_1m_model(environment_model), False
+
+    if inline:
+        selected_model = args[model_index].split("=", 1)[1].strip()
+    else:
+        selected_model = args[model_index].strip()
+
+    alias_model = selected_model.removesuffix(_CONTEXT_1M_SUFFIX).lower()
+    if alias_model in {"opusplan"}:
+        raise ValueError(
+            "--1m cannot be combined with Claude Code model alias "
+            f"{selected_model!r}; pass a concrete Claude model with --model"
+        )
+
+    resolved_model = _resolve_1m_model(selected_model)
+    if inline:
+        prefix = args[model_index].split("=", 1)[0]
+        args[model_index] = f"{prefix}={resolved_model}"
+    else:
+        args[model_index] = resolved_model
+    return tuple(args), resolved_model, True
+
+
 def _normalize_tool_search_mode(value: str) -> str:
     """Validate an ``ENABLE_TOOL_SEARCH`` value and return it normalized.
 
@@ -4725,12 +4785,18 @@ def claude(
 
         # Issue #1158: opt-in 1M context window. Claude Code only sends the
         # context-1m beta header when the model id carries the [1m] suffix, so
-        # force it via ANTHROPIC_MODEL on the launched process.
+        # force it on the model Claude Code will actually resolve. An explicit
+        # --model argument takes precedence over ANTHROPIC_MODEL.
         if context_1m:
-            env[_ANTHROPIC_MODEL_ENV] = _resolve_1m_model(env.get(_ANTHROPIC_MODEL_ENV))
+            claude_args, resolved_1m_model, explicit_model = _resolve_1m_model_selection(
+                claude_args,
+                env.get(_ANTHROPIC_MODEL_ENV),
+            )
+            env[_ANTHROPIC_MODEL_ENV] = resolved_1m_model
+            source = "explicit Claude model argument" if explicit_model else "environment"
             click.echo(
                 f"  {_ANTHROPIC_MODEL_ENV}={env[_ANTHROPIC_MODEL_ENV]} "
-                "(1M context window; issue #1158)"
+                f"(1M context window; {source}; issue #1158)"
             )
 
         result = subprocess.run([claude_bin, *claude_args], env=env)

--- a/tests/test_cli/test_wrap_helpers.py
+++ b/tests/test_cli/test_wrap_helpers.py
@@ -728,6 +728,46 @@ def test_resolve_1m_model_falls_back_to_default_when_unset() -> None:
     assert wrap_mod._resolve_1m_model("  ") == "claude-opus-4-8[1m]"
 
 
+def test_resolve_1m_model_selection_rewrites_explicit_model_argument() -> None:
+    args, model, explicit = wrap_mod._resolve_1m_model_selection(
+        ("--model", "claude-sonnet-4-5", "--permission-mode", "auto"),
+        "claude-opus-4-8",
+    )
+
+    assert args == ("--model", "claude-sonnet-4-5[1m]", "--permission-mode", "auto")
+    assert model == "claude-sonnet-4-5[1m]"
+    assert explicit is True
+
+
+def test_resolve_1m_model_selection_rewrites_inline_model_argument() -> None:
+    args, model, explicit = wrap_mod._resolve_1m_model_selection(
+        ("--model=claude-sonnet-4-5",),
+        None,
+    )
+
+    assert args == ("--model=claude-sonnet-4-5[1m]",)
+    assert model == "claude-sonnet-4-5[1m]"
+    assert explicit is True
+
+
+def test_resolve_1m_model_selection_rejects_mode_alias() -> None:
+    with pytest.raises(ValueError, match="opusplan"):
+        wrap_mod._resolve_1m_model_selection(("--model", "opusplan"), None)
+
+
+def test_resolve_1m_model_selection_rejects_missing_model_value() -> None:
+    with pytest.raises(ValueError, match="requires a model"):
+        wrap_mod._resolve_1m_model_selection(("--model",), None)
+
+
+def test_resolve_1m_model_selection_uses_environment_without_model_argument() -> None:
+    args, model, explicit = wrap_mod._resolve_1m_model_selection(("--verbose",), "claude-opus-4-8")
+
+    assert args == ("--verbose",)
+    assert model == "claude-opus-4-8[1m]"
+    assert explicit is False
+
+
 class TestFindAvailablePort:
     """Tests for _find_available_port (Vite-style port fallback)."""
 


### PR DESCRIPTION
## Summary

Fixes #2915.

`headroom wrap claude --1m --model opusplan` previously set `ANTHROPIC_MODEL`, but Claude Code gave the explicit CLI model argument precedence. The banner claimed 1M was active while the launched session remained capped at 200k.

## Changes

- parse `--model VALUE`, `-m VALUE`, `--model=VALUE`, and `-m=VALUE` in forwarded Claude arguments
- append `[1m]` to the explicit model argument that Claude Code will actually resolve
- keep `ANTHROPIC_MODEL` aligned with that resolved model
- fail before launch for the multi-model `opusplan` alias instead of claiming success
- report whether the effective model came from the explicit argument or environment
- support concrete model IDs such as newer Opus releases without hardcoding a new default

## Validation

- 52 wrap-helper tests passed
- existing Claude wrap/remote-control accuracy tests passed (119 total in the focused suite)
- regression coverage includes separated/inline model flags, environment fallback, alias rejection, and malformed flags
- Ruff check/format and `git diff --check` passed

## Review notes

Only the effective/last explicit model selection is rewritten; unrelated forwarded arguments remain byte-for-byte unchanged. The existing default model remains unchanged because Claude model availability is provider-controlled; explicit concrete IDs are now supported correctly.
