### PR TITLE
fix(proxy): complete buffered CCR response lifecycle

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -4136,122 +4136,60 @@ class AnthropicHandlerMixin:
 
                     class _BufferedCCRResponse(Response):
                         async def __call__(self, scope, receive, send):  # noqa: ANN001
-                            await asyncio.sleep(0)
-                            loop = asyncio.get_running_loop()
-                            keepalive_deadline = loop.time() + 1.0
-                            started = False
+                            # Send nothing until the buffered operation resolves.
+                            # The previous keepalive preamble committed
+                            # `200 text/event-stream` after 1s, i.e. before the
+                            # outcome was known: any upstream reply that then
+                            # failed to become SSE (non-200, unparseable body)
+                            # reached the client as a 200 whose body carried no
+                            # `message_start`, which Claude Code reports as "API
+                            # returned an empty or malformed response (HTTP 200) —
+                            # check for a proxy or gateway intercepting the
+                            # request". The real status was lost with it, so
+                            # client-side 429/5xx backoff never fired. Clients
+                            # budget minutes for a turn (Claude Code sends
+                            # `x-stainless-timeout: 600`), so waiting is free.
                             try:
-                                while True:
-                                    timeout = (
-                                        0.25
-                                        if started
-                                        else max(0.0, keepalive_deadline - loop.time())
+                                try:
+                                    result = await operation
+                                except Exception as e:
+                                    await record_failed(provider=provider_name)
+                                    logger.error(
+                                        f"[{request_id}] Request failed: {type(e).__name__}: {e}"
                                     )
-                                    done, _ = await asyncio.wait({operation}, timeout=timeout)
-                                    if done:
-                                        try:
-                                            result = operation.result()
-                                        except Exception as e:
-                                            await record_failed(provider=provider_name)
-                                            logger.error(
-                                                f"[{request_id}] Request failed: {type(e).__name__}: {e}"
-                                            )
-                                            if not started:
-                                                await send(
-                                                    {
-                                                        "type": "http.response.start",
-                                                        "status": 502,
-                                                        "headers": [
-                                                            (b"content-type", b"application/json")
-                                                        ],
-                                                    }
-                                                )
-                                                await send(
-                                                    {
-                                                        "type": "http.response.body",
-                                                        "body": json.dumps(
-                                                            {
-                                                                "type": "error",
-                                                                "error": {
-                                                                    "type": "api_error",
-                                                                    "message": "An error occurred while processing your request. Please try again.",
-                                                                },
-                                                            }
-                                                        ).encode(),
-                                                        "more_body": False,
-                                                    }
-                                                )
-                                                return
-                                            await send(
-                                                {
-                                                    "type": "http.response.body",
-                                                    "body": b'event: error\ndata: {"type":"error","error":{"type":"api_error","message":"An error occurred while processing the request."}}\n\n',
-                                                    "more_body": False,
-                                                }
-                                            )
-                                            return
-
-                                        if not started:
-                                            await result(scope, receive, send)
-                                            return
-
-                                        body_iterator = getattr(result, "body_iterator", None)
-                                        if body_iterator is not None:
-                                            async for chunk in body_iterator:
-                                                await send(
-                                                    {
-                                                        "type": "http.response.body",
-                                                        "body": chunk,
-                                                        "more_body": True,
-                                                    }
-                                                )
-                                            await send(
-                                                {
-                                                    "type": "http.response.body",
-                                                    "body": b"",
-                                                    "more_body": False,
-                                                }
-                                            )
-                                            return
-
-                                        await send(
-                                            {
-                                                "type": "http.response.body",
-                                                "body": b'event: error\ndata: {"type":"error","error":{"type":"api_error","message":"An error occurred while processing the request."}}\n\n',
-                                                "more_body": False,
-                                            }
-                                        )
-                                        return
-
-                                    if not started:
-                                        await send(
-                                            {
-                                                "type": "http.response.start",
-                                                "status": 200,
-                                                "headers": [
-                                                    (b"content-type", b"text/event-stream")
-                                                ],
-                                            }
-                                        )
-                                        started = True
+                                    await send(
+                                        {
+                                            "type": "http.response.start",
+                                            "status": 502,
+                                            "headers": [(b"content-type", b"application/json")],
+                                        }
+                                    )
                                     await send(
                                         {
                                             "type": "http.response.body",
-                                            "body": b'event: ping\ndata: {"type":"ping"}\n\n',
-                                            "more_body": True,
+                                            "body": json.dumps(
+                                                {
+                                                    "type": "error",
+                                                    "error": {
+                                                        "type": "api_error",
+                                                        "message": "An error occurred while processing your request. Please try again.",
+                                                    },
+                                                }
+                                            ).encode(),
+                                            "more_body": False,
                                         }
                                     )
-                            except asyncio.CancelledError:
-                                raise
+                                    return
+                                await result(scope, receive, send)
                             finally:
                                 if not operation.done():
                                     operation.cancel()
-                                try:
-                                    await operation
-                                except asyncio.CancelledError:
-                                    pass
-                                except Exception:
-                                    pass
+                                    try:
+                                        await operation
+                                    except asyncio.CancelledError:
+                                        pass
+                                    except Exception:
+                                        pass
 
                     return _BufferedCCRResponse(media_type="text/event-stream")
                 return await _buffered_ccr_operation()

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -4038,6 +4038,25 @@ class AnthropicHandlerMixin:
                                 headers=relay_headers,
                             )
 
+                        if buffered_stream_ccr and response.status_code == 200 and not resp_json:
+                            logger.warning(
+                                f"[{request_id}] CCR: rejecting malformed buffered 200 reply "
+                                f"(content-type={response.headers.get('content-type')!r}, "
+                                f"body_bytes={len(response.content)})"
+                            )
+                            return Response(
+                                content=json.dumps(
+                                    {
+                                        "error": {
+                                            "type": "upstream_protocol_error",
+                                            "message": "Upstream returned an invalid buffered response.",
+                                        }
+                                    }
+                                ),
+                                status_code=502,
+                                media_type="application/json",
+                            )
+
                         if buffered_stream_ccr and response.status_code == 200 and resp_json:
                             sse_headers = {
                                 k: v

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -6124,118 +6124,54 @@ class OpenAIHandlerMixin:
 
                 class _BufferedCCRResponse(Response):
                     async def __call__(self, scope, receive, send):  # noqa: ANN001
-                        await asyncio.sleep(0)
-                        loop = asyncio.get_running_loop()
-                        keepalive_deadline = loop.time() + 1.0
-                        started = False
+                        # Send nothing until the buffered operation resolves —
+                        # see the AnthropicHandler twin for the full rationale.
+                        # Committing `200 text/event-stream` on a keepalive timer,
+                        # before the outcome is known, turns every non-200 or
+                        # unparseable upstream reply into a 200 with no usable
+                        # body and discards the status the client needs to back
+                        # off on.
                         try:
-                            while True:
-                                timeout = (
-                                    0.25 if started else max(0.0, keepalive_deadline - loop.time())
+                            try:
+                                result = await operation
+                            except Exception as e:
+                                await record_failed(provider="openai")
+                                logger.error(
+                                    f"[{request_id}] OpenAI responses request failed: {type(e).__name__}: {e}"
                                 )
-                                done, _ = await asyncio.wait({operation}, timeout=timeout)
-                                if done:
-                                    try:
-                                        result = operation.result()
-                                    except Exception as e:
-                                        await record_failed(provider="openai")
-                                        logger.error(
-                                            f"[{request_id}] OpenAI responses request failed: {type(e).__name__}: {e}"
-                                        )
-                                        if not started:
-                                            await send(
-                                                {
-                                                    "type": "http.response.start",
-                                                    "status": 502,
-                                                    "headers": [
-                                                        (b"content-type", b"application/json")
-                                                    ],
-                                                }
-                                            )
-                                            await send(
-                                                {
-                                                    "type": "http.response.body",
-                                                    "body": json.dumps(
-                                                        {
-                                                            "error": {
-                                                                "message": "An error occurred while processing your request. Please try again.",
-                                                                "type": "server_error",
-                                                                "code": "proxy_error",
-                                                            }
-                                                        }
-                                                    ).encode(),
-                                                    "more_body": False,
-                                                }
-                                            )
-                                            return
-                                        await send(
-                                            {
-                                                "type": "http.response.body",
-                                                "body": b'event: error\ndata: {"type":"error","error":{"message":"An error occurred while processing the request."}}\n\n',
-                                                "more_body": False,
-                                            }
-                                        )
-                                        return
-
-                                    if not started:
-                                        await result(scope, receive, send)
-                                        return
-
-                                    body_iterator = getattr(result, "body_iterator", None)
-                                    if body_iterator is not None:
-                                        async for chunk in body_iterator:
-                                            await send(
-                                                {
-                                                    "type": "http.response.body",
-                                                    "body": chunk,
-                                                    "more_body": True,
-                                                }
-                                            )
-                                        await send(
-                                            {
-                                                "type": "http.response.body",
-                                                "body": b"",
-                                                "more_body": False,
-                                            }
-                                        )
-                                        return
-
-                                    await send(
-                                        {
-                                            "type": "http.response.body",
-                                            "body": b'event: error\ndata: {"type":"error","error":{"message":"An error occurred while processing the request."}}\n\n',
-                                            "more_body": False,
-                                        }
-                                    )
-                                    return
-
-                                if not started:
-                                    await send(
-                                        {
-                                            "type": "http.response.start",
-                                            "status": 200,
-                                            "headers": [(b"content-type", b"text/event-stream")],
-                                        }
-                                    )
-                                    started = True
+                                await send(
+                                    {
+                                        "type": "http.response.start",
+                                        "status": 502,
+                                        "headers": [(b"content-type", b"application/json")],
+                                    }
+                                )
                                 await send(
                                     {
                                         "type": "http.response.body",
-                                        "body": b'event: ping\ndata: {"type":"ping"}\n\n',
-                                        "more_body": True,
+                                        "body": json.dumps(
+                                            {
+                                                "error": {
+                                                    "message": "An error occurred while processing your request. Please try again.",
+                                                    "type": "server_error",
+                                                    "code": "proxy_error",
+                                                }
+                                            }
+                                        ).encode(),
+                                        "more_body": False,
                                     }
                                 )
-                        except asyncio.CancelledError:
-                            raise
+                                return
+                            await result(scope, receive, send)
                         finally:
                             if not operation.done():
                                 operation.cancel()
-                            try:
-                                await operation
-                            except asyncio.CancelledError:
-                                pass
-                            except Exception:
-                                pass
+                                try:
+                                    await operation
+                                except asyncio.CancelledError:
+                                    pass
+                                except Exception:
+                                    pass
 
                 return _BufferedCCRResponse(media_type="text/event-stream")
             return await _buffered_ccr_operation()

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -5761,6 +5761,7 @@ class OpenAIHandlerMixin:
                     total_input_tokens = original_tokens  # fallback
                     output_tokens = 0
                     cache_read_tokens = 0
+                    resp_json = None
                     try:
                         resp_json = response.json()
                         usage = resp_json.get("usage", {})
@@ -5779,7 +5780,13 @@ class OpenAIHandlerMixin:
                         details = usage.get("input_tokens_details")
                         if isinstance(details, dict):
                             cache_read_tokens = _usage_int(details.get("cached_tokens"))
-                    except (KeyError, TypeError, AttributeError) as e:
+                    except (
+                        json.JSONDecodeError,
+                        ValueError,
+                        KeyError,
+                        TypeError,
+                        AttributeError,
+                    ) as e:
                         logger.debug(
                             f"[{request_id}] Failed to extract cached tokens from OpenAI passthrough response: {e}"
                         )
@@ -6095,6 +6102,25 @@ class OpenAIHandlerMixin:
                             _buffered_ccr_sse(),
                             media_type="text/event-stream",
                             headers=sse_headers,
+                        )
+
+                    if buffered_stream_ccr and response.status_code == 200 and not resp_json:
+                        logger.warning(
+                            f"[{request_id}] CCR: rejecting malformed buffered Responses 200 "
+                            f"reply (content-type={response.headers.get('content-type')!r}, "
+                            f"body_bytes={len(response.content)})"
+                        )
+                        return Response(
+                            content=json.dumps(
+                                {
+                                    "error": {
+                                        "type": "upstream_protocol_error",
+                                        "message": "Upstream returned an invalid buffered response.",
+                                    }
+                                }
+                            ),
+                            status_code=502,
+                            media_type="application/json",
                         )
 
                     # Inline marker resolution, non-streaming only. Runs

--- a/tests/test_proxy/test_anthropic_streaming_ccr_retrieve.py
+++ b/tests/test_proxy/test_anthropic_streaming_ccr_retrieve.py
@@ -52,10 +52,6 @@ def _message_response(content: list[dict], *, stop_reason: str = "end_turn") -> 
     }
 
 
-def _is_client_visible_sse(body: bytes) -> bool:
-    return b"event:" in body or b"data:" in body
-
-
 class _ContinuationClient:
     def __init__(self, response_json: dict) -> None:
         self.response_json = response_json
@@ -355,7 +351,14 @@ def test_unresolved_ccr_only_streams_through_as_200() -> None:
 
 
 @pytest.mark.asyncio
-async def test_buffered_ccr_emits_keepalive_before_delayed_upstream() -> None:
+async def test_buffered_ccr_withholds_output_until_delayed_upstream_resolves() -> None:
+    """Nothing is sent — no status, no body — until the buffered result exists.
+
+    The response used to commit ``200 text/event-stream`` on a 1s keepalive
+    timer, which made every later failure unreportable: the client saw a 200
+    with no ``message_start`` and the real status was gone. See
+    ``test_buffered_ccr_preserves_late_failure_status_and_headers``.
+    """
     config = _make_config()
     final_response = _message_response([{"type": "text", "text": "done"}])
     started = asyncio.Event()
@@ -367,8 +370,17 @@ async def test_buffered_ccr_emits_keepalive_before_delayed_upstream() -> None:
         "tools": [create_ccr_tool_definition("anthropic")],
         "messages": [{"role": "user", "content": "wait"}],
     }
+    request_delivered = False
 
     async def receive():
+        # Mirror a real ASGI server: the body arrives once, then the channel
+        # stays open because the client is still connected. Returning instantly
+        # on every call spins `StreamingResponse.listen_for_disconnect`, which
+        # never yields, so the response body would never be scheduled.
+        nonlocal request_delivered
+        if request_delivered:
+            await asyncio.Event().wait()
+        request_delivered = True
         return {"type": "http.request", "body": json.dumps(body).encode(), "more_body": False}
 
     scope = {
@@ -400,24 +412,23 @@ async def test_buffered_ccr_emits_keepalive_before_delayed_upstream() -> None:
             await started.wait()
             response = await asyncio.wait_for(asyncio.shield(task), 1)
             events: list[dict] = []
-            first_visible_body = asyncio.Event()
 
             async def send(message):  # noqa: ANN001
                 events.append(message)
-                if message["type"] == "http.response.body" and _is_client_visible_sse(
-                    message["body"]
-                ):
-                    first_visible_body.set()
 
             response_task = asyncio.create_task(response(scope, receive, send))
-            await asyncio.wait_for(first_visible_body.wait(), 2)
-            assert not release.is_set()
+            # Longer than the deleted 1.0s keepalive deadline: an unresolved
+            # upstream must still have produced no ASGI message at all.
+            await asyncio.sleep(1.1)
+            assert events == []
             release.set()
             await response_task
 
-    bodies = [event["body"] for event in events if event["type"] == "http.response.body"]
-    assert bodies[0] == b'event: ping\ndata: {"type":"ping"}\n\n'
-    assert b"done" in b"".join(bodies)
+    start = next(event for event in events if event["type"] == "http.response.start")
+    assert start["status"] == 200
+    bodies = b"".join(event["body"] for event in events if event["type"] == "http.response.body")
+    assert b"event: ping" not in bodies
+    assert b"done" in bodies
 
 
 @pytest.mark.asyncio
@@ -480,7 +491,84 @@ async def test_buffered_ccr_preserves_early_failure_status_and_headers() -> None
 
 
 @pytest.mark.asyncio
-async def test_buffered_ccr_late_failure_emits_sanitized_error_event() -> None:
+async def test_buffered_ccr_preserves_late_failure_status_and_headers() -> None:
+    """The reported failure: a non-200 landing after the old keepalive deadline.
+
+    Headroom had already committed ``200 text/event-stream`` by then, so the 429
+    reached Claude Code as a 200 whose body carried no ``message_start`` — shown
+    as "API returned an empty or malformed response (HTTP 200) — check for a
+    proxy or gateway intercepting the request" — and ``retry-after`` was dropped,
+    so the client never backed off.
+    """
+    config = _make_config()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    body = {
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 64,
+        "stream": True,
+        "tools": [create_ccr_tool_definition("anthropic")],
+        "messages": [{"role": "user", "content": "fail late"}],
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": json.dumps(body).encode(), "more_body": False}
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/v1/messages",
+        "raw_path": b"/v1/messages",
+        "query_string": b"",
+        "headers": [(b"x-api-key", b"test-key"), (b"anthropic-version", b"2023-06-01")],
+        "server": ("testserver", 80),
+        "client": ("testclient", 123),
+        "root_path": "",
+    }
+
+    with patch("headroom.proxy.server.AnyLLMBackend"):
+        app = create_app(config)
+        with TestClient(app):
+            proxy = app.state.proxy
+
+            async def delayed_failure(*args, **kwargs):  # noqa: ANN002, ANN003
+                started.set()
+                await release.wait()
+                return httpx.Response(
+                    429,
+                    headers={"retry-after": "7"},
+                    json={"error": {"message": "slow down"}},
+                )
+
+            proxy._retry_request = delayed_failure
+            task = asyncio.create_task(proxy.handle_anthropic_messages(Request(scope, receive)))
+            await started.wait()
+            response = await asyncio.wait_for(asyncio.shield(task), 1)
+            events: list[dict] = []
+
+            async def send(message):  # noqa: ANN001
+                events.append(message)
+
+            response_task = asyncio.create_task(response(scope, receive, send))
+            # Past the deleted 1.0s keepalive deadline before the upstream fails.
+            await asyncio.sleep(1.1)
+            assert events == []
+            release.set()
+            await response_task
+
+    start = next(event for event in events if event["type"] == "http.response.start")
+    assert start["status"] == 429
+    assert dict(start["headers"])[b"retry-after"] == b"7"
+    assert b"slow down" in b"".join(
+        event["body"] for event in events if event["type"] == "http.response.body"
+    )
+
+
+@pytest.mark.asyncio
+async def test_buffered_ccr_late_failure_returns_sanitized_json_error() -> None:
+    """A slow crash gets the same 502 the fast one does, not a downgraded 200."""
     config = _make_config()
     started = asyncio.Event()
     release = asyncio.Event()
@@ -533,24 +621,23 @@ async def test_buffered_ccr_late_failure_emits_sanitized_error_event() -> None:
                 await started.wait()
                 response = await asyncio.wait_for(asyncio.shield(task), 1)
                 events: list[dict] = []
-                first_body = asyncio.Event()
 
                 async def send(message):  # noqa: ANN001
                     events.append(message)
-                    if message["type"] == "http.response.body" and message["body"]:
-                        first_body.set()
 
                 response_task = asyncio.create_task(response(scope, receive, send))
-                await asyncio.wait_for(first_body.wait(), 2)
+                await asyncio.sleep(0)
+                assert events == []
                 release.set()
                 await response_task
                 record_failed.assert_awaited_once_with(provider="anthropic")
             proxy_logger.removeHandler(log_handler)
 
-    bodies = [event["body"] for event in events if event["type"] == "http.response.body"]
-    assert bodies[0] == b'event: ping\ndata: {"type":"ping"}\n\n'
-    assert b"An error occurred while processing the request." in bodies[-1]
-    assert b"boom" not in bodies[-1]
+    start = next(event for event in events if event["type"] == "http.response.start")
+    assert start["status"] == 502
+    bodies = b"".join(event["body"] for event in events if event["type"] == "http.response.body")
+    assert b"An error occurred while processing your request." in bodies
+    assert b"boom" not in bodies
     assert events[-1]["more_body"] is False
     assert any(
         record.levelno == logging.ERROR and "RuntimeError: boom" in record.getMessage()

--- a/tests/test_proxy/test_anthropic_streaming_ccr_retrieve.py
+++ b/tests/test_proxy/test_anthropic_streaming_ccr_retrieve.py
@@ -566,6 +566,37 @@ async def test_buffered_ccr_preserves_late_failure_status_and_headers() -> None:
     )
 
 
+def test_buffered_ccr_rejects_malformed_success_as_502() -> None:
+    """A non-SSE, non-JSON 200 is an upstream protocol error, not success."""
+    config = _make_config()
+    with patch("headroom.proxy.server.AnyLLMBackend"):
+        app = create_app(config)
+        with TestClient(app) as client:
+            proxy = app.state.proxy
+            proxy._retry_request = AsyncMock(
+                return_value=httpx.Response(
+                    200,
+                    content=b"<html>gateway timeout</html>",
+                    headers={"content-type": "text/html"},
+                )
+            )
+            response = client.post(
+                "/v1/messages",
+                headers={"x-api-key": "test-key", "anthropic-version": "2023-06-01"},
+                json={
+                    "model": "claude-sonnet-4-6",
+                    "max_tokens": 64,
+                    "stream": True,
+                    "tools": [create_ccr_tool_definition("anthropic")],
+                    "messages": [{"role": "user", "content": "fail safely"}],
+                },
+            )
+
+    assert response.status_code == 502
+    assert response.json()["error"]["type"] == "upstream_protocol_error"
+    assert b"gateway timeout" not in response.content
+
+
 @pytest.mark.asyncio
 async def test_buffered_ccr_late_failure_returns_sanitized_json_error() -> None:
     """A slow crash gets the same 502 the fast one does, not a downgraded 200."""

--- a/tests/test_proxy/test_openai_responses_ccr.py
+++ b/tests/test_proxy/test_openai_responses_ccr.py
@@ -393,6 +393,35 @@ async def test_buffered_responses_ccr_preserves_early_failure_status_and_headers
     )
 
 
+def test_buffered_responses_ccr_rejects_malformed_success_as_502():
+    """A malformed upstream 200 must not become a successful streamed turn."""
+    app = _make_app()
+    with TestClient(app) as client:
+        server = app.state.proxy
+        server._retry_request = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                content=b"<html>gateway timeout</html>",
+                headers={"content-type": "text/html"},
+                request=httpx.Request("POST", "https://api.openai.com/v1/responses"),
+            )
+        )
+        response = client.post(
+            "/v1/responses",
+            headers={"authorization": "Bearer sk-test"},
+            json={
+                "model": "gpt-5-codex",
+                "input": "fail safely",
+                "stream": True,
+                "tools": [_RETRIEVE_TOOL],
+            },
+        )
+
+    assert response.status_code == 502
+    assert response.json()["error"]["type"] == "upstream_protocol_error", response.text
+    assert b"gateway timeout" not in response.content
+
+
 @pytest.mark.asyncio
 async def test_buffered_responses_ccr_late_failure_emits_sanitized_error_event():
     app = _make_app()

--- a/tests/test_proxy/test_openai_responses_ccr.py
+++ b/tests/test_proxy/test_openai_responses_ccr.py
@@ -266,7 +266,8 @@ def test_streaming_request_without_retrieve_tool_uses_normal_stream_path():
 
 
 @pytest.mark.asyncio
-async def test_buffered_responses_ccr_emits_keepalive_before_delayed_upstream():
+async def test_buffered_responses_ccr_withholds_output_until_upstream_resolves():
+    """Nothing is sent — no status, no body — until the buffered result exists."""
     app = _make_app()
     body = {
         "model": "gpt-5-codex",
@@ -276,8 +277,17 @@ async def test_buffered_responses_ccr_emits_keepalive_before_delayed_upstream():
     }
     started = asyncio.Event()
     release = asyncio.Event()
+    request_delivered = False
 
     async def receive():
+        # Mirror a real ASGI server: the body arrives once, then the channel
+        # stays open because the client is still connected. Returning instantly
+        # on every call spins `StreamingResponse.listen_for_disconnect`, which
+        # never yields, so the response body would never be scheduled.
+        nonlocal request_delivered
+        if request_delivered:
+            await asyncio.Event().wait()
+        request_delivered = True
         return {"type": "http.request", "body": json.dumps(body).encode(), "more_body": False}
 
     scope = {
@@ -307,22 +317,23 @@ async def test_buffered_responses_ccr_emits_keepalive_before_delayed_upstream():
         await started.wait()
         response = await asyncio.wait_for(asyncio.shield(task), 1)
         events: list[dict] = []
-        first_body = asyncio.Event()
 
         async def send(message):  # noqa: ANN001
             events.append(message)
-            if message["type"] == "http.response.body" and message["body"]:
-                first_body.set()
 
         response_task = asyncio.create_task(response(scope, receive, send))
-        await asyncio.wait_for(first_body.wait(), 2)
-        assert not release.is_set()
+        # Longer than the deleted 1.0s keepalive deadline: an unresolved upstream
+        # must still have produced no ASGI message at all.
+        await asyncio.sleep(1.1)
+        assert events == []
         release.set()
         await response_task
 
-    bodies = [event["body"] for event in events if event["type"] == "http.response.body"]
-    assert bodies[0] == b'event: ping\ndata: {"type":"ping"}\n\n'
-    assert b"Resolved!" in b"".join(bodies)
+    start = next(event for event in events if event["type"] == "http.response.start")
+    assert start["status"] == 200
+    bodies = b"".join(event["body"] for event in events if event["type"] == "http.response.body")
+    assert b"event: ping" not in bodies
+    assert b"Resolved!" in bodies
 
 
 @pytest.mark.asyncio
@@ -431,24 +442,23 @@ async def test_buffered_responses_ccr_late_failure_emits_sanitized_error_event()
             await started.wait()
             response = await asyncio.wait_for(asyncio.shield(task), 1)
             events: list[dict] = []
-            first_body = asyncio.Event()
 
             async def send(message):  # noqa: ANN001
                 events.append(message)
-                if message["type"] == "http.response.body" and message["body"]:
-                    first_body.set()
 
             response_task = asyncio.create_task(response(scope, receive, send))
-            await asyncio.wait_for(first_body.wait(), 2)
+            await asyncio.sleep(0)
+            assert events == []
             release.set()
             await response_task
             record_failed.assert_awaited_once_with(provider="openai")
         proxy_logger.removeHandler(log_handler)
 
-    bodies = [event["body"] for event in events if event["type"] == "http.response.body"]
-    assert bodies[0] == b'event: ping\ndata: {"type":"ping"}\n\n'
-    assert b"An error occurred while processing the request." in bodies[-1]
-    assert b"boom" not in bodies[-1]
+    start = next(event for event in events if event["type"] == "http.response.start")
+    assert start["status"] == 502
+    bodies = b"".join(event["body"] for event in events if event["type"] == "http.response.body")
+    assert b"An error occurred while processing your request." in bodies
+    assert b"boom" not in bodies
     assert events[-1]["more_body"] is False
     assert any(
         record.levelno == logging.ERROR and "RuntimeError: boom" in record.getMessage()


### PR DESCRIPTION
## Summary

Completes the buffered CCR transport fix across both Anthropic Messages and OpenAI Responses. This supersedes the partial alternatives in #2959 and #2968 for review: it preserves real upstream error status/headers and also rejects malformed successful responses instead of forwarding a broken HTTP 200 stream.

- Waits for the buffered operation before committing ASGI response headers, preserving real 429/5xx status and retry headers.
- Applies the lifecycle correction to both Anthropic and OpenAI Responses paths.
- Preserves valid JSON-to-SSE resynthesis and the existing valid upstream-SSE adaptation/relay behavior.
- Converts a non-JSON, non-SSE upstream 200 into a sanitized 502 `upstream_protocol_error` rather than a malformed successful turn.
- Initializes the OpenAI parsed-response state explicitly and contains JSON decoding at the usage boundary, so malformed input reaches the protocol guard rather than the generic exception wrapper.
- Semantically rebased onto current `main`, including the MCP SDK v1 compatibility cap and newer buffered-CCR fixes already merged there.

## Verification

- `uv run pytest tests/test_proxy/test_anthropic_streaming_ccr_retrieve.py tests/test_proxy/test_openai_responses_ccr.py -q -p no:randomly`: 20 passed.
- Ruff check passes for both handlers and both test modules.
- Ruff formatting and `git diff --check` pass.
- Dependency diff against current `main` is empty; this PR does not alter the `mcp>=1.28.1,<2.0.0` cap.

## Review notes

This PR is for human review only. No auto-merge is configured. #2968 explicitly identifies #2959 as the lifecycle owner but leaves malformed-200 handling as a residual gap; this branch incorporates that missing case into the complete transport correction.
