### PR TITLE
fix(savings): refresh stale price map instead of pricing new models at $0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **Savings: a long-lived proxy priced newly-released models at $0.00.**
+  `litellm.model_cost` is populated once, at import, so a proxy left up for
+  weeks prices every request against the map it fetched at startup and a model
+  released after that date is simply absent. The lookup treated absent as free
+  and returned `0.0` with no signal anywhere. A miss now schedules a bounded,
+  TTL'd refresh of the map on a background thread (the request-recording path
+  never blocks on network I/O) and records the tokens it could not price;
+  `/stats` gains `unpriced_savings` so a $0 is visible rather than silent.
+  Dashboard `formatCurrency` also widened its k-band — everything over $1000
+  rendered with one decimal, so $1,050-$1,149 all displayed "$1.1k" and a
+  lifetime figure growing a few dollars a day could not visibly move.
+
 ### Features
 
 * **proxy:** per-project savings breakdown on the dashboard for all wrapped agents — Claude Code, Codex, aider, Copilot, and Cursor ([#802](https://github.com/chopratejas/headroom/issues/802)). `headroom wrap claude`/`codex` tag requests with an `X-Headroom-Project` header (launch-directory name); `wrap aider`/`copilot`/`cursor` — whose clients cannot send custom headers — use a `/p/<name>` base-URL prefix the proxy strips. Savings are aggregated per project (persisted, schema v3 with transparent v2 migration), exposed as `savings.per_project` in `/stats` and `projects` in `/stats-history`, and shown in a Per-Project Savings dashboard table.

--- a/headroom/dashboard/templates/dashboard.html
+++ b/headroom/dashboard/templates/dashboard.html
@@ -1841,7 +1841,12 @@
 
                 formatCurrency(n) {
                     if (n < 0) return '-' + this.formatCurrency(-n);
-                    if (n >= 1000) return (n / 1000).toFixed(1) + 'k';
+                    // Below $10k show whole dollars. One decimal in the k-band
+                    // meant $1,050-$1,149 all rendered "$1.1k", so a lifetime
+                    // figure growing a few dollars a day looked frozen for
+                    // weeks and read as "compression stopped saving anything".
+                    if (n >= 10000) return (n / 1000).toFixed(1) + 'k';
+                    if (n >= 1000) return Math.round(n).toLocaleString('en-US');
                     if (n >= 1) return n.toFixed(2);
                     if (n >= 0.01) return n.toFixed(3);
                     if (n > 0) return n.toFixed(4);

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -13,6 +13,7 @@ import logging
 import os
 import tempfile
 import threading
+import time
 from csv import DictWriter
 from datetime import datetime, timedelta, timezone
 from io import StringIO
@@ -37,6 +38,28 @@ DEFAULT_DISPLAY_SESSION_INACTIVITY_MINUTES = 60
 LITELLM_AVAILABLE = importlib.util.find_spec("litellm") is not None
 litellm: Any | None = None
 
+# LiteLLM populates ``litellm.model_cost`` once, at import. A proxy that stays
+# up for weeks therefore prices every request against a snapshot taken when it
+# started, and a model released after that start date is simply absent from the
+# map. The lookup below used to treat "absent" as "free" and return 0.0, so the
+# savings counter silently stopped moving for the newest — usually the most
+# expensive — model in use.
+#
+# Observed: a proxy started 2026-07-01 priced 25,400,013 claude-opus-5 tokens at
+# $0.00 across 3,962 checkpoints while pricing claude-sonnet-5 normally, because
+# opus-5 did not exist in the July map. Restarting the process fixed it, which
+# is the whole problem — nothing about a long-lived proxy should require a
+# restart to learn a price.
+#
+# Fix: a miss schedules a *background*, TTL'd refresh of the map and records the
+# miss in a counter. The record path never blocks on network I/O, and a $0 is
+# now visible in ``/stats`` instead of silent.
+PRICE_MAP_REFRESH_INTERVAL_SECONDS = 3600.0
+_price_map_lock = threading.Lock()
+_price_map_last_refresh: float = 0.0
+_price_map_refresh_in_flight: bool = False
+_unpriced_tokens: dict[str, int] = {}
+
 
 def _get_litellm_module() -> Any | None:
     """Import LiteLLM only when cost metadata is requested."""
@@ -54,6 +77,76 @@ def _get_litellm_module() -> Any | None:
 
     litellm = imported_litellm
     return litellm
+
+
+def _refresh_price_map_blocking() -> None:
+    """Re-fetch LiteLLM's model cost map in place. Never raises."""
+    global _price_map_refresh_in_flight
+
+    module = _get_litellm_module()
+    try:
+        if module is None:
+            return
+        getter = getattr(module, "get_model_cost_map", None)
+        url = getattr(module, "model_cost_map_url", "") or ""
+        if getter is None or not url:
+            return
+        refreshed = getter(url)
+        if isinstance(refreshed, dict) and refreshed:
+            module.model_cost = refreshed
+            logger.info(
+                "refreshed litellm price map: %d models",
+                len(refreshed),
+            )
+    except Exception as exc:  # pragma: no cover - network/shape dependent
+        logger.debug("litellm price map refresh failed: %s", exc)
+    finally:
+        with _price_map_lock:
+            _price_map_refresh_in_flight = False
+
+
+def _schedule_price_map_refresh() -> None:
+    """Kick off at most one background price-map refresh per TTL window.
+
+    Deliberately off the calling thread: this runs from the request-recording
+    path, which must not block on a network fetch.
+    """
+    global _price_map_last_refresh, _price_map_refresh_in_flight
+
+    now = time.monotonic()
+    with _price_map_lock:
+        if _price_map_refresh_in_flight:
+            return
+        if _price_map_last_refresh and (
+            now - _price_map_last_refresh < PRICE_MAP_REFRESH_INTERVAL_SECONDS
+        ):
+            return
+        _price_map_last_refresh = now
+        _price_map_refresh_in_flight = True
+
+    threading.Thread(
+        target=_refresh_price_map_blocking,
+        name="headroom-price-map-refresh",
+        daemon=True,
+    ).start()
+
+
+def _record_unpriced(model: str, tokens: int) -> None:
+    """Count tokens we could not price, so a $0 is visible rather than silent."""
+    if tokens <= 0:
+        return
+    with _price_map_lock:
+        _unpriced_tokens[model] = _unpriced_tokens.get(model, 0) + tokens
+
+
+def unpriced_tokens_snapshot() -> dict[str, Any]:
+    """Tokens saved for models with no known price, for ``/stats``."""
+    with _price_map_lock:
+        by_model = dict(_unpriced_tokens)
+    return {
+        "total": sum(by_model.values()),
+        "by_model": by_model,
+    }
 
 
 def get_default_savings_storage_path() -> str:
@@ -196,6 +289,12 @@ def _estimate_compression_savings_usd(model: str, tokens_saved: int) -> float:
         info = litellm.model_cost.get(resolved, {})
         input_cost_per_token = info.get("input_cost_per_token")
         if not input_cost_per_token:
+            # Unknown model. Usually means this process's price map predates the
+            # model's release, so ask for a refresh (bounded, off-thread) and
+            # count the tokens we could not price. Returning 0.0 silently here
+            # is what froze the savings counter for weeks — see the note above.
+            _schedule_price_map_refresh()
+            _record_unpriced(resolved, tokens_saved)
             return 0.0
         return float(tokens_saved) * float(input_cost_per_token)
     except Exception:

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -103,6 +103,7 @@ from headroom.providers.registry import (
     format_backend_status,
     resolve_api_targets,
 )
+from headroom.proxy import savings_tracker as _savings_tracker_module
 
 # =============================================================================
 # Extracted modules (re-exported for backward compatibility)
@@ -2672,6 +2673,9 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
             "savings_history": m.savings_history[-100:],  # Last 100 data points
             "display_session": display_session,
             "persistent_savings": persistent_savings,
+            # Tokens saved for models with no known price. Surfaced so a $0 is
+            # visible instead of silently flattening the savings figure.
+            "unpriced_savings": _savings_tracker_module.unpriced_tokens_snapshot(),
             "prefix_cache": prefix_cache_stats,
             "cost": _merge_cost_stats(
                 proxy.cost_tracker.stats() if proxy.cost_tracker else None,

--- a/tests/test_savings_tracker_price_map_refresh.py
+++ b/tests/test_savings_tracker_price_map_refresh.py
@@ -1,0 +1,156 @@
+"""Regression tests for the stale-price-map bug (AQ-0609).
+
+LiteLLM fills ``litellm.model_cost`` once at import. A proxy that stays up for
+weeks prices everything against that snapshot, so a model released after the
+process started is absent from the map. The lookup used to read "absent" as
+"free" and return 0.0 forever, with no signal anywhere that it had done so.
+
+Field evidence: a proxy started 2026-07-01 priced 25,400,013 ``claude-opus-5``
+tokens at $0.00 across 3,962 consecutive checkpoints while pricing
+``claude-sonnet-5`` at the normal $3/Mtok. Restarting the process fixed it.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+from headroom.proxy import savings_tracker as st
+
+
+class _FakeLiteLLM:
+    """Minimal stand-in for the parts of litellm the tracker touches."""
+
+    model_cost_map_url = "https://example.invalid/model_prices.json"
+
+    def __init__(self, model_cost: dict[str, Any], refreshed: dict[str, Any] | None = None):
+        self.model_cost = model_cost
+        self._refreshed = refreshed or {}
+        self.refresh_calls = 0
+
+    def cost_per_token(self, **_kwargs: Any) -> tuple[float, float]:
+        # Force _resolve_litellm_model down its exception path so it returns the
+        # bare model name — that is the shape that actually reaches the lookup.
+        raise RuntimeError("not supported")
+
+    def get_model_cost_map(self, url: str) -> dict[str, Any]:
+        assert url == self.model_cost_map_url
+        self.refresh_calls += 1
+        return self._refreshed
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch: pytest.MonkeyPatch):
+    """Isolate the module-level refresh/unpriced state between tests."""
+    monkeypatch.setattr(st, "LITELLM_AVAILABLE", True)
+    monkeypatch.setattr(st, "_price_map_last_refresh", 0.0)
+    monkeypatch.setattr(st, "_price_map_refresh_in_flight", False)
+    monkeypatch.setattr(st, "_unpriced_tokens", {})
+    yield
+
+
+def _run_refresh_synchronously(monkeypatch: pytest.MonkeyPatch) -> list[threading.Thread]:
+    """Replace the background thread with an inline call, keeping the test deterministic."""
+    started: list[threading.Thread] = []
+    real_thread = threading.Thread
+
+    def _inline_thread(*args: Any, **kwargs: Any):
+        target = kwargs.get("target")
+
+        class _Inline:
+            def start(self_inner) -> None:
+                started.append(real_thread(target=target))
+                if target is not None:
+                    target()
+
+        return _Inline()
+
+    monkeypatch.setattr(st.threading, "Thread", _inline_thread)
+    return started
+
+
+def test_known_model_is_priced_normally(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Baseline: a model in the map prices at its list rate. Unchanged behavior."""
+    fake = _FakeLiteLLM({"claude-sonnet-5": {"input_cost_per_token": 3e-06}})
+    monkeypatch.setattr(st, "litellm", fake)
+
+    usd = st._estimate_compression_savings_usd("claude-sonnet-5", 1_000_000)
+
+    assert usd == pytest.approx(3.0)
+    assert st.unpriced_tokens_snapshot()["total"] == 0
+    assert fake.refresh_calls == 0, "a priceable model must not trigger a refresh"
+
+
+def test_unknown_model_is_counted_as_unpriced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The core regression: a $0 must be *visible*, not silent.
+
+    Before the fix this returned 0.0 and left no trace anywhere, which is why
+    the dashboard read the same number for weeks.
+    """
+    fake = _FakeLiteLLM({"claude-sonnet-5": {"input_cost_per_token": 3e-06}})
+    monkeypatch.setattr(st, "litellm", fake)
+    _run_refresh_synchronously(monkeypatch)
+
+    usd = st._estimate_compression_savings_usd("claude-opus-5", 25_400_013)
+
+    assert usd == 0.0
+    snapshot = st.unpriced_tokens_snapshot()
+    assert snapshot["total"] == 25_400_013
+    assert snapshot["by_model"] == {"claude-opus-5": 25_400_013}
+
+
+def test_unknown_model_triggers_a_price_map_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A miss must ask litellm for a fresh map rather than waiting for a restart."""
+    fake = _FakeLiteLLM(
+        {"claude-sonnet-5": {"input_cost_per_token": 3e-06}},
+        refreshed={
+            "claude-sonnet-5": {"input_cost_per_token": 2e-06},
+            "claude-opus-5": {"input_cost_per_token": 5e-06},
+        },
+    )
+    monkeypatch.setattr(st, "litellm", fake)
+    _run_refresh_synchronously(monkeypatch)
+
+    # First call misses and refreshes the map in place.
+    first = st._estimate_compression_savings_usd("claude-opus-5", 1_000_000)
+    assert first == 0.0
+    assert fake.refresh_calls == 1
+
+    # Second call now prices the model the running process had never heard of.
+    # This is exactly what previously required killing and relaunching the proxy.
+    second = st._estimate_compression_savings_usd("claude-opus-5", 1_000_000)
+    assert second == pytest.approx(5.0)
+
+
+def test_refresh_is_rate_limited_to_one_per_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A model that is genuinely unpriceable must not refetch on every request."""
+    fake = _FakeLiteLLM({}, refreshed={})
+    monkeypatch.setattr(st, "litellm", fake)
+    _run_refresh_synchronously(monkeypatch)
+
+    for _ in range(25):
+        st._estimate_compression_savings_usd("some-unlisted-model", 1_000)
+
+    assert fake.refresh_calls == 1, "TTL window must collapse repeated misses into one fetch"
+    assert st.unpriced_tokens_snapshot()["total"] == 25_000, "every miss is still counted"
+
+
+def test_refresh_failure_is_never_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pricing runs on the request-recording path; a network failure must not raise."""
+
+    class _ExplodingLiteLLM(_FakeLiteLLM):
+        def get_model_cost_map(self, url: str) -> dict[str, Any]:
+            self.refresh_calls += 1
+            raise ConnectionError("no network")
+
+    fake = _ExplodingLiteLLM({})
+    monkeypatch.setattr(st, "litellm", fake)
+    _run_refresh_synchronously(monkeypatch)
+
+    usd = st._estimate_compression_savings_usd("claude-opus-5", 500)
+
+    assert usd == 0.0
+    assert fake.refresh_calls == 1
+    assert st.unpriced_tokens_snapshot()["total"] == 500


### PR DESCRIPTION
## Problem

`litellm.model_cost` is populated once, at import. A proxy that stays up for weeks therefore prices every request against the map it fetched at startup, and a model released after that date is simply absent from it. `_estimate_compression_savings_usd` read "absent" as "free":

```python
input_cost_per_token = info.get("input_cost_per_token")
if not input_cost_per_token:
    return 0.0
```

There is no log line, no counter, and no dashboard signal. The savings figure just stops moving for whichever model you have most recently adopted — usually the newest and most expensive one.

## Reproduction

On a proxy started 2026-07-01 and still running 2026-08-14, walking consecutive checkpoints in `~/.headroom/proxy_savings.json` and grouping the deltas by model:

| model | tokens saved | $ accrued | implied $/Mtok | checkpoints |
|---|---:|---:|---:|---:|
| `claude-opus-5` | 25,400,013 | **$0.00** | **0.000** | 3,962 |
| `claude-sonnet-5` | 10,276,174 | $30.83 | 3.000 | 468 |
| `claude-opus-4-7` | 335,472 | $1.68 | 5.000 | 94 |
| `claude-fable-5` | 118,264 | $1.18 | 10.000 | 38 |
| `gpt-5.6-sol` | 43,844 | **$0.00** | **0.000** | 105 |

Every one of the 3,962 `claude-opus-5` checkpoints priced at exactly zero, while other models in the same process priced normally. `claude-opus-5` did not exist in the price map that process fetched on July 1.

A second signal in the same data: that process priced `claude-sonnet-5` at `$3.000/Mtok`, while today's map says `$2.000/Mtok`. Same code, two different maps — which is the point.

## Real behavior proof

**Setup**

- macOS 26.5.1, arm64, Python 3.13.13
- `headroom-ai` 0.25.0 installed non-editable in a venv, `litellm` 1.88.1
- Proxy: `headroom proxy --port 8787`, `HEADROOM_MODE=token`, backend `anthropic`
- Traffic: Claude Code (`claude-cli/2.1.233`) and Codex, primary model `claude-opus-5`

**Steps run after the patch**

1. Applied the change to the installed copy and restarted the proxy.
2. Let real session traffic accrue.
3. Re-read `~/.headroom/proxy_savings.json` and grouped deltas by model again.
4. Read `/stats`.

**After-fix evidence — observed result**

Splitting the same savings file at the restart boundary, nothing changed but the process:

```
BEFORE   claude-opus-5   25,400,013 tok  ->  $0.00    $0.000/Mtok   n=3,962
AFTER    claude-opus-5    1,937,548 tok  ->  $9.69    $5.000/Mtok   n=270
```

`/stats` now carries the new field, so an unpriceable model is visible rather than silent:

```json
"unpriced_savings": {"total": 0, "by_model": {}}
```

And the pricing path itself, run against the live installed module:

```
$ cd / && python -c "from headroom.proxy import savings_tracker as st; \
    print(st.__file__); \
    print(st._estimate_compression_savings_usd('claude-opus-5', 1_000_000))"
/…/site-packages/headroom/proxy/savings_tracker.py
5.0
```

**What I did not test**

- The background refresh against a genuinely stale map in a long-running process. The TTL path is unit-tested with an injected fake; I have not left a proxy up long enough for a real model release to land mid-process.
- Non-Anthropic providers beyond the `gpt-5.6-*` rows visible in the data above.
- Behaviour when `litellm` is absent entirely (the existing `LITELLM_AVAILABLE` guard is untouched).

## The fix

A miss now schedules a bounded, TTL'd refresh of `litellm.model_cost` on a background thread and records the tokens it could not price. Deliberately off the calling thread: this runs on the request-recording path, which must not block on a network fetch. A refresh failure is caught and is never fatal. `PRICE_MAP_REFRESH_INTERVAL_SECONDS` defaults to one hour, so a genuinely unpriceable model does not refetch on every request.

`/stats` gains `unpriced_savings: {total, by_model}`.

## Also included

`formatCurrency` in the dashboard rendered anything over `$1000` with one decimal, so `$1,050`–`$1,149` all displayed `"$1.1k"`. A lifetime figure growing a few dollars a day could not visibly move for weeks, which reads as "compression stopped saving anything". Below `$10k` now shows whole dollars:

```
999.994 -> $999.99   1000 -> $1,000   1112.59 -> $1,113   9999.4 -> $9,999   10000 -> $10.0k
```

Anchored on the `formatCurrency` signature so the identical line inside `formatNumber()` is untouched — `441.4M` is correct for token counts.

I kept this in the same PR because it is the same reported symptom (the savings number appears frozen) with a second contributing cause. Happy to split it out if you would rather.

## Tests

`tests/test_savings_tracker_price_map_refresh.py`, 5 cases. Each claim was mutated to red and back rather than trusted green:

- Restoring the original two-line body → 4 of 5 fail; the baseline "known model still prices at $3/Mtok" correctly stays green.
- Setting `PRICE_MAP_REFRESH_INTERVAL_SECONDS = 0.0` → only the rate-limit test fails.

Full suite on this branch matches `main` exactly: 11 failed / 86 passed across the pre-existing failures, which are environment gaps in my checkout (`cargo` not installed, ast-grep interceptors, tree-sitter) and are identical on `main`. `ruff check` and `ruff format --check` clean.
