### PR TITLE
fix(cache/ccr): tolerate a malformed CCR entry row instead of crashing the store

### DIFF
--- a/headroom/cache/backends/sqlite.py
+++ b/headroom/cache/backends/sqlite.py
@@ -150,8 +150,18 @@ class SQLiteBackend:
             data = json.loads(raw)
         except (json.JSONDecodeError, TypeError):
             return None
+        if not isinstance(data, dict):
+            return None
         known = {f.name for f in fields(CompressionEntry)}
-        return CompressionEntry(**{k: v for k, v in data.items() if k in known})
+        try:
+            return CompressionEntry(**{k: v for k, v in data.items() if k in known})
+        except (TypeError, ValueError):
+            # A blob that parses as JSON but is missing a required field (schema
+            # drift across an upgrade, a partially written row) must degrade to a
+            # miss, not raise. Otherwise a single bad row crashes get() — and,
+            # via items(), _clean_expired() runs it on every store's eviction, so
+            # one poison row would break all reads, evictions, and stores.
+            return None
 
     def _maybe_purge(self) -> None:
         """Delete expired rows; called opportunistically under the lock."""

--- a/tests/test_ccr_sqlite_backend.py
+++ b/tests/test_ccr_sqlite_backend.py
@@ -107,6 +107,37 @@ class TestSQLiteBackend:
         assert got is not None
         assert got.original_content == "x" * 600
 
+    def test_missing_required_field_degrades_to_miss(self, db_path):
+        """A row that parses as JSON but is missing a required CompressionEntry
+        field (schema drift across an upgrade, a partially written row) must
+        degrade to a miss, not raise. Otherwise it crashes get() and — via
+        items(), which _clean_expired runs on every store's eviction — breaks
+        all reads, evictions, and stores for one poison row."""
+        b = SQLiteBackend(db_path)
+        b.set("good", make_entry("good"))
+        # Insert a valid-JSON blob missing required fields, plus a non-dict blob.
+        with b._lock:
+            for hash_key, blob in (
+                ("poison", '{"hash": "poison", "original_content": "x"}'),
+                ("nulljson", "null"),
+            ):
+                b._conn.execute(
+                    "INSERT OR REPLACE INTO ccr_entries "
+                    "(hash, entry_json, created_at, ttl) VALUES (?, ?, ?, ?)",
+                    (hash_key, blob, time.time(), 1800),
+                )
+            b._conn.commit()
+
+        assert b.get("poison") is None  # no TypeError
+        assert b.get("nulljson") is None
+        # items() skips the bad rows instead of raising; the good row survives.
+        items = dict(b.items())
+        assert set(items) == {"good"}
+        # A store cycle (which evicts via items()) still works with poison present.
+        store = CompressionStore(backend=b, max_entries=1000)
+        store.store(original="fresh original", compressed="c", original_item_count=1)
+        assert b.get("good") is not None
+
     def test_store_ttl_enforcement_via_compression_store(self, db_path):
         """TTL checks stay in CompressionStore; expired entries miss."""
         store = CompressionStore(backend=SQLiteBackend(db_path))


### PR DESCRIPTION
## Description

`SQLiteBackend._entry_from_json` (the CCR compression store's persistent backend) deserializes each row's JSON blob into a `CompressionEntry`:

```python
try:
    data = json.loads(raw)
except (json.JSONDecodeError, TypeError):
    return None
known = {f.name for f in fields(CompressionEntry)}
return CompressionEntry(**{k: v for k, v in data.items() if k in known})
```

The `try` guards only the `json.loads`. The `CompressionEntry(**...)` construction is unguarded, and `CompressionEntry` has eleven required fields (no default): `hash`, `original_content`, `compressed_content`, `original_tokens`, `compressed_tokens`, `original_item_count`, `compressed_item_count`, `tool_name`, `tool_call_id`, `query_context`, `created_at`. A row that **parses as JSON but is missing a required field** — schema drift after an upgrade, or a partially written row — therefore raises `TypeError` (and a non-`dict` blob such as `null` raises too).

That exception propagates out of `get()` **and** `items()`. `items()` is the real problem: `CompressionStore._clean_expired()` calls it on **every** store's eviction pass, so a single malformed row does not just fail one retrieval — it crashes all reads, all evictions, and therefore all subsequent stores, until the row is somehow removed (which the crashing store can no longer do).

The field-filtering and the `Optional` return type of `_entry_from_json` already document the intent: unknown/malformed rows should degrade to a miss, not raise (the sibling `test_unknown_json_fields_tolerated` covers the forward-compat direction). This PR extends that resilience to the missing-required-field / non-dict cases by guarding the construction.

Reproduction:

```python
import json, time
from headroom.cache.backends.sqlite import SQLiteBackend
b = SQLiteBackend("ccr.db")
b._conn.execute(
    "INSERT OR REPLACE INTO ccr_entries (hash, entry_json, created_at, ttl) VALUES (?,?,?,?)",
    ("poison", '{"hash": "poison", "original_content": "x"}', time.time(), 1800),
)
b._conn.commit()
b.get("poison")   # before: TypeError (missing 9 required arguments)
b.items()         # before: TypeError -> breaks eviction on every store
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cache/backends/sqlite.py` (`_entry_from_json`): return `None` for a non-`dict` blob, and wrap the `CompressionEntry(**...)` construction in `except (TypeError, ValueError)` so a row missing a required field (or carrying a wrong-typed value) degrades to a miss instead of raising.
- `tests/test_ccr_sqlite_backend.py`: added `test_missing_required_field_degrades_to_miss` — a poison row and a `null` blob make `get()` return `None`, `items()` skip them (the good row survives), and a full `CompressionStore.store()` cycle (which evicts via `items()`) still works with the poison row present.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
tests/test_ccr_sqlite_backend.py  ->  21 passed, 1 skipped
uvx ruff@0.16.2 check headroom/cache/backends/sqlite.py tests/test_ccr_sqlite_backend.py  ->  All checks passed!
uvx mypy@1.20.2 headroom/cache/backends/sqlite.py  ->  Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.16.2 and mypy 1.20.2 via uvx.
- Exact command / steps: inserted a valid-JSON row missing required fields directly into `ccr_entries` and called the backend (`get('poison')` and `items()` both raised `TypeError: CompressionEntry.__init__() missing 9 required positional arguments`); applied the guard and re-ran the new regression against the un-patched method (`python -m pytest tests/test_ccr_sqlite_backend.py -k missing_required_field` -> failed on the raise), then with the fix -> 21 passed, 1 skipped for the file.
- Observed result: before, one malformed row raised out of `get()`/`items()` (and `items()` runs during every store's eviction); after, `get()` returns `None`, `items()` skips it, and stores/evictions continue normally.
- Not tested: an actual on-disk schema-drift upgrade path; the malformed row is injected directly, which is the exact shape `_entry_from_json` consumes.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. This is defensive deserialization in the CCR SQLite backend, not a rollout-channel-gated runtime feature.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: a malformed/partial CCR row now degrades to a miss instead of raising. Well-formed rows are loaded exactly as before.
- Kill switch / disable path: N/A.
- Unsafe override required: no.
- Qualification impact: the CCR store survives a corrupt/old-schema row instead of crashing reads, evictions, and stores; the affected marker simply misses until re-compressed (the same outcome the store already documents for an evicted entry).
- Rollback path: revert this PR; `_entry_from_json` returns to the unguarded construction.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A: internal backend behavior; the class docstring already notes the prior raise)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

The class docstring currently states that a blob missing a required field "raises `TypeError` on construction." That was accurate but is exactly the failure this PR removes; the field-filtering right above it exists to make the backend forward-compatible, and crashing on a missing field defeats that intent — especially because `items()` fans the crash out to eviction on every store. I left the docstring's forward-compat description intact since the observable contract (`_entry_from_json` returns `Optional`) is now honored for both directions.
