### PR TITLE
test(proxy): align quarantine and Codex WS PERF tests with merged main (#2412/#2164 skew)

### DIFF
--- a/tests/test_openai_codex_ws_lifecycle.py
+++ b/tests/test_openai_codex_ws_lifecycle.py
@@ -1030,8 +1030,18 @@ async def test_ws_session_log_prefix_uses_session_id(caplog: pytest.LogCaptureFi
         await handler.handle_openai_responses_ws(client_ws)
 
     assert handler.logger.entries
-    assert handler.logger.entries[0].request_id != "req-ws-1"
-    assert "[req-ws-1] PERF" in caplog.text
+    turn_request_id = handler.logger.entries[0].request_id
+    assert turn_request_id != "req-ws-1"
+    # Session lifecycle lines keep the session id so a session's log lines
+    # stay greppable together...
+    assert "[req-ws-1] WS /v1/responses accepted" in caplog.text
+    assert "[req-ws-1] WS /v1/responses completed" in caplog.text
+    # ...while the PERF line flows through the shared emit_request_outcome
+    # funnel, whose prefix IS the outcome's request_id — the same fresh
+    # per-turn id that keys the dashboard feed row (#2164). One id per
+    # emission, shared between the feed row and its PERF line.
+    assert f"[{turn_request_id}] PERF" in caplog.text
+    assert "[req-ws-1] PERF" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_tokenizer_count_offload.py
+++ b/tests/test_tokenizer_count_offload.py
@@ -176,8 +176,12 @@ async def test_count_tokens_offloaded_fails_open_on_executor_quarantine() -> Non
 
     proxy = _make_proxy()
     # Record a concurrent compression as timed out so the real executor guard
-    # quarantines the next call — no mock of the helper itself.
+    # quarantines the next call — no mock of the helper itself. Since the
+    # quarantine became time-capped (#2412), standing debt alone no longer
+    # quarantines: the deadline armed by the fresh timeout must still be in
+    # the future, so arm it the way a real timeout would.
     proxy._compression_timed_out_in_flight = 1
+    proxy._compression_quarantine_deadline = time.monotonic() + 60.0
 
     tokenizer, tokens = await proxy._count_tokens_offloaded(
         "qwen2.5-coder", [{"role": "user", "content": "hello world"}]
@@ -193,7 +197,10 @@ async def test_count_tokens_offloaded_returns_count_text_capable_tokenizer() -> 
     that need per-fragment accounting."""
     proxy = _make_proxy()
     # Quarantine forces the fail-open branch (an EstimatingTokenCounter).
+    # Post-#2412 the quarantine is time-capped, so the deadline must be armed
+    # alongside the standing debt.
     proxy._compression_timed_out_in_flight = 1
+    proxy._compression_quarantine_deadline = time.monotonic() + 60.0
 
     # The empty-messages count is intentionally discarded by that handler
     # (it sums text parts itself), so only the tokenizer matters here.


### PR DESCRIPTION
## Description

`main` has been red on test shards 3 and 4 since this morning's merge burst (first failing run: d7cf9810, 05:22 UTC). Two merges each passed CI on their own pre-merge base but break tests on merged `main` — classic merge skew, and every PR branch that rebases or re-runs now inherits the red X (observed on #2921 after a push).

Bisected both failures to their exact causes; this PR aligns the three affected tests with the behavior `main` actually ships. **No production code changes.**

**Failure 1 — `tests/test_tokenizer_count_offload.py` (2 tests, shard 4).** #2412 (`c5a08d22`) time-capped the compression timeout-debt quarantine: the executor gate now quarantines only while `timed_out_in_flight > 0` **and** `time.monotonic() < _compression_quarantine_deadline` (`headroom/proxy/server.py:1432`). The quarantine tests from #2498 predate the cap and set only the bare counter, so the gate no longer fires, a real tokenizer comes back, and `isinstance(tokenizer, EstimatingTokenCounter)` fails. The tests now also arm the deadline exactly the way a real fresh timeout does — which is the state they always meant to simulate.

**Failure 2 — `tests/test_openai_codex_ws_lifecycle.py::test_ws_session_log_prefix_uses_session_id` (shard 3).** #2164 (`d02df107`) mints a fresh per-turn `request_id` for each WS `RequestOutcome` so dashboard feed keys stay unique. But the PERF line is emitted by the shared `emit_request_outcome` funnel and its prefix IS `outcome.request_id` (`headroom/proxy/outcome.py:568`) — so the PERF prefix necessarily became the per-turn id too. The PR's new test asserts `"[req-ws-1] PERF"` (the session id), which was written against a base where the WS handler emitted PERF itself; on merged `main` it can never pass. The test now pins the actual invariant: session lifecycle lines (`WS /v1/responses accepted/completed`) keep the session id for greppability, while the PERF line carries the same per-turn id as its feed row — one id per emission, shared between the row and its PERF line.

If maintainers instead want the WS PERF line to keep the session prefix, that is a production change to the outcome funnel (plumbing a separate display id through `RequestOutcome`), and it would decouple the PERF line from the feed row id that `#2164` just made unique — happy to do that as a follow-up if preferred, but the test-level fix restores a green `main` today.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/test_tokenizer_count_offload.py`: the two quarantine fail-open tests arm `_compression_quarantine_deadline = time.monotonic() + 60.0` alongside the standing debt counter, matching the post-#2412 gate; comments explain why.
- `tests/test_openai_codex_ws_lifecycle.py`: `test_ws_session_log_prefix_uses_session_id` asserts session-id prefixes on the WS lifecycle lines and the per-turn outcome id on the PERF line (tied to `handler.logger.entries[0].request_id`), replacing the un-satisfiable session-id PERF assertion.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] Manual testing performed

### Test Output

```text
$ uv run pytest tests/test_tokenizer_count_offload.py tests/test_openai_codex_ws_lifecycle.py -q
45 passed in 2.14s

$ uvx ruff check tests/test_tokenizer_count_offload.py tests/test_openai_codex_ws_lifecycle.py
All checks passed!
$ uvx ruff format --check tests/test_tokenizer_count_offload.py tests/test_openai_codex_ws_lifecycle.py
2 files already formatted
```

## Real Behavior Proof

- Environment: macOS (darwin 24.6), Python 3.10 via `uv run --frozen --extra dev`, local worktree at upstream `main` @ `941c25d3`.
- Exact command / steps: reproduced all 3 failures on unmodified `main` @ `941c25d3` (`3 failed, 8 passed`), then bisected: tokenizer tests pass at `74275b7c` and fail at `c5a08d22` (3/3 deterministic runs each side); the WS test was added by `d02df107` and fails at its own merge commit (`no tests ran` at `d02df107~1`). CI cross-check: `main` push runs 31566354029 (`d7cf9810`) and 31568129622 (`941c25d3`) fail the identical three tests in shards 3 and 4.
- Observed result: with this patch, both files pass on `main` @ `941c25d3` (45 passed); the failing assertion text on `main` shows the PERF line present but prefixed `[req-ws-2]`, confirming the funnel-id mechanism rather than a missing emission.
- Not tested: full 4-shard suite locally (CI will run it); `mypy` (test-only change, no annotations altered).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)
