### PR TITLE
ci: allow Dependabot deps commits

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -12,6 +12,7 @@
         "chore",
         "ci",
         "docs",
+        "deps",
         "feat",
         "fix",
         "parity",


### PR DESCRIPTION
## Description

Allow the `deps:` Conventional Commit type emitted by Dependabot. Dependabot PRs currently fail the CI `commitlint` job because `deps` is not included in the repository's configured `type-enum`.

Closes # N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Added `deps` to the allowed commit types in `.commitlintrc.json`.
- Existing and future Dependabot commits using `deps: ...` can pass the commit-message policy.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
deps: bump ruff from 0.15.22 to 0.16.2
exit code: 0

bogus: should fail
type must be one of [build, chore, ci, docs, deps, feat, fix, parity, perf, refactor, revert, style, test] [type-enum]
exit code: 1

git diff --check
exit code: 0
```

## Real Behavior Proof

- Environment: Windows PowerShell; Node.js 22; `@commitlint/cli` and `@commitlint/config-conventional` 19.8.1.
- Exact command / steps: Ran commitlint with `.commitlintrc.json` against a real failing Dependabot subject, then against an unapproved `bogus:` type.
- Observed result: The `deps:` subject passed; the unapproved type remained rejected by `type-enum`.
- Not tested: Python/Rust unit tests and runtime behavior; this change only modifies commit-message validation configuration.

## Runtime Rollout Safety

- Rollout-managed feature(s): N/A; CI configuration only.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: Commitlint now accepts the `deps` type.
- Kill switch / disable path: Revert this commit or remove `deps` from `type-enum`.
- Unsafe override required: No.
- Qualification impact: Dependabot PR commit messages no longer fail solely because their type is `deps`.
- Rollback path: Revert this commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A; this change has no user interface.

## Additional Notes

- The comment and documentation checklist items are not applicable to this one-line commitlint configuration change.
- No automated test file was added; the exact positive and negative commitlint cases were run manually as shown above.
- Full application tests were not run because no application code or runtime behavior changed.
- Keep this PR unmerged pending maintainer review.
