### PR TITLE
fix(copilot): restore VS Code 0.60 proxy settings

### DIFF
--- a/e2e/wrap/run.py
+++ b/e2e/wrap/run.py
@@ -786,12 +786,12 @@ def verify_vscode_wrap(base_env: dict[str, str], project_dir: Path) -> None:
         project_prefix = f"/p/{quote(project_dir.name, safe='')}"
         configured = settings_path.read_text(encoding="utf-8")
         assert_true(
-            f'"github.copilot.advanced.debug.overrideProxyUrl": '
-            f'"http://127.0.0.1:{port}{project_prefix}"' in configured,
+            f'"github.copilot.advanced": {{' in configured
+            and f'"overrideProxyUrl": "http://127.0.0.1:{port}{project_prefix}"' in configured,
             "VS Code wrap should configure the project-scoped proxy URL",
         )
         assert_true(
-            '"github.copilot.advanced.debug.overrideAuthType": "token"' in configured,
+            '"overrideAuthType": "token"' in configured,
             "VS Code wrap should configure token auth",
         )
         assert_true(

--- a/e2e/wrap/run.py
+++ b/e2e/wrap/run.py
@@ -786,7 +786,7 @@ def verify_vscode_wrap(base_env: dict[str, str], project_dir: Path) -> None:
         project_prefix = f"/p/{quote(project_dir.name, safe='')}"
         configured = settings_path.read_text(encoding="utf-8")
         assert_true(
-            f'"github.copilot.advanced": {{' in configured
+            '"github.copilot.advanced": {' in configured
             and f'"overrideProxyUrl": "http://127.0.0.1:{port}{project_prefix}"' in configured,
             "VS Code wrap should configure the project-scoped proxy URL",
         )

--- a/headroom/providers/copilot/vscode.py
+++ b/headroom/providers/copilot/vscode.py
@@ -18,6 +18,7 @@ _MARKER_START = "// --- Headroom Copilot proxy ---"
 _MARKER_END = "// --- end Headroom Copilot proxy ---"
 _PROXY_KEY = "github.copilot.advanced.debug.overrideProxyUrl"
 _AUTH_KEY = "github.copilot.advanced.debug.overrideAuthType"
+_ADVANCED_KEY = "github.copilot.advanced"
 
 
 def _read_settings(path: Path) -> str:
@@ -117,8 +118,17 @@ def _managed_block(proxy_url: str, *, owns_preceding_comma: bool, line_sep: str)
     marker = _MARKER_START + (" (comma-added)" if owns_preceding_comma else "")
     return (
         f"\t{marker}{line_sep}"
-        f"\t{json.dumps(_PROXY_KEY)}: {json.dumps(proxy_url)},{line_sep}"
-        f'\t{json.dumps(_AUTH_KEY)}: "token"{line_sep}'
+        # VS Code 1.1x / Copilot 0.60 reads object-valued configuration from
+        # the nested namespace. Older releases accepted the flattened dotted
+        # keys, but the extension no longer reliably maps those keys back to
+        # `advanced.debug`. Emit the canonical object shape so both settings
+        # are applied as one configuration value.
+        f"\t{json.dumps(_ADVANCED_KEY)}: {{{line_sep}"
+        f'\t\t"debug": {{{line_sep}'
+        f'\t\t\t"overrideProxyUrl": {json.dumps(proxy_url)},{line_sep}'
+        f'\t\t\t"overrideAuthType": "token"{line_sep}'
+        f"\t\t}}{line_sep}"
+        f"\t}}{line_sep}"
         f"\t{_MARKER_END}"
     )
 
@@ -161,9 +171,9 @@ def configure_vscode_proxy_settings(path: Path, proxy_url: str) -> str:
     if had_managed_block:
         remove_vscode_proxy_settings(path)
         raw = _read_settings(path)
-    elif _PROXY_KEY in raw or _AUTH_KEY in raw:
+    elif _PROXY_KEY in raw or _AUTH_KEY in raw or f'"{_ADVANCED_KEY}"' in raw:
         raise click.ClickException(
-            f"{path} already configures a Copilot endpoint override outside Headroom's "
+            f"{path} already configures Copilot advanced settings outside Headroom's "
             "managed block; refusing to replace it. Remove it or use --no-configure."
         )
 

--- a/tests/test_provider_copilot_vscode_config.py
+++ b/tests/test_provider_copilot_vscode_config.py
@@ -49,8 +49,9 @@ def test_configure_update_and_remove_preserve_jsonc_verbatim(tmp_path: Path) -> 
     configured = path.read_text(encoding="utf-8")
     assert "editor.fontSize" in configured
     assert "user comment" in configured
-    assert '"github.copilot.advanced.debug.overrideProxyUrl"' in configured
-    assert '"github.copilot.advanced.debug.overrideAuthType": "token"' in configured
+    assert '"github.copilot.advanced": {' in configured
+    assert '"overrideProxyUrl": "http://127.0.0.1:8787"' in configured
+    assert '"overrideAuthType": "token"' in configured
 
     assert configure_vscode_proxy_settings(path, "http://127.0.0.1:9999") == "updated"
     assert "9999" in path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Description
Restore transparent Copilot routing for VS Code Copilot extension 0.60.0, which no longer reliably recognizes the flattened dotted override keys emitted by Headroom.

## Type of Change
- [x] Bug fix

## Changes Made
- Emit the canonical nested `github.copilot.advanced.debug` settings object.
- Preserve the proxy URL and token auth override.
- Keep marker-based safe removal and refuse to overwrite unmanaged advanced settings.

## Testing

- [x] Focused unit tests pass
- [x] Ruff, formatting, and diff checks pass
- [ ] Docker wrap E2E passes

### Test Output

```text
64 focused Copilot VS Code/wrap tests passed
Ruff, format, and diff checks passed
Docker wrap E2E: fails at the stale flattened-key assertion in verify_vscode_wrap
```
- 64 focused Copilot VS Code/wrap tests passed.
- Ruff, format, and diff checks passed.

## Real Behavior Proof

- Environment: current PR head, VS Code Copilot 0.60 settings writer and focused wrapper/config tests.
- Exact command / steps: generated a managed VS Code settings block, updated it, removed it, and ran 64 focused Copilot VS Code/wrap tests plus Ruff and formatting checks.
- Observed result: the unit-level writer emits the nested github.copilot.advanced.debug object and unwrap restores the original JSONC; Docker E2E still expects the former flattened key and currently fails.
- Not tested: a live VS Code Copilot 0.60 session successfully routing through the generated configuration.
The generated settings now match the object-valued configuration shape consumed by current Copilot Chat configuration code, while unwrap restores the original JSONC content.

## Review Readiness
- [x] I have performed a self-review
- [x] This PR is ready for human review