### PR TITLE
fix(proxy): add HEADROOM_LOG_TO_STDOUT so container deployments can collect logs

### DIFF
--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -15,6 +15,7 @@ import logging
 import os
 import random
 import re
+import sys
 import threading
 import time
 from collections import OrderedDict
@@ -1512,6 +1513,10 @@ def _setup_file_logging() -> None:
     """
     from logging.handlers import RotatingFileHandler
 
+    # Attach to the headroom root logger so all sub-loggers are captured.
+    headroom_logger = logging.getLogger("headroom")
+    headroom_logger.setLevel(logging.INFO)
+
     try:
         log_dir = _headroom_log_dir()
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -1526,17 +1531,39 @@ def _setup_file_logging() -> None:
         handler.setFormatter(
             logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
         )
-        # Attach to the headroom root logger so all sub-loggers are captured.
         # Disable propagation to root to avoid duplicate writes when
         # wrap.py redirects stderr to the same log file.
-        headroom_logger = logging.getLogger("headroom")
-        headroom_logger.setLevel(logging.INFO)
         if not any(isinstance(h, RotatingFileHandler) for h in headroom_logger.handlers):
             headroom_logger.addHandler(handler)
         headroom_logger.propagate = False
     except OSError:
         # Non-fatal: can't write logs (read-only fs, permissions, etc.)
         pass
+
+    # Container platforms (Docker, Kubernetes, ...) collect stdout, not the
+    # workspace log file inside the container. With propagation disabled above,
+    # headroom.* records otherwise never reach stdout, so every application log
+    # is silently lost in those deployments. HEADROOM_LOG_TO_STDOUT adds a
+    # dedicated stdout handler on the headroom logger — no propagation, so this
+    # never double-writes the rotating file (#3087). Opt-in keeps the default
+    # file-only behavior unchanged.
+    if os.environ.get("HEADROOM_LOG_TO_STDOUT", "").strip().lower() in ("true", "1", "yes", "on"):
+        _ensure_stdout_log_handler(headroom_logger)
+
+
+def _ensure_stdout_log_handler(headroom_logger: logging.Logger) -> None:
+    """Attach a stdout ``StreamHandler`` to ``headroom_logger`` once (idempotent)."""
+    for existing in headroom_logger.handlers:
+        # RotatingFileHandler is a StreamHandler subclass, so match on the
+        # bound stream rather than the type to avoid re-adding on every call.
+        if getattr(existing, "stream", None) is sys.stdout:
+            return
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setLevel(logging.INFO)
+    stream_handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    headroom_logger.addHandler(stream_handler)
 
 
 def is_anthropic_auth(headers: dict[str, str]) -> bool:

--- a/tests/test_setup_file_logging_stdout.py
+++ b/tests/test_setup_file_logging_stdout.py
@@ -1,0 +1,77 @@
+"""Regression tests for opt-in stdout logging (#3087).
+
+``_setup_file_logging`` disables propagation on the ``headroom`` logger, so in
+container deployments (which collect stdout, not the in-container log file)
+application logs are silently lost. ``HEADROOM_LOG_TO_STDOUT`` restores them via
+a dedicated stdout handler without re-enabling propagation.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import Iterator
+
+import pytest
+
+from headroom.proxy.helpers import _setup_file_logging
+
+
+@pytest.fixture(autouse=True)
+def _restore_headroom_logger() -> Iterator[None]:
+    """Snapshot and restore the shared ``headroom`` logger around each test."""
+    logger = logging.getLogger("headroom")
+    saved_handlers = list(logger.handlers)
+    saved_level = logger.level
+    saved_propagate = logger.propagate
+    try:
+        yield
+    finally:
+        logger.handlers = saved_handlers
+        logger.setLevel(saved_level)
+        logger.propagate = saved_propagate
+
+
+def _stdout_handlers(logger: logging.Logger) -> list[logging.Handler]:
+    return [h for h in logger.handlers if getattr(h, "stream", None) is sys.stdout]
+
+
+def test_no_stdout_handler_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HEADROOM_LOG_TO_STDOUT", raising=False)
+    logger = logging.getLogger("headroom")
+    logger.handlers = []
+
+    _setup_file_logging()
+
+    assert _stdout_handlers(logger) == []
+    # Propagation stays disabled — the historical de-dup behavior is unchanged.
+    assert logger.propagate is False
+
+
+def test_opt_in_adds_stdout_handler_and_emits(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("HEADROOM_LOG_TO_STDOUT", "1")
+    logger = logging.getLogger("headroom")
+    logger.handlers = []
+
+    _setup_file_logging()
+
+    assert len(_stdout_handlers(logger)) == 1
+    # Propagation is still off — the stdout handler, not the root logger, is
+    # what carries records to stdout, so the rotating file is never doubled.
+    assert logger.propagate is False
+
+    logging.getLogger("headroom.proxy").info("container-visible-line")
+    assert "container-visible-line" in capsys.readouterr().out
+
+
+def test_opt_in_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEADROOM_LOG_TO_STDOUT", "yes")
+    logger = logging.getLogger("headroom")
+    logger.handlers = []
+
+    _setup_file_logging()
+    _setup_file_logging()
+
+    assert len(_stdout_handlers(logger)) == 1


### PR DESCRIPTION
## Description

`_setup_file_logging()` sets `propagate = False` on the `headroom` logger so that when `wrap` redirects the proxy subprocess's stdio into the rotating log file, records are not written twice. The side effect is that no `headroom.*` record ever reaches stdout: every application log goes only to `~/.headroom/logs/proxy.log`.

On a workstation that's invisible but harmless. In a containerized deployment it is a silent, total loss of application logs: Docker, Kubernetes, and similar platforms collect stdout/stderr, and `~/.headroom/logs/proxy.log` lives inside the container where nothing reads it.

This adds an opt-in `HEADROOM_LOG_TO_STDOUT` env var. When truthy, a dedicated `StreamHandler(sys.stdout)` is attached to the `headroom` logger. Because it is the logger's own handler (not propagation to the root logger), it never re-introduces the double-write to the rotating file that `propagate = False` was guarding against. Default behavior is unchanged (file-only), so no existing deployment is affected unless it opts in.

Closes #3087.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/helpers.py`: `_setup_file_logging` now attaches an idempotent stdout handler to the `headroom` logger when `HEADROOM_LOG_TO_STDOUT` is truthy (`1`/`true`/`yes`/`on`), via a new `_ensure_stdout_log_handler` helper. Propagation stays disabled, so the rotating file is never doubled. Added the `sys` import.
- `tests/test_setup_file_logging_stdout.py`: new tests for default-off (no stdout handler, propagation still disabled), opt-in (handler added, a `headroom.*` record reaches stdout), and idempotency (repeat setup adds only one handler).

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
tests/test_setup_file_logging_stdout.py  ->  3 passed
uvx ruff@0.16.2 check headroom/proxy/helpers.py tests/test_setup_file_logging_stdout.py  ->  All checks passed!
uvx mypy@1.20.2 headroom/proxy/helpers.py  ->  Success: no issues found
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.16.2 and mypy 1.20.2 via uvx.
- Exact command / steps: neutralized the opt-in branch (`if False:`) and ran `python -m pytest tests/test_setup_file_logging_stdout.py` -> 2 failed (`assert len(_stdout_handlers(logger)) == 1` -> `0 == 1`, and the emitted `headroom.proxy` line never appeared on stdout); restored the fix and re-ran -> 3 passed. The default-off test passes in both directions, confirming no behavior change when the env var is unset.
- Observed result: with `HEADROOM_LOG_TO_STDOUT=1` a `logging.getLogger("headroom.proxy").info(...)` record is captured on stdout while propagation stays `False`; with the var unset the headroom logger carries no stdout handler.
- Not tested: a live container run (`docker logs`); the handler-attachment and record-emission are exercised directly against the shared `headroom` logger, which is the exact object `create_app` configures.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. This is process-level logging configuration, not a rollout-channel-gated runtime feature.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: no. Stdout logging is off unless `HEADROOM_LOG_TO_STDOUT` is set; the rotating file handler and `propagate = False` are unchanged.
- Kill switch / disable path: unset `HEADROOM_LOG_TO_STDOUT` (or set it falsy) to return to file-only logging.
- Unsafe override required: no.
- Qualification impact: operators in containers can opt into stdout application logs that were previously unreachable.
- Rollback path: revert this PR; the stdout handler and env var are removed, leaving the prior file-only behavior.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (happy to add a note to the deployment docs if maintainers prefer the var documented there)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

I kept this opt-in to stay strictly non-breaking and to preserve the existing wrap de-duplication guarantee. If maintainers would rather have stdout logging on by default for the standalone-server path (with an off switch), I'm glad to flip the default in a follow-up.
