### PR TITLE
fix(ccr): expire stale proactive contexts by turn

### DIFF
--- a/headroom/ccr/context_tracker.py
+++ b/headroom/ccr/context_tracker.py
@@ -115,6 +115,9 @@ class ContextTrackerConfig:
     # Maximum age for contexts (seconds) - older contexts less likely to expand
     max_context_age_seconds: float = 300.0  # 5 minutes
 
+    # Maximum number of compressing turns before a context is stale
+    max_turn_distance: int = 10
+
     # Whether to proactively expand based on query analysis
     proactive_expansion: bool = True
 
@@ -284,12 +287,30 @@ class ContextTracker:
             if age > self.config.max_context_age_seconds:
                 continue
 
+            # Fast agentic sessions can advance through many compressing turns
+            # before the wall-clock limit expires. Conversational distance is
+            # therefore an independent staleness boundary.
+            turn_distance = 0
+            if current_turn is not None:
+                turn_distance = max(0, current_turn - context.turn_number)
+                if turn_distance > self.config.max_turn_distance:
+                    continue
+
             # Calculate relevance
             relevance = self._calculate_relevance(query, context)
 
             # Age discount: older contexts get lower scores
             age_factor = 1.0 - (age / self.config.max_context_age_seconds) * 0.5
-            relevance *= age_factor
+            turn_factor = 1.0
+            if current_turn is not None:
+                if self.config.max_turn_distance <= 0:
+                    turn_factor = 1.0 if turn_distance == 0 else 0.0
+                else:
+                    turn_factor = max(
+                        0.2,
+                        1.0 - (turn_distance / self.config.max_turn_distance) * 0.8,
+                    )
+            relevance *= age_factor * turn_factor
 
             if relevance >= self.config.relevance_threshold:
                 recommendations.append(

--- a/headroom/proxy/models.py
+++ b/headroom/proxy/models.py
@@ -211,6 +211,7 @@ class ProxyConfig:
     ccr_context_tracking: bool = True
     ccr_proactive_expansion: bool = True
     ccr_max_proactive_expansions: int = 2
+    ccr_max_turn_distance: int = 10
 
     # Code-aware compression (disabled by default — use code graph tools instead)
     code_aware_enabled: bool = False

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -1233,6 +1233,7 @@ class HeadroomProxy(
                     enabled=True,
                     proactive_expansion=config.ccr_proactive_expansion,
                     max_proactive_expansions=config.ccr_max_proactive_expansions,
+                    max_turn_distance=config.ccr_max_turn_distance,
                 )
             )
             if config.ccr_context_tracking

--- a/tests/test_anthropic_ccr_workspace_unbound.py
+++ b/tests/test_anthropic_ccr_workspace_unbound.py
@@ -39,6 +39,7 @@ def _client() -> TestClient:
         # Tracker + proactive expansion enabled (defaults) reach the unbound use:
         ccr_context_tracking=True,
         ccr_proactive_expansion=True,
+        ccr_max_turn_distance=3,
         image_optimize=False,
     )
     return TestClient(create_app(config))
@@ -49,6 +50,7 @@ def test_proactive_expansion_does_not_raise_when_ccr_inject_disabled() -> None:
         proxy = client.app.state.proxy
         # Sanity: the tracker is wired up (necessary for the bug to trigger).
         assert proxy.ccr_context_tracker is not None
+        assert proxy.ccr_context_tracker.config.max_turn_distance == 3
 
         async def _fake_retry(method, url, headers, body, stream=False, **kwargs):  # noqa: ANN001
             return httpx.Response(

--- a/tests/test_ccr_context_tracker.py
+++ b/tests/test_ccr_context_tracker.py
@@ -346,6 +346,60 @@ class TestQueryAnalysis:
 
         assert len(recommendations) <= 2
 
+    def test_analyze_query_rejects_context_beyond_turn_distance(self):
+        """Fast sessions expire old contexts by conversational distance."""
+        tracker = ContextTracker(
+            ContextTrackerConfig(relevance_threshold=0.1, max_turn_distance=10)
+        )
+        tracker.track_compression(
+            hash_key="stale_auth",
+            turn_number=3,
+            tool_name="Read",
+            original_count=100,
+            compressed_count=10,
+            query_context="debug authentication middleware",
+            sample_content="authentication middleware validates bearer tokens",
+            workspace_key="project-a",
+        )
+
+        recommendations = tracker.analyze_query(
+            "debug authentication middleware",
+            current_turn=14,
+            workspace_key="project-a",
+        )
+
+        assert recommendations == []
+
+    def test_analyze_query_decays_relevance_by_turn_distance(self):
+        """A nearby context outranks identical older context in a fast session."""
+        tracker = ContextTracker(
+            ContextTrackerConfig(
+                relevance_threshold=0.0,
+                max_proactive_expansions=2,
+                max_turn_distance=10,
+            )
+        )
+        for hash_key, turn in (("older", 2), ("newer", 9)):
+            tracker.track_compression(
+                hash_key=hash_key,
+                turn_number=turn,
+                tool_name="Read",
+                original_count=100,
+                compressed_count=10,
+                query_context="debug authentication middleware",
+                sample_content="authentication middleware validates bearer tokens",
+                workspace_key="project-a",
+            )
+
+        recommendations = tracker.analyze_query(
+            "debug authentication middleware",
+            current_turn=10,
+            workspace_key="project-a",
+        )
+
+        scores = {item.hash_key: item.relevance_score for item in recommendations}
+        assert scores["newer"] > scores["older"]
+
 
 class TestRelevanceCalculation:
     """Test relevance score calculation."""
@@ -594,6 +648,7 @@ class TestContextTrackerConfig:
         assert config.max_tracked_contexts == 100
         assert config.relevance_threshold == 0.3
         assert config.max_context_age_seconds == 300.0
+        assert config.max_turn_distance == 10
         assert config.proactive_expansion is True
         assert config.max_proactive_expansions == 2
 
@@ -604,12 +659,14 @@ class TestContextTrackerConfig:
             max_tracked_contexts=50,
             relevance_threshold=0.5,
             max_proactive_expansions=5,
+            max_turn_distance=4,
         )
 
         assert config.enabled is False
         assert config.max_tracked_contexts == 50
         assert config.relevance_threshold == 0.5
         assert config.max_proactive_expansions == 5
+        assert config.max_turn_distance == 4
 
 
 class TestCompressedContextDataClass:


### PR DESCRIPTION
## Description

Prevent proactive CCR expansion from resurfacing contexts that are recent in wall-clock time but stale in conversational position during fast agentic sessions.

Closes #709

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add a ten-compressing-turn staleness boundary alongside the existing five-minute wall-clock boundary.
- Decay relevance by both elapsed time and compressing-turn distance so older contexts require stronger matches.
- Thread the boundary through `ProxyConfig` into each proxy's `ContextTracker`.
- Cover hard expiry, relative ranking, defaults, overrides, and proxy wiring.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
uv run pytest -q tests/test_ccr_context_tracker.py tests/test_anthropic_ccr_workspace_unbound.py
40 passed in 3.41s

uv run pytest -q tests/test_proxy_ccr.py tests/test_proxy_anthropic_cache_stability.py tests/test_cli_proxy_env.py tests/test_testing_harness.py
142 passed, 1 skipped in 14.65s

uv run ruff check headroom/ccr/context_tracker.py headroom/proxy/models.py headroom/proxy/server.py tests/test_ccr_context_tracker.py tests/test_anthropic_ccr_workspace_unbound.py
All checks passed!

uv run ruff format --check headroom/ccr/context_tracker.py headroom/proxy/models.py headroom/proxy/server.py tests/test_ccr_context_tracker.py tests/test_anthropic_ccr_workspace_unbound.py
5 files already formatted

uv run mypy headroom/ccr/context_tracker.py headroom/proxy/models.py headroom/proxy/server.py
Success: no issues found in 3 source files
```

## Real Behavior Proof

- Environment: macOS arm64, CPython 3.12.13, deterministic `ContextTracker` test harness.
- Exact command / steps: Track identical relevant contexts at compressing turns 2 and 9, analyze at turn 10, then track a context at turn 3 and analyze at turn 14.
- Observed result: The turn-9 context ranks above turn 2; the turn-3 context is excluded once its distance reaches 11 despite remaining within the wall-clock window.
- Not tested: Live multi-hour Claude Code traffic.

## Runtime Rollout Safety

- Rollout-managed feature(s): Proactive CCR expansion.
- Minimum rollout channel: Normal CI-qualified release.
- Stable/default behavior changed: Yes; proactive candidates older than ten compressing turns are no longer injected.
- Kill switch / disable path: Set `ccr_proactive_expansion=False` through the existing proxy configuration path.
- Unsafe override required: No.
- Qualification impact: Low; selection becomes more conservative and never changes stored compressed content or explicit retrieval.
- Rollback path: Disable proactive expansion while retaining explicit `headroom_retrieve` recovery.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

Exact-head GitHub CI completed successfully.


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

Not applicable; no UI changes.

## Additional Notes

The configuration field documentation is colocated with the dataclass; no user-facing CLI or environment option is added because the existing proactive-tracker limits are internal configuration fields. Explicit retrieval and workspace isolation are unchanged.

