### PR TITLE
fix(deps): bump datasets past PYSEC-2026-3716

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,12 +246,12 @@ voice = [
 # Voice training (includes voice deps + training extras)
 voice-train = [
     "headroom-ai[voice]",
-    "datasets>=2.14.0",
+    "datasets>=5.0.1",
     "accelerate>=0.20.0",
 ]
 # Evaluation framework
 evals = [
-    "datasets>=2.14.0",
+    "datasets>=5.0.1",
     "sentence-transformers>=2.2.0,<6.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
     "numpy>=1.24.0",
     "scikit-learn>=1.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1121,7 +1121,7 @@ nvtx = [
 
 [[package]]
 name = "datasets"
-version = "4.5.0"
+version = "5.0.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "dill" },
@@ -1141,9 +1141,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/bf/bb927bde63d649296c83e883171ae77074717c1b80fe2868b328bd0dbcbb/datasets-4.5.0.tar.gz", hash = "sha256:00c698ce1c2452e646cc5fad47fef39d3fe78dd650a8a6eb205bb45eb63cd500", size = 588384, upload-time = "2026-01-14T18:27:54.297Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/5b/836516269d4f618efe621661cfb6f9acc57e6f95265db3efaee48a5ffe04/datasets-5.0.1.tar.gz", hash = "sha256:ce22bb851efd7494f08aad33b940803784434f6e77763d00679a0dc45fcf686a", size = 641498, upload-time = "2026-07-28T11:09:12.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/d5/0d563ea3c205eee226dc8053cf7682a8ac588db8acecd0eda2b587987a0b/datasets-4.5.0-py3-none-any.whl", hash = "sha256:b5d7e08096ffa407dd69e58b1c0271c9b2506140839b8d99af07375ad31b6726", size = 515196, upload-time = "2026-01-14T18:27:52.419Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0b/98fc6eb83333508ca5f44c52b3e287ea8137a0ad582714e2cbc67a02154b/datasets-5.0.1-py3-none-any.whl", hash = "sha256:9fbf73688f8c18f7529b4fe592abd04015f81d1e58001e4bac73ffb2b39d7cc4", size = 559079, upload-time = "2026-07-28T11:09:10.266Z" },
 ]
 
 [[package]]
@@ -1928,8 +1928,8 @@ requires-dist = [
     { name = "botocore", extras = ["crt"], marker = "extra == 'bedrock'", specifier = ">=1.41.0" },
     { name = "click", specifier = ">=8.3.3" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=1.0" },
-    { name = "datasets", marker = "extra == 'evals'", specifier = ">=2.14.0" },
-    { name = "datasets", marker = "extra == 'voice-train'", specifier = ">=2.14.0" },
+    { name = "datasets", marker = "extra == 'evals'", specifier = ">=5.0.1" },
+    { name = "datasets", marker = "extra == 'voice-train'", specifier = ">=5.0.1" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.100.0" },
     { name = "fastapi", marker = "extra == 'proxy'", specifier = ">=0.100.0" },
     { name = "fastembed", marker = "extra == 'relevance'", specifier = ">=0.4.0" },


### PR DESCRIPTION
## Why this is urgent

`datasets` 4.5.0 picked up **PYSEC-2026-3716** — path traversal in folder-based dataset builders, where an unvalidated `file_name` metadata field is joined to the dataset directory, so crafted traversal sequences can read arbitrary local files into output on `save_to_disk`/`push_to_hub`.

**The advisory was published today between 07:17 and 15:35 UTC.** `main`'s audit passed at 07:17 on `17522fb0`; every PR run after 15:35 fails. So `Dependency audit (pip-audit)` is now **red repo-wide and blocks all open PRs**, not just one.

## Exposure

Negligible for us. `datasets` is confined to the `evals` and `voice-train` extras, and every call site in the repo uses `load_dataset` against public Hub datasets — we never build folder-based datasets from untrusted metadata, and never call `save_to_disk`/`push_to_hub` on them.

But the gate audits the `[all]` production set and fails on any actionable finding, so it has to be resolved rather than waived.

## The change

Bump both extras to `>=5.0.1` and relock. `load_dataset` — the only API this repo touches — is unchanged across 2.x → 5.x.

Lock diff is **5 lines, `datasets` alone**; nothing else re-resolved.

## Verification

Ran the workflow's own command locally (`uv export --frozen --no-dev --no-emit-project --no-hashes --extra all`, audited under Python 3.12 to match CI):

```
No known vulnerabilities found
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
