### PR TITLE
fix(wrap): route OpenCode custom OpenAI-compatible upstreams

### DIFF
--- a/docs/content/docs/opencode-deepseek.mdx
+++ b/docs/content/docs/opencode-deepseek.mdx
@@ -193,9 +193,15 @@ API key to the proxy, and the proxy forwards it to DeepSeek. Make sure
 
 ### Models appear but requests fail
 
-You ran `headroom wrap opencode`. That command replaces your config with Claude
-and GPT models. **Do not use `headroom wrap`.** Configure OpenCode manually as
-shown above, and launch OpenCode directly with `opencode`.
+If you ran `headroom wrap opencode` without `--openai-api-url`, OpenAI-compatible
+traffic is forwarded to OpenAI's own API by default, so your DeepSeek key is
+rejected with an HTTP 401 error. Two fixes:
+
+- Add the flag so the proxy is started with the right upstream:
+  `headroom wrap opencode --openai-api-url https://api.deepseek.com/v1`
+- Or fall back to the manual setup shown above (`headroom proxy --openai-api-url
+  https://api.deepseek.com/v1` plus the `opencode.json` edits), and launch
+  OpenCode directly with `opencode`.
 
 ### "headroom" command not found
 
@@ -223,7 +229,10 @@ shaper is active immediately — the numbers just need calibration.
 ## What's NOT in this guide
 
 - **Claude or GPT models** — this setup uses DeepSeek exclusively
-- **`headroom wrap`** — do not use it; it overrides the config
+- **Every moving part of the manual setup** — this guide documents the manual
+  path deliberately, step by step, so you can see exactly what gets configured.
+  `headroom wrap opencode --openai-api-url https://api.deepseek.com/v1` is now
+  also a supported shortcut that automates the same config-injection steps.
 - **Deprecated model names** — `deepseek-chat` and `deepseek-reasoner` are
   compatibility aliases that will be deprecated on 2026-07-24; use
   `deepseek-v4-pro` and `deepseek-v4-flash` instead

--- a/docs/content/docs/opencode.mdx
+++ b/docs/content/docs/opencode.mdx
@@ -41,6 +41,7 @@ headroom wrap opencode \
   --no-serena \
   --code-graph \
   --no-proxy \
+  --openai-api-url https://api.deepseek.com/v1 \
   --learn \
   --memory \
   --backend anthropic \
@@ -48,6 +49,13 @@ headroom wrap opencode \
   --region ... \
   -- <opencode args>
 ```
+
+Pass `--openai-api-url` when OpenCode should route through a third-party
+OpenAI-compatible provider instead of OpenAI itself — for example DeepSeek's
+`https://api.deepseek.com/v1`. Without it, OpenAI-compatible traffic is
+forwarded to OpenAI's own API by default, and a non-OpenAI API key is
+rejected with an HTTP 401 error. See
+[OpenCode + DeepSeek](/docs/opencode-deepseek) for a full walkthrough.
 
 ## Provider Model Mapping
 

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -7215,6 +7215,16 @@ def openclaw(
 )
 @click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
 @click.option(
+    "--openai-api-url",
+    metavar="URL",
+    help=(
+        "Base URL of the actual OpenAI-compatible provider you are using, for example "
+        "DeepSeek's https://api.deepseek.com/v1. Set this when OpenCode is configured for "
+        "a provider other than OpenAI; without it, requests are forwarded to OpenAI's own "
+        "API by default and a non-OpenAI API key is rejected with an HTTP 401 error."
+    ),
+)
+@click.option(
     "--copilot-subscription",
     is_flag=True,
     help="Route headroom/* models through the authenticated GitHub Copilot subscription",
@@ -7235,6 +7245,7 @@ def opencode(
     no_serena: bool,
     code_graph: bool,
     no_proxy: bool,
+    openai_api_url: str | None,
     copilot_subscription: bool,
     learn: bool,
     memory: bool,
@@ -7253,6 +7264,13 @@ def opencode(
     Also sets OPENAI_BASE_URL and ANTHROPIC_BASE_URL as fallbacks.
 
     \b
+    By default, OpenAI-compatible traffic is forwarded to OpenAI's own API.
+    If OpenCode is configured to use a different OpenAI-compatible provider
+    (for example DeepSeek), pass that provider's base URL via
+    --openai-api-url so requests and your existing API key reach the right
+    upstream instead of being rejected by OpenAI with an HTTP 401 error.
+
+    \b
     Examples:
         headroom wrap opencode                         # Start proxy + opencode
         headroom wrap opencode -- "fix the bug"        # Pass prompt to opencode
@@ -7261,6 +7279,7 @@ def opencode(
         headroom wrap opencode --port 9999             # Custom proxy port
         headroom wrap opencode --backend anyllm --anyllm-provider groq
         headroom wrap opencode --copilot-subscription # Use a GitHub Copilot subscription
+        headroom wrap opencode --openai-api-url https://api.deepseek.com/v1
     """
     subscription_resolution = None
     if copilot_subscription:
@@ -7279,6 +7298,11 @@ def opencode(
             raise click.ClickException(
                 "--copilot-subscription cannot be combined with --prepare-only because "
                 "it requires a running private seeded proxy."
+            )
+        if openai_api_url:
+            raise click.ClickException(
+                "--copilot-subscription cannot be combined with --openai-api-url because "
+                "the Copilot subscription flow already selects its own upstream API URL."
             )
         subscription_resolution = _require_copilot_subscription_resolution()
 
@@ -7357,7 +7381,9 @@ def opencode(
         backend=backend,
         anyllm_provider=anyllm_provider,
         region=region,
-        openai_api_url=(subscription_resolution.api_url if subscription_resolution else None),
+        openai_api_url=(
+            openai_api_url or (subscription_resolution.api_url if subscription_resolution else None)
+        ),
         copilot_api_token=(subscription_resolution.token if subscription_resolution else None),
         copilot_refresh_oauth_token=(
             subscription_resolution.refresh_oauth_token if subscription_resolution else None

--- a/tests/test_cli/test_wrap_opencode.py
+++ b/tests/test_cli/test_wrap_opencode.py
@@ -1055,6 +1055,114 @@ def test_wrap_opencode_with_no_proxy(
     assert result.exit_code == 0, result.output
 
 
+def test_wrap_opencode_with_openai_api_url(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--openai-api-url is forwarded to _ensure_proxy so third-party OpenAI-compatible
+    providers (e.g. DeepSeek) are reached instead of the default OpenAI upstream."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    _set_test_home(monkeypatch, tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_ensure_proxy(*args, **kwargs):  # noqa: ANN002, ANN003
+        captured.update(kwargs)
+        return None, 9000
+
+    with (
+        patch.object(wrap_mod.shutil, "which", return_value="opencode"),
+        patch.object(wrap_mod, "_ensure_proxy", side_effect=fake_ensure_proxy),
+        patch.object(wrap_mod, "_launch_tool", side_effect=SystemExit(0)),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "wrap",
+                "opencode",
+                "--port",
+                "9000",
+                "--openai-api-url",
+                "https://api.deepseek.com/v1",
+                "--no-mcp",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["openai_api_url"] == "https://api.deepseek.com/v1"
+
+
+def test_wrap_opencode_without_openai_api_url_defaults_to_none(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting --openai-api-url leaves the upstream selection to _ensure_proxy's
+    default (OpenAI), matching behavior before this flag existed."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    _set_test_home(monkeypatch, tmp_path)
+    captured: dict[str, object] = {}
+
+    def fake_ensure_proxy(*args, **kwargs):  # noqa: ANN002, ANN003
+        captured.update(kwargs)
+        return None, 9000
+
+    with (
+        patch.object(wrap_mod.shutil, "which", return_value="opencode"),
+        patch.object(wrap_mod, "_ensure_proxy", side_effect=fake_ensure_proxy),
+        patch.object(wrap_mod, "_launch_tool", side_effect=SystemExit(0)),
+    ):
+        result = runner.invoke(main, ["wrap", "opencode", "--port", "9000", "--no-mcp"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["openai_api_url"] is None
+
+
+def test_wrap_opencode_help_lists_openai_api_url(runner: CliRunner) -> None:
+    """--openai-api-url is scoped to `wrap opencode`, not other wrap subcommands."""
+    opencode_help = runner.invoke(main, ["wrap", "opencode", "--help"])
+    codex_help = runner.invoke(main, ["wrap", "codex", "--help"])
+
+    assert opencode_help.exit_code == 0, opencode_help.output
+    assert "--openai-api-url URL" in opencode_help.output
+    assert codex_help.exit_code == 0, codex_help.output
+    assert "--openai-api-url" not in codex_help.output
+
+
+def test_wrap_opencode_openai_api_url_conflicts_with_copilot_subscription(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--openai-api-url and --copilot-subscription pick different, incompatible
+    upstream-selection strategies, so combining them must fail fast."""
+    monkeypatch.chdir(tmp_path)
+    _set_test_home(monkeypatch, tmp_path)
+    _clear_copilot_route_config(monkeypatch)
+    config_file = tmp_path / ".config" / "opencode" / "opencode.json"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text("{}", encoding="utf-8")
+
+    with patch.object(wrap_mod, "_ensure_proxy", side_effect=AssertionError("proxy launched")):
+        result = runner.invoke(
+            main,
+            [
+                "wrap",
+                "opencode",
+                "--copilot-subscription",
+                "--openai-api-url",
+                "https://api.deepseek.com/v1",
+                "--no-mcp",
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert "--openai-api-url" in result.output
+    assert not config_file.with_name("opencode.json.headroom-backup").exists()
+
+
 def test_wrap_opencode_with_verbose_flag(
     runner: CliRunner,
     tmp_path: Path,


### PR DESCRIPTION
## Description

`headroom wrap opencode` always forwards OpenAI-shaped traffic to `https://api.openai.com/v1`, with no flag or env var to point it at a third-party OpenAI-compatible provider. A user who configures OpenCode for DeepSeek and then runs `headroom wrap opencode` gets their requests silently forwarded to OpenAI instead, which rejects the DeepSeek key with an HTTP 401 error. Making this worse, `docs/content/docs/opencode-deepseek.mdx` explicitly told users not to use `headroom wrap` at all for this case, leaving no documented path for DeepSeek users through `wrap opencode`.

The proxy-side plumbing to support a custom upstream already exists and is already used by other `wrap` subcommands (`vibe`, `grok` hardcode their own upstream URLs through the same `_ensure_proxy(openai_api_url=...)` path). This PR exposes it as a user-settable `--openai-api-url` option on `opencode()`, following the same pattern as the open sibling PR #3018 (`fix(wrap): route Cline custom upstreams`), and updates the docs so DeepSeek users have a working `wrap opencode` path.

Closes #3107

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cli/wrap.py`: add `--openai-api-url` option to `opencode()`, thread it into the `_ensure_proxy(...)` call, and reject combining it with `--copilot-subscription` (the two pick different, incompatible upstream-selection strategies), matching the file's existing incompatible-flag validation pattern.
- `tests/test_cli/test_wrap_opencode.py`: four new tests covering the flag being forwarded, the `None` default when omitted, its presence in `--help` (and absence from `wrap codex --help`), and the conflict with `--copilot-subscription` failing fast before any proxy work.
- `docs/content/docs/opencode.mdx`: document the new flag in the Options block, with a cross-link to the DeepSeek guide.
- `docs/content/docs/opencode-deepseek.mdx`: rewrite the "Models appear but requests fail" troubleshooting section and the "What's NOT in this guide" bullet, which previously told readers not to use `headroom wrap` at all, to instead document `--openai-api-url` as the supported fix/shortcut.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ .venv/Scripts/python -m pytest tests/test_cli/test_wrap_opencode.py -v
...
tests/test_cli/test_wrap_opencode.py::test_wrap_opencode_with_openai_api_url PASSED
tests/test_cli/test_wrap_opencode.py::test_wrap_opencode_without_openai_api_url_defaults_to_none PASSED
tests/test_cli/test_wrap_opencode.py::test_wrap_opencode_help_lists_openai_api_url PASSED
tests/test_cli/test_wrap_opencode.py::test_wrap_opencode_openai_api_url_conflicts_with_copilot_subscription PASSED
...
44 passed in 6.32s

$ ruff check headroom/cli/wrap.py tests/test_cli/test_wrap_opencode.py
All checks passed!

$ ruff format --check headroom/cli/wrap.py tests/test_cli/test_wrap_opencode.py
2 files already formatted

$ .venv/Scripts/mypy headroom --ignore-missing-imports
Success: no issues found in 522 source files

$ .venv/Scripts/headroom.exe wrap opencode --openai-api-url https://api.deepseek.com/v1 --copilot-subscription
Error: --copilot-subscription cannot be combined with --openai-api-url because the Copilot subscription flow already selects its own upstream API URL.
(exit code 1, no proxy started)
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.13.11, project `.venv` (mypy 1.19.1, pytest 9.0.3, ruff 0.15.17), local editable install of `headroom`
- Exact command / steps: `.venv/Scripts/headroom.exe wrap opencode --help` to confirm the flag is listed; `.venv/Scripts/headroom.exe wrap opencode --openai-api-url https://api.deepseek.com/v1 --copilot-subscription` to confirm the conflict check fires before any proxy/config work
- Observed result: `--help` output lists `--openai-api-url URL` with the full help text; the conflicting-flags command exits 1 with the new `ClickException` message and does not start a proxy or touch OpenCode's config
- Not tested: an actual end-to-end request through a running proxy to `api.deepseek.com` (would require a real DeepSeek API key and a running OpenCode install); this PR only adds the CLI plumbing, the underlying `_ensure_proxy`/proxy-side forwarding of `openai_api_url` is pre-existing and already covered by other `wrap` subcommands' tests

## Runtime Rollout Safety

- Rollout-managed feature(s): none; this is a plain CLI option with no feature flag or rollout channel
- Minimum rollout channel: n/a
- Stable/default behavior changed: no; omitting `--openai-api-url` preserves the exact prior behavior (upstream defaults to OpenAI, or to the Copilot subscription URL when `--copilot-subscription` is set)
- Kill switch / disable path: n/a; simply not passing `--openai-api-url` reverts to prior behavior
- Unsafe override required: no
- Qualification impact: none; no changes to compression, pricing, or tokenizer logic
- Rollback path: revert this commit; no data migration or state to unwind

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

Coordination: this touches a different section of `headroom/cli/wrap.py` (OpenCode, ~line 7203) than the open sibling PR #3018 (Cline, ~line 6564), which fixes the identical class of bug for `wrap cline`. No textual conflict expected between the two, but line numbers may shift if #3018 merges first.