### PR TITLE
fix(proxy): read HEADROOM_COMPRESSION_MAX_WORKERS, which was never wired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **`HEADROOM_COMPRESSION_MAX_WORKERS` was documented but never read.**
+  `ProxyConfig.compression_max_workers` has documented that environment variable
+  and a `--compression-max-workers` CLI flag since the field was introduced, but
+  the string appeared exactly once in the tree — inside the comment promising it.
+  The compression pool was therefore pinned to `min(32, cpu_count * 4)` with no
+  way to change it short of editing source. That matters because the pool sits in
+  front of Kompress's execution semaphore, which defaults to 1 concurrent
+  inference: the remaining workers block on an untimed `acquire()` while still
+  holding a pool slot, so the pool reports 32/32 in-flight while at most one
+  inference runs. The env var is now read; malformed or non-positive values are
+  ignored with a warning rather than taking startup down, and `/stats` reports
+  `source` as `explicit` / `env` / `auto`.
+
 ### Features
 
 * **proxy:** per-project savings breakdown on the dashboard for all wrapped agents — Claude Code, Codex, aider, Copilot, and Cursor ([#802](https://github.com/chopratejas/headroom/issues/802)). `headroom wrap claude`/`codex` tag requests with an `X-Headroom-Project` header (launch-directory name); `wrap aider`/`copilot`/`cursor` — whose clients cannot send custom headers — use a `/p/<name>` base-URL prefix the proxy strips. Savings are aggregated per project (persisted, schema v3 with transparent v2 migration), exposed as `savings.per_project` in `/stats` and `projects` in `/stats-history`, and shown in a Per-Project Savings dashboard table.

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -449,6 +449,27 @@ _RUST_CORE_REQUIRED_ENV = "HEADROOM_REQUIRE_RUST_CORE"
 _EXIT_CONFIG = 78
 
 
+def _env_int_or_none(name: str) -> int | None:
+    """Read a positive int from the environment, ignoring junk.
+
+    A malformed or non-positive value falls back to the caller's default rather
+    than crashing proxy startup — an unparseable tuning knob should not take
+    the proxy down.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("ignoring non-integer %s=%r", name, raw)
+        return None
+    if value < 1:
+        logger.warning("ignoring non-positive %s=%d", name, value)
+        return None
+    return value
+
+
 def _check_rust_core() -> tuple[str, str | None]:
     """Verify the Rust extension `headroom._core` is loadable at startup.
 
@@ -759,6 +780,8 @@ class HeadroomProxy(
         #      the worker, so this is the only signal that some pool slots
         #      are sitting on stuck work.
         _compression_max_cfg = config.compression_max_workers
+        if _compression_max_cfg is None:
+            _compression_max_cfg = _env_int_or_none("HEADROOM_COMPRESSION_MAX_WORKERS")
         if _compression_max_cfg is None:
             _compression_max = min(32, (os.cpu_count() or 1) * 4)
         else:
@@ -1917,7 +1940,13 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
                 "run_seconds_total": _comp_run_total,
                 "run_seconds_max": _comp_run_max,
                 "leaked_threads_total": _comp_leaked,
-                "source": ("auto" if config.compression_max_workers is None else "explicit"),
+                "source": (
+                    "explicit"
+                    if config.compression_max_workers is not None
+                    else "env"
+                    if _env_int_or_none("HEADROOM_COMPRESSION_MAX_WORKERS") is not None
+                    else "auto"
+                ),
             },
             "websocket_sessions": {
                 "active_sessions": ws_active_sessions,

--- a/tests/test_proxy_compression_max_workers_env.py
+++ b/tests/test_proxy_compression_max_workers_env.py
@@ -1,0 +1,58 @@
+"""``HEADROOM_COMPRESSION_MAX_WORKERS`` wiring tests (AQ-0610).
+
+``ProxyConfig.compression_max_workers`` has documented both a
+``HEADROOM_COMPRESSION_MAX_WORKERS`` env var and a ``--compression-max-workers``
+CLI flag since the field was added, but neither was ever implemented — the
+string appeared exactly once in the tree, inside that comment. The pool size was
+therefore pinned to the auto-size with no way to change it short of editing
+source.
+
+That is not cosmetic. The auto-size is ``min(32, cpu_count * 4)`` = 32 on this
+class of machine, and it sits in front of Kompress's execution semaphore, which
+defaults to 1 concurrent inference. Workers 2..32 block on an *untimed*
+``BoundedSemaphore.acquire()`` while still holding their pool slot, so the pool
+reports 32/32 in-flight while at most one inference is running. Being able to
+size the pool to the semaphore is the documented mitigation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from headroom.proxy import server as srv
+
+
+class TestEnvIntOrNone:
+    """The parser must never take proxy startup down over a bad knob."""
+
+    def test_reads_a_positive_integer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HEADROOM_COMPRESSION_MAX_WORKERS", "3")
+
+        assert srv._env_int_or_none("HEADROOM_COMPRESSION_MAX_WORKERS") == 3
+
+    def test_unset_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("HEADROOM_COMPRESSION_MAX_WORKERS", raising=False)
+
+        assert srv._env_int_or_none("HEADROOM_COMPRESSION_MAX_WORKERS") is None
+
+    def test_whitespace_is_tolerated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HEADROOM_COMPRESSION_MAX_WORKERS", "  8  ")
+
+        assert srv._env_int_or_none("HEADROOM_COMPRESSION_MAX_WORKERS") == 8
+
+    @pytest.mark.parametrize("junk", ["", "   ", "abc", "3.5", "1e3"])
+    def test_malformed_values_fall_back_rather_than_raise(
+        self, monkeypatch: pytest.MonkeyPatch, junk: str
+    ) -> None:
+        monkeypatch.setenv("HEADROOM_COMPRESSION_MAX_WORKERS", junk)
+
+        assert srv._env_int_or_none("HEADROOM_COMPRESSION_MAX_WORKERS") is None
+
+    @pytest.mark.parametrize("bad", ["0", "-1", "-32"])
+    def test_non_positive_values_are_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, bad: str
+    ) -> None:
+        """A zero-worker pool would deadlock every compression, so refuse it."""
+        monkeypatch.setenv("HEADROOM_COMPRESSION_MAX_WORKERS", bad)
+
+        assert srv._env_int_or_none("HEADROOM_COMPRESSION_MAX_WORKERS") is None


### PR DESCRIPTION
## Problem

`ProxyConfig.compression_max_workers` documents both an environment variable and a CLI flag:

```python
# … Lower the cap to
# tighten resource use on multi-tenant hosts; raise it to handle larger
# bursts. CLI: ``--compression-max-workers``. Env:
# ``HEADROOM_COMPRESSION_MAX_WORKERS``.
compression_max_workers: int | None = None
```

Neither exists. The string `HEADROOM_COMPRESSION_MAX_WORKERS` appears exactly once in the whole tree — inside the comment promising it:

```
$ grep -rn "HEADROOM_COMPRESSION_MAX_WORKERS" --include="*.py" .
headroom/proxy/models.py:326:    # ``HEADROOM_COMPRESSION_MAX_WORKERS``.

$ headroom proxy --help | grep -i "max-workers"
(no output)
```

So the field is settable only programmatically, and the auto-size `min(32, (cpu_count or 1) * 4)` is the only reachable value for anyone running the proxy normally.

## Why this is not cosmetic

The compression pool sits in front of Kompress's execution semaphore, and `_default_max_concurrent()` returns `1` for every backend:

```python
def _default_max_concurrent(backend: str, device_type: str) -> int:
    if backend.startswith("onnx"):
        return 1
    if backend == "pytorch" and device_type in {"cuda", "mps", "cpu"}:
        return 1
    return 1
```

That semaphore is a blocking, **untimed** `BoundedSemaphore`, acquired inside the worker:

```python
with _execution_semaphore(backend, device_type):
    ...  # inference
```

So a 32-worker executor feeds a 1-wide model. Workers beyond the semaphore limit block on `acquire()` while still holding their pool slot — the executor reports 32/32 in-flight while at most one inference is actually running. That is a queue converted into 32 occupied slots plus a 30 s `COMPRESSION_TIMEOUT_SECONDS`, and because `asyncio.wait_for` cannot preempt a started worker, the timeouts land in `leaked_threads_total` rather than freeing capacity.

Sizing the pool to the semaphore moves the queueing back in front of the pool, where the asyncio side can still cancel a job before a worker picks it up. The existing docs already name that as the tuning knob. It just was not reachable.

## Real behavior proof

**Setup**

- macOS 26.5.1, arm64, Python 3.13.13, `headroom-ai` 0.25.0 installed non-editable in a venv
- Proxy on `127.0.0.1:8787`, `HEADROOM_MODE=token`, backend `anthropic`, ONNX Kompress
- Shared by several concurrent Claude Code sessions plus Codex

**Before — the knob does nothing**

```
$ HEADROOM_COMPRESSION_MAX_WORKERS=3 headroom proxy --port 8787
$ curl -s localhost:8787/debug/warmup | jq .runtime.compression_executor
{ "max_workers": 32, "source": "auto", ... }
```

Live gauges from that proxy under ordinary load, showing the mechanism biting:

```
max_workers 32   in_flight 32   in_flight_max 32   queued 8
queue_timeouts_total 4466   queue_wait_seconds_max 218.3
run_seconds_max 14379.5     leaked_threads_total 1848
```

and on its replacement, sampled again while busy: `in_flight 32`, `source "auto"`.

**After — observed result**

```
$ curl -s localhost:8787/debug/warmup | jq .runtime.compression_executor
{ "max_workers": 3, "source": "env", ... }
```

`source` now distinguishes `explicit` (programmatic) / `env` / `auto`.

**What I did not test**

- I have **not** yet measured a sustained before/after on saturation, timeout rate, or p99 latency with the pool sized to the semaphore. This PR makes the documented knob reachable and does not claim a performance number. I did not change any default — an unset env var behaves exactly as before.
- The `--compression-max-workers` CLI flag is still absent; I only wired the env var. Say the word and I will add the flag in the same PR.
- Non-ONNX backends, where `_default_max_concurrent()` also returns 1 but the inference cost profile differs.

## The fix

`server.py` reads the env var when `config.compression_max_workers` is `None`, so the precedence is programmatic → env → auto. Malformed or non-positive values are ignored with a warning rather than raising, because an unparseable tuning knob should not take proxy startup down — a `0` in particular would produce a deadlocked pool.

## Tests

`tests/test_proxy_compression_max_workers_env.py`, 11 cases: valid, surrounding whitespace, unset, malformed (`abc`, `3.5`, `1e3`, empty), and non-positive (`0`, `-1`, `-32`).

Full suite on this branch matches `main` exactly: 11 failed / 86 passed on the pre-existing failures, which are environment gaps in my checkout (`cargo` not installed, ast-grep, tree-sitter) and identical on `main`. `ruff check` and `ruff format --check` clean.
