### PR TITLE
fix: surface unexpected enabled extension failures

### DIFF
--- a/headroom/proxy/extensions.py
+++ b/headroom/proxy/extensions.py
@@ -135,6 +135,13 @@ def install_all(
         try:
             install(app, config)
         except Exception as exc:  # noqa: BLE001 — one bad extension must not brick the proxy
+            message = str(exc).lower()
+            optional_failure = any(
+                marker in message
+                for marker in ("license", "auth", "credential", "optional dependency")
+            )
+            if not optional_failure:
+                raise
             # A failing extension disables *itself* and the proxy keeps running
             # without it — covers environment/auth failures and compatibility
             # errors (e.g. a plugin built against a core API this version lacks).

--- a/tests/test_proxy_extensions.py
+++ b/tests/test_proxy_extensions.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import pytest
+
 from headroom.proxy import extensions
 
 
@@ -44,3 +46,13 @@ def test_install_all_warns_for_missing_requested_extension(caplog, monkeypatch) 
 
     assert installed == []
     assert "proxy extensions requested but not found: missing_ext" in caplog.text
+
+
+def test_install_all_surfaces_unexpected_enabled_extension_errors(monkeypatch) -> None:
+    def broken(app: Any, config: Any) -> None:
+        raise RuntimeError("extension bug")
+
+    monkeypatch.setattr(extensions, "discover", lambda: iter([("broken_ext", broken)]))
+
+    with pytest.raises(RuntimeError, match="extension bug"):
+        extensions.install_all(object(), object(), enabled=["broken_ext"])


### PR DESCRIPTION
## Description

Explicitly enabled proxy extensions currently swallow all installation exceptions. This makes unexpected extension bugs look like successful proxy startup. Optional dependency, authentication, credential, and license failures remain fail-open; unexpected runtime failures now propagate to the caller.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no function changes)

## Changes Made

- Classify recognized optional installation failures by message.
- Re-raise unexpected exceptions from explicitly enabled extensions.
- Add a regression test proving unexpected `RuntimeError` is surfaced.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added
- [ ] Manual testing performed

### Test Output

```text
pytest tests/test_proxy_extensions.py tests/test_cli_extension_seam.py tests/test_critical_fixes.py -q
16 passed
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.14.5.
- Exact command / steps: enabled a synthetic extension that raises `RuntimeError("extension bug")`.
- Observed result: the exception propagates instead of being silently skipped; recognized optional failures retain the existing fail-open behavior.
- Not tested: third-party extension packages.

## Runtime Rollout Safety

- Rollout-managed feature(s): explicitly enabled proxy extensions.
- Minimum rollout channel: stable/default.
- Stable/default behavior changed: only unexpected failures now stop startup, making configured failures visible.
- Kill switch / disable path: remove the extension from `HEADROOM_PROXY_EXTENSIONS` or `--proxy-extension`.
- Unsafe override required: No.
- Qualification impact: proxy extension startup tests.
- Rollback path: revert this MR.

## Review Readiness

- [x] Self-review performed
- [x] Ready for human review

## Checklist

- [x] Style guidelines followed
- [x] Tests added
- [x] `CHANGELOG.md` not edited

## Additional Notes

No open upstream MR was found for this exact defect after reviewing all current open upstream PR titles, bodies, and changed-file lists. This branch is based directly on `headroomlabs-ai/main` and contains only `headroom/proxy/extensions.py` and its focused test.
