### PR TITLE
fix(proxy/cost): fail closed on missing LiteLLM cache prices instead of over-charging

### DIFF
--- a/headroom/proxy/cost.py
+++ b/headroom/proxy/cost.py
@@ -129,22 +129,6 @@ _CACHE_ECONOMICS = {
 }
 
 
-def _cache_economics_provider(litellm_provider: str | None) -> str:
-    """Map a LiteLLM ``litellm_provider`` id to a ``_CACHE_ECONOMICS`` key.
-
-    Unknown or absent providers fall back to ``anthropic``, matching the default
-    used in :func:`build_prefix_cache_stats`.
-    """
-    provider = (litellm_provider or "").lower()
-    if "bedrock" in provider:
-        return "bedrock"
-    if provider.startswith(("gemini", "vertex_ai", "google")):
-        return "gemini"
-    if provider.startswith(("openai", "azure", "text-completion-openai")):
-        return "openai"
-    return "anthropic"
-
-
 def _summarize_transforms(transforms: list[str]) -> str:
     """Collapse repeated transforms into counted summary.
 
@@ -1070,28 +1054,26 @@ class CostTracker:
             # LiteLLM carries explicit per-token cache prices for only a minority
             # of its priced models; the long tail (most Bedrock, Mistral,
             # Fireworks and OpenAI-compatible gateway models) omits them. The old
-            # ``.get(field, uncached)`` default billed cache reads at the FULL
-            # uncached rate and cache writes with no premium, so ``totals()`` (and
-            # the /stats dollar figures it feeds) over-charged every cache-warm
-            # request on those models and diverged from the primary
-            # ``litellm.cost_per_token`` path. When a field is absent, fall back to
-            # the provider cache economics the dashboard already uses: reads at the
-            # discounted multiplier, writes at the write multiplier, defaulting to
-            # Anthropic's when the provider is unknown (matching
-            # ``build_prefix_cache_stats``).
+            # ``.get(field, uncached)`` default billed those cache reads at the
+            # FULL uncached rate (and cache writes with no premium), so ``totals()``
+            # (and the /stats dollar figures it feeds) over-charged every cache-warm
+            # request on those models.
+            #
+            # Do NOT substitute a provider guess for a missing rate. Bedrock alone
+            # fronts Anthropic, Amazon, Meta, Mistral, Cohere and others whose cache
+            # economics are not interchangeable, and ``_CACHE_ECONOMICS`` is a
+            # coarse dashboard-savings convention, not per-model billing metadata.
+            # Fail closed instead: reconcile with the canonical
+            # ``litellm.cost_per_token`` path (the one ``estimate_cost`` uses),
+            # which books $0 for a cache slice LiteLLM cannot price, so ``totals()``
+            # agrees with the primary accounting rather than inventing a discount
+            # or a premium. Explicit LiteLLM cache fields still win.
             cache_read = info.get("cache_read_input_token_cost")
             cache_write = info.get("cache_creation_input_token_cost")
-            if cache_read is None or cache_write is None:
-                econ = _CACHE_ECONOMICS.get(
-                    _cache_economics_provider(info.get("litellm_provider")),
-                    _CACHE_ECONOMICS["anthropic"],
-                )
-                read_mult: float = econ["read_multiplier"]  # type: ignore[assignment]
-                write_mult: float = econ["write_multiplier"]  # type: ignore[assignment]
-                if cache_read is None:
-                    cache_read = uncached * read_mult
-                if cache_write is None:
-                    cache_write = uncached * write_mult
+            if cache_read is None:
+                cache_read = 0.0
+            if cache_write is None:
+                cache_write = 0.0
             return (cache_read, cache_write, uncached)
         except Exception:
             return None

--- a/headroom/proxy/cost.py
+++ b/headroom/proxy/cost.py
@@ -129,6 +129,22 @@ _CACHE_ECONOMICS = {
 }
 
 
+def _cache_economics_provider(litellm_provider: str | None) -> str:
+    """Map a LiteLLM ``litellm_provider`` id to a ``_CACHE_ECONOMICS`` key.
+
+    Unknown or absent providers fall back to ``anthropic``, matching the default
+    used in :func:`build_prefix_cache_stats`.
+    """
+    provider = (litellm_provider or "").lower()
+    if "bedrock" in provider:
+        return "bedrock"
+    if provider.startswith(("gemini", "vertex_ai", "google")):
+        return "gemini"
+    if provider.startswith(("openai", "azure", "text-completion-openai")):
+        return "openai"
+    return "anthropic"
+
+
 def _summarize_transforms(transforms: list[str]) -> str:
     """Collapse repeated transforms into counted summary.
 
@@ -1051,8 +1067,31 @@ class CostTracker:
             uncached = info.get("input_cost_per_token")
             if not uncached:
                 return None
-            cache_read = info.get("cache_read_input_token_cost", uncached)
-            cache_write = info.get("cache_creation_input_token_cost", uncached)
+            # LiteLLM carries explicit per-token cache prices for only a minority
+            # of its priced models; the long tail (most Bedrock, Mistral,
+            # Fireworks and OpenAI-compatible gateway models) omits them. The old
+            # ``.get(field, uncached)`` default billed cache reads at the FULL
+            # uncached rate and cache writes with no premium, so ``totals()`` (and
+            # the /stats dollar figures it feeds) over-charged every cache-warm
+            # request on those models and diverged from the primary
+            # ``litellm.cost_per_token`` path. When a field is absent, fall back to
+            # the provider cache economics the dashboard already uses: reads at the
+            # discounted multiplier, writes at the write multiplier, defaulting to
+            # Anthropic's when the provider is unknown (matching
+            # ``build_prefix_cache_stats``).
+            cache_read = info.get("cache_read_input_token_cost")
+            cache_write = info.get("cache_creation_input_token_cost")
+            if cache_read is None or cache_write is None:
+                econ = _CACHE_ECONOMICS.get(
+                    _cache_economics_provider(info.get("litellm_provider")),
+                    _CACHE_ECONOMICS["anthropic"],
+                )
+                read_mult: float = econ["read_multiplier"]  # type: ignore[assignment]
+                write_mult: float = econ["write_multiplier"]  # type: ignore[assignment]
+                if cache_read is None:
+                    cache_read = uncached * read_mult
+                if cache_write is None:
+                    cache_write = uncached * write_mult
             return (cache_read, cache_write, uncached)
         except Exception:
             return None

--- a/tests/test_cost_cache_prices.py
+++ b/tests/test_cost_cache_prices.py
@@ -1,12 +1,17 @@
-"""``_get_cache_prices`` must not bill cache reads at the full uncached rate.
+"""``_get_cache_prices`` must not bill cache slices it cannot authoritatively price.
 
 LiteLLM omits ``cache_read_input_token_cost`` / ``cache_creation_input_token_cost``
 for the long tail of its priced models (most Bedrock, Mistral, Fireworks and
 OpenAI-compatible gateway models). The old ``.get(field, uncached)`` default
-billed cache reads at the full uncached rate and cache writes with no premium,
-so ``totals()`` (and the /stats figures it feeds) over-charged every cache-warm
-request on those models. When a field is absent the tracker must fall back to
-the provider cache economics the dashboard already uses (``_CACHE_ECONOMICS``).
+billed those cache reads at the full uncached rate, so ``totals()`` (and the
+/stats figures it feeds) over-charged every cache-warm request on those models.
+
+The fix fails closed: a missing cache field is priced at ``$0`` to reconcile
+with the canonical ``litellm.cost_per_token`` path (which books $0 for a slice
+it cannot price), rather than fabricating a provider-wide discount or premium.
+Bedrock in particular fronts many vendors whose cache economics are not
+interchangeable, so no provider heuristic is applied. Explicit LiteLLM cache
+fields still win.
 """
 
 from __future__ import annotations
@@ -15,11 +20,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from headroom.proxy.cost import (
-    _CACHE_ECONOMICS,
-    CostTracker,
-    _cache_economics_provider,
-)
+from headroom.proxy.cost import CostTracker
 
 
 def _patch_litellm(monkeypatch: pytest.MonkeyPatch, model_cost: dict) -> None:
@@ -31,28 +32,6 @@ def _patch_litellm(monkeypatch: pytest.MonkeyPatch, model_cost: dict) -> None:
         "headroom.pricing.litellm_pricing.resolve_litellm_model",
         lambda model: model,
     )
-
-
-class TestCacheEconomicsProvider:
-    @pytest.mark.parametrize(
-        ("litellm_provider", "expected"),
-        [
-            ("bedrock", "bedrock"),
-            ("bedrock_converse", "bedrock"),
-            ("openai", "openai"),
-            ("azure", "openai"),
-            ("azure_ai", "openai"),
-            ("gemini", "gemini"),
-            ("vertex_ai", "gemini"),
-            ("anthropic", "anthropic"),
-            ("mistral", "anthropic"),  # unknown -> anthropic default
-            ("fireworks_ai", "anthropic"),
-            (None, "anthropic"),
-            ("", "anthropic"),
-        ],
-    )
-    def test_maps_to_cache_economics_key(self, litellm_provider, expected) -> None:
-        assert _cache_economics_provider(litellm_provider) == expected
 
 
 class TestGetCachePrices:
@@ -72,62 +51,75 @@ class TestGetCachePrices:
         )
         assert CostTracker()._get_cache_prices("m") == (1e-7, 1.25e-6, 1e-6)
 
-    def test_missing_cache_read_uses_provider_discount_not_full_rate(
+    def test_missing_cache_fields_priced_at_zero_not_full_rate(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Bedrock model with an input price but no cache fields: exactly the
-        # 1600+ long-tail models the bug affects.
+        # A model with an input price but no cache fields: exactly the 1600+
+        # long-tail models the bug affects. Before the fix both slices billed at
+        # the full uncached rate; now they fail closed at $0, reconciling with
+        # what litellm.cost_per_token books for the same slice.
         _patch_litellm(
             monkeypatch,
-            {"m": {"input_cost_per_token": 5e-7, "litellm_provider": "bedrock"}},
+            {"m": {"input_cost_per_token": 5e-7, "litellm_provider": "mistral"}},
         )
-        cache_read, cache_write, uncached = CostTracker()._get_cache_prices("m")
-        assert uncached == 5e-7
-        # Before the fix this was 5e-7 (the full uncached rate) — the bug.
-        assert cache_read == pytest.approx(5e-7 * _CACHE_ECONOMICS["bedrock"]["read_multiplier"])
-        assert cache_read < uncached
-        assert cache_write == pytest.approx(5e-7 * _CACHE_ECONOMICS["bedrock"]["write_multiplier"])
+        assert CostTracker()._get_cache_prices("m") == (0.0, 0.0, 5e-7)
 
-    def test_openai_provider_uses_openai_multipliers(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        _patch_litellm(
-            monkeypatch,
-            {"m": {"input_cost_per_token": 1e-6, "litellm_provider": "openai"}},
-        )
-        cache_read, cache_write, uncached = CostTracker()._get_cache_prices("m")
-        # OpenAI: reads at 0.5x, writes at 1.0x (no write premium).
-        assert cache_read == pytest.approx(1e-6 * 0.5)
-        assert cache_write == pytest.approx(1e-6 * 1.0)
-
-    def test_unknown_provider_defaults_to_anthropic(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        _patch_litellm(
-            monkeypatch,
-            {"m": {"input_cost_per_token": 2e-6}},  # no litellm_provider
-        )
-        cache_read, cache_write, uncached = CostTracker()._get_cache_prices("m")
-        assert cache_read == pytest.approx(2e-6 * _CACHE_ECONOMICS["anthropic"]["read_multiplier"])
-        assert cache_write == pytest.approx(
-            2e-6 * _CACHE_ECONOMICS["anthropic"]["write_multiplier"]
-        )
-
-    def test_only_the_missing_field_is_filled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_only_the_missing_field_is_zeroed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Explicit read cost present, write cost absent: keep the real read,
-        # infer only the write.
+        # fail closed on the write.
         _patch_litellm(
             monkeypatch,
             {
                 "m": {
                     "input_cost_per_token": 1e-6,
                     "cache_read_input_token_cost": 3e-7,
-                    "litellm_provider": "anthropic",
+                    "litellm_provider": "openai",
                 }
             },
         )
-        cache_read, cache_write, _ = CostTracker()._get_cache_prices("m")
-        assert cache_read == 3e-7  # untouched real value
-        assert cache_write == pytest.approx(
-            1e-6 * _CACHE_ECONOMICS["anthropic"]["write_multiplier"]
-        )
+        assert CostTracker()._get_cache_prices("m") == (3e-7, 0.0, 1e-6)
 
     def test_no_input_price_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_litellm(monkeypatch, {"m": {"litellm_provider": "anthropic"}})
         assert CostTracker()._get_cache_prices("m") is None
+
+    @pytest.mark.parametrize(
+        "litellm_provider",
+        ["bedrock", "bedrock_converse", "mistral", "fireworks_ai", "cohere_chat", None, "made-up"],
+    )
+    def test_heterogeneous_and_unknown_providers_do_not_inherit_anthropic_rates(
+        self, monkeypatch: pytest.MonkeyPatch, litellm_provider
+    ) -> None:
+        # Regression: a missing cache field must never be back-filled with
+        # Anthropic's 0.1x/1.25x economics. Bedrock fronts Anthropic, Amazon,
+        # Meta, Mistral, Cohere and others; unknown OpenAI-compatible providers
+        # are likewise not Anthropic-priced.
+        uncached = 4e-6
+        info = {"input_cost_per_token": uncached}
+        if litellm_provider is not None:
+            info["litellm_provider"] = litellm_provider
+        _patch_litellm(monkeypatch, {"m": info})
+        cache_read, cache_write, got_uncached = CostTracker()._get_cache_prices("m")
+        assert got_uncached == uncached
+        assert cache_read == 0.0
+        assert cache_write == 0.0
+        # Explicitly not the Anthropic multipliers the old fallback would apply.
+        assert cache_read != pytest.approx(uncached * 0.1)
+        assert cache_write != pytest.approx(uncached * 1.25)
+
+    def test_missing_cache_slices_match_canonical_zero_pricing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The missing cache slices are priced at $0, the same amount the canonical
+        litellm.cost_per_token path books for a slice LiteLLM cannot price, so the
+        cache breakdown reconciles with the primary accounting instead of diverging.
+        """
+        _patch_litellm(
+            monkeypatch,
+            {"m": {"input_cost_per_token": 5e-7, "litellm_provider": "fireworks_ai"}},
+        )
+        cr_price, cw_price, uncached_price = CostTracker()._get_cache_prices("m")
+        cr_tokens, cw_tokens = 20_000, 5_000
+        # Cache-slice cost contributed to totals() is exactly $0, matching canonical.
+        assert cr_tokens * cr_price + cw_tokens * cw_price == 0.0
+        assert uncached_price == 5e-7

--- a/tests/test_cost_cache_prices.py
+++ b/tests/test_cost_cache_prices.py
@@ -1,0 +1,133 @@
+"""``_get_cache_prices`` must not bill cache reads at the full uncached rate.
+
+LiteLLM omits ``cache_read_input_token_cost`` / ``cache_creation_input_token_cost``
+for the long tail of its priced models (most Bedrock, Mistral, Fireworks and
+OpenAI-compatible gateway models). The old ``.get(field, uncached)`` default
+billed cache reads at the full uncached rate and cache writes with no premium,
+so ``totals()`` (and the /stats figures it feeds) over-charged every cache-warm
+request on those models. When a field is absent the tracker must fall back to
+the provider cache economics the dashboard already uses (``_CACHE_ECONOMICS``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from headroom.proxy.cost import (
+    _CACHE_ECONOMICS,
+    CostTracker,
+    _cache_economics_provider,
+)
+
+
+def _patch_litellm(monkeypatch: pytest.MonkeyPatch, model_cost: dict) -> None:
+    monkeypatch.setattr(
+        "headroom.proxy.cost._get_litellm_module",
+        lambda: SimpleNamespace(model_cost=model_cost),
+    )
+    monkeypatch.setattr(
+        "headroom.pricing.litellm_pricing.resolve_litellm_model",
+        lambda model: model,
+    )
+
+
+class TestCacheEconomicsProvider:
+    @pytest.mark.parametrize(
+        ("litellm_provider", "expected"),
+        [
+            ("bedrock", "bedrock"),
+            ("bedrock_converse", "bedrock"),
+            ("openai", "openai"),
+            ("azure", "openai"),
+            ("azure_ai", "openai"),
+            ("gemini", "gemini"),
+            ("vertex_ai", "gemini"),
+            ("anthropic", "anthropic"),
+            ("mistral", "anthropic"),  # unknown -> anthropic default
+            ("fireworks_ai", "anthropic"),
+            (None, "anthropic"),
+            ("", "anthropic"),
+        ],
+    )
+    def test_maps_to_cache_economics_key(self, litellm_provider, expected) -> None:
+        assert _cache_economics_provider(litellm_provider) == expected
+
+
+class TestGetCachePrices:
+    def test_uses_explicit_litellm_cache_fields_when_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_litellm(
+            monkeypatch,
+            {
+                "m": {
+                    "input_cost_per_token": 1e-6,
+                    "cache_read_input_token_cost": 1e-7,
+                    "cache_creation_input_token_cost": 1.25e-6,
+                    "litellm_provider": "anthropic",
+                }
+            },
+        )
+        assert CostTracker()._get_cache_prices("m") == (1e-7, 1.25e-6, 1e-6)
+
+    def test_missing_cache_read_uses_provider_discount_not_full_rate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Bedrock model with an input price but no cache fields: exactly the
+        # 1600+ long-tail models the bug affects.
+        _patch_litellm(
+            monkeypatch,
+            {"m": {"input_cost_per_token": 5e-7, "litellm_provider": "bedrock"}},
+        )
+        cache_read, cache_write, uncached = CostTracker()._get_cache_prices("m")
+        assert uncached == 5e-7
+        # Before the fix this was 5e-7 (the full uncached rate) — the bug.
+        assert cache_read == pytest.approx(5e-7 * _CACHE_ECONOMICS["bedrock"]["read_multiplier"])
+        assert cache_read < uncached
+        assert cache_write == pytest.approx(5e-7 * _CACHE_ECONOMICS["bedrock"]["write_multiplier"])
+
+    def test_openai_provider_uses_openai_multipliers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_litellm(
+            monkeypatch,
+            {"m": {"input_cost_per_token": 1e-6, "litellm_provider": "openai"}},
+        )
+        cache_read, cache_write, uncached = CostTracker()._get_cache_prices("m")
+        # OpenAI: reads at 0.5x, writes at 1.0x (no write premium).
+        assert cache_read == pytest.approx(1e-6 * 0.5)
+        assert cache_write == pytest.approx(1e-6 * 1.0)
+
+    def test_unknown_provider_defaults_to_anthropic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_litellm(
+            monkeypatch,
+            {"m": {"input_cost_per_token": 2e-6}},  # no litellm_provider
+        )
+        cache_read, cache_write, uncached = CostTracker()._get_cache_prices("m")
+        assert cache_read == pytest.approx(2e-6 * _CACHE_ECONOMICS["anthropic"]["read_multiplier"])
+        assert cache_write == pytest.approx(
+            2e-6 * _CACHE_ECONOMICS["anthropic"]["write_multiplier"]
+        )
+
+    def test_only_the_missing_field_is_filled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Explicit read cost present, write cost absent: keep the real read,
+        # infer only the write.
+        _patch_litellm(
+            monkeypatch,
+            {
+                "m": {
+                    "input_cost_per_token": 1e-6,
+                    "cache_read_input_token_cost": 3e-7,
+                    "litellm_provider": "anthropic",
+                }
+            },
+        )
+        cache_read, cache_write, _ = CostTracker()._get_cache_prices("m")
+        assert cache_read == 3e-7  # untouched real value
+        assert cache_write == pytest.approx(
+            1e-6 * _CACHE_ECONOMICS["anthropic"]["write_multiplier"]
+        )
+
+    def test_no_input_price_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_litellm(monkeypatch, {"m": {"litellm_provider": "anthropic"}})
+        assert CostTracker()._get_cache_prices("m") is None


### PR DESCRIPTION
## Description

`CostTracker._get_cache_prices` (`headroom/proxy/cost.py`) priced provider-reported cache-read and cache-write tokens at the full uncached input rate whenever LiteLLM lacked explicit per-token cache price fields:

```python
cache_read = info.get("cache_read_input_token_cost", uncached)
cache_write = info.get("cache_creation_input_token_cost", uncached)
```

LiteLLM carries those two fields for only a minority of its priced models. Measured against the bundled LiteLLM pricing DB, 1681 of the models that have an `input_cost_per_token` lack both cache fields (Bedrock, Mistral, Fireworks, several OpenAI-compatible gateways). For every one of those models a provider-reported cache read was billed at the full uncached rate, over-charging `totals()` and the `/stats` dollar figures it feeds on every cache-warm request, and diverging from the primary `litellm.cost_per_token` accounting path.

## Fix

When a LiteLLM cache field is absent, **fail closed**: price that slice at `$0`, which is exactly what the canonical `litellm.cost_per_token` path (the one `estimate_cost` uses) books for a cache slice LiteLLM cannot price. So `totals()` reconciles with the primary accounting instead of over-charging.

Crucially, this does **not** substitute a provider guess for a missing rate. An earlier revision back-filled missing fields with `_CACHE_ECONOMICS` provider multipliers (defaulting unknown providers to Anthropic); that fabricates rates, because Bedrock alone fronts Anthropic, Amazon, Meta, Mistral and Cohere with non-interchangeable cache economics, and `_CACHE_ECONOMICS` is a coarse dashboard-savings convention rather than per-model billing metadata. Explicit LiteLLM cache fields still win.

Fixes #3032

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/cost.py` (`_get_cache_prices`): when `cache_read_input_token_cost` / `cache_creation_input_token_cost` is absent, price that slice at `$0` (fail closed / reconcile with `litellm.cost_per_token`) instead of the full uncached rate. Removed the `_cache_economics_provider` helper and the provider-multiplier fallback.
- `tests/test_cost_cache_prices.py`: explicit fields used verbatim; missing fields priced at `$0` (not full rate); only the missing field is zeroed; negative regressions proving heterogeneous Bedrock (`bedrock`, `bedrock_converse`) and unknown/unrecognized providers (`mistral`, `fireworks_ai`, `cohere_chat`, absent, made-up) do not inherit Anthropic rates; the missing cache slices match the canonical `$0`; no input price returns `None`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] New tests added

### Test Output

```text
tests/test_cost_cache_prices.py  18 passed
tests/test_cost_tracker_totals.py  7 passed
# uvx ruff@0.15.22 check  -> All checks passed!
# uvx mypy@1.20.2 headroom/proxy/cost.py -> Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.15.22 and mypy 1.20.2 via uvx.
- Exact command / steps: verified against the bundled LiteLLM DB that `litellm.cost_per_token` books `0.0` for a 10k cache-read (and 10k cache-write) slice on missing-field models (`mistral/mistral-large-latest`, `command-r`) while it uses the explicit field when present (`gpt-4o-mini` cache-read = `7.5e-08`/token); ran `python -m pytest tests/test_cost_cache_prices.py tests/test_cost_tracker_totals.py tests/test_savings_ledger.py -q`; confirmed the negative regressions fail against the old provider-multiplier fabrication (old Bedrock cache-read `= uncached * 0.1`); then `uvx ruff@0.15.22 check` and `uvx mypy@1.20.2 headroom/proxy/cost.py`.
- Observed result: a model lacking LiteLLM cache fields now prices cache reads and writes at `$0` (matching the canonical path) rather than the full uncached rate, and no provider heuristic is applied, so no model inherits Anthropic economics; explicit LiteLLM cache prices are unchanged.
- Not tested: a live proxy session billing real long-tail-model traffic (the pricing contract is verified directly against `_get_cache_prices` with a mocked `model_cost`, mirroring the shape LiteLLM exposes, plus the bundled-DB canonical-pricing check above).

## Runtime Rollout Safety

- Rollout-managed feature(s): none. This is the cost-accounting path behind `CostTracker.totals()` and `/stats`, not a rollout-channel-gated runtime feature.
- Minimum rollout channel: N/A (no rollout-managed behavior).
- Stable/default behavior changed: yes, as a bug fix. For models where LiteLLM omits cache price fields, cache-read/write slices are now priced at `$0` (reconciling with the canonical path) rather than the full uncached rate. Models where LiteLLM carries explicit cache prices are unaffected.
- Kill switch / disable path: N/A. There is no behavioral toggle; the change corrects the dollar figures `/stats` reports and does not alter routing, compression, or request handling.
- Unsafe override required: no.
- Qualification impact: `totals()` / `/stats` cost for long-tail models now matches the canonical `litellm.cost_per_token` accounting for the cache slices instead of over-charging cache reads or inventing a write premium.
- Rollback path: revert this PR; `_get_cache_prices` returns to defaulting missing cache fields to the full uncached rate.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`: it is generated by release-please from my Conventional Commit PR title

## Additional Notes

Reported by @EvolveAegis in #2620 as a distinct follow-up to the OpenAI cache-write double-charge fixed there. This revision replaces the earlier provider-multiplier fallback with fail-closed `$0` pricing per review feedback, so the fix reconciles with the primary accounting path and never fabricates a per-model rate from `litellm_provider`.
