### PR TITLE
fix(proxy): restore the Codex WS PERF session prefix and re-arm the quarantine test guard

### DIFF
--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -7922,6 +7922,10 @@ class OpenAIHandlerMixin:
                                 RequestOutcome(
                                     # Per-emission ids keep dashboard request-log keys unique.
                                     request_id=await self._next_request_id(),
+                                    # ...while the PERF prefix stays the session
+                                    # id, so every line of one WS session is
+                                    # greppable together.
+                                    log_request_id=request_id,
                                     provider="openai",
                                     model=model_for_metrics,
                                     original_tokens=max(0, input_delta) + max(0, saved_delta),
@@ -8498,6 +8502,9 @@ class OpenAIHandlerMixin:
                     RequestOutcome(
                         # Per-emission ids keep dashboard request-log keys unique.
                         request_id=await self._next_request_id(),
+                        # ...while the PERF prefix stays the session id, so every
+                        # line of one WS session is greppable together.
+                        log_request_id=request_id,
                         provider="openai",
                         model=model_name,
                         original_tokens=residual_input_tokens + residual_tokens_saved,

--- a/headroom/proxy/outcome.py
+++ b/headroom/proxy/outcome.py
@@ -167,6 +167,15 @@ class RequestOutcome:
     tags: dict[str, str] = field(default_factory=dict)
     client: str | None = None
     project: str | None = None
+    # Optional override for the ``[id]`` prefix on the PERF log line only. The
+    # RequestLog row (effect 3) always keys off ``request_id``, which must be
+    # unique per emission or the dashboard's Alpine ``:key`` collides and blanks
+    # the feed (#310/#2164). A long-lived connection that emits many rows —
+    # today only the Codex ``/v1/responses`` WebSocket — therefore cannot also
+    # use ``request_id`` to keep its log lines greppable as one session. It sets
+    # this to the session id instead; every other caller leaves it ``None`` and
+    # the prefix stays ``request_id``.
+    log_request_id: str | None = None
 
     # ── Derived (computed once, no caching needed — properties are cheap) ─
 
@@ -564,8 +573,11 @@ async def emit_request_outcome(handler: Any, outcome: RequestOutcome) -> None:
     # compaction is already inside tok_saved and must not be added twice.
     tool_saved = tool_schema_saved_from_tags(outcome.tags or {})
     total_saved = headline_tokens_saved(outcome.tokens_saved, outcome.tags or {})
+    # The prefix identifies the connection an operator greps for, which is not
+    # always the per-row id — see ``RequestOutcome.log_request_id``.
+    log_prefix = outcome.log_request_id or outcome.request_id
     logger.info(
-        f"[{outcome.request_id}] PERF "
+        f"[{log_prefix}] PERF "
         f"model={outcome.model} msgs={outcome.num_messages} "
         f"tok_before={outcome.original_tokens} tok_after={outcome.optimized_tokens} "
         f"tok_saved={outcome.tokens_saved} "

--- a/tests/test_tokenizer_count_offload.py
+++ b/tests/test_tokenizer_count_offload.py
@@ -176,8 +176,11 @@ async def test_count_tokens_offloaded_fails_open_on_executor_quarantine() -> Non
 
     proxy = _make_proxy()
     # Record a concurrent compression as timed out so the real executor guard
-    # quarantines the next call — no mock of the helper itself.
+    # quarantines the next call — no mock of the helper itself. #2412 time-caps
+    # the quarantine, so the debt counter alone is no longer enough: an unarmed
+    # deadline reads as "already lapsed" and the guard lets the call through.
     proxy._compression_timed_out_in_flight = 1
+    proxy._compression_quarantine_deadline = time.monotonic() + 60.0
 
     tokenizer, tokens = await proxy._count_tokens_offloaded(
         "qwen2.5-coder", [{"role": "user", "content": "hello world"}]
@@ -192,8 +195,10 @@ async def test_count_tokens_offloaded_returns_count_text_capable_tokenizer() -> 
     """The fail-open tokenizer should still support text counting for callers
     that need per-fragment accounting."""
     proxy = _make_proxy()
-    # Quarantine forces the fail-open branch (an EstimatingTokenCounter).
+    # Quarantine forces the fail-open branch (an EstimatingTokenCounter). The
+    # deadline must be armed too — see the quarantine test above.
     proxy._compression_timed_out_in_flight = 1
+    proxy._compression_quarantine_deadline = time.monotonic() + 60.0
 
     # The empty-messages count is intentionally discarded by that handler
     # (it sums text parts itself), so only the tokenizer matters here.


### PR DESCRIPTION
## Description

`main` is currently red. Two test files fail on every PR opened against it, so
unrelated PRs (#2941, #2945, and anything rebased onto current `main`) show
failing `test (3)` and `test (4)` shards that have nothing to do with their own
diffs. This PR fixes both root causes.

### 1. `test_ws_session_log_prefix_uses_session_id` (shard `test (3)`)

```
assert '[req-ws-1] PERF' in '...event=proxy_inbound_websocket request_id=req-ws-1 ...'
```

#2164 gave each Codex `/v1/responses` WebSocket emission a unique `request_id`
so the dashboard's Alpine `:key` stops colliding and blanking the Recent
Requests feed (#310). That part is correct and is preserved here.

Its PR body also states that "the `[{request_id}]` PERF/log prefixes keep the
session id for operator correlation" — but that half was never implemented.
`emit_request_outcome` (`headroom/proxy/outcome.py`) builds the PERF bracket
prefix from the same `RequestOutcome.request_id` field that becomes the
`RequestLog` row id. A single field cannot be both unique-per-emission and
stable-per-session, so the two assertions in the test added by that same commit
are mutually unsatisfiable:

- `handler.logger.entries[0].request_id != "req-ws-1"` — row id must be unique
- `"[req-ws-1] PERF" in caplog.text` — PERF prefix must be the session id

In practice the WS session consumes the first id, the per-turn outcome mints the
second, and the PERF line prints `[req-ws-2]`.

Fix: add an optional `RequestOutcome.log_request_id` that overrides the PERF
bracket prefix **only**. The `RequestLog` row (effect 3 of the funnel) still
keys off `request_id`, so #2164's uniqueness invariant is untouched. Both WS
emit sites pass the session id. The `None` default leaves every other caller in
the codebase behaviourally identical.

### 2. `tests/test_tokenizer_count_offload.py`, 2 tests (shard `test (4)`)

```
assert isinstance(tokenizer, EstimatingTokenCounter)
E  where False = isinstance(HuggingFaceTokenizer(model='qwen2.5-coder', tokenizer='Qwen/Qwen2.5-7B'), EstimatingTokenCounter)
```

#2412 time-capped the compression timeout-debt quarantine, so the guard in
`headroom/proxy/server.py` is now:

```python
quarantined = timed_out_in_flight > 0 and now < self._compression_quarantine_deadline
```

Both tests force the quarantine by setting only
`proxy._compression_timed_out_in_flight = 1`. They never arm
`_compression_quarantine_deadline`, which stays at its `0.0` initial value —
read as "already lapsed". No `CompressionQuarantinedError` is raised, the real
HuggingFace tokenizer resolves, and the fail-open branch under test is never
entered.

The production guard is correct; the time cap is the whole point of #2360. The
tests are stale, and now arm the deadline alongside the debt counter.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/outcome.py`: add `RequestOutcome.log_request_id: str | None =
  None`. In `emit_request_outcome`, the PERF line's `[id]` prefix becomes
  `outcome.log_request_id or outcome.request_id`. Effects 1-3 (Prometheus, cost
  tracker, `RequestLog`) are untouched and still use `request_id`.
- `headroom/proxy/handlers/openai.py`: in `handle_openai_responses_ws`, both
  `RequestOutcome` construction sites (the per-turn outcome and the
  session-residual outcome) keep `request_id=await self._next_request_id()` and
  add `log_request_id=request_id` — the session id already in scope.
- `tests/test_tokenizer_count_offload.py`: in
  `test_count_tokens_offloaded_fails_open_on_executor_quarantine` and
  `test_count_tokens_offloaded_returns_count_text_capable_tokenizer`, set
  `_compression_quarantine_deadline = time.monotonic() + 60.0` alongside
  `_compression_timed_out_in_flight = 1` so the #2412 guard actually engages.

No production behaviour changes outside the Codex WS PERF log prefix. Dashboard
row ids, token and savings values, metrics, and cost bookkeeping are unchanged.

## Testing

- [x] Unit tests pass
- [x] Linting passes
- [x] Type checking passes on the changed modules
- [x] Existing tests cover the fix (both were failing before, both pass now)

### Test Output

```text
$ python -m pytest tests/test_openai_codex_ws_lifecycle.py tests/test_tokenizer_count_offload.py \
    tests/test_savings_ledger_before_forwarded.py tests/test_observability_metrics.py \
    tests/test_request_outcome.py tests/test_outcome_dual_ruler_funnel.py \
    tests/test_outcome_records_5xx_as_failed.py tests/test_outcome_token_scale.py \
    tests/test_handler_outcome_tag_invariant.py -q
tests\test_openai_codex_ws_lifecycle.py ................................ [ 30%]
tests\test_tokenizer_count_offload.py ..........                         [ 39%]
tests\test_savings_ledger_before_forwarded.py ....                       [ 43%]
tests\test_observability_metrics.py ..........                           [ 52%]
tests\test_request_outcome.py .......................................    [ 86%]
tests\test_outcome_dual_ruler_funnel.py .....                            [ 91%]
tests\test_outcome_records_5xx_as_failed.py ..                           [ 92%]
tests\test_outcome_token_scale.py .....                                  [ 97%]
tests\test_handler_outcome_tag_invariant.py ...                          [100%]

============================ 113 passed in 16.57s =============================

$ python -m ruff check .
All checks passed!

$ python -m ruff format --check headroom/proxy/outcome.py headroom/proxy/handlers/openai.py tests/test_tokenizer_count_offload.py
3 files already formatted

$ python -m mypy headroom/proxy/outcome.py headroom/proxy/handlers/openai.py --ignore-missing-imports --python-version 3.13
(no errors reported in either changed module; the 8 errors emitted are all in
transitively-imported headroom/ccr/mcp_server.py and headroom/release_version.py
and are present on unmodified main)
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.13.11, pytest 9.1.1, ruff 0.15.x, mypy 1.20.x, no live provider. The Codex WS handler is exercised through the in-process `_FakeWebSocket` / `_FakeUpstream` harness that mirrors the production wire shape; the tokenizer tests drive the real `create_app` proxy and the real executor guard with no mock of the helper under test.
- Exact command / steps: on unmodified `upstream/main` (`941c25d3`) ran `python -m pytest tests/test_openai_codex_ws_lifecycle.py::test_ws_session_log_prefix_uses_session_id -q` and `python -m pytest tests/test_tokenizer_count_offload.py -q` to reproduce; applied this branch and re-ran both plus the 9-file outcome-funnel regression set above.
- Observed result: before the change, the WS test failed with the PERF line logged as `INFO headroom.proxy:outcome.py:567 [req-ws-2] PERF model=unknown msgs=0 tok_before=100 ...` against an expected `[req-ws-1]`, and the two quarantine tests failed with `isinstance(HuggingFaceTokenizer(model='qwen2.5-coder', tokenizer='Qwen/Qwen2.5-7B'), EstimatingTokenCounter) == False`. After the change the PERF line carries the session id, the row id stays unique, the quarantine engages and returns the fail-open estimator, and all 113 tests in the regression set pass.
- Not tested: live dashboard browser render of the Recent Requests feed, and a real Codex WebSocket session against api.openai.com.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

- `CHANGELOG.md` is deliberately untouched — release-please generates it from
  the Conventional Commit title, and the `no-manual-changelog` check rejects any
  PR that edits it.
- No new tests were added: both failures are existing tests that encode the
  correct intent and were simply not satisfied by the code. #2164's
  `test_ws_session_log_prefix_uses_session_id` passes unmodified once
  `log_request_id` exists, which is the cleanest evidence that this restores
  what that PR described rather than redefining it.
- Alternative considered and rejected: relaxing
  `test_ws_session_log_prefix_uses_session_id` to accept any PERF prefix. That
  is a smaller diff but silently drops the per-session log-correlation property
  #2164 set out to preserve.
