### PR TITLE
fix(proxy/anthropic): stop answering a non-streaming turn with an event stream

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -226,6 +226,66 @@ def _looks_like_sse_response(response: httpx.Response) -> bool:
 class AnthropicHandlerMixin:
     """Mixin providing Anthropic API handler methods for HeadroomProxy."""
 
+    def _adapt_event_stream_to_json(
+        self,
+        response: httpx.Response,
+        request_id: str,
+    ) -> httpx.Response:
+        """Rebuild an SSE reply as the JSON a non-streaming caller asked for.
+
+        A caller that sent ``stream: false`` cannot parse ``text/event-stream``,
+        so relaying it verbatim loses a turn the upstream already charged for
+        (#3130). Reconstruction is strict: a truncated stream, or one carrying
+        an ``error`` event, becomes an explicit 502 rather than a successful
+        HTTP 200 whose message is silently short.
+        """
+        headers = {
+            k: v
+            for k, v in sanitize_forwarded_response_headers(
+                response.headers,
+                "content-type",
+            ).items()
+            if not k.lower().startswith("cf-")
+        }
+
+        parsed = None
+        try:
+            parsed = self._parse_sse_to_response(
+                response.content.decode("utf-8", "replace"),
+                "anthropic",
+                require_complete=True,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(f"[{request_id}] SSE->JSON reconstruction raised: {exc}")
+
+        if parsed is None:
+            logger.error(
+                f"[{request_id}] Upstream answered a non-streaming request with an "
+                f"event stream that could not be faithfully reconstructed "
+                f"(body_bytes={len(response.content)}); returning 502 rather than "
+                f"a wire format the client cannot parse"
+            )
+            return httpx.Response(
+                502,
+                json={
+                    "type": "error",
+                    "error": {
+                        "type": "upstream_protocol_error",
+                        "message": (
+                            "Upstream answered a non-streaming request with an "
+                            "incomplete event stream."
+                        ),
+                    },
+                },
+                headers=headers,
+            )
+
+        logger.info(
+            f"[{request_id}] Upstream answered a non-streaming request with an "
+            f"event stream; adapted {len(response.content)} bytes of SSE to JSON"
+        )
+        return httpx.Response(200, json=parsed, headers=headers)
+
     async def _count_tokens_offloaded(self, model, messages):  # noqa: ANN001, ANN201
         from headroom.proxy.token_counting import count_tokens_offloaded
 
@@ -3509,20 +3569,9 @@ class AnthropicHandlerMixin:
                         body_mutation_tracker.mark_mutated(
                             "ccr_streaming_retrieve_buffered_non_stream"
                         )
-                    # The body now asks for a non-streaming reply, so the
-                    # client's ``Accept: text/event-stream`` no longer describes
-                    # the response being requested. Forwarding it unchanged
-                    # sends upstream a self-contradicting request: "answer as
-                    # JSON" in the body, "I only accept SSE" in the headers.
-                    #
-                    # Anthropic tolerates that. Stricter Anthropic-compatible
-                    # gateways do not: GitHub Copilot's returns a generic
-                    # ``api_error``, which is why a session's first call
-                    # succeeded and the next one — the first to carry a
-                    # redeemable marker, and so the first to be buffered —
-                    # failed (#3078).
-                    _accept_key = next((k for k in headers if k.lower() == "accept"), "accept")
-                    headers[_accept_key] = "application/json"
+                    # The ``Accept`` rewrite this flip used to do lives at the
+                    # buffered boundary below, which every non-streaming
+                    # request reaches — this one and the client's own (#3130).
                     logger.info(
                         f"[{request_id}] CCR: stream:true request has "
                         "headroom_retrieve available; using buffered stream:false "
@@ -3681,6 +3730,29 @@ class AnthropicHandlerMixin:
                         session_key=session_key,
                     )
                 else:
+                    # Whatever set it — the client's own ``stream: false`` or
+                    # the CCR flip above — this branch sends a non-streaming
+                    # request, so the client's ``Accept: text/event-stream`` no
+                    # longer describes what is being asked for. Forwarding it
+                    # unchanged puts a self-contradicting request on the wire:
+                    # "answer as JSON" in the body, "I only accept SSE" in the
+                    # headers.
+                    #
+                    # Anthropic tolerates the contradiction; stricter
+                    # Anthropic-compatible gateways do not — GitHub Copilot's
+                    # answers a generic ``api_error`` (#3078). On a
+                    # client-originated non-stream turn — Claude Code's retry
+                    # after a failed stream — an SSE answer to a JSON request
+                    # is the empty/malformed HTTP 200 of #3130.
+                    #
+                    # Mutated in place: ``headers`` is captured by the
+                    # closures defined below, and rebinding it here would
+                    # leave them holding the old mapping.
+                    if body.get("stream", False) is False:
+                        for _accept_key in [k for k in headers if k.lower() == "accept"]:
+                            headers.pop(_accept_key, None)
+                        headers["accept"] = "application/json"
+
                     # Populated once the upstream answers 200 with parseable
                     # JSON, so the guard below can fall back to it (#3088).
                     _salvageable_upstream: dict[str, Any] = {}
@@ -3850,6 +3922,28 @@ class AnthropicHandlerMixin:
                                     logger.error(
                                         f"[{request_id}] Failed to write debug dump: {dump_err}"
                                     )
+
+                        # A non-streaming request answered with an event
+                        # stream (#3130). The turn is complete and already
+                        # paid for — it is just wearing the wrong wire
+                        # format — so adapt it to the JSON this caller asked
+                        # for *here*, ahead of everything that reads the
+                        # body: CCR retrieval, memory, turn hooks, usage and
+                        # cost accounting, prefix tracking, the response
+                        # cache, marker resolution and the security scan.
+                        # Adapting at the final return instead would leave
+                        # every one of those looking at an unparseable body.
+                        #
+                        # ``stream`` is what the *client* asked for, not what
+                        # went upstream: a buffered CCR turn deliberately
+                        # requests JSON on behalf of a streaming client and
+                        # re-emits SSE further down, and must keep doing so.
+                        if (
+                            response.status_code == 200
+                            and not stream
+                            and _looks_like_sse_response(response)
+                        ):
+                            response = self._adapt_event_stream_to_json(response, request_id)
 
                         # Parse response for CCR handling
                         resp_json = None
@@ -4363,12 +4457,23 @@ class AnthropicHandlerMixin:
                             )
                         )
 
-                        # Remove compression headers since httpx already decompressed the response
-                        response_headers = dict(response.headers)
-                        response_headers.pop("content-encoding", None)
-                        response_headers.pop(
-                            "content-length", None
-                        )  # Length changed after decompression
+                        # Framing headers describe how the *upstream* framed
+                        # its body, not what this response is: httpx already
+                        # decompressed it, Starlette recomputes the length,
+                        # and uvicorn owns the connection. Replaying a stale
+                        # ``transfer-encoding: chunked`` over a fixed-length
+                        # body is what made an HTTP 200 read as empty in
+                        # #3019. ``cf-*`` is CDN provenance the caller has no
+                        # use for, and the header set clients cite as
+                        # evidence of an intermediary mangling a reply
+                        # (#3130).
+                        response_headers = {
+                            k: v
+                            for k, v in sanitize_forwarded_response_headers(
+                                response.headers
+                            ).items()
+                            if not k.lower().startswith("cf-")
+                        }
 
                         # Inject Headroom compression metrics (for SaaS metering)
                         response_headers["x-headroom-tokens-before"] = str(original_tokens)

--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -350,7 +350,13 @@ class StreamingMixin:
 
         return usage_found if usage_found else None
 
-    def _parse_sse_to_response(self, sse_data: str, provider: str) -> dict[str, Any] | None:
+    def _parse_sse_to_response(
+        self,
+        sse_data: str,
+        provider: str,
+        *,
+        require_complete: bool = False,
+    ) -> dict[str, Any] | None:
         """Parse SSE data to reconstruct the API response JSON.
 
         Args:
@@ -358,6 +364,10 @@ class StreamingMixin:
                 from a complete-events bytes buffer (see
                 ``parse_sse_events_from_byte_buffer``).
             provider: Provider type for parsing.
+            require_complete: Reject anything short of a whole, replayable
+                message — see the strictness note below. Off by default so
+                streaming callers keep the lenient reconstruction they were
+                written against.
 
         Returns:
             Reconstructed response dict or None if parsing fails.
@@ -366,11 +376,32 @@ class StreamingMixin:
         ``text_delta``, ``input_json_delta``, ``thinking_delta``,
         ``signature_delta``, ``citations_delta``. Also preserves
         ``redacted_thinking.data`` and accumulates citations as a list.
+
+        Permissive mode answers with whatever blocks it managed to
+        accumulate. That is right for a streaming caller salvaging a
+        partial stream, and wrong for #3130, where the reconstruction is
+        handed to the client *as* the turn: a truncated stream would become
+        a successful — and silently short — message, and an ``error`` event
+        would vanish behind an HTTP 200. ``require_complete`` demands
+        ``message_start``, a terminal ``message_stop``, every opened block
+        closed, no ``error`` event, and no delta type this reconstructor
+        cannot replay; anything else returns None so the caller can fail
+        loudly instead.
         """
         if provider != "anthropic":
             return None  # Only implemented for Anthropic
 
+        # Event framing is CRLF in some intermediaries (and mixed after a
+        # retry through one). Normalize before the line split so a
+        # correctly framed stream is never read as zero events.
+        sse_data = sse_data.replace("\r\n", "\n").replace("\r", "\n")
+
         response: dict[str, Any] = {"content": [], "usage": {}}
+        saw_message_start = False
+        saw_message_stop = False
+        saw_error = False
+        saw_unreplayable_delta = False
+        open_block_indices: set[int] = set()
         # Track blocks by their `index` field so out-of-order events
         # don't corrupt the reconstruction. The current block pointer
         # remains for backward-compat with code that walks this dict
@@ -392,9 +423,9 @@ class StreamingMixin:
         appended_block_keys: set[int] = set()
 
         for line in sse_data.split("\n"):
-            if not line.startswith("data: "):
+            if not line.startswith("data:"):
                 continue
-            data_str = line[6:].strip()
+            data_str = line[5:].strip()
             if not data_str or data_str == "[DONE]":
                 continue
 
@@ -406,8 +437,12 @@ class StreamingMixin:
             event_type = data.get("type", "")
 
             if event_type == "message_start":
+                saw_message_start = True
                 msg = data.get("message", {})
                 response["id"] = msg.get("id")
+                response["type"] = msg.get("type", "message")
+                if "stop_sequence" in msg:
+                    response["stop_sequence"] = msg["stop_sequence"]
                 response["model"] = msg.get("model")
                 response["role"] = msg.get("role", "assistant")
                 response["stop_reason"] = msg.get("stop_reason")
@@ -454,6 +489,7 @@ class StreamingMixin:
                         if _k != "type":
                             current_block[_k] = _v
                 blocks_by_index[block_index] = current_block
+                open_block_indices.add(block_index)
 
             elif event_type == "content_block_delta":
                 # Resolve the target block by index (preferred) or fall
@@ -490,6 +526,10 @@ class StreamingMixin:
                         citation = delta.get("citation")
                         if citation is not None:
                             citations.append(citation)
+                    else:
+                        # A delta this reconstructor has no rule for: the
+                        # accumulated block is missing whatever it carried.
+                        saw_unreplayable_delta = True
 
             elif event_type == "content_block_stop":
                 idx = data.get("index")
@@ -523,6 +563,8 @@ class StreamingMixin:
                     if block_key not in appended_block_keys:
                         response["content"].append(target)
                         appended_block_keys.add(block_key)
+                    if idx is not None:
+                        open_block_indices.discard(idx)
                     current_block = None
 
             elif event_type == "message_delta":
@@ -531,8 +573,37 @@ class StreamingMixin:
                     response["stop_reason"] = delta["stop_reason"]
                 if "stop_details" in delta:
                     response["stop_details"] = delta["stop_details"]
+                if "stop_sequence" in delta:
+                    response["stop_sequence"] = delta["stop_sequence"]
                 if data.get("usage"):
                     response["usage"].update(data["usage"])
+
+            elif event_type == "message_stop":
+                saw_message_stop = True
+
+            elif event_type == "error":
+                # An in-band failure. Permissive callers keep salvaging
+                # what arrived before it; a strict caller must not dress
+                # the remains up as a successful turn.
+                saw_error = True
+
+        if require_complete:
+            if (
+                not saw_message_start
+                or not saw_message_stop
+                or saw_error
+                or saw_unreplayable_delta
+                or open_block_indices
+            ):
+                return None
+            # ``index`` is a response-delta field. Anthropic rejects it on
+            # the next request ("content.0.text.index: Extra inputs are not
+            # permitted"), so it must not survive into a body the client
+            # will persist and echo back.
+            for block in response["content"]:
+                if isinstance(block, dict):
+                    block.pop("index", None)
+            return response
 
         return response if response.get("content") else None
 

--- a/tests/test_anthropic_buffered_sse.py
+++ b/tests/test_anthropic_buffered_sse.py
@@ -1,0 +1,318 @@
+"""A non-streaming turn must never be answered with an event stream (#3130).
+
+Claude Code retries a failed streaming turn as ``stream: false``. The buffered
+Anthropic path forwarded the upstream response headers wholesale, so when the
+upstream answered that JSON request with ``content-type: text/event-stream``
+the SDK got a wire format it never asked for and lost a complete, already-paid
+turn:
+
+    API returned an empty or malformed response (HTTP 200) ... content-type
+    event-stream, body is an event stream (the non-streaming request was
+    answered with a stream), 8756 bytes
+
+Two defects, fixed on both sides:
+
+* the request went out contradicting itself — ``stream: false`` in the body,
+  ``Accept: text/event-stream`` in the headers (the narrow CCR-only rewrite
+  from #3078 never covered a client-originated non-stream turn), and
+* the response was relayed verbatim instead of being adapted to the JSON the
+  caller asked for.
+
+Reconstruction is deliberately strict: a partial stream must fail loudly as a
+502 rather than be handed back as a successful — and silently truncated —
+message.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from headroom.proxy.server import ProxyConfig, create_app  # noqa: E402
+
+COMPLETE_SSE = (
+    "event: message_start\n"
+    'data: {"type":"message_start","message":{"id":"msg_1","type":"message",'
+    '"role":"assistant","model":"claude-sonnet-4-6","content":[],'
+    '"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,'
+    '"output_tokens":1,"cache_read_input_tokens":2,'
+    '"cache_creation_input_tokens":3}}}\n\n'
+    "event: content_block_start\n"
+    'data: {"type":"content_block_start","index":0,'
+    '"content_block":{"type":"text","text":""}}\n\n'
+    "event: content_block_delta\n"
+    'data: {"type":"content_block_delta","index":0,'
+    '"delta":{"type":"text_delta","text":"hello"}}\n\n'
+    "event: content_block_stop\n"
+    'data: {"type":"content_block_stop","index":0}\n\n'
+    "event: message_delta\n"
+    'data: {"type":"message_delta","delta":{"stop_reason":"end_turn",'
+    '"stop_sequence":null},"usage":{"output_tokens":5}}\n\n'
+    "event: message_stop\n"
+    'data: {"type":"message_stop"}\n\n'
+)
+
+# Everything up to — but not including — the terminal event.
+TRUNCATED_SSE = COMPLETE_SSE.split("event: message_delta")[0]
+
+ERROR_SSE = (
+    COMPLETE_SSE.split("event: message_delta")[0] + "event: error\n"
+    'data: {"type":"error","error":{"type":"overloaded_error",'
+    '"message":"Overloaded"}}\n\n'
+)
+
+JSON_REPLY = {
+    "id": "msg_1",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-sonnet-4-6",
+    "content": [{"type": "text", "text": "hello"}],
+    "stop_reason": "end_turn",
+    "usage": {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    },
+}
+
+
+def _config() -> ProxyConfig:
+    return ProxyConfig(
+        optimize=False,
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        memory_enabled=False,
+        ccr_inject_tool=False,
+        ccr_handle_responses=False,
+        ccr_context_tracking=False,
+        image_optimize=False,
+    )
+
+
+def _drive(
+    *,
+    upstream: httpx.Response,
+    accept: str | None = "text/event-stream",
+    stream: bool = False,
+) -> tuple[httpx.Response, dict[str, object]]:
+    """Run one turn against a canned upstream reply.
+
+    Returns the client-facing response and what went upstream.
+    """
+    seen: dict[str, object] = {}
+    app = create_app(_config())
+    with TestClient(app) as client:
+        proxy = client.app.state.proxy
+
+        async def _fake_retry(method, url, headers, body, stream=False, **kwargs):  # noqa: ANN001
+            sent = json.loads(body) if isinstance(body, (str, bytes)) else body
+            seen["stream"] = sent.get("stream")
+            seen["headers"] = dict(headers or {})
+            return upstream
+
+        proxy._retry_request = _fake_retry  # type: ignore[assignment]
+
+        headers = {"x-api-key": "test-key", "anthropic-version": "2023-06-01"}
+        if accept is not None:
+            headers["accept"] = accept
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 64,
+                "stream": stream,
+                "messages": [{"role": "user", "content": "go"}],
+            },
+            headers=headers,
+        )
+    return resp, seen
+
+
+def _sse_response(body: str, **extra_headers: str) -> httpx.Response:
+    headers = {"content-type": "text/event-stream", **extra_headers}
+    return httpx.Response(200, content=body.encode(), headers=headers)
+
+
+def _accepts(headers: dict) -> list[str]:
+    return [v for k, v in headers.items() if k.lower() == "accept"]
+
+
+# --------------------------------------------------------------------------- #
+# Request side: a stream:false body must not carry an SSE-only Accept
+# --------------------------------------------------------------------------- #
+def test_non_stream_turn_asks_upstream_for_json() -> None:
+    _, seen = _drive(upstream=httpx.Response(200, json=JSON_REPLY))
+
+    assert seen["stream"] is False
+    assert _accepts(seen["headers"]) == ["application/json"]  # type: ignore[arg-type]
+
+
+def test_non_stream_turn_replaces_rather_than_appends_accept() -> None:
+    _, seen = _drive(upstream=httpx.Response(200, json=JSON_REPLY), accept="TEXT/EVENT-STREAM")
+
+    values = _accepts(seen["headers"])  # type: ignore[arg-type]
+    assert values == ["application/json"]
+    assert not any("event-stream" in v.lower() for v in values)
+
+
+def test_non_stream_turn_without_client_accept_still_asks_for_json() -> None:
+    _, seen = _drive(upstream=httpx.Response(200, json=JSON_REPLY), accept=None)
+
+    assert _accepts(seen["headers"]) == ["application/json"]  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# Response side: SSE at 200 for a JSON request is adapted, not relayed
+# --------------------------------------------------------------------------- #
+def test_event_stream_answer_is_adapted_to_json() -> None:
+    resp, _ = _drive(upstream=_sse_response(COMPLETE_SSE))
+
+    assert resp.status_code == 200
+    assert "application/json" in resp.headers["content-type"]
+    body = resp.json()
+    assert body["type"] == "message"
+    assert body["content"] == [{"type": "text", "text": "hello"}]
+    assert body["stop_reason"] == "end_turn"
+
+
+def test_adapted_reply_preserves_usage_for_accounting() -> None:
+    resp, _ = _drive(upstream=_sse_response(COMPLETE_SSE))
+
+    usage = resp.json()["usage"]
+    assert usage["input_tokens"] == 10
+    assert usage["output_tokens"] == 5
+    assert usage["cache_read_input_tokens"] == 2
+    assert usage["cache_creation_input_tokens"] == 3
+
+
+def test_adapted_reply_carries_no_streaming_only_index() -> None:
+    """``index`` is a response-delta field; Anthropic rejects it on replay."""
+    resp, _ = _drive(upstream=_sse_response(COMPLETE_SSE))
+
+    assert all("index" not in block for block in resp.json()["content"])
+
+
+def test_adapted_reply_drops_cdn_and_framing_headers() -> None:
+    resp, _ = _drive(
+        upstream=_sse_response(
+            COMPLETE_SSE,
+            **{
+                "server": "cloudflare",
+                "cf-ray": "abc123",
+                "cf-cache-status": "DYNAMIC",
+                "request-id": "req_011CeC1JTMS8egPL3FBteQay",
+                "anthropic-ratelimit-requests-remaining": "42",
+            },
+        )
+    )
+
+    lowered = {k.lower() for k in resp.headers}
+    assert "server" not in lowered
+    assert not any(k.startswith("cf-") for k in lowered)
+    # Provenance the caller legitimately needs survives.
+    assert resp.headers["request-id"] == "req_011CeC1JTMS8egPL3FBteQay"
+    assert resp.headers["anthropic-ratelimit-requests-remaining"] == "42"
+
+
+def test_truncated_event_stream_fails_loudly() -> None:
+    """A partial stream is not a successful short answer."""
+    resp, _ = _drive(upstream=_sse_response(TRUNCATED_SSE))
+
+    assert resp.status_code == 502
+    assert "application/json" in resp.headers["content-type"]
+    assert resp.json()["error"]["type"] == "upstream_protocol_error"
+
+
+def test_error_event_is_not_reported_as_success() -> None:
+    resp, _ = _drive(upstream=_sse_response(ERROR_SSE))
+
+    assert resp.status_code == 502
+    assert resp.json()["error"]["type"] == "upstream_protocol_error"
+
+
+def test_plain_json_reply_is_untouched() -> None:
+    resp, _ = _drive(upstream=httpx.Response(200, json=JSON_REPLY))
+
+    assert resp.status_code == 200
+    assert "application/json" in resp.headers["content-type"]
+    assert resp.json()["content"] == [{"type": "text", "text": "hello"}]
+
+
+# --------------------------------------------------------------------------- #
+# Strict reconstruction, exercised directly
+# --------------------------------------------------------------------------- #
+@pytest.fixture()
+def proxy():
+    from headroom.proxy.server import HeadroomProxy
+
+    return HeadroomProxy(_config())
+
+
+def test_strict_mode_requires_a_terminal_event(proxy) -> None:
+    assert proxy._parse_sse_to_response(TRUNCATED_SSE, "anthropic", require_complete=True) is None
+
+
+def test_strict_mode_rejects_an_error_event(proxy) -> None:
+    assert proxy._parse_sse_to_response(ERROR_SSE, "anthropic", require_complete=True) is None
+
+
+def test_strict_mode_rejects_an_unclosed_block(proxy) -> None:
+    unclosed = COMPLETE_SSE.replace(
+        'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n', ""
+    )
+
+    assert proxy._parse_sse_to_response(unclosed, "anthropic", require_complete=True) is None
+
+
+def test_strict_mode_rejects_an_unknown_delta_type(proxy) -> None:
+    """A future delta Headroom cannot replay must not pass as complete."""
+    unknown = COMPLETE_SSE.replace('"type":"text_delta","text":"hello"', '"type":"future_delta"')
+
+    assert proxy._parse_sse_to_response(unknown, "anthropic", require_complete=True) is None
+
+
+def test_strict_mode_reads_crlf_framed_events(proxy) -> None:
+    parsed = proxy._parse_sse_to_response(
+        COMPLETE_SSE.replace("\n", "\r\n"), "anthropic", require_complete=True
+    )
+
+    assert parsed is not None
+    assert parsed["content"] == [{"type": "text", "text": "hello"}]
+
+
+def test_strict_mode_keeps_stop_sequence_and_type(proxy) -> None:
+    parsed = proxy._parse_sse_to_response(COMPLETE_SSE, "anthropic", require_complete=True)
+
+    assert parsed is not None
+    assert parsed["type"] == "message"
+    assert parsed["stop_sequence"] is None
+
+
+def test_permissive_mode_is_unchanged_for_existing_callers(proxy) -> None:
+    """Streaming callers keep the lenient reconstruction they rely on."""
+    parsed = proxy._parse_sse_to_response(TRUNCATED_SSE, "anthropic")
+
+    assert parsed is not None
+    assert parsed["content"][0]["text"] == "hello"
+
+
+def test_event_stream_under_a_vague_content_type_is_still_adapted() -> None:
+    """A gateway may relay the stream without declaring it (#3130)."""
+    resp, _ = _drive(
+        upstream=httpx.Response(
+            200,
+            content=COMPLETE_SSE.encode(),
+            headers={"content-type": "application/octet-stream"},
+        )
+    )
+
+    assert resp.status_code == 200
+    assert "application/json" in resp.headers["content-type"]
+    assert resp.json()["content"] == [{"type": "text", "text": "hello"}]


### PR DESCRIPTION
## Description

Claude Code retries a failed streaming turn as `stream: false`. When the upstream answers that JSON request with `content-type: text/event-stream`, the buffered Anthropic path relays it verbatim, so the SDK gets a wire format it never asked for and a complete, already-billed turn is lost:

```
API Error: API returned an empty or malformed response (HTTP 200) — check for a proxy or
gateway intercepting the request. Response: content-type event-stream, body is an event
stream (the non-streaming request was answered with a stream), 8756 bytes, request-id
req_011CeC1JTMS8egPL3FBteQay, server cloudflare, intermediary headers anthropic-*
cf-cache-status cf-ray. This was the non-streaming retry of streaming request (no Anthropic
request-id), which failed with: other; 0 stream events received.
```

Two defects, one on each side of the hop.

**Request side.** #3078 normalized `Accept` only when Headroom itself flips `stream: true` to `false` for CCR (inside `if buffered_stream_ccr`). A *client-originated* non-stream turn never passed through that block, so it kept `Accept: text/event-stream` and put a self-contradicting request on the wire — "answer as JSON" in the body, "I only accept SSE" in the headers. The rewrite moves to the buffered boundary, which every non-streaming request reaches, so the CCR flip and the client's own turn are covered by one rule. Header-only: the body is untouched, so cache keys and breakpoints do not move.

**Response side.** `stream: false` should already select JSON, so an SSE reply is an upstream protocol violation whichever header provoked it — this half is what makes the turn recoverable regardless. The buffered path now adapts the reply to the JSON the caller asked for, reusing the existing `_looks_like_sse_response` detector so a gateway relaying SSE under a vaguer content-type is caught too.

Adaptation happens **before the first `response.json()`** — ahead of CCR retrieval, memory, turn hooks, usage and cost accounting, prefix tracking, the response cache, marker resolution and the security scan. Adapting at the final return would leave every one of those reading an unparseable body: zero usage recorded, markers unresolved, raw SSE in the cache.

The guard keys on what the **client** asked for, not what went upstream. A buffered CCR turn deliberately requests JSON on behalf of a streaming client and re-emits SSE further down; that path is untouched, with an existing test pinning it.

Closes #3130

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `handlers/anthropic.py`: force `Accept: application/json` at the buffered boundary whenever the outgoing body is `stream: false`; removed the narrower CCR-only rewrite it supersedes (the CCR flip reaches the same boundary, and `tests/test_buffered_ccr_accept_header.py` still passes unchanged).
- `handlers/anthropic.py`: new `_adapt_event_stream_to_json()`, called before the first `response.json()` when a non-streaming client gets a 200 that `_looks_like_sse_response()`. Faithful reconstruction is returned as JSON; anything else becomes `502 upstream_protocol_error` rather than a plausible-looking 200 carrying a silently short message.
- `handlers/anthropic.py`: the buffered return now uses `sanitize_forwarded_response_headers()` instead of popping two headers by hand. It was also replaying `transfer-encoding`, `connection` and `keep-alive` — the stale chunked framing behind the empty HTTP 200 in #3019 — plus `server`. `cf-*` is dropped locally rather than added to `FRAMING_RESPONSE_HEADERS`, since those are hop-by-hop by definition and CDN provenance is not.
- `handlers/streaming.py`: `_parse_sse_to_response()` gains `require_complete`. Strict mode demands `message_start`, a terminal `message_stop`, every opened block closed, no `error` event, and no delta type the reconstructor cannot replay; it also strips the streaming-only `index` that Anthropic rejects on the next request (`content.0.text.index: Extra inputs are not permitted`). Existing streaming callers keep the permissive default. Shared by both modes: CRLF normalization and accepting `data:` without the space.
- `tests/test_anthropic_buffered_sse.py`: new, 18 cases.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/test_anthropic_buffered_sse.py -q
tests/test_anthropic_buffered_sse.py ..................                  [100%]
======================== 18 passed, 1 warning in 6.09s =========================

$ pytest -q tests/test_proxy tests/test_*{anthropic,sse,stream,ccr,cache,proxy}*.py
FAILED tests/test_cli_proxy_improvements.py::TestMissingProxyDepsError::test_proxy_command_exits_when_mcp_missing
FAILED tests/test_cli_proxy_improvements.py::TestMissingProxyDepsError::test_ensure_proxy_dependencies_exits_when_fastapi_missing
===== 2 failed, 2347 passed, 113 skipped, 9 warnings in 515.49s (0:08:35) ======

$ pytest -q          # whole suite
== 27 failed, 11641 passed, 273 skipped, 5838 warnings in 4491.02s (1:14:51) ===

# None of those failures come from this change. Re-running exactly the failing set
# with the two changed files reverted to origin/main gives an identical result, so
# they are pre-existing (kompress health, graceful shutdown, crewai/strands
# integrations, an evals benchmark, and the missing-proxy-deps CLI tests; the four
# that pass in isolation are order-dependent):

$ git checkout origin/main -- headroom/proxy/handlers/{anthropic,streaming}.py
$ pytest -q --tb=no $(cat failed.txt)
=================== 9 failed, 4 passed, 4 warnings in 32.57s ===================

$ git checkout HEAD -- headroom/proxy/handlers/{anthropic,streaming}.py
$ pytest -q --tb=no $(cat failed.txt)
=================== 9 failed, 4 passed, 4 warnings in 23.55s ===================

$ ruff check .
All checks passed!

$ mypy headroom/proxy/handlers/anthropic.py headroom/proxy/handlers/streaming.py
Success: no issues found in 2 source files
```

The new tests were confirmed red before the change — with the two source files stashed, 15 of the then-17 failed; all pass after.

## Real Behavior Proof

- Environment: macOS 15 (arm64), Python 3.13.2, `headroom proxy` on `127.0.0.1:8787`, `rust_core: loaded`. A stand-in upstream on `127.0.0.1:9911` answers every request with the #3130 shape — HTTP 200, `content-type: text/event-stream`, plus `server: cloudflare`, `cf-ray`, `cf-cache-status`, `request-id` and `anthropic-ratelimit-requests-remaining` — and logs the `Accept` it received. The proxy is aimed at it with `x-headroom-base-url`.

- Exact command / steps: one `curl` at the running proxy with `stream: false` in the body and `accept: text/event-stream` in the headers, aimed at the stand-in upstream via `x-headroom-base-url`; run once on this branch, and once with `origin/main` checked out over the two changed files. Full command:

```bash
curl -s -D - http://127.0.0.1:8787/v1/messages \
  -H 'content-type: application/json' \
  -H 'accept: text/event-stream' \
  -H 'x-api-key: test-key' \
  -H 'anthropic-version: 2023-06-01' \
  -H 'x-headroom-base-url: http://127.0.0.1:9911' \
  -d '{"model":"claude-sonnet-4-6","max_tokens":64,"stream":false,
       "messages":[{"role":"user","content":"go"}]}'
```

- Observed result: before the change the client receives `content-type: text/event-stream` with a raw SSE body plus `cf-ray`, `cf-cache-status` and `server: cloudflare`, and the upstream logs `accept='text/event-stream'` — the reported failure, reproduced end to end. After the change the upstream logs `accept='application/json'` and the client receives a parseable JSON message with usage intact, `index` stripped, `request-id` and `anthropic-ratelimit-*` preserved, and the CDN headers gone. Full transcripts:

*Before* (`origin/main` checked out over the two files, same request, same upstream) — the reported failure, reproduced end to end:

```text
HTTP/1.1 200 OK
server: uvicorn
server: BaseHTTP/0.6 Python/3.14.3, cloudflare
content-type: text/event-stream
cf-ray: 9abc123def-AMS
cf-cache-status: DYNAMIC
request-id: req_011CeC1JTMS8egPL3FBteQay

event: message_start
data: {"type":"message_start","message":{"id":"msg_live", ...

# upstream log:
UPSTREAM SAW accept='text/event-stream' body_stream=false
```

*After* (this branch):

```text
HTTP/1.1 200 OK
server: uvicorn
request-id: req_011CeC1JTMS8egPL3FBteQay
anthropic-ratelimit-requests-remaining: 42
content-type: application/json
content-length: 281

{"content":[{"type":"text","text":"live proof"}],
 "usage":{"input_tokens":11,"output_tokens":7,"cache_read_input_tokens":0,
          "cache_creation_input_tokens":0},
 "id":"msg_live","type":"message","stop_sequence":null,
 "model":"claude-sonnet-4-6","role":"assistant","stop_reason":"end_turn"}

# upstream log:
UPSTREAM SAW accept='application/json' body_stream=false
```

Both halves are visible: the upstream now receives `Accept: application/json`, and the client gets JSON with `index` stripped, usage intact, `request-id` and `anthropic-ratelimit-*` preserved, and `server: cloudflare` / `cf-*` gone.

- Not tested: a live reproduction against the real Anthropic endpoint. The SSE-at-200 answer is intermittent and I could not provoke it on demand, so the upstream side of the proof is a stand-in that emits exactly the reported shape. The 502 path was exercised in tests, not live.

## Runtime Rollout Safety

- Rollout-managed feature(s): none — no flag or channel gate is introduced.
- Minimum rollout channel: n/a.
- Stable/default behavior changed: yes, on the buffered Anthropic path. (1) A `stream: false` request now always leaves with `Accept: application/json`. (2) A 200 that looks like SSE for a non-streaming client is adapted to JSON, or 502s if it cannot be faithfully reconstructed — previously it was relayed as-is, which is the bug. (3) `transfer-encoding`, `connection`, `keep-alive`, `server` and `cf-*` are no longer replayed downstream. Streaming clients, the buffered-CCR SSE relay, translated backends and cache hits are unchanged.
- Kill switch / disable path: none. The prior behavior is the defect, so a flag would only preserve a broken path; `x-headroom-bypass` / `x-headroom-mode: passthrough` still converge on the same forwarder and are equally covered. Happy to add a gate if maintainers want one.
- Unsafe override required: no.
- Qualification impact: none expected. The 502 replaces a response the client already treats as a hard failure, so it converts a silent malformed 200 into a legible error.
- Rollback path: revert this commit; it is self-contained across two source files plus one new test file.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

- Documentation unchecked: this is an internal wire-protocol correction with no user-facing surface, so there is nothing in the docs to amend. Screenshots n/a.
- The `Accept` mismatch is the most credible trigger for the SSE reply but is not proven from the code — `stream: false` alone should select JSON. That is why both halves are here: the request side removes the contradiction, the response side makes the turn recoverable no matter what provoked it.
- This does not explain the *preceding* streaming failure that delivered zero events and caused Claude Code to retry non-streaming in the first place. That remains a separate trigger, and I did not investigate it here.
- Open question for maintainers: strict reconstruction currently returns 502 on an incomplete stream. The alternative is returning the partial message with `stop_reason: null`. I chose the 502 because a silently truncated answer is harder to notice than an error, but I will switch it if you prefer salvage.
