### PR TITLE
fix(wrap): route Cline custom upstreams

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -7033,7 +7033,7 @@ def grok_build(
 
 
 # =============================================================================
-# Cline (VS Code extension)
+# Cline (CLI and VS Code extension)
 # =============================================================================
 
 
@@ -7043,6 +7043,11 @@ def grok_build(
     "--port", "-p", default=8787, type=click.IntRange(1, 65535), help="Proxy port (default: 8787)"
 )
 @click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option(
+    "--openai-api-url",
+    metavar="URL",
+    help="Original OpenAI-compatible upstream URL (required for custom Cline providers)",
+)
 @click.option("--learn", is_flag=True, help="Enable live traffic learning")
 @click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
@@ -7050,17 +7055,24 @@ def grok_build(
 def cline(
     port: int,
     no_proxy: bool,
+    openai_api_url: str | None,
     learn: bool,
     memory: bool,
     verbose: bool,
     prepare_only: bool,
 ) -> None:
-    """Start Headroom proxy for use with Cline (VS Code extension).
+    """Start Headroom proxy for use with Cline CLI or the VS Code extension.
 
     \b
-    Cline is a VS Code extension that reads its API configuration from the
-    VS Code settings UI, not from environment variables. This command starts
-    the proxy and prints the Cline settings the user should configure.
+    Cline stores provider configuration itself rather than reading standard
+    OpenAI environment variables. This command starts the proxy and prints the
+    Cline CLI and VS Code settings the user should configure.
+
+    \b
+    For a custom OpenAI-compatible provider, pass its ORIGINAL base URL via
+    ``--openai-api-url``. Configure Cline's base URL to the local URL printed
+    below. Headroom then forwards Cline's existing API key to that upstream;
+    without the original URL, the proxy would route the request to OpenAI.
 
     \b
     After running this command, open Cline's settings in VS Code and configure
@@ -7074,6 +7086,7 @@ def cline(
     Examples:
         headroom wrap cline                  # Start proxy + Cline settings
         headroom wrap cline --port 9999      # Custom proxy port
+        headroom wrap cline --openai-api-url https://api.example.com/v1
     """
     if prepare_only:
         return
@@ -7081,6 +7094,13 @@ def cline(
     def _print_cline_setup(actual_port: int) -> None:
         anthropic_base = _claude_proxy_base_url(actual_port)
         openai_base = f"http://127.0.0.1:{actual_port}/v1"
+        if openai_api_url:
+            click.echo(f"  OpenAI-compatible upstream: {openai_api_url}")
+            click.echo()
+        click.echo("  Configure Cline CLI:")
+        click.echo(f"    cline auth --provider openai-native --baseurl {openai_base}")
+        click.echo("    Keep your existing API key and model configuration.")
+        click.echo()
         click.echo("  Configure Cline in VS Code:")
         click.echo("    Settings > Cline > API Provider")
         click.echo(f"    Anthropic Base URL: {anthropic_base}")
@@ -7093,6 +7113,7 @@ def cline(
         learn=learn,
         memory=memory,
         agent_type="cline",
+        openai_api_url=openai_api_url,
         print_setup_lines=_print_cline_setup,
     )
 

--- a/tests/test_cli/test_wrap_cline.py
+++ b/tests/test_cli/test_wrap_cline.py
@@ -1,0 +1,59 @@
+"""CLI coverage for Cline CLI and extension proxy routing."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+
+
+def test_wrap_cline_forwards_custom_openai_upstream() -> None:
+    captured: dict[str, object] = {}
+
+    def fake_watcher(**kwargs):  # noqa: ANN003, ANN202
+        captured.update(kwargs)
+        kwargs["print_setup_lines"](9123)
+
+    with patch("headroom.cli.wrap._run_proxy_only_watcher", side_effect=fake_watcher):
+        result = CliRunner().invoke(
+            main,
+            [
+                "wrap",
+                "cline",
+                "--openai-api-url",
+                "https://api.example.com/v1",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["openai_api_url"] == "https://api.example.com/v1"
+    assert "cline auth --provider openai-native" in result.output
+    assert "--baseurl http://127.0.0.1:9123/v1" in result.output
+    assert "OpenAI-compatible upstream: https://api.example.com/v1" in result.output
+
+
+def test_wrap_cline_keeps_default_openai_routing_explicit() -> None:
+    captured: dict[str, object] = {}
+
+    def fake_watcher(**kwargs):  # noqa: ANN003, ANN202
+        captured.update(kwargs)
+
+    with patch("headroom.cli.wrap._run_proxy_only_watcher", side_effect=fake_watcher):
+        result = CliRunner().invoke(main, ["wrap", "cline"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["openai_api_url"] is None
+
+
+def test_openai_upstream_option_belongs_to_cline_not_codex() -> None:
+    runner = CliRunner()
+
+    cline_help = runner.invoke(main, ["wrap", "cline", "--help"])
+    codex_help = runner.invoke(main, ["wrap", "codex", "--help"])
+
+    assert cline_help.exit_code == 0, cline_help.output
+    assert "--openai-api-url URL" in cline_help.output
+    assert codex_help.exit_code == 0, codex_help.output
+    assert "--openai-api-url" not in codex_help.output


### PR DESCRIPTION
## Description

Route Cline CLI requests for custom OpenAI-compatible providers back to the provider's original upstream instead of falling through to OpenAI. The wrapper now supports Cline's official CLI configuration flow as well as the VS Code extension.

Closes #1626

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add `--openai-api-url` to `headroom wrap cline` so the proxy retains the original custom-provider route.
- Print the official Cline CLI partial-auth command that changes only its base URL to Headroom while retaining the existing key and model.
- Keep the extension setup path and default OpenAI routing unchanged.
- Add regression coverage for upstream forwarding, actual fallback ports, and option ownership.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
uv run pytest -q tests/test_cli
675 passed, 1 skipped in 10.70s

uv run pytest -q tests/test_cli/test_wrap_cline.py tests/test_cli/test_wrap_helpers.py
56 passed in 0.79s

uv run ruff check headroom/cli/wrap.py tests/test_cli/test_wrap_cline.py
All checks passed!

uv run ruff format --check headroom/cli/wrap.py tests/test_cli/test_wrap_cline.py
2 files already formatted

uv run mypy headroom/cli/wrap.py
Success: no issues found

pytest -q tests/test_release_workflows.py::test_no_native_tls_in_wheel_build_tree tests/test_release_workflows.py::test_no_openssl_in_wheel_build_tree
2 passed, 44 deselected in 0.82s
```

## Real Behavior Proof

- Environment: macOS, Python 3.12, current `origin/main` at `2d88e31a4`.
- Exact command / steps: invoke `headroom wrap cline --openai-api-url https://api.example.com/v1` with the proxy watcher captured at fallback port 9123.
- Observed result: the watcher receives `https://api.example.com/v1` as `openai_api_url`, and Cline is instructed to use `http://127.0.0.1:9123/v1` while retaining its configured key and model.
- Not tested: a live request against a third-party provider because no provider credential is available in CI.

## Runtime Rollout Safety

- Rollout-managed feature(s): none.
- Minimum rollout channel: stable.
- Stable/default behavior changed: only when `--openai-api-url` is explicitly supplied; the default route is unchanged.
- Kill switch / disable path: omit `--openai-api-url` to retain the previous default OpenAI route.
- Unsafe override required: no.
- Qualification impact: adds isolated wrapper CLI tests; no proxy pipeline or dependency changes.
- Rollback path: fix forward in the Cline option/routing path while retaining custom-upstream support; do not remove the route and recreate #1626.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

Not applicable; this is a terminal routing change.

## Additional Notes

The current diff is limited to the Cline wrapper and its tests; earlier release-tree maintenance is already upstream. Latest-source audit at `fcad662787b8d335525ab67fb175516fa1d1990c`: all three focused Cline tests pass, and current reported GitHub checks are passing or skipped. The broader test output above records earlier validation.




