### PR TITLE
fix(savings): write the output-savings ledger atomically

### DIFF
--- a/headroom/proxy/output_savings.py
+++ b/headroom/proxy/output_savings.py
@@ -326,11 +326,26 @@ class SavingsLedger:
         return ledger
 
     def save(self, path: Any) -> None:
+        """Persist the ledger, atomically.
+
+        ``Path.write_text`` truncates the file to zero bytes before writing the
+        new content, so a crash, SIGKILL or ENOSPC mid-write leaves a truncated
+        document that ``load`` discards -- taking the baseline and every
+        accumulated observation with it. The recorder rewrites this file every
+        ``flush_every`` requests on a busy proxy, and readers (``estimate``,
+        ``_reload_baseline_locked``, out-of-process consumers of the ledger)
+        can be part-way through a read at that moment. ``fsutil.write_text``
+        writes a temp file in the same directory and ``os.replace``s it in, so
+        both crashes and concurrent readers see either the old ledger or the
+        complete new one.
+        """
         from pathlib import Path
+
+        from ..fsutil import write_text
 
         p = Path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(json.dumps(self.to_dict(), separators=(",", ":")))
+        write_text(p, json.dumps(self.to_dict(), separators=(",", ":")))
 
     @classmethod
     def load(cls, path: Any) -> SavingsLedger:

--- a/tests/test_output_savings.py
+++ b/tests/test_output_savings.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 from headroom.proxy.output_savings import (
     BaselineModel,
     SavingsLedger,
@@ -350,6 +354,44 @@ class TestLedgerPersistence:
         p.write_text("{not json")
         ledger = SavingsLedger.load(p)
         assert ledger.baseline.total_samples == 0
+
+    def test_failed_save_leaves_the_previous_ledger_intact(self, tmp_path, monkeypatch):
+        """A write that dies mid-flight must not cost the user their baseline.
+
+        Both failure paths are patched so this test describes the requirement
+        rather than one implementation: an in-place ``write_text`` truncates
+        first and loses everything, while the temp-file-plus-rename path leaves
+        the original untouched.
+        """
+        path = tmp_path / "savings.json"
+        ledger = SavingsLedger()
+        ledger.baseline.observe("opus|a|s|tools", 1000)
+        ledger.record("treatment", "opus|a|s|tools", 800)
+        ledger.save(path)
+        before = path.read_bytes()
+        assert before, "precondition: a ledger exists on disk"
+
+        def truncate_then_die(self, *_args, **_kwargs):
+            # What open(path, "w") does before the first byte is written.
+            Path(self).write_bytes(b"")
+            raise OSError(28, "No space left on device")
+
+        def die(*_args, **_kwargs):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(Path, "write_text", truncate_then_die)
+        monkeypatch.setattr("headroom.fsutil.os.replace", die)
+
+        doomed = SavingsLedger()
+        doomed.baseline.observe("opus|a|s|tools", 2000)
+        with pytest.raises(OSError):
+            doomed.save(path)
+
+        assert path.read_bytes() == before, "the previous ledger survived"
+        monkeypatch.undo()
+        assert SavingsLedger.load(path).baseline.total_samples == 1
+        # And no temp file left behind for the next reader to trip over.
+        assert [f.name for f in tmp_path.iterdir()] == ["savings.json"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`SavingsLedger.save` used `Path.write_text`, which truncates the file to zero bytes before writing the new content. A crash, SIGKILL or ENOSPC at that moment leaves a partial document that `load` discards on the next read, taking the seeded verbosity baseline and every accumulated treatment/control observation with it.

The window recurs continuously under load: `SavingsRecorder` rewrites this file every `flush_every` records on a busy proxy, and readers (`estimate`, `_reload_baseline_locked`, anything inspecting the ledger out of process) can be part-way through a read when it opens.

`fsutil.write_text` already implements the fix used elsewhere in the codebase (temp file in the same directory, fsync, `os.replace`), so this is a two-line reuse rather than new machinery.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `SavingsLedger.save` writes via `fsutil.write_text` instead of `Path.write_text`.
- Regression test: a save that dies mid-write leaves the previous ledger byte-identical and no temp file behind.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run --frozen --extra dev pytest tests/test_output_savings.py -q
tests/test_output_savings.py ........................................    [100%]
40 passed in 1.40s

$ uvx ruff check headroom/proxy/output_savings.py tests/test_output_savings.py
All checks passed!

$ uv run --frozen --extra dev mypy headroom/proxy/output_savings.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: macOS 24.6.0, Python 3.10.18, uv, upstream/main at 17522fb0
- Exact command / steps: reverted `headroom/proxy/output_savings.py` to `upstream/main`, kept the new test, ran `uv run --frozen --extra dev pytest tests/test_output_savings.py::TestLedgerPersistence::test_failed_save_leaves_the_previous_ledger_intact -q`
- Observed result: fails on main with the data loss it describes, `AssertionError: the previous ledger survived / assert b'' == b'{"baseline"..."control":{}}'` -- the ledger is empty after the interrupted write. Passes with the fix.
- Not tested: no power-loss or real ENOSPC test; the failure is injected by patching the write. The atomicity itself comes from `os.replace` and is already relied on by `settings_store`, `install/state` and `fsutil`.

## Runtime Rollout Safety

- Rollout-managed feature(s): None. This is the persistence path of an existing feature, not a gated one.
- Minimum rollout channel: N/A
- Stable/default behavior changed: No. The same bytes land at the same path; only the write is staged through a same-directory temp file and renamed over the target.
- Kill switch / disable path: N/A. No new flag, no new setting.
- Unsafe override required: No
- Qualification impact: None. One test added, no existing test changed.
- Rollback path: Revert the commit. The on-disk format is untouched, so a ledger written either way loads under either version.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
