### PR TITLE
ci: allow generated dependency commit bodies

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": ["@commitlint/config-conventional"],
   "rules": {
-    "body-max-line-length": [2, "always", 200],
+    "body-max-line-length": [0],
     "footer-leading-blank": [0],
     "subject-case": [0],
     "type-enum": [


### PR DESCRIPTION
## Description

Disable commitlint's per-line body length limit because Dependabot generates grouped-update commit bodies with dependency/link lines whose length varies with group contents. PR #2964 currently fails only because one generated line is 274 characters long.

Closes # N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Disabled `body-max-line-length` in `.commitlintrc.json`.
- Kept Conventional Commit type, subject, and all other configured validation rules enforced.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
PR #2964 Dependabot commit (49 lines; maximum line length 274)
exit code: 0

bogus: should fail
type must be one of [build, chore, ci, docs, deps, feat, fix, parity, perf, refactor, revert, style, test] [type-enum]
exit code: 1

fix:
subject may not be empty [subject-empty]
exit code: 1

git diff --check
exit code: 0
```

## Real Behavior Proof

- Environment: Windows PowerShell; Node.js 22; `@commitlint/cli` and `@commitlint/config-conventional` 19.8.1.
- Exact command / steps: Fetched the current PR #2964 commit message through the GitHub API and piped the complete message into commitlint using this branch's `.commitlintrc.json`; then ran negative type and subject cases.
- Observed result: The exact grouped Dependabot commit passed; an unapproved type and empty subject remained rejected.
- Not tested: Python/Rust unit tests and runtime behavior; this change only modifies commit-message validation configuration.

## Runtime Rollout Safety

- Rollout-managed feature(s): N/A; CI configuration only.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: Commit bodies may contain lines of any length; all other commitlint rules remain active.
- Kill switch / disable path: Revert this commit or restore a numeric `body-max-line-length` limit.
- Unsafe override required: No.
- Qualification impact: Generated Dependabot group descriptions no longer fail CI due solely to a long dependency/link line.
- Rollback path: Revert this commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A; this change has no user interface.

## Additional Notes

- The comment and documentation checklist items are not applicable to this one-line commitlint configuration change.
- No automated test file was added; the exact positive and negative commitlint cases were run manually as shown above.
- Full application tests were not run because no application code or runtime behavior changed.
- Keep this PR unmerged pending maintainer review.
