### PR TITLE
fix(cli): honor HEADROOM_PORT in install apply and deploy commands

### DIFF
--- a/headroom/cli/install.py
+++ b/headroom/cli/install.py
@@ -506,8 +506,9 @@ def _echo_installed(manifest: DeploymentManifest, *, prefix: str = "Installed pe
     "-p",
     default=8787,
     type=click.IntRange(1, 65535),
+    envvar="HEADROOM_PORT",
     show_default=True,
-    help="Persistent proxy port.",
+    help="Persistent proxy port. (env: HEADROOM_PORT)",
 )
 @click.option(
     "--backend",
@@ -682,7 +683,13 @@ def install_apply(
 @main.command("deploy")
 @click.option("--profile", default="default", show_default=True, help="Deployment profile name.")
 @click.option(
-    "--port", "-p", default=8787, type=int, show_default=True, help="Persistent proxy port."
+    "--port",
+    "-p",
+    default=8787,
+    type=int,
+    envvar="HEADROOM_PORT",
+    show_default=True,
+    help="Persistent proxy port. (env: HEADROOM_PORT)",
 )
 @click.option(
     "--backend",


### PR DESCRIPTION
## Description

`headroom proxy --port` already honors `HEADROOM_PORT` via Click's `envvar` support (see `headroom/cli/proxy.py`), but the `--port` options on `headroom install apply --preset persistent-service` and `headroom deploy` did not declare that `envvar`, so an explicit `HEADROOM_PORT=8788` was silently ignored — both commands always fell back to the hardcoded `8787` default and generated a persistent-service manifest bound to the wrong port. Users running multiple instances or avoiding a port conflict got a silently wrong config with no error.

This addresses bug 1 of the two independent bugs reported in #3072. Bug 2 (`install status` reporting "stopped" while `doctor` reports healthy) has a different root cause — `runtime_status()` in `headroom/install/runtime.py` only tracks liveness via a locally-written PID file, which is never written for supervisor-managed presets (systemd/launchd/Task Scheduler start the process directly) — and needs its own fix querying the actual supervisor, which is out of scope here.

Related to #3072

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Added `envvar="HEADROOM_PORT"` to the `--port` option on `headroom install apply` (`headroom/cli/install.py`).
- Added `envvar="HEADROOM_PORT"` to the `--port` option on `headroom deploy` (`headroom/cli/install.py`).
- Updated both options' `help=` text to note the env var, matching the existing `headroom proxy --port` help string.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ ruff check .
All checks passed!

$ pytest tests/test_cli/test_install_cli.py -q
collected 37 items
tests/test_cli/test_install_cli.py .....................................  [100%]
37 passed in 0.28s
```

`mypy headroom` was not run to a clean result in this sandbox: it fails before reaching this file on a pre-existing, unrelated error in the installed `numpy` stub (`Type statement is only supported in Python 3.12 and greater`). Not caused by this change (a Click option kwarg addition).

No new tests added: the existing 37 `test_install_cli.py` tests already exercise `install apply`/`deploy` option parsing and all continue to pass; a small `envvar=` kwarg addition to two existing options doesn't warrant new test scaffolding beyond what's demonstrated live in Real Behavior Proof below. Happy to add a `CliRunner` regression test asserting `HEADROOM_PORT` resolution if maintainers want one pinned in the suite.

## Real Behavior Proof

- Environment: local sandbox, Python 3.12.3, Click 8.x, using `click.testing.CliRunner` against the exact option definition now used by both `install apply` and `deploy` (same `default=8787, type=..., envvar="HEADROOM_PORT"` kwargs).
- Exact command / steps: invoked a minimal Click command built from the same option kwargs three ways — no flag/no env, `HEADROOM_PORT=8788` env only, and `HEADROOM_PORT=8788` env plus an explicit `--port 9000` flag — then separately ran `install apply --help` / `deploy --help` through the real CLI to confirm the env var now appears in `--help` output.
- Observed result: `default:` printed `port=8787`; `env only:` printed `port=8788` (the fix — previously this printed `port=8787`, ignoring the env var entirely); `env + explicit flag:` printed `port=9000`, confirming an explicit `--port` still wins over `HEADROOM_PORT` exactly like `headroom proxy --port` does. `install apply --help` and `deploy --help` both now show `HEADROOM_PORT` in the port option's help text (`grep` confirmed `True`/`True`).
- Not tested: the full `install apply`/`deploy` command end-to-end (writing an actual systemd/launchd unit or Windows Task and starting it) — that requires a real supervisor (systemd/launchd/schtasks) and elevated permissions not available in this sandbox. The port value is proven to flow unchanged from the Click option into `_build_deployment_manifest(port=port, ...)` → `build_manifest(port=port, ...)` (read directly in `headroom/cli/install.py`), which is the same `port` field `headroom/install/planner.py` writes into `HEADROOM_PORT` in the generated service env — so the isolated proof above covers the actual code path, just not a live supervisor invocation.

## Runtime Rollout Safety

- Rollout-managed feature(s): None — this is CLI option parsing for a one-time install/deploy command, not a proxy runtime behavior behind a rollout flag.
- Minimum rollout channel: N/A
- Stable/default behavior changed: Yes, but only when `HEADROOM_PORT` is exported and no explicit `--port` is passed — previously ignored, now honored (matches `headroom proxy --port`'s existing, documented behavior). No change to default behavior when `HEADROOM_PORT` is unset.
- Kill switch / disable path: None needed — pass `--port` explicitly to override, exactly as today.
- Unsafe override required: No
- Qualification impact: None
- Rollback path: Revert this commit to restore the previous (env-ignoring) `--port` options.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — CLI option change, no UI impact.

## Additional Notes

- "New and existing unit tests pass locally" and "I have added tests" are left unchecked for the same reasons detailed in Testing above: the full `pytest tests/` collection can't complete in this sandbox (missing compiled `headroom._core` Rust extension, unrelated to this change), and no new tests were added — see Testing and Real Behavior Proof for what was actually verified.
- This PR intentionally does not close #3072 — it only fixes bug 1 (`HEADROOM_PORT` ignored). Bug 2 (`install status` vs `doctor` disagreement) needs a separate PR that teaches `runtime_status()` to query the actual supervisor (systemd/launchd/Task Scheduler) instead of relying solely on a PID file that supervisor-managed presets never write.
