### PR TITLE
fix(proxy): stop handing a non-streaming caller an event-stream body

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -51,6 +51,10 @@ from headroom.proxy.image_isolation import run_image_compression_isolated
 from headroom.proxy.memory_decision import MemoryDecision
 from headroom.proxy.memory_query import MemoryQuery
 from headroom.proxy.model_router import estimate_input_tokens
+from headroom.proxy.nonstream_sse_policy import (
+    json_reply_headers,
+    should_recover_sse_reply,
+)
 from headroom.proxy.outcome import RequestOutcome
 
 logger = logging.getLogger("headroom.proxy")
@@ -383,6 +387,37 @@ class AnthropicHandlerMixin:
         except Exception:  # pragma: no cover - defensive
             logger.debug("CCR: marker probe failed; keeping the buffered path", exc_info=True)
             return True
+
+    def _recover_sse_reply(
+        self, response: httpx.Response, request_id: str
+    ) -> dict[str, Any] | None:
+        """Rebuild a Messages JSON object from an SSE body sent to a JSON caller.
+
+        Reuses ``StreamingMixin._parse_sse_to_response`` — the reconstruction
+        the streaming path already runs for usage accounting — so no new
+        parsing surface is introduced. Returns ``None`` when the frames do not
+        yield a usable message, which the caller must treat as a refusal
+        rather than a reason to pass the SSE body through.
+
+        HeadroomProxy inherits StreamingMixin, but this handler is also tested
+        and embedded without it, so the helper is resolved defensively.
+        """
+        parse_sse = getattr(self, "_parse_sse_to_response", None)
+        if parse_sse is None:  # pragma: no cover - defensive
+            logger.debug(f"[{request_id}] SSE recovery: StreamingMixin unavailable")
+            return None
+        try:
+            recovered = parse_sse(response.text, "anthropic")
+        except Exception:  # pragma: no cover - defensive
+            logger.debug(f"[{request_id}] SSE recovery: parse raised", exc_info=True)
+            return None
+        # ``_parse_sse_to_response`` always returns a skeleton dict, so a
+        # truthy result proves nothing. ``id`` is only ever set from
+        # ``message_start``, which makes it the cheapest evidence that real
+        # frames were seen rather than a truncated or empty body.
+        if not recovered or not recovered.get("id"):
+            return None
+        return recovered
 
     @staticmethod
     def _extract_anthropic_cache_ttl_metrics(usage: dict[str, Any] | None) -> tuple[int, int]:
@@ -3877,6 +3912,57 @@ class AnthropicHandlerMixin:
                                     f"[{request_id}] CCR: buffered stream:false request got a "
                                     f"non-JSON {response.status_code} reply "
                                     f"(content-type={response.headers.get('content-type')!r}): {e}"
+                                )
+                            elif should_recover_sse_reply(
+                                client_requested_stream=stream,
+                                status_code=response.status_code,
+                                content_type=response.headers.get("content-type"),
+                            ):
+                                # Same wire-format mismatch as the buffered-stream
+                                # case above; only the direction differs. This
+                                # caller never asked for SSE, and the headers
+                                # further down are copied from upstream verbatim —
+                                # so passing this through hands it a 200 in a
+                                # format it cannot parse, and the turn is lost even
+                                # though the reply arrived complete. Rebuild the
+                                # message in place so CCR, turn hooks, the security
+                                # scan and usage accounting all see a normal reply.
+                                recovered = self._recover_sse_reply(response, request_id)
+                                if recovered is None:
+                                    logger.error(
+                                        f"[{request_id}] Upstream answered a non-streaming "
+                                        f"{response.status_code} request with an unrecoverable "
+                                        f"event stream "
+                                        f"(content-type={response.headers.get('content-type')!r}, "
+                                        f"body_bytes={len(response.content)}): {e}"
+                                    )
+                                    return Response(
+                                        content=json.dumps(
+                                            {
+                                                "type": "error",
+                                                "error": {
+                                                    "type": "upstream_protocol_error",
+                                                    "message": (
+                                                        "Upstream answered a non-streaming "
+                                                        "request with an event stream that "
+                                                        "could not be recovered."
+                                                    ),
+                                                },
+                                            }
+                                        ).encode(),
+                                        status_code=502,
+                                        media_type="application/json",
+                                    )
+                                logger.warning(
+                                    f"[{request_id}] Upstream answered a non-streaming request "
+                                    f"with an event stream; recovered the message from "
+                                    f"{len(response.content)} SSE bytes"
+                                )
+                                resp_json = recovered
+                                response = httpx.Response(
+                                    status_code=200,
+                                    content=json.dumps(recovered).encode(),
+                                    headers=json_reply_headers(dict(response.headers)),
                                 )
                             else:
                                 logger.debug(

--- a/headroom/proxy/nonstream_sse_policy.py
+++ b/headroom/proxy/nonstream_sse_policy.py
@@ -1,0 +1,135 @@
+"""Wire-format contract policy for the buffered (non-streaming) reply path.
+
+The problem
+-----------
+
+The buffered Anthropic path returns the upstream reply with its headers
+copied wholesale::
+
+    response_headers = dict(response.headers)
+    response_headers.pop("content-encoding", None)
+    response_headers.pop("content-length", None)
+    ...
+    return Response(content=..., status_code=..., headers=response_headers)
+
+``content-type`` rides along untouched. When the upstream answers a
+``stream``-less request with ``text/event-stream``, that body reaches a
+caller that asked for JSON, as a ``200`` it cannot parse. Clients report
+it as an empty or malformed response and the turn is lost — the reply is
+*present and complete*, just wearing the wrong wire format.
+
+The buffered-stream (CCR) path already refuses this shape, logging the
+offending ``content-type`` and returning ``upstream_protocol_error``
+(#2952). The plain non-streaming path never got the same treatment: an
+unparseable body there was assumed to mean "no CCR handling", so it was
+logged at DEBUG and passed through.
+
+The contract
+------------
+
+A caller that did not set ``stream: true`` must never receive an
+event-stream body. Headroom owns both ends of that boundary, so it can
+enforce it rather than let the mismatch reach the client.
+
+Behaviour matrix
+----------------
+
+============================  ==============  =========  ====================
+Client asked for streaming?   Upstream C-T    Status     Result
+============================  ==============  =========  ====================
+yes                           any             any        untouched
+no                            application/…   any        untouched
+no                            text/event-…    != 200     untouched (real error)
+no                            text/event-…    200        recover, else refuse
+============================  ==============  =========  ====================
+
+Recovery reuses ``StreamingMixin._parse_sse_to_response``, the same
+reconstruction the streaming path already runs for usage accounting, so
+this adds no new parsing surface. Recovering in place — rather than
+returning early — keeps the rest of the buffered path (CCR, turn hooks,
+security scan, usage accounting) operating on a normal reply.
+
+Non-200 is deliberately excluded: an error status is already actionable
+by the client, and passing it through unchanged preserves the upstream's
+own error payload.
+
+Public API
+----------
+
+* :func:`is_event_stream` — media-type test, parameter- and case-tolerant.
+* :func:`should_recover_sse_reply` — the gate above, as one predicate.
+* :func:`json_reply_headers` — upstream headers with the wire format corrected.
+
+Constraints (per project memory)
+--------------------------------
+
+* pure: no I/O, no logging, no config — the handler owns those.
+* no regexes: media-type parsing is a single ``split``.
+* no silent fallbacks: the caller refuses loudly when recovery fails.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+SSE_MEDIA_TYPE = "text/event-stream"
+JSON_MEDIA_TYPE = "application/json"
+
+# Headers that describe the *streamed* framing of the upstream body. Once the
+# body has been rebuilt as a single JSON document they describe nothing, and
+# a stale value is worse than an absent one.
+_FRAMING_HEADERS = ("content-type", "content-length", "content-encoding", "transfer-encoding")
+
+
+def media_type(content_type: str | None) -> str:
+    """Return the bare media type, lower-cased, with parameters dropped.
+
+    ``"text/event-stream; charset=utf-8"`` and ``"Text/Event-Stream"`` both
+    yield ``"text/event-stream"``. Returns ``""`` for a missing header.
+    """
+    if not content_type:
+        return ""
+    return content_type.split(";", 1)[0].strip().lower()
+
+
+def is_event_stream(content_type: str | None) -> bool:
+    """True when ``content_type`` denotes an SSE body."""
+    return media_type(content_type) == SSE_MEDIA_TYPE
+
+
+def should_recover_sse_reply(
+    *,
+    client_requested_stream: bool,
+    status_code: int,
+    content_type: str | None,
+) -> bool:
+    """True when a buffered reply violates the caller's non-streaming contract.
+
+    See the behaviour matrix in the module docstring. The three negative
+    arms are all deliberate: a streaming caller *wants* SSE, a JSON
+    content-type is already correct, and a non-200 carries an upstream
+    error the client should see verbatim.
+    """
+    if client_requested_stream:
+        return False
+    if status_code != 200:
+        return False
+    return is_event_stream(content_type)
+
+
+def json_reply_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    """Copy ``headers`` with the streamed-framing headers replaced by JSON.
+
+    Every other upstream header is preserved — ``request-id``, the
+    ``anthropic-*`` family and the rate-limit headers are what clients use
+    for correlation and backoff, and dropping them to fix a content-type
+    would trade one defect for another.
+    """
+    corrected = {
+        key: value for key, value in headers.items() if key.lower() not in _FRAMING_HEADERS
+    }
+    corrected["content-type"] = JSON_MEDIA_TYPE
+    return corrected

--- a/tests/test_nonstream_sse_policy.py
+++ b/tests/test_nonstream_sse_policy.py
@@ -1,0 +1,299 @@
+"""Regression tests: a non-streaming caller must never receive an SSE body.
+
+The buffered Anthropic path copies the upstream response headers wholesale,
+``content-type`` included. When the upstream answers a ``stream``-less request
+with ``text/event-stream``, that body reached the caller as a ``200`` it could
+not parse — the reply was complete, just in the wrong wire format, and the turn
+was lost.
+
+The buffered-stream (CCR) path already refused this shape (#2952). These tests
+pin the same protection on the plain non-streaming path, plus the recovery that
+turns a lost turn into a normal reply.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from headroom.proxy.nonstream_sse_policy import (
+    is_event_stream,
+    json_reply_headers,
+    media_type,
+    should_recover_sse_reply,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_SSE_REPLY = (
+    "event: message_start\n"
+    'data: {"type":"message_start","message":{"id":"msg_sse_recovered",'
+    '"type":"message","role":"assistant","model":"claude-sonnet-4-6",'
+    '"content":[],"usage":{"input_tokens":11,"output_tokens":0}}}\n'
+    "\n"
+    "event: content_block_start\n"
+    'data: {"type":"content_block_start","index":0,'
+    '"content_block":{"type":"text","text":""}}\n'
+    "\n"
+    "event: content_block_delta\n"
+    'data: {"type":"content_block_delta","index":0,'
+    '"delta":{"type":"text_delta","text":"recovered body"}}\n'
+    "\n"
+    "event: content_block_stop\n"
+    'data: {"type":"content_block_stop","index":0}\n'
+    "\n"
+    "event: message_delta\n"
+    'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
+    '"usage":{"output_tokens":4}}\n'
+    "\n"
+    "event: message_stop\n"
+    'data: {"type":"message_stop"}\n'
+    "\n"
+)
+
+# Upstream headers as they actually arrive through Anthropic's edge — the
+# correlation headers here are what a client uses to report and dedup a turn,
+# so the fix must not drop them while correcting the content-type.
+_UPSTREAM_SSE_HEADERS = {
+    "content-type": "text/event-stream; charset=utf-8",
+    "request-id": "req_011CeC1JTMS8egPL3FBteQay",
+    "anthropic-ratelimit-requests-remaining": "49",
+    "cf-ray": "9a1b2c3d4e5f6789-GRU",
+    "server": "cloudflare",
+}
+
+
+# ---------------------------------------------------------------------------
+# Pure policy
+# ---------------------------------------------------------------------------
+
+
+class TestMediaTypeParsing:
+    @pytest.mark.parametrize(
+        ("header", "expected"),
+        [
+            ("text/event-stream", "text/event-stream"),
+            ("text/event-stream; charset=utf-8", "text/event-stream"),
+            ("Text/Event-Stream", "text/event-stream"),
+            ("  text/event-stream  ", "text/event-stream"),
+            ("application/json", "application/json"),
+            (None, ""),
+            ("", ""),
+        ],
+    )
+    def test_parameters_and_case_are_normalized(self, header, expected) -> None:
+        assert media_type(header) == expected
+
+    def test_is_event_stream_only_matches_sse(self) -> None:
+        assert is_event_stream("text/event-stream; charset=utf-8") is True
+        assert is_event_stream("application/json") is False
+        assert is_event_stream(None) is False
+
+
+class TestShouldRecoverSseReply:
+    """The gate has three deliberate negative arms; each is a separate risk."""
+
+    def test_recovers_sse_200_for_a_non_streaming_caller(self) -> None:
+        assert (
+            should_recover_sse_reply(
+                client_requested_stream=False,
+                status_code=200,
+                content_type="text/event-stream",
+            )
+            is True
+        )
+
+    def test_streaming_caller_is_untouched(self) -> None:
+        """A streaming caller asked for SSE — rewriting it would break the turn."""
+        assert (
+            should_recover_sse_reply(
+                client_requested_stream=True,
+                status_code=200,
+                content_type="text/event-stream",
+            )
+            is False
+        )
+
+    def test_json_reply_is_untouched(self) -> None:
+        assert (
+            should_recover_sse_reply(
+                client_requested_stream=False,
+                status_code=200,
+                content_type="application/json",
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize("status", [429, 500, 529])
+    def test_error_status_is_passed_through(self, status) -> None:
+        """A non-200 carries an upstream error payload the client should see."""
+        assert (
+            should_recover_sse_reply(
+                client_requested_stream=False,
+                status_code=status,
+                content_type="text/event-stream",
+            )
+            is False
+        )
+
+
+class TestJsonReplyHeaders:
+    def test_content_type_is_corrected(self) -> None:
+        corrected = json_reply_headers(_UPSTREAM_SSE_HEADERS)
+        assert corrected["content-type"] == "application/json"
+
+    def test_correlation_headers_survive(self) -> None:
+        """Dropping request-id to fix a content-type trades one defect for another."""
+        corrected = json_reply_headers(_UPSTREAM_SSE_HEADERS)
+        assert corrected["request-id"] == "req_011CeC1JTMS8egPL3FBteQay"
+        assert corrected["anthropic-ratelimit-requests-remaining"] == "49"
+        assert corrected["cf-ray"] == "9a1b2c3d4e5f6789-GRU"
+
+    def test_stale_framing_headers_are_dropped(self) -> None:
+        corrected = json_reply_headers(
+            {
+                "Content-Type": "text/event-stream",
+                "Content-Length": "8756",
+                "Transfer-Encoding": "chunked",
+                "content-encoding": "gzip",
+                "request-id": "req_x",
+            }
+        )
+        lowered = {key.lower() for key in corrected}
+        assert "content-length" not in lowered
+        assert "transfer-encoding" not in lowered
+        assert "content-encoding" not in lowered
+        assert corrected["content-type"] == "application/json"
+        assert corrected["request-id"] == "req_x"
+
+    def test_input_mapping_is_not_mutated(self) -> None:
+        original = dict(_UPSTREAM_SSE_HEADERS)
+        json_reply_headers(original)
+        assert original == _UPSTREAM_SSE_HEADERS
+
+
+# ---------------------------------------------------------------------------
+# Handler end-to-end — the wiring is where the bug lived
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from headroom.proxy.server import ProxyConfig, create_app  # noqa: E402
+
+
+def _make_proxy_client() -> TestClient:
+    config = ProxyConfig(
+        optimize=True,
+        mode="token",
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+        log_requests=False,
+        ccr_inject_tool=False,
+        ccr_handle_responses=False,
+        ccr_context_tracking=False,
+        image_optimize=False,
+    )
+    return TestClient(create_app(config))
+
+
+def _post_non_streaming(client: TestClient):
+    return client.post(
+        "/v1/messages",
+        headers={"x-api-key": "test-key", "anthropic-version": "2023-06-01"},
+        json={
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+
+def _stub_upstream(proxy, response: httpx.Response) -> None:
+    async def _fake_retry(method, url, headers, body, stream=False, **kwargs):  # noqa: ANN001
+        return response
+
+    proxy._retry_request = _fake_retry
+
+
+class TestNonStreamingCallerNeverGetsAnEventStream:
+    def test_sse_reply_is_recovered_as_json(self) -> None:
+        """Before the fix this returned text/event-stream and the SDK reported
+        an empty or malformed response despite a complete reply."""
+        with _make_proxy_client() as client:
+            _stub_upstream(
+                client.app.state.proxy,
+                httpx.Response(
+                    200,
+                    headers=_UPSTREAM_SSE_HEADERS,
+                    content=_SSE_REPLY.encode(),
+                ),
+            )
+            response = _post_non_streaming(client)
+
+        assert response.status_code == 200
+        assert "event-stream" not in response.headers["content-type"]
+        assert response.headers["content-type"].startswith("application/json")
+
+        payload = response.json()
+        assert payload["id"] == "msg_sse_recovered"
+        assert payload["content"][0]["text"] == "recovered body"
+
+    def test_upstream_correlation_headers_survive_recovery(self) -> None:
+        with _make_proxy_client() as client:
+            _stub_upstream(
+                client.app.state.proxy,
+                httpx.Response(
+                    200,
+                    headers=_UPSTREAM_SSE_HEADERS,
+                    content=_SSE_REPLY.encode(),
+                ),
+            )
+            response = _post_non_streaming(client)
+
+        assert response.headers["request-id"] == "req_011CeC1JTMS8egPL3FBteQay"
+
+    def test_unrecoverable_event_stream_is_refused_not_forwarded(self) -> None:
+        """No message_start means no message. Refuse loudly rather than hand
+        the caller a 200 it cannot parse."""
+        with _make_proxy_client() as client:
+            _stub_upstream(
+                client.app.state.proxy,
+                httpx.Response(
+                    200,
+                    headers=_UPSTREAM_SSE_HEADERS,
+                    content=b'event: ping\ndata: {"type":"ping"}\n\n',
+                ),
+            )
+            response = _post_non_streaming(client)
+
+        assert response.status_code == 502
+        assert "event-stream" not in response.headers["content-type"]
+        assert response.json()["error"]["type"] == "upstream_protocol_error"
+
+    def test_ordinary_json_reply_is_unaffected(self) -> None:
+        """Control: the fix must be inert on the overwhelmingly common path."""
+        with _make_proxy_client() as client:
+            _stub_upstream(
+                client.app.state.proxy,
+                httpx.Response(
+                    200,
+                    json={
+                        "id": "msg_plain",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "ok"}],
+                        "usage": {"input_tokens": 10, "output_tokens": 3},
+                    },
+                ),
+            )
+            response = _post_non_streaming(client)
+
+        assert response.status_code == 200
+        assert json.loads(response.content)["id"] == "msg_plain"


### PR DESCRIPTION
## Description

The buffered (non-streaming) Anthropic path returns the upstream reply with its headers copied
wholesale, `content-type` included. When the upstream answers a `stream`-less request with
`text/event-stream`, that body reaches a caller that asked for JSON as a `200` it cannot parse.
The reply is **complete** — the client just cannot read it, and the turn is lost.

Directly above it, the buffered-**stream** (CCR) path already refuses this exact shape and logs
the offending content-type (#2952). The plain non-streaming path never got the same treatment;
its sibling comment states the assumption that made it invisible:

```python
# DEBUG is right for the buffered non-stream path, where
# an unparseable body is just "no CCR handling".
```

On that path an unparseable body is not benign — it is a reply the client cannot consume.

Closes #3130

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- **`headroom/proxy/nonstream_sse_policy.py` (new)** — the contract as three pure functions:
  `is_event_stream` (parameter- and case-tolerant media-type test), `should_recover_sse_reply`
  (the gate), `json_reply_headers` (upstream headers with the stale streamed-framing headers
  replaced by JSON). No I/O, no logging, no config — the handler owns those.
- **`headroom/proxy/handlers/anthropic.py`** — on the `resp_json` parse failure, recover instead
  of passing the body through. `_recover_sse_reply` rebuilds the message via
  `StreamingMixin._parse_sse_to_response`, the reconstruction the streaming path already runs for
  usage accounting, so no new parsing surface is added. When the frames yield nothing usable the
  request is refused with `upstream_protocol_error`, matching the vocabulary the CCR guard above
  already uses.

### Design notes

**Recovery happens in place, not as an early return.** It runs before CCR, turn hooks, the
security scan and usage accounting, so the rest of the buffered path sees a normal reply rather
than being skipped. A turn the provider already produced and billed stays a real turn.

**Three deliberate no-ops**, each pinned by its own test:
- a streaming caller is untouched — it asked for SSE, and rewriting it would break the turn;
- a JSON content-type is untouched — already correct;
- **non-200 is untouched** — an error status is already actionable, and its payload should reach
  the client verbatim. This keeps the change off the error path entirely.

**Correlation headers survive.** `request-id`, the `anthropic-*` family and the rate-limit headers
are preserved through recovery; only `content-type`, `content-length`, `content-encoding` and
`transfer-encoding` are dropped, because after the body is rebuilt as one JSON document they
describe nothing and a stale value is worse than an absent one. Dropping `request-id` to fix a
content-type would trade one defect for another.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`) — not run, see Not tested
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

**Before the fix** — handler tests against an unmodified `anthropic.py`, reproducing the reported
symptom exactly:

```text
$ pytest tests/test_nonstream_sse_policy.py -q -k TestNonStreamingCallerNeverGetsAnEventStream
tests/test_nonstream_sse_policy.py F.F.                                  [100%]

_ TestNonStreamingCallerNeverGetsAnEventStream.test_sse_reply_is_recovered_as_json _
tests/test_nonstream_sse_policy.py:241: in test_sse_reply_is_recovered_as_json
    assert "event-stream" not in response.headers["content-type"]
E   AssertionError: assert 'event-stream' not in 'text/event-...harset=utf-8'
E     'event-stream' is contained here:
E       text/event-stream; charset=utf-8

_ TestNonStreamingCallerNeverGetsAnEventStream.test_unrecoverable_event_stream_is_refused_not_forwarded _
tests/test_nonstream_sse_policy.py:276: in test_unrecoverable_event_stream_is_refused_not_forwarded
    assert response.status_code == 502
E   assert 200 == 502
E    +  where 200 = <Response [200 OK]>.status_code

================== 2 failed, 2 passed, 18 deselected in 5.44s ==================
```

The two that pass in both runs are controls: an ordinary JSON reply, and the correlation-header
assertion.

**After the fix:**

```text
$ pytest tests/test_nonstream_sse_policy.py -q
tests/test_nonstream_sse_policy.py ......................                [100%]
============================= 22 passed in 15.73s ==============================
```

**Neighbouring suites:**

```text
$ pytest tests/test_nonstream_sse_policy.py tests/test_anthropic_compaction_transforms.py \
         tests/test_anthropic_ccr_workspace_unbound.py tests/test_5xx_accounting_all_providers.py \
         tests/test_sse_byte_buffer_policy.py -q
============================== 43 passed in 6.27s ==============================
```

**Lint:**

```text
$ ruff check headroom/proxy/nonstream_sse_policy.py headroom/proxy/handlers/anthropic.py \
             tests/test_nonstream_sse_policy.py
All checks passed!
$ ruff format --check <same three files>
3 files already formatted
```

A broader sweep (`-k "anthropic or sse or buffered or ccr"`) ran 1382 passed / 12 failed. All 12
are in `tests/test_transforms/test_code_compressor.py` and are pre-existing in my environment —
the same file fails 43 tests on a checkout with this commit reverted. Missing tree-sitter grammars
locally; untouched by this change.

## Real Behavior Proof

- **Environment:** Ubuntu 24.04, Linux 6.17, Python 3.12.3. headroom-ai 0.35.0 installed via pip
  into a venv, running as `headroom proxy --port 8787 --memory` under `systemd --user`. Client:
  Claude Code 2.1.235 with `ANTHROPIC_BASE_URL=http://localhost:8787`. Upstream: `api.anthropic.com`
  (claude-opus-5, claude-sonnet-5).

- **Before — real client failure, not synthetic:**

  ```
  API Error: API returned an empty or malformed response (HTTP 200) — check for a proxy or
  gateway intercepting the request. Response: content-type event-stream, body is an event
  stream (the non-streaming request was answered with a stream), 8756 bytes, request-id
  req_011CeC1JTMS8egPL3FBteQay, server cloudflare, intermediary headers anthropic-*
  cf-cache-status cf-ray. This was the non-streaming retry of streaming request (no Anthropic
  request-id), which failed with: other; 0 stream events received.
  ```

  8756 bytes and a valid upstream `request-id` — the reply arrived intact and was discarded on
  wire format alone. The `server: cloudflare` / `cf-ray` / `cf-cache-status` headers the client
  flags as intermediary evidence are the same wholesale `dict(response.headers)` copy.

- **Exact steps after the patch:** applied the equivalent hunks to the installed 0.35.0 (the
  release predates the #2952 branch, so the anchor differs but the change is the same), then:

  ```
  $ systemctl --user restart headroom.service
  listening again after ~8s
  $ systemctl --user is-active headroom.service
  active
  ```

- **Observed result:** the patched build has been serving this workstation's live Claude Code
  traffic since the restart with no protocol failures:

  ```
  $ awk '$0 >= "2026-08-19 08:42:34"' ~/.headroom/logs/proxy.log \
      | grep "path=/v1/messages" | grep -oE "status=[0-9]+" | sort | uniq -c
       17 status=200
  ```

  No startup errors or tracebacks in `proxy.log`.

- **Not tested:**
  - **I could not reproduce the upstream-returns-SSE condition on demand.** The originating client
    failure above is real and captured, but my after-fix reproduction is at the handler seam
    (stubbed `_retry_request`), not against a live upstream emitting SSE. So the live evidence
    shows the patched build is healthy on the normal path; it does not show a production recovery.
  - **Why the upstream answered a `stream`-less request with an event stream is unresolved,** and I
    am not claiming Headroom caused it. This PR fixes the downstream handling, which holds either
    way.
  - The streaming forwarder's own `status >= 400` header passthrough in `streaming.py` has the same
    shape. I left it alone: there the client *did* ask for SSE, and forwarding an upstream JSON
    error verbatim is correct, since SDKs check status before parsing frames. Flagging it only so a
    maintainer can confirm that reading.
  - Non-Anthropic providers (`openai.py`, `gemini.py`, `bedrock.py`) — not examined.
  - `mypy headroom` — not run; the dev extra was not installed in this environment.

## Runtime Rollout Safety

- **Rollout-managed feature(s):** none — correctness fix, always on.
- **Minimum rollout channel:** n/a.
- **Stable/default behavior changed:** only for a reply that is currently unusable. A non-streaming
  caller that would have received an SSE `200` now receives the recovered JSON, or a `502
  upstream_protocol_error` when the frames yield nothing. Every other reply is byte-identical.
- **Kill switch / disable path:** none added. The code is inert unless a non-streaming request
  returns `200` with `content-type: text/event-stream`; adding a flag would mean a switch whose
  "off" position restores an unparseable response.
- **Unsafe override required:** no.
- **Qualification impact:** none expected — the buffered JSON path is untouched (control test).
- **Rollback path:** revert this commit. No migration, no persisted state, no config.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — n/a, no user-facing surface
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

Happy to split the policy module into the handler if a separate file is more than this deserves —
I put it out of line to match `sse_byte_buffer_policy.py` and the other `*_policy.py` modules, and
because the gate's three negative arms are each a real risk worth a named test.
