### PR TITLE
ci: run eval smoke test on Rust compressor changes

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -9,6 +9,9 @@ on:
       - 'headroom/transforms/**'
       - 'headroom/evals/**'
       - 'headroom/compress.py'
+      - 'crates/**'          # Rust compressors are compiled into headroom._core
+      - 'Cargo.toml'         # and exercised by the eval smoke test (SmartCrusher
+      - 'Cargo.lock'         # import in the smoke-test job); Rust-only PRs currently skip it
 
 jobs:
   # Fast smoke test on PRs touching compression code (~$0.05, ~2 min)


### PR DESCRIPTION
## Description

`eval.yml`'s `pull_request` trigger watches only `headroom/transforms/**`, `headroom/evals/**`, and `headroom/compress.py`. But the eval smoke test installs the package with `pip install -e ".[all]"`, which compiles the Rust workspace into `headroom._core` and imports `SmartCrusher` from it — so the eval suite exercises Rust compressor code, yet a PR that changes only `crates/**` never runs it. This PR adds `crates/**`, `Cargo.toml`, and `Cargo.lock` to the paths filter so Rust compressor changes get the same zero-cost eval gate as their Python callers.

Related to #2949.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [x] CI/workflow change (no runtime code affected)

## Changes Made

- `.github/workflows/eval.yml`: added `crates/**`, `Cargo.toml`, `Cargo.lock` to `pull_request.paths` (+3 lines; nothing else touched).

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/eval.yml')); print('YAML is valid')"
YAML is valid

Trigger proof (fork): crates-only PR creates the "Evaluation Suite" check run
with this patch applied — https://github.com/r3bb1t/headroom/actions/runs/31614601951
```

## Real Behavior Proof

- Environment: Fork `r3bb1t/headroom` with GitHub Actions enabled; Windows 11 host for git operations; upstream base `main`.
- Exact command / steps: Pushed this branch to the fork; created a scratch branch on top adding one comment line to `crates/headroom-core/src/lib.rs`; opened a draft PR on the fork (crates-only diff) and observed which workflows were created.
- Observed result: The crates-only PR created the `Evaluation Suite` check run (run 31614601951, link in Test Output) alongside the `rust` workflow; under the pre-change filter the identical diff creates no Evaluation Suite run.
- Not tested: The `weekly-suite` job (schedule/dispatch-only; path filters do not affect it) and the live-eval steps requiring `OPENAI_API_KEY` (skipped with a warning on forks without the secret, by design).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — workflows-only change.

## Additional Notes

Unchecked checklist items are N/A for a 3-line workflows-only diff: there is no code to comment, no docs impact, and no unit-testable surface — the fork trigger-proof above is the behavioral test. Branch-protection caveat (same one `rust.yml` documents in its header): `eval.yml` uses a workflow-level `paths:` filter, so on non-matching PRs the check run is never created (rather than created-then-skipped). If `Evaluation Suite / smoke-test` is ever made a required check, the filter should move to a `dorny/paths-filter` job-level gate like `rust.yml`'s — out of scope here; happy to follow up if wanted.
