### PR TITLE
fix(proxy): scope the signed-thinking lock to blocks that actually changed

### DIFF
--- a/docs/metrics-technical-guide.md
+++ b/docs/metrics-technical-guide.md
@@ -1,0 +1,223 @@
+# Headroom Metrics — Dashboard Guide
+
+What each metric shows, so you can build panels against it.
+
+**Two endpoints.** Both are on the proxy (default `:8787`).
+
+| Surface | How to get it | Use it for |
+|---|---|---|
+| **Prometheus** — `GET /metrics` | Always on, no config | Everything below. Start here. |
+| **OpenTelemetry** — OTLP/HTTP | `HEADROOM_OTEL_METRICS_ENABLED=1` + `pip install "headroom-ai[proxy,otel]"` | Same data, dotted names, plus per-tenant labels |
+
+Names differ between them: Prometheus uses `headroom_tokens_saved_total` (**milliseconds** for timings), OTel uses `headroom.proxy.tokens.saved` (**seconds**). Both are listed below.
+
+---
+
+## The savings panel — start here
+
+**`headroom.proxy.tokens.saved`** is the headline number. It already combines compression + tool-schema deferral — no need to add anything to it.
+
+| Metric | What it shows |
+|---|---|
+| **`headroom.proxy.tokens.saved`** *(OTel)* | **Total input tokens Headroom kept out of the request.** Compression + tool savings, combined. This is your hero number. |
+| `headroom.proxy.savings.usd{source}` *(OTel)* | **Dollars saved**, split by layer: `compression`, `tool_schema`, `output_shaping`, `provider_cache`. Sum for the total. |
+| `headroom_persistent_savings_tokens_saved_total` | Same tokens-saved number, but **survives proxy restarts**. Use for "lifetime saved" tiles. |
+| `headroom_persistent_savings_compression_savings_usd_total` | **Lifetime dollars saved**, durable across restarts. |
+| `headroom_tokens_input_total` | Input tokens actually sent upstream (post-compression). The denominator for a reduction %. |
+| `headroom_tokens_output_total` | Output tokens returned by the provider. |
+
+```promql
+# Hero tile: tokens saved per second
+rate(headroom_tokens_saved_total[5m])
+  + sum(rate(headroom_savings_attributed_tokens_total{source="tool_search",realized="true"}[5m]))
+
+# Context reduction %
+100 * rate(headroom_tokens_saved_total[5m])
+    / clamp_min(rate(headroom_tokens_input_total[5m]) + rate(headroom_tokens_saved_total[5m]), 1)
+
+# Lifetime tiles (survive restart)
+headroom_persistent_savings_tokens_saved_total
+headroom_persistent_savings_compression_savings_usd_total
+```
+
+> **One catch on the Prometheus side.** `headroom_tokens_saved_total` is compression **only** — it leaves out tool-schema deferral. The OTel `headroom.proxy.tokens.saved` includes both. That's why the query above adds the `tool_search` term back in. On tool-heavy workloads the gap is large.
+
+---
+
+## Latency panel
+
+All Prometheus timings are in **milliseconds**, exposed as `_sum` / `_count` / `_min` / `_max`. Build means with `rate(sum)/rate(count)`.
+
+| Metric | What it shows |
+|---|---|
+| **`headroom_overhead_ms_*`** | **Latency Headroom itself adds.** Handler entry → end of compression. Excludes the LLM call. This is the "what does this cost us" number. |
+| `headroom_latency_ms_*` | Total request duration, including the provider. |
+| `headroom_ttfb_ms_*` | Time to first byte from upstream. Streaming requests only. |
+| `headroom_stage_timing_ms_*{path,stage}` | Where time went inside the handler — `compression_first_stage`, `upstream_connect`, `memory_context`, etc. |
+| `headroom_transform_timing_ms_*{transform}` | Time per compression transform. Use to find a slow transform. |
+
+```promql
+# Headroom's added overhead, mean ms
+rate(headroom_overhead_ms_sum[5m]) / rate(headroom_overhead_ms_count[5m])
+
+# End-to-end, mean ms
+rate(headroom_latency_ms_sum[5m]) / rate(headroom_latency_ms_count[5m])
+
+# Slowest stages
+topk(5, rate(headroom_stage_timing_ms_sum[5m]) / rate(headroom_stage_timing_ms_count[5m]))
+```
+
+> **No percentiles are available.** There are no histogram buckets on `/metrics`, and the OTel histograms ship with default buckets that put every request into one bucket, so `histogram_quantile()` returns nonsense. **Means work fine.** For real p95/p99 today, use the `headroom perf` CLI.
+>
+> Also: divide each `_sum` by **its own** `_count`. Overhead and TTFB are only sampled when > 0, so their counts are smaller than the latency count.
+
+---
+
+## Cache panel
+
+| Metric | What it shows |
+|---|---|
+| `headroom_provider_cache_hit_requests_total{provider}` | Requests that read from the provider's prompt cache. |
+| `headroom_provider_cache_requests_total{provider}` | Requests with any cache activity. **The correct denominator for hit rate.** |
+| `headroom_cache_read_tokens_total{provider}` | Tokens served from cache (the discounted ones). |
+| `headroom_cache_write_tokens_total{provider}` | Tokens written into cache (these carry a premium). |
+| `headroom_cache_write_ttl_tokens_total{provider,ttl}` | Cache writes split by TTL — `5m` vs `1h`. |
+| `headroom_uncached_input_tokens_total{provider}` | Input tokens that missed cache entirely. |
+| `headroom_cache_bust_total` | Requests where compression broke a cached prefix. **Should stay near zero.** |
+| `headroom_cache_miss_attribution_total{provider,reason}` | Why a cached prefix missed — `ttl_expiry`, `prefix_change`, `unknown`. |
+
+```promql
+# Cache hit rate by provider
+sum by (provider) (rate(headroom_provider_cache_hit_requests_total[5m]))
+  / sum by (provider) (rate(headroom_provider_cache_requests_total[5m]))
+
+# Compression breaking cache — alert if this rises
+rate(headroom_cache_bust_total[5m])
+```
+
+> **Don't use `headroom_requests_cached_total` as a hit rate.** It mixes the provider's prompt cache with Headroom's own response cache into one boolean, so it measures neither.
+
+---
+
+## Traffic & health panel
+
+| Metric | What it shows |
+|---|---|
+| `headroom_requests_total` | Requests handled. Unlabelled. |
+| `headroom_requests_by_provider{provider}` | Traffic split by provider — `anthropic`, `openai`, `gemini`, `bedrock`… |
+| `headroom_requests_by_model{model}` | Traffic split by model. Capped at 1024 distinct; overflow lands in `model="other"`. |
+| `headroom_requests_failed_total` | Upstream 5xx errors. |
+| `headroom_requests_rate_limited_total` | Requests **Headroom** rejected via its own rate limiter (not upstream 429s). |
+| `headroom_compression_failed_total{reason}` | Compression failures — `timeout` or `error`. Fails open, so traffic keeps flowing but savings quietly stop. **Worth an alert.** |
+| `headroom_compression_quarantine_total{event}` | Compression disabled after repeated timeouts — `activated`, `skipped`, `released`. |
+| `headroom_inbound_requests_active` | In-flight requests, gauge. Counts all HTTP including `/metrics`. |
+| `headroom_active_ws_sessions` | Live Codex WebSocket sessions, gauge. |
+
+```promql
+# Failure rate
+rate(headroom_requests_failed_total[5m])
+  / clamp_min(rate(headroom_requests_total[5m]) + rate(headroom_requests_failed_total[5m]), 1)
+
+# Savings silently stopped
+sum by (reason) (rate(headroom_compression_failed_total[5m]))
+
+# Traffic mix
+sum by (provider) (rate(headroom_requests_by_provider[5m]))
+```
+
+---
+
+## Anthropic subscription panel
+
+Only if you're on an Anthropic OAuth/subscription plan. OTel only, gauges, no labels.
+
+| Metric | What it shows |
+|---|---|
+| `headroom.subscription.5h_utilization_pct` | How much of the 5-hour rate-limit window is used (0–100). |
+| `headroom.subscription.7d_utilization_pct` | Same for the 7-day window. |
+| `headroom.subscription.5h_seconds_to_reset` | Seconds until the 5-hour window resets. |
+| `headroom.subscription.7d_seconds_to_reset` | Seconds until the 7-day window resets. |
+| `headroom.subscription.overage_usd` | Extra-usage credits consumed, in dollars. |
+
+---
+
+## Attribution — where savings came from
+
+| Metric | What it shows |
+|---|---|
+| `headroom_savings_attributed_tokens_total{source,realized}` | Tokens saved, broken out by named source. `source="tool_search"` is tool-schema deferral. |
+| `headroom_savings_attributed_usd_total{source,realized}` | Dollars saved by source. **Gauge, can go negative** — don't `rate()` it. |
+| `headroom_savings_attribution_events_total{source,realized}` | How often each source contributed. |
+| `headroom_waste_signal_tokens_total{signal}` | Wasteful patterns *detected* in the input — `json_bloat`, `base64`, `repetition`, `reread`… This is diagnosis, **not savings**. |
+
+These rows *explain* the headline total — they are never added to it.
+
+---
+
+## Compression internals
+
+| Metric | What it shows |
+|---|---|
+| `headroom.compression.tokens.input` *(OTel)* | Tokens going into the compression pipeline. |
+| `headroom.compression.tokens.output` *(OTel)* | Tokens coming out. |
+| `headroom.compression.tokens.saved` *(OTel)* | The difference. Pipeline-level view of compression only. |
+| `headroom.compression.runs` *(OTel)* | Pipeline executions. Note: **per pipeline run, not per request.** |
+| `headroom.compression.pipeline.duration` *(OTel, seconds)* | How long the pipeline took. |
+| `headroom.compression.transforms{transform}` *(OTel)* | Which transforms fired. **High cardinality — drop or aggregate at the collector.** |
+
+---
+
+## Five things that will break a dashboard
+
+1. **Only savings counters survive a restart.** 55 of 60 Prometheus families reset to zero when the proxy restarts. Only `headroom_persistent_savings_*` is durable, and it needs `HEADROOM_WORKSPACE_DIR` on a persistent volume — otherwise it resets on every deploy.
+
+2. **No percentiles anywhere.** Use means. See the latency section.
+
+3. **`headroom_latency_ms` measures differently for streaming.** On streaming requests the timer starts *after* compression, so end-to-end is `latency + overhead`. On non-streaming it's just `latency`. Don't mix both in one panel.
+
+4. **A 5xx erases its own savings.** Requests that fail upstream are dropped from every savings and token counter. During a provider incident, savings rates look artificially clean while throughput falls.
+
+5. **`/metrics` needs auth if you set a proxy token.** With `HEADROOM_PROXY_TOKEN` set, any non-loopback scraper must send `Authorization: Bearer <token>`. Loopback is always exempt.
+
+---
+
+## Metrics the docs mention that don't exist
+
+If panels came back empty, this is probably why. These names appear in the published docs but not in the code:
+
+`headroom_compression_ratio` · `headroom_latency_seconds` (and `_bucket`) · `headroom_cache_hits_total` · `headroom_cache_misses_total` · `headroom_cost_usd_total` · the `mode="optimize"` label on `headroom_requests_total`
+
+The shipped `examples/grafana/headroom-dashboard.json` also filters every panel on `pool` and `hook` labels that no metric emits — the dropdowns will be permanently empty. Its metric names are otherwise correct.
+
+---
+
+## Setup reference
+
+```bash
+# Prometheus — nothing to do, GET /metrics is always on
+
+# OpenTelemetry
+pip install "headroom-ai[proxy,otel]"
+export HEADROOM_OTEL_METRICS_ENABLED=1
+export HEADROOM_OTEL_METRICS_ENDPOINT=https://otel.corp.example/v1/metrics
+export HEADROOM_OTEL_METRICS_HEADERS="authorization=Bearer XXX"
+export HEADROOM_OTEL_RESOURCE_ATTRIBUTES="service.instance.id=$HOSTNAME"
+```
+
+| Variable | Default | Notes |
+|---|---|---|
+| `HEADROOM_OTEL_METRICS_ENABLED` | `0` | Master switch |
+| `HEADROOM_OTEL_METRICS_EXPORTER` | `otlp_http` | Or `console`. No gRPC exporter exists. |
+| `HEADROOM_OTEL_METRICS_ENDPOINT` | unset | Passed verbatim — `/v1/metrics` is **not** appended |
+| `HEADROOM_OTEL_METRICS_HEADERS` | unset | `k=v,k2=v2` |
+| `HEADROOM_OTEL_METRICS_EXPORT_INTERVAL_MS` | `10000` | |
+| `HEADROOM_OTEL_SERVICE_NAME` | `headroom-proxy` | |
+| `HEADROOM_OTEL_RESOURCE_ATTRIBUTES` | unset | **Set `service.instance.id` here** — Headroom doesn't, and replicas will collide |
+
+Verify with `curl -s localhost:8787/stats | jq .otel`.
+
+**Multi-tenant labels:** `register_otel_metric_attribute_provider()` adds request-scoped attributes (tenant, team, cost centre) to every OTel datapoint. Max 16 attributes, 256 chars each.
+
+**Air-gapped deployments:** `HEADROOM_OFFLINE=1` disables all outbound traffic — the anonymous usage beacon (which is **on by default**), the update check, and model downloads.
+
+---

--- a/headroom/agent_savings.py
+++ b/headroom/agent_savings.py
@@ -207,27 +207,43 @@ _PROFILES: dict[str, AgentSavingsProfile] = {
 def get_agent_savings_profile(name: str | None = None) -> AgentSavingsProfile:
     """Return a named agent savings profile.
 
-    An unrecognized name falls back to the ``balanced`` profile with a warning
-    instead of raising. The savings profile is a soft config knob, but it is
-    resolved during proxy startup (``proxy_pipeline_kwargs`` -> ``create_app``),
-    so raising here takes the whole proxy down before it can open its port. That
-    happens on desktop/runtime version skew: a newer client requests a profile
-    (e.g. ``coding``) that an older pinned or fallback runtime predates. Degrade
-    to ``balanced`` rather than leaving the user with no proxy at all.
+    An unrecognized name degrades with a warning instead of raising. The savings
+    profile is a soft config knob, but it is resolved during proxy startup
+    (``proxy_pipeline_kwargs`` -> ``create_app``), so raising here takes the
+    whole proxy down before it can open its port. That happens on desktop/runtime
+    version skew: a newer client requests a profile (e.g. ``coding``) that an
+    older pinned or fallback runtime predates. Degrade rather than leaving the
+    user with no proxy at all.
+
+    **Where it degrades to matters.** This used to land on ``balanced``
+    unconditionally, which is a drastically different posture from the
+    out-of-box default: cache->token mode, cross-turn dedup off, tool-search
+    off, user messages uncompressed, the message floor 25x higher (250 vs 10)
+    and the block floor 20x higher (500 vs 25). A single typo in
+    ``HEADROOM_SAVINGS_PROFILE`` therefore silently reconfigured the whole
+    proxy, and the only trace was one WARNING at startup that operators read
+    past. Prefer :data:`DEFAULT_PROFILE` — the documented out-of-box posture and
+    the same thing an unset variable resolves to, so a typo now costs nothing.
+    ``balanced`` remains the last resort for the genuine version-skew case,
+    where an older runtime has no ``DEFAULT_PROFILE`` entry to fall back to.
     """
 
     key = (name or DEFAULT_PROFILE).strip().lower()
     profile = _PROFILES.get(key)
     if profile is not None:
         return profile
+    fallback_name = DEFAULT_PROFILE if DEFAULT_PROFILE in _PROFILES else FALLBACK_PROFILE
     valid = ", ".join(sorted(_PROFILES))
     logger.warning(
-        "unknown savings profile %r; falling back to %r (known: %s)",
+        "unknown savings profile %r; falling back to %r (known: %s). "
+        "Set HEADROOM_SAVINGS_PROFILE to one of the known names, or unset it to "
+        "get %r explicitly.",
         name,
-        FALLBACK_PROFILE,
+        fallback_name,
         valid,
+        DEFAULT_PROFILE,
     )
-    return _PROFILES[FALLBACK_PROFILE]
+    return _PROFILES[fallback_name]
 
 
 def apply_agent_savings_env_defaults(
@@ -300,6 +316,28 @@ def proxy_pipeline_kwargs(config: object) -> dict[str, object]:
         # unset → Kompress decides / ambient default applies).
         if profile.target_ratio is not None:
             kwargs["target_ratio"] = profile.target_ratio
+        # Block-compression char floor. Every OTHER router pipeline kwarg in this
+        # function travels on the config object; this one alone was populated
+        # only from ``HEADROOM_MIN_CHARS_FOR_BLOCK`` (read below), so a proxy
+        # whose config carries ``savings_profile="coding"`` but whose process env
+        # was never seeded applied every sibling coding knob while this floor
+        # silently stayed at ``ContentRouterConfig.min_chars_for_block_compression``
+        # (500) instead of the profile's 25 — a 20x gap on the gate that governs
+        # tool_result blocks, the dominant content type in agent traffic.
+        #
+        # NOTE: this does not make the profile fully config-deliverable. The
+        # profile's ``cross_turn_dedup`` / ``tool_search`` / ``lossless_then_lossy``
+        # / ``protect_reads`` / ``code_aware`` / ``effort_router`` / ``lossless``
+        # fields are still env-only, but by a different mechanism: their consumers
+        # read ``os.environ`` directly (ContentRouter.__init__ for HEADROOM_DEDUPE,
+        # the Anthropic handler for HEADROOM_TOOL_SEARCH) and never pass through
+        # this function at all. Those remain seed-dependent and are the reason a
+        # profile can still be half-applied; fixing them means threading each
+        # consumer, which is a larger change than this one.
+        #
+        # The env read below still wins, since it is an explicit operator override.
+        if profile.min_chars_for_block is not None:
+            kwargs["min_chars_for_block_compression"] = profile.min_chars_for_block
 
     if getattr(config, "compress_user_messages", False):
         kwargs["compress_user_messages"] = True

--- a/headroom/perf/analyzer.py
+++ b/headroom/perf/analyzer.py
@@ -157,6 +157,12 @@ class PerfRecord:
     tokens_before: int = 0
     tokens_after: int = 0
     tokens_saved: int = 0
+    # Tokens the forwarded request GREW by (PERF ``tok_inflated``). Both
+    # endpoints are clamped — ``tok_saved`` at zero and ``tok_inflated`` at zero
+    # — so a turn that left the proxy bigger reports ``tok_saved=0`` and hides
+    # its growth in a field nothing downstream read. Carrying it here is what
+    # lets the report state net alongside gross instead of implying they agree.
+    tokens_inflated: int = 0
     tool_saved: int = 0
     cache_read: int = 0
     cache_write: int = 0
@@ -397,6 +403,7 @@ def parse_log_files(last_n_hours: float = 168.0) -> PerfReport:
                                 tokens_before=int(kv.get("tok_before", 0)),
                                 tokens_after=int(kv.get("tok_after", 0)),
                                 tokens_saved=int(kv.get("tok_saved", 0)),
+                                tokens_inflated=int(kv.get("tok_inflated", 0)),
                                 tool_saved=int(kv.get("tool_saved", 0)),
                                 savings_breakdown=_decode_perf_savings(kv.get("savings", "none")),
                                 cache_read=int(kv.get("cache_read", 0)),
@@ -546,6 +553,19 @@ def format_report(report: PerfReport) -> str:
         # include tool bytes), so it used to render as a rival "Tool saved" line — which
         # read as a side metric and hid the win on tool-heavy turns where tok_saved=0.
         lines.append(f"Tokens saved: {total_headline_saved:,} ({headline_pct:.1f}% reduction)")
+        # Gross vs net. ``tok_saved`` is clamped at zero per request, so turns
+        # where Headroom made the body BIGGER (CCR proactive expansion, memory
+        # injection) contribute nothing negative to the headline — their growth
+        # lands in ``tok_inflated`` instead, which nothing here used to read.
+        # Printing "321,239,562 -> 313,274,727" directly above "8,455,763 saved"
+        # implies the two reconcile; they differ by exactly the inflation. Show
+        # it whenever it is non-zero so the arithmetic closes on the page.
+        total_inflated = sum(r.tokens_inflated for r in records)
+        if total_inflated > 0:
+            lines.append(
+                f"  · inflated      {total_inflated:,} "
+                f"(net message reduction {total_before - total_after:,})"
+            )
         if total_tool_saved > 0:
             lines.append(f"  · messages       {max(0, total_saved):,}")
             lines.append(f"  · tool schemas   {total_tool_saved:,}")
@@ -698,6 +718,31 @@ def format_report(report: PerfReport) -> str:
             lines.append(
                 f"  {name}: {avg_pct:.1f}% avg reduction, {len(recs)} uses, {total_s:,} saved"
             )
+        # This table is built ONLY from "Transform NAME: B -> A tokens (saved N)"
+        # lines, which just one engine emits (transforms/pipeline.py). The
+        # OpenAI-Responses engine (transforms/compression_units.py +
+        # compression_batches.py) applies the same strategies and contains no
+        # logging calls at all, so none of its work appears above. On real
+        # traffic that hid ~7M of ~8.5M message-token savings — the table read
+        # "content_router: 189,783 saved" against a PERF total 44x larger, which
+        # invites exactly the wrong conclusion about which compressors work.
+        #
+        # State the divergence, NOT a coverage ratio. The two totals are
+        # different populations and neither strictly contains the other: the
+        # Transform lines carry no request_id, fire once per pipeline STAGE (so
+        # several can describe one request), and are emitted before the forwarder
+        # decides anything — a mutation later discarded by the signed-thinking
+        # byte-lock still logs its "saved" here while the request's PERF line
+        # correctly reports 0. So "table covers X of Y" would be a false subset
+        # claim in both directions; report the two sums and let the reader judge.
+        table_total = sum(r.tokens_saved for r in report.transform_records)
+        perf_total = sum(r.tokens_saved for r in report.perf_records)
+        if table_total != perf_total:
+            lines.append(
+                f"  ! stage-level total {table_total:,} != PERF message total {perf_total:,} "
+                "— this table sees only engines that emit a Transform line, counts "
+                "per stage, and does not check whether the mutation shipped"
+            )
         lines.append("")
 
     # Router routing breakdown
@@ -717,10 +762,23 @@ def format_report(report: PerfReport) -> str:
                 f"  Excluded:    {total_excluded} ({total_excluded / total_all * 100:.0f}%) — Read/Glob outputs"
             )
             lines.append(
-                f"  Skipped:     {total_skipped} ({total_skipped / total_all * 100:.0f}%) — <50 words"
+                f"  Skipped:     {total_skipped} ({total_skipped / total_all * 100:.0f}%) — below size floor"
             )
             lines.append(
                 f"  Unchanged:   {total_unchanged} ({total_unchanged / total_all * 100:.0f}%) — ratio too high"
+            )
+            # These four buckets are NOT the router's full outcome space — the
+            # `[router] route_counts=` line carries 17 keys, and the ones omitted
+            # here (cache_hit, system_msg, error_protected, already_compressed,
+            # …) are individually larger than "Excluded". Percentages taken over
+            # this subset therefore overstate every share: on real traffic the
+            # "skipped" bucket read 77% here against 49.5% of actual terminal
+            # fates, which reads as a mis-set threshold rather than a narrow
+            # denominator. Say what the denominator is instead of implying it is
+            # everything.
+            lines.append(
+                f"  (shares are of these 4 buckets only, n={total_all}; "
+                "see `[router] route_counts=` for the full outcome space)"
             )
         if total_excluded > total_compressed * 3:
             lines.append("  ! Excluded tools dominate — consider compressing stale Read outputs")
@@ -803,6 +861,7 @@ PERF_RECORD_FIELDS = [
     # Appended last so every existing CSV column keeps its position; a reader
     # that indexes by name is unaffected either way.
     "from_response_cache",
+    "tokens_inflated",
 ]
 
 

--- a/headroom/proxy/body_forwarding.py
+++ b/headroom/proxy/body_forwarding.py
@@ -81,13 +81,26 @@ def has_signed_thinking_blocks(body: dict[str, Any]) -> bool:
     return False
 
 
-#: Any body carrying a ``thinking`` or ``redacted_thinking`` block must contain
-#: this substring, because it appears in the block's own ``type`` value. Scanning
-#: for it is orders of magnitude cheaper than parsing, and request bodies here
-#: reach 9.3 MB in real agent traffic -- so this prescreen keeps the common case
-#: (no thinking anywhere, ~2 of every 3 requests) from paying a full JSON parse
-#: it cannot learn anything from. Conservative direction: a false positive costs
-#: one parse we would have done anyway, and a false negative is impossible.
+#: A body carrying a ``thinking`` or ``redacted_thinking`` block contains this
+#: substring, because it appears in the block's own ``type`` value. Scanning for
+#: it is orders of magnitude cheaper than parsing, and request bodies here reach
+#: 9.3 MB in real agent traffic -- so this prescreen keeps the common case (no
+#: thinking anywhere, ~2 of every 3 requests) from paying a full JSON parse it
+#: cannot learn anything from.
+#:
+#: A false positive costs one parse we would have done anyway. A false negative
+#: is not strictly impossible -- a ``type`` value whose ASCII letters are written
+#: as JSON unicode escapes still parses to ``thinking`` while containing no
+#: literal match, and that is legal JSON no standard encoder emits
+#: (``json.dumps`` does not escape ASCII even under
+#: ``ensure_ascii=True``, and neither does any client we forward for) -- and its
+#: consequences are asymmetric in our favour: when the mutated body still holds
+#: the block, ``has_signed_thinking_blocks(body)`` sees it on the parsed dict and
+#: we lock anyway. The single reachable gap needs an escaped ``type`` in the
+#: original AND a transform that removed the block from the body, which is the
+#: rare #3015 shape crossed with an encoder nobody uses. Documented rather than
+#: defended, because closing it means re-parsing every large body to catch a case
+#: no observed client can produce.
 _THINKING_SUBSTRING = b"thinking"
 
 

--- a/headroom/proxy/body_forwarding.py
+++ b/headroom/proxy/body_forwarding.py
@@ -81,14 +81,41 @@ def has_signed_thinking_blocks(body: dict[str, Any]) -> bool:
     return False
 
 
-def _original_body_has_signed_thinking_blocks(original_body_bytes: bytes | None) -> bool:
+#: Any body carrying a ``thinking`` or ``redacted_thinking`` block must contain
+#: this substring, because it appears in the block's own ``type`` value. Scanning
+#: for it is orders of magnitude cheaper than parsing, and request bodies here
+#: reach 9.3 MB in real agent traffic -- so this prescreen keeps the common case
+#: (no thinking anywhere, ~2 of every 3 requests) from paying a full JSON parse
+#: it cannot learn anything from. Conservative direction: a false positive costs
+#: one parse we would have done anyway, and a false negative is impossible.
+_THINKING_SUBSTRING = b"thinking"
+
+
+def _parse_original_body(original_body_bytes: bytes | None) -> dict[str, Any] | None:
+    """Parse the client's body once, or ``None`` when it cannot be used.
+
+    Every caller here needs the same parsed document, and a 9.3 MB body parsed
+    twice per decision (and twice again in the handler's earlier probe) is real
+    latency on a stage that already has a 30s timeout whose expiry quarantines
+    compression process-wide. Parse in one place and pass the result down.
+
+    ``None`` means "cannot prove anything from the original", which every caller
+    must treat as the conservative answer.
+    """
     if original_body_bytes is None:
-        return False
+        return None
+    if _THINKING_SUBSTRING not in original_body_bytes:
+        return None
     try:
         original = json.loads(original_body_bytes)
     except (json.JSONDecodeError, UnicodeDecodeError, ValueError, MemoryError, RecursionError):
-        return False
-    return isinstance(original, dict) and has_signed_thinking_blocks(original)
+        return None
+    return original if isinstance(original, dict) else None
+
+
+def _original_body_has_signed_thinking_blocks(original_body_bytes: bytes | None) -> bool:
+    original = _parse_original_body(original_body_bytes)
+    return original is not None and has_signed_thinking_blocks(original)
 
 
 #: Allow canonical re-serialization on a thinking-bearing request when every
@@ -163,6 +190,7 @@ def thinking_block_fingerprint(body: Any) -> list[tuple[int, int, str]]:
 def thinking_blocks_survived_mutation(
     body: dict[str, Any],
     original_body_bytes: bytes | None,
+    original: dict[str, Any] | None = None,
 ) -> bool:
     """True when every thinking block is byte-equal to the one the client sent.
 
@@ -177,14 +205,13 @@ def thinking_blocks_survived_mutation(
 
     Conservative by construction: any parse failure, or any detectable
     difference at all, returns False and the caller keeps today's passthrough.
+
+    Pass ``original`` when the caller has already parsed the client body, so a
+    multi-megabyte document is not re-parsed once per predicate.
     """
-    if original_body_bytes is None:
-        return False
-    try:
-        original = json.loads(original_body_bytes)
-    except (json.JSONDecodeError, UnicodeDecodeError, ValueError, MemoryError, RecursionError):
-        return False
-    if not isinstance(original, dict):
+    if original is None:
+        original = _parse_original_body(original_body_bytes)
+    if original is None:
         return False
     try:
         return thinking_block_fingerprint(body) == thinking_block_fingerprint(original)
@@ -236,9 +263,12 @@ def select_outbound_body(
     upstream instead of silently claiming the edit landed.
     """
     mode = forwarder_mode if forwarder_mode is not None else get_python_forwarder_mode()
+    # Parse the client body at most once for the whole decision (bodies here
+    # reach 9.3 MB in real traffic; this used to cost two full parses).
+    original_parsed = _parse_original_body(original_body_bytes)
     if original_body_bytes is not None and (
         has_signed_thinking_blocks(body)
-        or _original_body_has_signed_thinking_blocks(original_body_bytes)
+        or (original_parsed is not None and has_signed_thinking_blocks(original_parsed))
     ):
         # The lock is about the SEAL, not the box. When every thinking block is
         # provably identical to the one the client sent, no signature can have
@@ -248,7 +278,7 @@ def select_outbound_body(
         # request for the rest of the session -- on real Claude Code traffic that
         # discarded every computed compression on 34% of requests.
         if thinking_preserving_mutations_enabled() and thinking_blocks_survived_mutation(
-            body, original_body_bytes
+            body, original_body_bytes, original=original_parsed
         ):
             if mode == "legacy_json_kwarg":
                 content = json.dumps(body, separators=(", ", ": "), ensure_ascii=True).encode(
@@ -325,13 +355,14 @@ def outbound_body_is_client_bytes(
     """
     if original_body_bytes is None:
         return False
+    original_parsed = _parse_original_body(original_body_bytes)
     if not (
         has_signed_thinking_blocks(body)
-        or _original_body_has_signed_thinking_blocks(original_body_bytes)
+        or (original_parsed is not None and has_signed_thinking_blocks(original_parsed))
     ):
         return False
     if thinking_preserving_mutations_enabled() and thinking_blocks_survived_mutation(
-        body, original_body_bytes
+        body, original_body_bytes, original=original_parsed
     ):
         return False
     return True

--- a/headroom/proxy/body_forwarding.py
+++ b/headroom/proxy/body_forwarding.py
@@ -91,6 +91,109 @@ def _original_body_has_signed_thinking_blocks(original_body_bytes: bytes | None)
     return isinstance(original, dict) and has_signed_thinking_blocks(original)
 
 
+#: Allow canonical re-serialization on a thinking-bearing request when every
+#: thinking block is provably unchanged. **Default ON**; set this to ``0`` (or
+#: ``false``/``no``/``off``) to restore the previous blanket lock.
+#:
+#: Risk note, recorded deliberately. The lock this relaxes was added by #2254
+#: after real upstream 400s ("`thinking` blocks ... cannot be modified"). That
+#: report attributed the failure to a plain canonical re-encode, which cannot
+#: alter parsed values and therefore cannot by itself invalidate a signature --
+#: and the report's own log shows a transform (`tool_search_deferral`) firing on
+#: the failing turn. So the stated cause does not hold up, but the failure was
+#: real and its true trigger was never isolated. This relaxation is narrower
+#: than what broke: it forwards edits ONLY when every thinking block is
+#: byte-identical to the client's, which is exactly the property #2254's blanket
+#: rule was a crude proxy for.
+#:
+#: It is on by default at the maintainer's direction, to recover the savings the
+#: lock was discarding. If Anthropic starts rejecting thinking-bearing turns,
+#: set the env var to ``0`` -- that is a single-variable, no-deploy rollback to
+#: the previous behaviour, and the 400s stop immediately.
+THINKING_PRESERVING_MUTATIONS_ENV = "HEADROOM_THINKING_PRESERVING_MUTATIONS"
+
+
+def thinking_preserving_mutations_enabled() -> bool:
+    """Whether to forward edits that provably left every thinking block intact.
+
+    Defaults to enabled. Only an explicit falsey value restores the blanket lock,
+    so an unset or unparseable variable keeps the documented default rather than
+    silently reverting behaviour.
+    """
+    raw = os.environ.get(THINKING_PRESERVING_MUTATIONS_ENV)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def thinking_block_fingerprint(body: Any) -> list[tuple[int, int, str]]:
+    """Positional, order-sensitive fingerprint of every thinking block.
+
+    Each entry is ``(message_index, block_index, canonical_json_of_block)``, so
+    the comparison catches a block whose text or ``signature`` changed, one that
+    was added, removed, reordered, or moved between messages. Keys are sorted so
+    a dict rebuilt in a different order is not mistaken for an edit -- the wire
+    contract is over parsed values, not key order.
+    """
+    out: list[tuple[int, int, str]] = []
+    messages = body.get("messages") if isinstance(body, dict) else None
+    if not isinstance(messages, list):
+        return out
+    for message_index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block_index, block in enumerate(content):
+            if isinstance(block, dict) and block.get("type") in {
+                "thinking",
+                "redacted_thinking",
+            }:
+                out.append(
+                    (
+                        message_index,
+                        block_index,
+                        json.dumps(block, sort_keys=True, ensure_ascii=False),
+                    )
+                )
+    return out
+
+
+def thinking_blocks_survived_mutation(
+    body: dict[str, Any],
+    original_body_bytes: bytes | None,
+) -> bool:
+    """True when every thinking block is byte-equal to the one the client sent.
+
+    This is the whole point of the relaxation. Anthropic signs the thinking
+    block, not the request: the signature covers that block's own content, so
+    edits to a ``tool_result`` twenty turns back, or to the top-level ``tools``
+    and ``system`` fields (which are not even inside ``messages`` and therefore
+    cannot be covered by any per-block signature), leave every seal intact.
+    Treating the presence of a sealed block as a reason to freeze the entire
+    body is a category error -- it protects bytes the signature says nothing
+    about, and on Claude Code traffic that is nearly the whole request.
+
+    Conservative by construction: any parse failure, or any detectable
+    difference at all, returns False and the caller keeps today's passthrough.
+    """
+    if original_body_bytes is None:
+        return False
+    try:
+        original = json.loads(original_body_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError, MemoryError, RecursionError):
+        return False
+    if not isinstance(original, dict):
+        return False
+    try:
+        return thinking_block_fingerprint(body) == thinking_block_fingerprint(original)
+    except (TypeError, ValueError, RecursionError):
+        # An unserializable block (or pathological nesting) means we cannot prove
+        # the blocks are untouched, so we must not claim they are.
+        return False
+
+
 class BodyMutationTracker:
     """Records whether a request body was mutated and why."""
 
@@ -137,6 +240,24 @@ def select_outbound_body(
         has_signed_thinking_blocks(body)
         or _original_body_has_signed_thinking_blocks(original_body_bytes)
     ):
+        # The lock is about the SEAL, not the box. When every thinking block is
+        # provably identical to the one the client sent, no signature can have
+        # been invalidated, so the remaining edits (compressed tool_result text,
+        # compacted tool schemas, tool-search deferral) are safe to forward.
+        # Without this, one thinking block anywhere in history froze the entire
+        # request for the rest of the session -- on real Claude Code traffic that
+        # discarded every computed compression on 34% of requests.
+        if thinking_preserving_mutations_enabled() and thinking_blocks_survived_mutation(
+            body, original_body_bytes
+        ):
+            if mode == "legacy_json_kwarg":
+                content = json.dumps(body, separators=(", ", ": "), ensure_ascii=True).encode(
+                    "utf-8"
+                )
+                return OutboundBody(content=content, source="legacy")
+            if body_mutated:
+                return OutboundBody(content=serialize_body_canonical(body), source="canonical")
+            return OutboundBody(content=original_body_bytes, source="passthrough")
         return OutboundBody(
             content=original_body_bytes,
             source="passthrough",
@@ -190,10 +311,27 @@ def outbound_body_is_client_bytes(
     send the client's bytes verbatim. Asking before acting is cheaper than
     discovering it from a reply in the wrong wire format.
 
-    Mirrors the first branch of :func:`select_outbound_body`; the forwarder mode
-    is deliberately not consulted because that branch overrides it too.
+    Mirrors the first branch of :func:`select_outbound_body`, INCLUDING the
+    thinking-preserving relaxation. These two must agree exactly: the caller
+    flips ``stream`` to False to buy a buffered reply, and that flip only lands
+    if the mutated body actually reaches the wire. If this said "locked" while
+    ``select_outbound_body`` shipped canonical bytes, we would ask upstream for a
+    stream and then parse the reply as buffered JSON -- the 200-with-empty-body
+    failure from #2952, in reverse.
+
+    The forwarder mode is deliberately not consulted: the lock branch overrides
+    it, and the relaxation only ever returns bytes derived from ``body``, so
+    either way the caller's edits are on the wire.
     """
-    return original_body_bytes is not None and (
+    if original_body_bytes is None:
+        return False
+    if not (
         has_signed_thinking_blocks(body)
         or _original_body_has_signed_thinking_blocks(original_body_bytes)
-    )
+    ):
+        return False
+    if thinking_preserving_mutations_enabled() and thinking_blocks_survived_mutation(
+        body, original_body_bytes
+    ):
+        return False
+    return True

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -3559,7 +3559,23 @@ class AnthropicHandlerMixin:
                 # edits that will not be sent (#2990). This covers PERF, /stats,
                 # durable savings, response headers, pipeline events, and the
                 # prefix tracker rather than fixing only one reporting surface.
-                if outbound_locked_to_client_bytes and body_mutation_tracker.mutated:
+                #
+                # RECOMPUTE rather than reusing the probe from before the CCR
+                # branch. That probe answers "will my stream flip survive?" and
+                # has to be asked early; this asks "what are we actually about to
+                # bill for?" and must be asked last. The two diverge now that the
+                # predicate tests thinking-block CONTENT and not merely presence:
+                # `enforce_cache_control_ttl_order` immediately above rewrites
+                # `body["messages"]`, so a marker moved onto or off a message
+                # holding a thinking block changes the answer after the early
+                # probe was taken. Evaluating the same predicate on the same
+                # final `body` that `select_outbound_body` will see is what keeps
+                # the accounting and the wire in agreement.
+                final_locked_to_client_bytes = outbound_body_is_client_bytes(
+                    body=body,
+                    original_body_bytes=original_body_bytes,
+                )
+                if final_locked_to_client_bytes and body_mutation_tracker.mutated:
                     discarded_reasons = body_mutation_tracker.reasons
                     try:
                         wire_body = json.loads(original_body_bytes or b"")

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -768,11 +768,31 @@ class SavingsTracker:
         delta_output_tokens_saved = max(_coerce_int(output_tokens_saved), 0)
         delta_cache_read_tokens = _coerce_int(cache_read_tokens)
         priced = estimated_savings_usd
-        delta_savings_usd = (
-            max(_coerce_float(priced.get("compression")), 0.0)
-            if priced is not None
-            else _estimate_compression_savings_usd(model, delta_tokens_saved)
-        )
+        # ``estimate_request_savings_usd`` prices FOUR buckets, but this method
+        # only ever read three — ``tool_schema`` was computed and dropped on the
+        # floor. Tool-schema deferral is a quarter of the token headline on real
+        # traffic (2.7M of 11.2M), and ``tokens_saved`` here is the bare
+        # message-level figure (the caller folds deferral in separately for the
+        # ledger, see prometheus_metrics.record_request), so the dollars were
+        # simply missing rather than counted elsewhere. That is why "Cost saved"
+        # read materially below the token-savings percent on the same traffic.
+        # Add it to the compression bucket, matching how the PERF headline and
+        # perf/analyzer fold deferral into one number.
+        if priced is not None:
+            # Two DISJOINT buckets: the caller passes bare message savings as
+            # ``compression_tokens_saved`` and deferral separately as
+            # ``tool_schema_tokens_saved`` (see prometheus_metrics.record_request),
+            # so summing them is additive, not double counting. Written as a
+            # statement rather than folded into the ternary below — a money path
+            # should not depend on the reader knowing that ``a + b if c else d``
+            # groups as ``(a + b) if c else d``.
+            delta_savings_usd = max(_coerce_float(priced.get("compression")), 0.0) + max(
+                _coerce_float(priced.get("tool_schema")), 0.0
+            )
+        else:
+            # No priced breakdown available: only message savings are known here,
+            # so this path stays message-only exactly as before.
+            delta_savings_usd = _estimate_compression_savings_usd(model, delta_tokens_saved)
         delta_output_savings_usd = (
             max(_coerce_float(priced.get("output_shaping")), 0.0)
             if priced is not None

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -66,7 +66,7 @@ except ImportError:
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from headroom._version import __version__
-from headroom.agent_savings import proxy_pipeline_kwargs
+from headroom.agent_savings import DEFAULT_PROFILE, proxy_pipeline_kwargs
 from headroom.cache.compression_feedback import get_compression_feedback
 from headroom.cache.compression_store import format_retrieval_miss_detail, get_compression_store
 from headroom.ccr import (
@@ -1737,6 +1737,38 @@ class HeadroomProxy(
         if self.config.mode == PROXY_MODE_CACHE:
             logger.info("  Prefix freeze: strict (all prior turns immutable)")
             logger.info("  Mutations: latest turn only")
+        # Effective compression posture, resolved (not merely requested). The
+        # savings profile reaches the router through two paths — the config
+        # object and the seeded process env — and `setdefault` semantics mean a
+        # stale HEADROOM_* value silently overrides the profile that names it.
+        # A deployment can therefore log `savings_profile=coding` while actually
+        # running balanced's thresholds, and the only prior evidence was a
+        # single easily-missed WARNING. Print what is actually in force so
+        # "which profile am I really running?" is answerable from the banner.
+        try:
+            _eff = proxy_pipeline_kwargs(self.config)
+            # Read cross-turn dedup off the CONSTRUCTED router, not off the env.
+            # ContentRouter resolves it as `config.enable_cross_turn_dedup OR
+            # $HEADROOM_DEDUPE`, so reporting the env alone would be a guess that
+            # happens to be right only while nothing sets the config field. A
+            # banner line exists to be trusted; it must read what was resolved.
+            _dedupe: object = "unknown"
+            for _t in getattr(self.anthropic_pipeline, "transforms", []):
+                if isinstance(_t, ContentRouter):
+                    _dedupe = bool(getattr(_t, "_cross_turn_dedup_enabled", False))
+                    break
+            logger.info(
+                "Savings profile: %s (effective: min_tokens=%s min_chars_block=%s "
+                "compress_user=%s dedupe=%s tool_search=%s)",
+                self.config.savings_profile or DEFAULT_PROFILE,
+                _eff.get("min_tokens_to_compress", "default"),
+                _eff.get("min_chars_for_block_compression", "default(500)"),
+                _eff.get("compress_user_messages", False),
+                _dedupe,
+                os.environ.get("HEADROOM_TOOL_SEARCH", "1") in ("1", "true", "yes", "on", "auto"),
+            )
+        except Exception:  # never let a banner line block startup
+            logger.debug("effective savings-profile banner skipped", exc_info=True)
         logger.info(f"Caching: {'ENABLED' if self.config.cache_enabled else 'DISABLED'}")
         logger.info(f"Rate Limiting: {'ENABLED' if self.config.rate_limit_enabled else 'DISABLED'}")
         logger.info(

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -5552,7 +5552,16 @@ class ContentRouter(Transform):
         if route_counts["user_msg"]:
             parts.append(f"{route_counts['user_msg']} skipped (user)")
         if route_counts["small"]:
-            parts.append(f"{route_counts['small']} skipped (<50 words)")
+            # Report the thresholds actually in force, not a literal. This line
+            # used to read "skipped (<50 words)" unconditionally: wrong number
+            # (the message gate is `min_tokens`, which profiles set anywhere from
+            # 10 to 250), wrong unit (tokens and characters, never words), and it
+            # merged two different gates under one label. Operators read it as
+            # evidence of a mis-set threshold and tuned the wrong knob.
+            parts.append(
+                f"{route_counts['small']} skipped "
+                f"(<{min_tokens} tok msg / <{min_chars_for_block_compression} chars block)"
+            )
         if route_counts["recent_code"]:
             parts.append(f"{route_counts['recent_code']} protected (recent code)")
         if route_counts["analysis_ctx"]:

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -1857,7 +1857,11 @@ class ContentRouter(Transform):
         ).strip().lower() in ("1", "true", "yes", "on")
         self._text_crusher: Any = None
         # Cross-turn dedup: config field OR env HEADROOM_DEDUPE (robust to how the
-        # config was built). Effective only in lossless mode (guarded in apply()).
+        # config was built). Runs in BOTH modes — the call site in ``apply()`` has
+        # no lossless guard, and ``_cross_turn_dedup_messages`` documents working
+        # against lossless folds and CCR-recoverable forms alike. (This comment
+        # previously claimed "lossless mode only", which reads as "inert in your
+        # config" to anyone auditing why dedup never fired.)
         self._cross_turn_dedup_enabled: bool = (
             self.config.enable_cross_turn_dedup
             or os.environ.get("HEADROOM_DEDUPE", "").strip().lower() in ("1", "true", "yes", "on")

--- a/tests/test_agent_savings.py
+++ b/tests/test_agent_savings.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from headroom.agent_savings import (
     AGENT_90_PROFILE,
+    DEFAULT_PROFILE,
     apply_agent_savings_env_defaults,
     apply_agent_savings_profile,
     get_agent_savings_profile,
@@ -170,17 +171,30 @@ def test_agent_savings_env_defaults_preserve_user_overrides() -> None:
     assert env["HEADROOM_SMART_CRUSHER_COMPACTION"] == "0"
 
 
-def test_unknown_agent_savings_profile_falls_back_to_balanced(
+def test_unknown_agent_savings_profile_falls_back_to_default(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     # An unknown profile must NOT raise: it's resolved during proxy startup, so
     # raising takes the whole proxy down before it opens its port (desktop asked
-    # for a profile a fallback runtime predates). Degrade to "balanced" instead.
+    # for a profile a fallback runtime predates).
+    #
+    # It must degrade to the DEFAULT profile, not to "balanced". The two are not
+    # interchangeable: balanced flips cache->token mode, turns cross-turn dedup
+    # and tool-search off, stops compressing user messages, and raises the
+    # message floor 25x (250 vs 10) and the block floor 20x (500 vs 25). A typo
+    # in HEADROOM_SAVINGS_PROFILE used to silently reconfigure the entire proxy
+    # into that posture, which is strictly worse than behaving as if the
+    # variable were unset.
     with caplog.at_level(logging.WARNING):
         profile = get_agent_savings_profile("missing")
-    assert profile is get_agent_savings_profile("balanced")
+    assert profile is get_agent_savings_profile(None)
+    assert profile.name == DEFAULT_PROFILE
+    assert profile is not get_agent_savings_profile("balanced")
     assert "unknown savings profile" in caplog.text
     assert "missing" in caplog.text
+    # The warning has to name the resolved profile, so an operator reading it
+    # knows what they actually got rather than only what they asked for.
+    assert DEFAULT_PROFILE in caplog.text
 
 
 def test_with_target_savings_recomputes_target_ratio() -> None:
@@ -784,3 +798,45 @@ def test_agent_savings_smoke_fixture_passes_real_gate(tmp_path) -> None:
     assert "codex: 91.0% savings meets 90.0%" in gate_result.output
     assert "cursor: 93.0% savings meets 90.0%" in gate_result.output
     assert "100.0% accuracy meets 90.0%" in gate_result.output
+
+
+def test_coding_profile_min_chars_block_reaches_router_without_env_seeding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The block-char floor must travel on the config object, not env only.
+
+    Every other router pipeline kwarg this function builds travels on the config
+    object; ``min_chars_for_block`` alone was populated only from
+    ``HEADROOM_MIN_CHARS_FOR_BLOCK`` (emitted by ``proxy_env()``). A proxy whose
+    config carried ``savings_profile="coding"`` but whose process env was never
+    seeded applied every sibling coding knob while this floor silently stayed at
+    ``ContentRouterConfig.min_chars_for_block_compression`` (500) instead of the
+    profile's 25 — a 20x gap on the gate that governs tool_result blocks.
+
+    Note this does not make the profile fully config-deliverable: fields whose
+    consumers read ``os.environ`` directly (``cross_turn_dedup`` via
+    ContentRouter, ``tool_search`` via the Anthropic handler) never pass through
+    this function and remain seed-dependent.
+    """
+    monkeypatch.delenv("HEADROOM_MIN_CHARS_FOR_BLOCK", raising=False)
+
+    class _Config:
+        savings_profile = "coding"
+        min_tokens_to_crush = 500
+
+    kwargs = proxy_pipeline_kwargs(_Config())
+    assert kwargs["min_chars_for_block_compression"] == 25
+    assert kwargs["min_tokens_to_compress"] == 10
+
+
+def test_explicit_min_chars_block_env_overrides_the_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit operator override still wins over the profile value."""
+    monkeypatch.setenv("HEADROOM_MIN_CHARS_FOR_BLOCK", "120")
+
+    class _Config:
+        savings_profile = "coding"
+        min_tokens_to_crush = 500
+
+    assert proxy_pipeline_kwargs(_Config())["min_chars_for_block_compression"] == 120

--- a/tests/test_ccr_buffered_stream_signed_thinking.py
+++ b/tests/test_ccr_buffered_stream_signed_thinking.py
@@ -108,13 +108,30 @@ def _headers() -> dict[str, str]:
 
 
 @pytest.mark.parametrize(
-    ("with_thinking", "expect_plain_streaming"),
-    [(True, True), (False, False)],
+    ("with_thinking", "relaxation_enabled", "expect_plain_streaming"),
+    [
+        # Locked (kill switch engaged): the flip cannot reach upstream, so
+        # buffering would ask for a stream and then parse it as JSON, stranding
+        # the client with an unreadable 200. This is #2952 exactly.
+        (True, False, True),
+        # Relaxed (default): no transform touched the thinking block, so the
+        # flip DOES land and buffered retrieval becomes the coherent choice --
+        # the outcome #2952 wanted before the blanket lock made it unreachable.
+        (True, True, False),
+        # No thinking block: unaffected in either regime.
+        (False, True, False),
+        (False, False, False),
+    ],
 )
 def test_signed_thinking_history_skips_the_buffered_ccr_path(
-    with_thinking: bool, expect_plain_streaming: bool, ccr_marker: str
+    with_thinking: bool,
+    relaxation_enabled: bool,
+    expect_plain_streaming: bool,
+    ccr_marker: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The buffered path is only chosen when the stream:false flip can land."""
+    monkeypatch.setenv("HEADROOM_THINKING_PRESERVING_MUTATIONS", "1" if relaxation_enabled else "0")
     calls: dict[str, object] = {}
 
     async def fake_stream_response(url, headers, body, *args, **kwargs):  # noqa: ANN001

--- a/tests/test_proxy_byte_faithful_forwarding.py
+++ b/tests/test_proxy_byte_faithful_forwarding.py
@@ -38,6 +38,7 @@ from headroom.proxy.body_forwarding import (
     prepare_outbound_body_bytes,
     select_outbound_body,
     serialize_body_canonical,
+    thinking_blocks_survived_mutation,
 )
 from headroom.proxy.helpers import (
     _reset_session_beta_tracker_for_test,
@@ -196,6 +197,11 @@ def test_signed_thinking_history_with_original_bytes_uses_passthrough(
         ],
     }
     original = json.dumps(body, indent=2).encode("utf-8")
+    # The lock triggers on a MODIFIED thinking block, not merely a present one:
+    # the signature covers the block's own content, so a body whose blocks are
+    # untouched has no seal to break. Tamper with the block so this test still
+    # exercises the guard it was written for.
+    body["messages"][1]["content"][0]["thinking"] = "rewritten by a transform"
 
     outbound = select_outbound_body(
         body=body,
@@ -245,6 +251,11 @@ def test_signed_thinking_history_overrides_legacy_encoder() -> None:
         ]
     }
     original = json.dumps(body, indent=2).encode("utf-8")
+    # Modified block => the lock engages and still outranks the legacy encoder.
+    # (An UNmodified block no longer overrides legacy mode: with every seal
+    # provably intact there is nothing for the override to protect, and honoring
+    # the operator's explicit rollback request is the more useful behaviour.)
+    body["messages"][0]["content"][0]["signature"] = "tampered"
 
     outbound = select_outbound_body(
         body=body,
@@ -268,6 +279,12 @@ def test_signed_thinking_passthrough_reports_the_mutations_it_discarded() -> Non
         ],
     }
     original = json.dumps({**body, "stream": True}).encode("utf-8")
+    # A thinking block the transforms did NOT touch no longer forces
+    # passthrough, so the CCR stream flip in this very scenario now reaches
+    # upstream — which is the outcome #2952 wanted in the first place. The
+    # discard-reporting path still has to work when a block really was edited,
+    # so tamper with it here and keep guarding that.
+    body["messages"][0]["content"][0]["signature"] = "rewritten"
 
     outbound = select_outbound_body(
         body=body,
@@ -591,7 +608,15 @@ def _make_no_optimize_app() -> tuple[TestClient, _CapturingTransport]:
     return _make_anthropic_app(optimize=False)
 
 
-def test_signed_thinking_discarded_mutation_uses_wire_truth_for_all_accounting() -> None:
+def test_signed_thinking_discarded_mutation_uses_wire_truth_for_all_accounting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Exercised with the relaxation DISABLED, which is both the documented
+    # rollback and the pre-existing behaviour. Keeping #3015's wire-truth
+    # assertions under the kill switch proves two things at once: the accounting
+    # neutralisation still works whenever the lock does engage, and the env-var
+    # rollback really is a complete restoration rather than a partial one.
+    monkeypatch.setenv("HEADROOM_THINKING_PRESERVING_MUTATIONS", "0")
     config = ProxyConfig(
         optimize=False,
         cache_enabled=False,
@@ -671,6 +696,89 @@ def test_signed_thinking_discarded_mutation_uses_wire_truth_for_all_accounting()
     assert proxy.metrics.tokens_saved_total == 0
     assert proxy.metrics.tool_search_saved_total == 0
     assert tracker._last_forwarded_messages[: len(inbound["messages"])] == inbound["messages"]
+
+
+def test_untouched_thinking_lets_tool_compaction_reach_the_wire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end counterpart: the same request, with the relaxation active.
+
+    This is the whole point of the change. Tool schemas are a top-level field --
+    not inside ``messages`` at all, so no per-block thinking signature can
+    possibly cover them -- yet the blanket lock discarded their compaction on
+    every turn of a thinking-bearing session. Here the compaction must reach
+    upstream AND be credited, while the thinking block goes out untouched.
+    """
+    monkeypatch.delenv("HEADROOM_THINKING_PRESERVING_MUTATIONS", raising=False)
+    config = ProxyConfig(
+        optimize=False,
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+        log_requests=False,
+        ccr_inject_tool=False,
+        ccr_handle_responses=False,
+        ccr_context_tracking=False,
+        image_optimize=False,
+    )
+    app = create_app(config)
+    proxy = app.state.proxy
+    transport = _CapturingTransport()
+    proxy.http_client = httpx.AsyncClient(transport=transport)
+    proxy._record_request_outcome = AsyncMock(wraps=proxy._record_request_outcome)
+
+    tracker = _FakePrefixTracker(frozen_count=0)
+    proxy.session_tracker_store.compute_session_id = lambda request, model, messages: "signed"
+    proxy.session_tracker_store.get_or_create = lambda session_id, provider: tracker
+
+    signed_block = {"type": "thinking", "thinking": "private", "signature": "sig123"}
+    inbound = {
+        "model": "claude-opus-5",
+        "max_tokens": 64,
+        "messages": [
+            {"role": "user", "content": "Solve this."},
+            {
+                "role": "assistant",
+                "content": [dict(signed_block), {"type": "text", "text": "Working."}],
+            },
+            {"role": "user", "content": "Continue."},
+        ],
+        "tools": [
+            {
+                "name": "lookup",
+                "description": "  Look up a value.  ",
+                "input_schema": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "title": "LookupArgs",
+                    "type": "object",
+                    "properties": {"q": {"type": "string", "title": "Q"}},
+                },
+            }
+        ],
+    }
+    inbound_bytes = json.dumps(inbound, indent=2).encode()
+
+    response = TestClient(app).post(
+        "/v1/messages",
+        headers={
+            "x-api-key": "test-key",
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+        content=inbound_bytes,
+    )
+
+    assert response.status_code == 200
+    # The edit shipped: the annotation keys the compaction strips are gone.
+    assert transport.captured_body != inbound_bytes
+    wire = json.loads(transport.captured_body)
+    assert "$schema" not in wire["tools"][0]["input_schema"]
+    assert "title" not in wire["tools"][0]["input_schema"]
+    # ...and the seal went out byte-identical, which is what makes it safe.
+    assert wire["messages"][1]["content"][0] == signed_block
+
+    outcome = proxy._record_request_outcome.await_args.args[0]
+    assert "wire_mutations_discarded" not in outcome.tags
 
 
 def _openai_responses_body_bytes(*, stream: bool) -> bytes:
@@ -1608,3 +1716,180 @@ def test_ws_http_fallback_uses_canonical_serializer() -> None:
     assert b"\\u" not in out
     # Round-trip equality via JSON parse.
     assert json.loads(out.decode("utf-8")) == body
+
+
+# ---------------------------------------------------------------------------
+# Thinking-preserving mutations (relaxing the blanket signed-thinking byte-lock)
+#
+# Anthropic signs the thinking BLOCK, not the request. The signature covers that
+# block's own content, so edits elsewhere -- a compressed ``tool_result`` twenty
+# turns back, a compacted ``tools`` array that is not even inside ``messages``
+# -- cannot invalidate it. The original lock (#2254) froze the entire body
+# whenever any thinking block was present, which on Claude Code traffic meant
+# every computed compression was discarded from turn 2 of a session onward.
+#
+# The relaxation ships dark behind ``HEADROOM_THINKING_PRESERVING_MUTATIONS``
+# and only engages when every thinking block is provably byte-equal to the one
+# the client sent. These tests pin both directions: what must now ship, and what
+# must still lock.
+# ---------------------------------------------------------------------------
+
+_TB_SIGNED_BLOCK = {
+    "type": "thinking",
+    "thinking": "Let me think about this… café",
+    "signature": "EuYBCkQYBCKMAQ==",
+}
+
+
+def _tb_body(tool_text: str = "LOG LINE\n" * 500) -> dict:
+    """Claude-Code-shaped turn: signed thinking in history + a fat tool_result."""
+    return {
+        "model": "claude-sonnet-5",
+        "tools": [{"name": "Bash", "description": "x" * 400, "input_schema": {"type": "object"}}],
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            {
+                "role": "assistant",
+                "content": [dict(_TB_SIGNED_BLOCK), {"type": "text", "text": "ok"}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t1",
+                        "content": [{"type": "text", "text": tool_text}],
+                    }
+                ],
+            },
+        ],
+    }
+
+
+def _tb_select(mutated: dict, original_bytes: bytes):
+    return select_outbound_body(
+        body=mutated,
+        original_body_bytes=original_bytes,
+        body_mutated=True,
+        forwarder_mode="byte_faithful",
+        mutation_reasons=["content_router", "anthropic:tool_schema_compaction"],
+    )
+
+
+def test_thinking_preserving_mutation_ships_compression(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Untouched thinking block => the rest of the body may be re-serialized."""
+    monkeypatch.setenv("HEADROOM_THINKING_PRESERVING_MUTATIONS", "1")
+    original = json.dumps(_tb_body()).encode()
+    mutated = json.loads(original)
+    mutated["messages"][2]["content"][0]["content"][0]["text"] = "[compressed]"
+
+    outbound = _tb_select(mutated, original)
+
+    assert outbound.source == "canonical"
+    assert outbound.dropped_mutations is False
+    assert b"[compressed]" in outbound.content
+    # The seal itself must survive verbatim, or we have merely moved the bug.
+    assert _TB_SIGNED_BLOCK["signature"].encode() in outbound.content
+    assert json.loads(outbound.content)["messages"][1]["content"][0] == _TB_SIGNED_BLOCK
+
+
+@pytest.mark.parametrize(
+    ("label", "tamper"),
+    [
+        ("edited_text", lambda b: b["messages"][1]["content"][0].__setitem__("thinking", "x")),
+        (
+            "edited_signature",
+            lambda b: b["messages"][1]["content"][0].__setitem__("signature", "x"),
+        ),
+        ("dropped_block", lambda b: b["messages"][1]["content"].__delitem__(0)),
+        ("reordered_blocks", lambda b: b["messages"][1]["content"].reverse()),
+    ],
+)
+def test_touching_a_thinking_block_still_locks(
+    monkeypatch: pytest.MonkeyPatch, label: str, tamper
+) -> None:
+    """Any detectable change to a thinking block keeps today's verbatim passthrough."""
+    monkeypatch.setenv("HEADROOM_THINKING_PRESERVING_MUTATIONS", "1")
+    original = json.dumps(_tb_body()).encode()
+    mutated = json.loads(original)
+    tamper(mutated)
+
+    outbound = _tb_select(mutated, original)
+
+    assert outbound.source == "passthrough", label
+    assert outbound.dropped_mutations is True
+    assert outbound.content == original
+
+
+def test_thinking_relaxation_is_on_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset flag => relaxation active (maintainer chose on-by-default)."""
+    monkeypatch.delenv("HEADROOM_THINKING_PRESERVING_MUTATIONS", raising=False)
+    original = json.dumps(_tb_body()).encode()
+    mutated = json.loads(original)
+    mutated["messages"][2]["content"][0]["content"][0]["text"] = "[compressed]"
+
+    outbound = _tb_select(mutated, original)
+
+    assert outbound.source == "canonical"
+    assert outbound.dropped_mutations is False
+
+
+@pytest.mark.parametrize("off_value", ["0", "false", "no", "off", "OFF"])
+def test_kill_switch_restores_the_blanket_lock(
+    monkeypatch: pytest.MonkeyPatch, off_value: str
+) -> None:
+    """The documented rollback must work without a deploy, on every falsey spelling."""
+    monkeypatch.setenv("HEADROOM_THINKING_PRESERVING_MUTATIONS", off_value)
+    original = json.dumps(_tb_body()).encode()
+    mutated = json.loads(original)
+    mutated["messages"][2]["content"][0]["content"][0]["text"] = "[compressed]"
+
+    outbound = _tb_select(mutated, original)
+
+    assert outbound.source == "passthrough", off_value
+    assert outbound.dropped_mutations is True
+    assert outbound.content == original
+
+
+def test_thinking_block_key_reorder_is_not_an_edit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The contract is over parsed values, so dict key order must not matter."""
+    monkeypatch.setenv("HEADROOM_THINKING_PRESERVING_MUTATIONS", "1")
+    original = json.dumps(_tb_body()).encode()
+    mutated = json.loads(original)
+    block = mutated["messages"][1]["content"][0]
+    mutated["messages"][1]["content"][0] = {
+        "signature": block["signature"],
+        "thinking": block["thinking"],
+        "type": block["type"],
+    }
+
+    assert thinking_blocks_survived_mutation(mutated, original) is True
+
+
+def test_is_client_bytes_agrees_with_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CCR buffering probe must never disagree with the forwarder (#2952)."""
+    monkeypatch.setenv("HEADROOM_THINKING_PRESERVING_MUTATIONS", "1")
+    original = json.dumps(_tb_body()).encode()
+
+    preserved = json.loads(original)
+    preserved["messages"][2]["content"][0]["content"][0]["text"] = "[compressed]"
+    tampered = json.loads(original)
+    tampered["messages"][1]["content"][0]["thinking"] = "tampered"
+
+    for mutated in (preserved, tampered):
+        probe_says_locked = outbound_body_is_client_bytes(
+            body=mutated, original_body_bytes=original
+        )
+        forwarder_locked = _tb_select(mutated, original).source == "passthrough"
+        assert probe_says_locked is forwarder_locked
+
+
+def test_unparseable_original_cannot_prove_preservation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No proof => no relaxation. Fail closed."""
+    monkeypatch.setenv("HEADROOM_THINKING_PRESERVING_MUTATIONS", "1")
+    assert thinking_blocks_survived_mutation(_tb_body(), b"{not json") is False
+    assert thinking_blocks_survived_mutation(_tb_body(), None) is False


### PR DESCRIPTION
## Description

Anthropic signs the thinking **block**, not the request — the signature covers that block's own content. #2254 responded to real 400s by freezing the **entire body** whenever any thinking block appeared anywhere in history. That protects bytes no signature covers, including top-level `tools` and `system`, which are not even inside `messages`.

Measured on 227,777 lines of real proxy logs from a user reporting ~1% savings:

- **618 of 1,802 requests (34.3%)** had every computed compression discarded. **100%** were `client=claude-code`; Codex/GPT traffic was untouched.
- One session logged turn 1 saving 428 tokens, then **229 consecutive turns saving exactly 0**.
- **491.9s — 34.2% of all optimization time** — was spent computing compressions that were then thrown away. One request paid 21.2s to compute a real 8.0% reduction that never shipped.
- It orphaned the turn-1 cache prefix on **12 of 35** sessions, corroborated by Headroom's own `CACHE-MISS-ATTRIBUTION` events (21/21 are `reason=prefix_change`, **none** TTL expiry), with an exact token match: `expected_cached=27,541` equalling turn 1's write.

## Changes Made

- Replace the presence test with a **positional, order-sensitive fingerprint** of every `thinking` / `redacted_thinking` block, compared against the client's original. Byte-equal blocks → forward the edits. Any difference (edited text, edited signature, dropped, reordered, moved) or any failure to prove equality → today's verbatim passthrough. Keys are sorted so a dict rebuilt in a different order is not mistaken for an edit.
- `outbound_body_is_client_bytes` mirrors the relaxation exactly, or the CCR buffering probe and the forwarder would disagree and re-create #2952 in reverse.
- The #2990/#3015 accounting reset now **recomputes** the lock immediately before use instead of reusing the probe taken before the CCR branch. The predicate tests block *content* now, and `enforce_cache_control_ttl_order` rewrites `body["messages"]` in between, so the early answer can go stale. (Latent before this PR; load-bearing after.)
- **Perf:** parse the client body once per decision, plus a substring prescreen. A 9.3 MB body (the real production maximum) could otherwise be parsed four times per request on a stage that already carries a 30s timeout whose expiry quarantines compression process-wide.

## Rollout safety

**On by default at the maintainer's explicit direction.** `HEADROOM_THINKING_PRESERVING_MUTATIONS=0` restores the previous blanket lock with no deploy.

The risk is recorded in the module rather than smoothed over: #2254's stated cause — a plain canonical re-encode — cannot alter parsed values and therefore cannot by itself invalidate a signature, and that report's own log shows a transform (`tool_search_deferral`) firing on the failing turn. So the stated cause does not hold up, **but the failure was real and its true trigger was never isolated.** This relaxation is strictly narrower than what broke: it forwards edits only when every block is provably identical, which is the property the blanket rule was a crude proxy for.

## Testing

```text
uv run pytest tests/test_proxy_byte_faithful_forwarding.py tests/test_ccr_buffered_stream_signed_thinking.py \
              tests/test_proxy/test_anthropic_ccr_deferred_injection.py
92 passed
uv run mypy headroom/proxy/body_forwarding.py headroom/proxy/handlers/anthropic.py  # Success
uv run ruff check . && ruff format --check .  # clean
```

Existing tests that encoded the blanket lock were **re-pointed at the correct trigger, not deleted** — each now tampers with a thinking block so it still guards what it was written for. `test_signed_thinking_discarded_mutation_uses_wire_truth_for_all_accounting` (#3015) now runs under the kill switch, which proves both that the accounting neutralisation still works and that the env-var rollback is a complete restoration.

## Real behavior proof

- **Setup:** macOS arm64, Python 3.12, this branch, byte-capturing transport.
- **After-fix evidence** — end-to-end through `/v1/messages` with a signed thinking block in history and a compactable tool schema (`test_untouched_thinking_lets_tool_compaction_reach_the_wire`): the annotation keys the compaction strips (`$schema`, `title`) are **absent from the captured upstream bytes**, and `wire["messages"][1]["content"][0]` is **byte-identical to the client's signed block**. Under the kill switch the same request forwards the client's bytes unchanged with accounting zeroed.
- **Parse-count measured, not assumed:** 7.2 MB thinking-bearing body → 2 parses became 1. 2 MB body with no thinking blocks (~2 of 3 requests) → 1 parse became **0**, i.e. faster than before this feature existed.
- **Projected effect on the reporting user's traffic**, derived from their unlocked requests: Claude Code headline **2.27% → roughly 5–6%**. Their unlocked requests already achieve 5.62% overall and 7.2–7.4% in the 20K–150K band, which matches our fleet beacon (~8%); the 2.27% is a blend where 60% of tokens sat in requests that shipped nothing.
- **NOT tested: live paid Anthropic traffic with a real signed thinking block.** This is the one thing that matters most and I could not do it here. The signature-verification behaviour is Anthropic's, and no local test can prove it accepts a re-serialized body carrying an untouched block. **Please validate on live traffic before relying on the default.** Watch for 400 `invalid_request_error` mentioning `thinking`, and `CACHE-MISS-ATTRIBUTION reason=prefix_change` rates.

## Known risk not eliminated

Enabling this changes the wire bytes for in-flight sessions, so expect a **one-time prefix change** on the first affected turn of each live conversation. Supporting evidence that this is bounded: canonical serialization is already the norm for the ~66% of traffic without thinking blocks, and that traffic sustains a 94.3% cache hit rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)