### PR TITLE
fix(cli): keep Claude wrapper diagnostics off stdout

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -33,6 +33,8 @@ import sys
 import time
 import urllib.parse
 from collections.abc import Callable
+from contextlib import redirect_stdout
+from functools import wraps
 from pathlib import Path
 from typing import Any, cast
 
@@ -4369,6 +4371,22 @@ def wrap_selfheal(marker: str | None) -> None:
 # =============================================================================
 
 
+def _wrapper_diagnostics_to_stderr(command: Callable[..., Any]) -> Callable[..., Any]:
+    """Keep wrapper diagnostics off an agent's machine-readable stdout.
+
+    ``redirect_stdout`` affects Python output only. The wrapped CLI is started
+    without a stdout/stderr override, so it still inherits the caller's
+    original OS file descriptors.
+    """
+
+    @wraps(command)
+    def redirected(*args: Any, **kwargs: Any) -> Any:
+        with redirect_stdout(sys.stderr):
+            return command(*args, **kwargs)
+
+    return redirected
+
+
 @wrap.command(context_settings={"ignore_unknown_options": True})
 @_retired_context_tool_option
 @_serena_instructions_option
@@ -4452,6 +4470,7 @@ def wrap_selfheal(marker: str | None) -> None:
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
 @click.option("--prepare-only", is_flag=True, hidden=True)
 @click.argument("claude_args", nargs=-1, type=click.UNPROCESSED)
+@_wrapper_diagnostics_to_stderr
 def claude(
     port: int,
     no_mcp: bool,

--- a/tests/test_cli/test_main_help_version.py
+++ b/tests/test_cli/test_main_help_version.py
@@ -58,3 +58,35 @@ def test_subcommand_verbose_flag_still_works() -> None:
 
     assert result.exit_code == 0, result.output
     assert "HEADROOM WRAP: CLAUDE" in result.output
+
+
+def test_wrap_claude_keeps_diagnostics_off_child_stdout() -> None:
+    """Wrapper chatter must not corrupt Claude print/JSON output on stdout."""
+    runner = CliRunner()
+    completed = SimpleNamespace(returncode=0)
+
+    with patch("headroom.cli.wrap.shutil.which", return_value="claude"):
+        with patch("headroom.cli.wrap._ensure_proxy", return_value=(None, 8787)):
+            with patch("headroom.cli.wrap.subprocess.run", return_value=completed) as run_mock:
+                result = runner.invoke(
+                    main,
+                    [
+                        "wrap",
+                        "claude",
+                        "--no-mcp",
+                        "--code-memory",
+                        "none",
+                        "--",
+                        "--print",
+                        "--output-format",
+                        "json",
+                        "hello",
+                    ],
+                )
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout == ""
+    assert "HEADROOM WRAP: CLAUDE" in result.stderr
+    assert "Launching Claude Code" in result.stderr
+    assert "Extra args:" in result.stderr
+    assert run_mock.call_args.kwargs.keys() == {"env"}


### PR DESCRIPTION
## Summary

- route Python-level `headroom wrap claude` diagnostics to stderr
- leave the Claude subprocess stdout/stderr descriptors inherited and untouched
- add a regression test covering Claude `--print --output-format json`

## Problem

`headroom wrap claude` currently writes its banner, setup notices, routing state, and effective argv to stdout before launching Claude. In Claude print/JSON mode, that prefixes non-JSON text to the agent result and makes stdout impossible to parse as one document.

## Verification

- `uv run --extra dev ruff check headroom/cli/wrap.py tests/test_cli/test_main_help_version.py`
- `uv run --extra dev ruff format --check headroom/cli/wrap.py tests/test_cli/test_main_help_version.py`
- 58 focused Claude wrapper tests passed
- live on macOS with Headroom 0.31.0 and Claude Code 2.1.228: stdout parsed as a single Claude JSON document, while `HEADROOM WRAP: CLAUDE`, `Launching Claude Code`, and `Extra args` appeared only on stderr

The decorator uses Python's `redirect_stdout` only. The wrapped CLI still starts through `subprocess.run(..., env=env)` with no `stdout` or `stderr` override, so it inherits the caller's original OS descriptors.