### PR TITLE
fix(learn): run codex exec with --skip-git-repo-check so analysis runs anywhere

### DIFF
--- a/headroom/learn/analyzer.py
+++ b/headroom/learn/analyzer.py
@@ -56,7 +56,10 @@ _MAX_DIGEST_TOKENS = 80_000  # Budget for the digest (leave room for prompt + ou
 _CLI_BACKENDS: list[tuple[str, str, list[str]]] = [
     ("claude", "claude-cli", ["claude", "-p", "--output-format", "stream-json", "--verbose"]),
     ("gemini", "gemini-cli", ["gemini", "-p"]),
-    ("codex", "codex-cli", ["codex", "exec"]),
+    # ``--skip-git-repo-check`` so the analysis runs from any cwd. The prompt is
+    # delivered entirely on stdin and needs no repository context; current Codex
+    # CLIs otherwise refuse to run outside a trusted git repo (#3008).
+    ("codex", "codex-cli", ["codex", "exec", "--skip-git-repo-check"]),
 ]
 
 # Set of valid CLI model identifiers, derived from _CLI_BACKENDS.

--- a/tests/test_learn/test_analyzer.py
+++ b/tests/test_learn/test_analyzer.py
@@ -865,7 +865,23 @@ class TestCallCliLlm:
         result = _call_cli_llm("test digest", "codex-cli")
         assert result == {"context_file_rules": [], "memory_file_rules": []}
         cmd = mock_run.call_args[0][0]
-        assert cmd == ["codex", "exec"]
+        # --skip-git-repo-check so the analysis runs from any cwd; the prompt is
+        # delivered on stdin and needs no repository context (#3008).
+        assert cmd == ["codex", "exec", "--skip-git-repo-check"]
+
+    @patch("headroom.learn.analyzer.subprocess.run")
+    def test_codex_cli_skips_git_repo_check(self, mock_run: MagicMock):
+        # Regression for #3008: current Codex CLIs refuse to run outside a
+        # trusted git repo without this flag, so `learn --agent codex` failed
+        # from any non-repo cwd. The prompt is on stdin; no repo context needed.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='{"context_file_rules": [], "memory_file_rules": []}',
+            stderr="",
+        )
+        _call_cli_llm("test digest", "codex-cli")
+        cmd = mock_run.call_args[0][0]
+        assert "--skip-git-repo-check" in cmd
 
     @patch("headroom.learn.analyzer.subprocess.run")
     def test_gemini_cli_uses_p_flag(self, mock_run: MagicMock):


### PR DESCRIPTION
## Description

`headroom learn`'s codex-cli backend spawns `["codex", "exec"]` with the analysis prompt on stdin. Current Codex CLIs (observed on codex-cli 0.147.0) refuse to run outside a trusted git repository unless `--skip-git-repo-check` is passed, so the backend failed from any non-repo working directory (and even from a trusted but non-git home directory):

```
LLM analysis failed: `codex exec` failed (exit 1):
Not inside a trusted directory and --skip-git-repo-check was not specified.
```

The learn digest is delivered entirely via stdin and needs no repository context (the repo check is meant to protect interactive/agentic runs, not this usage), so appending the flag is always safe here.

Closes #3008.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/learn/analyzer.py`: the codex entry in `_CLI_BACKENDS` is now `["codex", "exec", "--skip-git-repo-check"]`.
- `tests/test_learn/test_analyzer.py`: updated `test_codex_cli_uses_exec` to expect the flag and added `test_codex_cli_skips_git_repo_check` (order-independent) as a dedicated regression.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
tests/test_learn/test_analyzer.py -k codex  ->  12 passed
uvx ruff@0.16.2 check headroom/learn/analyzer.py tests/test_learn/test_analyzer.py  ->  All checks passed!
uvx mypy@1.20.2 headroom/learn/analyzer.py  ->  Success: no issues found
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.16.2 and mypy 1.20.2 via uvx.
- Exact command / steps: reverted the argv to `["codex", "exec"]` and ran the two flag assertions (`python -m pytest tests/test_learn/test_analyzer.py -k "codex_cli_skips or codex_cli_uses_exec"` -> 2 failed: `assert '--skip-git-repo-check' in ['codex', 'exec']`); restored the flag and re-ran the codex subset (`-k codex` -> 12 passed).
- Observed result: before the change the codex backend argv omitted the flag, matching the exit-1 "Not inside a trusted directory" failure from the issue; after the change the argv carries `--skip-git-repo-check`, so the spawn no longer depends on the invocation cwd being a git repo.
- Not tested: a live `codex exec` spawn (no Codex CLI or subscription auth in this environment); the argv construction that provider init uses is exercised directly.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. This is a fixed CLI argument on the learn analyzer's codex backend, not a rollout-channel-gated runtime feature.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: the codex-cli learn backend now runs from any working directory instead of only from a trusted git repo. No effect on the claude/gemini backends or on API-key backends.
- Kill switch / disable path: N/A (select a different `--model` backend if ever needed).
- Unsafe override required: no.
- Qualification impact: `headroom learn --agent codex` succeeds outside git repositories where it previously exited 1.
- Rollback path: revert this PR; the codex backend returns to `["codex", "exec"]`.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A: no user-facing docs describe the codex spawn argv)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

This addresses the first (root-cause) defect in #3008. The issue also notes a second, separable concern: `SessionAnalyzer.analyze` swallows a backend failure and renders it as `No actionable patterns found.` with exit 0. That failure-surfacing change is intentionally left out of this PR so the spawn fix stays minimal and reviewable on its own.
