### PR TITLE
fix(anthropic): preserve Claude tool search in token mode

### DIFF
--- a/headroom/ccr/marker_resolution.py
+++ b/headroom/ccr/marker_resolution.py
@@ -1,4 +1,4 @@
-"""Inline resolution of ``<<ccr:...>>`` markers on the response path.
+"""Inline resolution of CCR markers on the response path.
 
 Normal CCR resolution relies on the ``headroom_retrieve`` tool: a marker is
 redeemed when the model calls the tool back. That path assumes there's a
@@ -27,27 +27,33 @@ from ..cache.compression_store import (
 
 logger = logging.getLogger(__name__)
 
-# Matches the opaque-blob marker form `<<ccr:HASH,KIND,SIZE>>` (and the
-# row-offload form `<<ccr:HASH N_rows_offloaded>>`) emitted by SmartCrusher.
+# Matches the opaque-blob and row-offload forms emitted by SmartCrusher, plus
+# bracketed markers emitted by the text, config, read, log, and Kompress paths.
 # HASH is 12-24 hex chars; see headroom/ccr/tool_injection.py for the same
-# constant used on the injection side.
-_MARKER_RE = re.compile(r"<<ccr:([a-f0-9]{12,24})[^>]*>>")
+# ownership boundary used on the injection side.
+_MARKER_RE = re.compile(
+    r"<<ccr:([a-f0-9]{12,24})[^>]*>>"
+    r"|\[[^\]]*?Retrieve (?:more|original): hash=([a-f0-9]{12,24})[^\]]*\]",
+    re.IGNORECASE,
+)
 
 
 def resolve_markers_in_text(text: str, *, store: CompressionStore | None = None) -> str:
-    """Replace every ``<<ccr:HASH,...>>`` marker in ``text`` with its original content.
+    """Replace supported CCR markers in ``text`` with their original content.
 
     A miss (expired/evicted/unknown hash) can't be reported back to the
     model on this path — there's no tool-call round-trip — so the marker is
     left in place with the miss reason appended rather than raising.
     """
-    if "<<ccr:" not in text:
+    if not (
+        "<<ccr:" in text or "Retrieve more: hash=" in text or "Retrieve original: hash=" in text
+    ):
         return text
 
     resolved_store = store or get_compression_store()
 
     def _replace(match: re.Match[str]) -> str:
-        hash_key = match.group(1)
+        hash_key = (match.group(1) or match.group(2)).lower()
         entry = resolved_store.retrieve(hash_key)
         if entry is not None:
             original = entry.original_content
@@ -63,7 +69,7 @@ def resolve_markers_in_text(text: str, *, store: CompressionStore | None = None)
 
 
 def resolve_markers_in_response(response: Any, *, store: CompressionStore | None = None) -> Any:
-    """Recursively resolve ``<<ccr:...>>`` markers in every string field of a payload.
+    """Recursively resolve CCR markers in every string field of a payload.
 
     Walks the full response structure rather than picking out
     provider-specific fields (``content`` blocks, ``message.content``,

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -1027,6 +1027,31 @@ class AnthropicHandlerMixin:
             # original, forwarded, and the recorded/replayed prefix are all identical)
             # keeps it cache-safe: overlay_cached_prefix replays the same stripped bytes.
             _strip_streaming_only_content_fields(messages)
+            _bypass = (
+                request.headers.get("x-headroom-bypass", "").lower() == "true"
+                or request.headers.get("x-headroom-mode", "").lower() == "passthrough"
+            )
+            raw_tools = body.get("tools")
+            raw_client = classify_client(dict(request.headers), default="claude")
+            from headroom.proxy.helpers import (
+                anthropic_first_party_tool_search_supported,
+                claude_code_tool_search_active,
+            )
+
+            _claude_tool_search_active = (
+                not _bypass
+                and provider_name == "anthropic"
+                and upstream_base_url is None
+                and getattr(self, "anthropic_backend", None) is None
+                and anthropic_first_party_tool_search_supported(self.ANTHROPIC_API_URL)
+                and is_token_mode(self.config.mode)
+                and claude_code_tool_search_active(
+                    client=raw_client,
+                    tools=raw_tools,
+                    anthropic_beta=request.headers.get("anthropic-beta"),
+                )
+            )
+            _locked_tools = copy.deepcopy(raw_tools) if _claude_tool_search_active else None
             pipeline_provider = provider_name
             pipeline_path = request.url.path if upstream_base_url else "/v1/messages"
             pipeline_stream = bool(body.get("stream", False) or force_stream)
@@ -1039,14 +1064,16 @@ class AnthropicHandlerMixin:
                 provider=pipeline_provider,
                 model=model,
                 messages=messages,
-                tools=body.get("tools"),
+                tools=copy.deepcopy(_locked_tools)
+                if _claude_tool_search_active
+                else body.get("tools"),
                 metadata={"path": pipeline_path, "stream": pipeline_stream},
             )
             if input_event.messages is not None:
                 messages = input_event.messages
                 with stage_timer.measure("deep_copy"):
                     original_client_messages = copy.deepcopy(messages)
-            if input_event.tools is not None:
+            if input_event.tools is not None and not _claude_tool_search_active:
                 body["tools"] = input_event.tools
 
             # Snapshot the client's cache_control breakpoints before any
@@ -1093,10 +1120,6 @@ class AnthropicHandlerMixin:
             # when the caller explicitly opts out via header.
             # Prevents Headroom from corrupting sub-agent API calls
             # (e.g., Claude Code sub-agents that inherit ANTHROPIC_BASE_URL).
-            _bypass = (
-                request.headers.get("x-headroom-bypass", "").lower() == "true"
-                or request.headers.get("x-headroom-mode", "").lower() == "passthrough"
-            )
             preserve_tool_order = _bypass or not self.config.optimize
             if _bypass:
                 logger.info(f"[{request_id}] Bypass: skipping compression (header)")
@@ -1137,6 +1160,8 @@ class AnthropicHandlerMixin:
             # from User-Agent or X-Client. Surfaced via the funnel into
             # PERF logs and RequestLog.tags — see RequestOutcome.client.
             client = classify_client(headers, default="claude")
+            if _claude_tool_search_active:
+                preserve_tool_order = True
             # PR-A5 (P5-49): strip internal x-headroom-* from upstream-bound
             # headers AFTER `_extract_tags` reads them. Inbound bypass gating
             # uses `request.headers.get(...)` directly above; memory user-id
@@ -2269,8 +2294,12 @@ class AnthropicHandlerMixin:
             # existing per-request scan (it lives in the system prompt, which
             # is the cache hot zone — gated separately by the
             # `frozen_message_count > 0` guard below).
-            tools = body.get("tools")
-            _original_tools = tools  # Preserve for diagnostic / future retry
+            tools = (
+                copy.deepcopy(_locked_tools) if _claude_tool_search_active else body.get("tools")
+            )
+            _original_tools = copy.deepcopy(tools) if _claude_tool_search_active else tools
+            if _claude_tool_search_active:
+                body["tools"] = copy.deepcopy(_locked_tools)
 
             # Issue #746: when Claude Code talks to a custom ANTHROPIC_BASE_URL
             # with ENABLE_TOOL_SEARCH unset, it stops deferring tool schemas and
@@ -2310,7 +2339,9 @@ class AnthropicHandlerMixin:
             # set. The downstream uses already treat falsy as "unresolved".
             ccr_workspace_key, ccr_workspace_label = None, None
             if (
-                self.config.ccr_inject_tool or self.config.ccr_inject_system_instructions
+                self.config.ccr_inject_tool
+                or self.config.ccr_inject_system_instructions
+                or _claude_tool_search_active
             ) and not _bypass:
                 inject_system_instructions = self.config.ccr_inject_system_instructions
                 if inject_system_instructions and frozen_message_count > 0:
@@ -2351,7 +2382,7 @@ class AnthropicHandlerMixin:
                 # a session that has never compressed still gets no tool, so
                 # dropping the gate cannot start injecting into non-CCR
                 # conversations.
-                if configured_inject_tool:
+                if configured_inject_tool and not _claude_tool_search_active:
                     from headroom.proxy.helpers import (
                         apply_session_sticky_ccr_tool,
                         history_references_ccr_tool,
@@ -2423,6 +2454,7 @@ class AnthropicHandlerMixin:
                                         f"[{request_id}] CCR: skipping proactive "
                                         f"tracking for Claude Code compact summary {hash_key}"
                                     )
+
                                     continue
                                 self.ccr_context_tracker.track_compression(
                                     hash_key=hash_key,
@@ -2440,6 +2472,21 @@ class AnthropicHandlerMixin:
                             "track_compression (fail-closed — no x-headroom-cwd / "
                             "x-headroom-project-id header and no cwd: in system prompt)"
                         )
+
+                # Active Claude Tool Search owns the tools array, so CCR cannot
+                # add ``headroom_retrieve``. Resolve any newly visible CCR
+                # marker inline instead of forwarding an unredeemable marker.
+                if (
+                    _claude_tool_search_active
+                    and injector.has_compressed_content
+                    and not self._has_headroom_retrieve_tool(tools)
+                ):
+                    optimized_messages = resolve_markers_in_response(optimized_messages)
+                    logger.info(
+                        "[%s] CCR: resolved active-route markers inline because "
+                        "the client-owned tools array cannot add headroom_retrieve",
+                        request_id,
+                    )
 
             # CCR Proactive Expansion: Check if current query needs expanded context.
             # Same workspace gate as track_compression above.
@@ -2624,23 +2671,24 @@ class AnthropicHandlerMixin:
                 # turn (i.e. memory_handler.config.inject_tools and we
                 # have a memory_user_id, which the outer guard at line
                 # 1192 already enforces).
-                from headroom.proxy.helpers import (
-                    apply_session_sticky_memory_tools,
-                )
+                memory_tool_defs = []
+                mem_tools_injected = False
+                if not _claude_tool_search_active:
+                    from headroom.proxy.helpers import apply_session_sticky_memory_tools
 
-                memory_tool_defs = (
-                    self.memory_handler.compute_memory_tool_definitions("anthropic")
-                    if self.memory_handler.config.inject_tools
-                    else []
-                )
-                tools, mem_tools_injected = apply_session_sticky_memory_tools(
-                    provider="anthropic",
-                    session_id=session_id,
-                    request_id=request_id,
-                    existing_tools=tools,
-                    memory_tools_to_inject=memory_tool_defs,
-                    inject_this_turn=bool(self.memory_handler.config.inject_tools),
-                )
+                    memory_tool_defs = (
+                        self.memory_handler.compute_memory_tool_definitions("anthropic")
+                        if self.memory_handler.config.inject_tools
+                        else []
+                    )
+                    tools, mem_tools_injected = apply_session_sticky_memory_tools(
+                        provider="anthropic",
+                        session_id=session_id,
+                        request_id=request_id,
+                        existing_tools=tools,
+                        memory_tools_to_inject=memory_tool_defs,
+                        inject_this_turn=bool(self.memory_handler.config.inject_tools),
+                    )
                 if mem_tools_injected:
                     memory_tools_injected = True
                     tool_names = [
@@ -2716,7 +2764,7 @@ class AnthropicHandlerMixin:
                 )
                 if remembered_event.messages is not None:
                     optimized_messages = remembered_event.messages
-                if remembered_event.tools is not None:
+                if remembered_event.tools is not None and not _claude_tool_search_active:
                     tools = remembered_event.tools
                 if remembered_event.headers is not None:
                     headers = remembered_event.headers
@@ -2766,7 +2814,12 @@ class AnthropicHandlerMixin:
                 from headroom.proxy.tool_schema_compaction import compact_tools
 
                 _pre_compaction_tools = body.get("tools")
-                body, _tools_modified, _tools_before_bytes, _tools_after_bytes = compact_tools(body)
+                if not _claude_tool_search_active:
+                    body, _tools_modified, _tools_before_bytes, _tools_after_bytes = compact_tools(
+                        body
+                    )
+                else:
+                    _tools_modified = False
                 if _tools_modified:
                     tools = body["tools"]
                     transforms_applied.append("anthropic:tool_schema_compaction")
@@ -2799,9 +2852,12 @@ class AnthropicHandlerMixin:
                 _desc_max = tool_desc_max_chars()
                 if _desc_max > 0:
                     _pre_desc_tools = body.get("tools")
-                    body, _desc_modified, _desc_before, _desc_after = compact_tool_descriptions(
-                        body, _desc_max
-                    )
+                    if not _claude_tool_search_active:
+                        body, _desc_modified, _desc_before, _desc_after = compact_tool_descriptions(
+                            body, _desc_max
+                        )
+                    else:
+                        _desc_modified = False
                     if _desc_modified:
                         tools = body["tools"]
                         transforms_applied.append("anthropic:tool_desc_compaction")
@@ -2866,7 +2922,7 @@ class AnthropicHandlerMixin:
                 provider=pipeline_provider,
                 model=model,
                 messages=optimized_messages,
-                tools=tools,
+                tools=copy.deepcopy(_locked_tools) if _claude_tool_search_active else tools,
                 headers=headers,
                 metadata={"path": pipeline_path, "stream": stream},
             )
@@ -2874,7 +2930,7 @@ class AnthropicHandlerMixin:
             if presend_event.messages is not None:
                 optimized_messages = presend_event.messages
                 body["messages"] = optimized_messages
-            if presend_event.tools is not None:
+            if presend_event.tools is not None and not _claude_tool_search_active:
                 tools = self._tools_for_forwarding(
                     presend_event.tools,
                     preserve_order=preserve_tool_order,
@@ -2931,7 +2987,8 @@ class AnthropicHandlerMixin:
             # strip client-originated tool_search_tool_* entries above and skip
             # Headroom's own injector here.
             if (
-                provider_name == "anthropic"
+                not _claude_tool_search_active
+                and provider_name == "anthropic"
                 and anthropic_first_party_tool_search_supported(_anthropic_target_base_url)
                 and getattr(self, "anthropic_backend", None) is None
                 and os.environ.get("HEADROOM_TOOL_SEARCH", "1").strip().lower()
@@ -2980,7 +3037,11 @@ class AnthropicHandlerMixin:
                     provider="anthropic",
                     model=str(model),
                     messages=optimized_messages,
-                    tools=body.get("tools"),
+                    tools=(
+                        copy.deepcopy(_locked_tools)
+                        if _claude_tool_search_active
+                        else body.get("tools")
+                    ),
                     config=self.config,
                     tags=tags,
                     count_messages=tokenizer.count_messages,
@@ -2999,7 +3060,7 @@ class AnthropicHandlerMixin:
                 if _req_ctx.messages is not optimized_messages:
                     optimized_messages = _req_ctx.messages
                     body["messages"] = optimized_messages
-                if _req_ctx.tools is not body.get("tools"):
+                if _req_ctx.tools is not body.get("tools") and not _claude_tool_search_active:
                     tools = _req_ctx.tools
                     body["tools"] = tools
                 # A hook may shrink the tool array either by replacing it or in place,
@@ -3068,6 +3129,10 @@ class AnthropicHandlerMixin:
                     request_id,
                     _ccr_neutralized,
                 )
+
+            if _claude_tool_search_active:
+                tools = copy.deepcopy(_locked_tools)
+                body["tools"] = copy.deepcopy(_locked_tools)
 
             # Consistency: report tok_before/tok_after with ONE tokenizer. The pipeline
             # and the handler use different token estimators, and cache-mode branches
@@ -3604,9 +3669,10 @@ class AnthropicHandlerMixin:
                     if body.get("system") is not None:
                         body["system"] = _ttl_system
                     body["messages"] = _ttl_messages
-                    if body.get("tools") is not None:
+                    if body.get("tools") is not None and not _claude_tool_search_active:
                         body["tools"] = _ttl_tools
-                    tools = _ttl_tools
+                    if not _claude_tool_search_active:
+                        tools = _ttl_tools
                     body_mutation_tracker.mark_mutated("cache_control_ttl_order")
 
                 # Signed thinking locks the request to the client's original
@@ -3998,7 +4064,9 @@ class AnthropicHandlerMixin:
                                     **body,
                                     "messages": msgs,
                                 }
-                                if tls is not None:
+                                if _claude_tool_search_active:
+                                    continuation_body["tools"] = copy.deepcopy(_locked_tools)
+                                elif tls is not None:
                                     continuation_body["tools"] = tls
 
                                 # Use clean headers for continuation
@@ -4180,7 +4248,9 @@ class AnthropicHandlerMixin:
 
                                     # Make continuation API call
                                     continuation_body = {**body, "messages": continuation_messages}
-                                    if tools:
+                                    if _claude_tool_search_active:
+                                        continuation_body["tools"] = copy.deepcopy(_locked_tools)
+                                    elif tools:
                                         continuation_body["tools"] = tools
 
                                     cont_response = await self._retry_request(

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -1051,6 +1051,123 @@ class AnthropicHandlerMixin:
                     anthropic_beta=request.headers.get("anthropic-beta"),
                 )
             )
+            _provider_history_snapshot: tuple[
+                tuple[int, int, str | None, str | None, dict[str, Any]], ...
+            ] = ()
+
+            def _restore_provider_history(candidate: list[dict[str, Any]]) -> list[dict[str, Any]]:
+                if not _claude_tool_search_active or not _provider_history_snapshot:
+                    return candidate
+                provider_types = {"server_tool_use", "tool_search_tool_result"}
+                protected_paths = {
+                    (message_index, content_index)
+                    for message_index, content_index, *_ in _provider_history_snapshot
+                }
+                for message_index, _, _, role, _ in sorted(
+                    _provider_history_snapshot,
+                    key=lambda entry: entry[0],
+                    reverse=True,
+                ):
+                    if message_index >= len(candidate):
+                        continue
+                    if isinstance(candidate[message_index].get("content"), list):
+                        continue
+                    candidate.insert(
+                        message_index,
+                        {"role": role or "assistant", "content": []},
+                    )
+                for (
+                    message_index,
+                    content_index,
+                    identity,
+                    role,
+                    frozen_block,
+                ) in _provider_history_snapshot:
+                    block = copy.deepcopy(frozen_block)
+                    found: tuple[int, int] | None = None
+                    if identity is not None:
+                        for current_message_index, message in enumerate(candidate):
+                            content = message.get("content")
+                            if not isinstance(content, list):
+                                continue
+                            for current_content_index, current_block in enumerate(content):
+                                current_identity = (
+                                    current_block.get("id") or current_block.get("tool_use_id")
+                                    if isinstance(current_block, dict)
+                                    else None
+                                )
+                                if (
+                                    isinstance(current_block, dict)
+                                    and current_block.get("type") == block.get("type")
+                                    and current_identity == identity
+                                ):
+                                    found = (current_message_index, current_content_index)
+                                    break
+                            if found is not None:
+                                break
+
+                    if found is not None and found != (message_index, content_index):
+                        found_content = candidate[found[0]]["content"]
+                        del found_content[found[1]]
+                        if found[0] == message_index and found[1] < content_index:
+                            content_index -= 1
+
+                    while len(candidate) <= message_index:
+                        candidate.append({"role": role or "assistant", "content": []})
+                    target_message = candidate[message_index]
+                    target_content = target_message.get("content")
+                    if not isinstance(target_content, list):
+                        candidate.insert(
+                            message_index,
+                            {"role": role or "assistant", "content": []},
+                        )
+                        target_content = candidate[message_index]["content"]
+                    if content_index < len(target_content):
+                        current_block = target_content[content_index]
+                        if (
+                            isinstance(current_block, dict)
+                            and current_block.get("type") in provider_types
+                        ):
+                            target_content[content_index] = block
+                        else:
+                            target_content.insert(content_index, block)
+                    else:
+                        target_content.insert(content_index, block)
+
+                for current_message_index, message in enumerate(candidate):
+                    content = message.get("content")
+                    if not isinstance(content, list):
+                        continue
+                    for current_content_index in range(len(content) - 1, -1, -1):
+                        current_block = content[current_content_index]
+                        if (
+                            isinstance(current_block, dict)
+                            and current_block.get("type") in provider_types
+                            and (current_message_index, current_content_index)
+                            not in protected_paths
+                        ):
+                            del content[current_content_index]
+                return candidate
+
+            for message_index, message in enumerate(messages):
+                content = message.get("content")
+                if not isinstance(content, list):
+                    continue
+                for content_index, block in enumerate(content):
+                    if not isinstance(block, dict) or block.get("type") not in {
+                        "server_tool_use",
+                        "tool_search_tool_result",
+                    }:
+                        continue
+                    _provider_history_snapshot += (
+                        (
+                            message_index,
+                            content_index,
+                            block.get("id") or block.get("tool_use_id"),
+                            message.get("role"),
+                            copy.deepcopy(block),
+                        ),
+                    )
             _locked_tools = copy.deepcopy(raw_tools) if _claude_tool_search_active else None
             pipeline_provider = provider_name
             pipeline_path = request.url.path if upstream_base_url else "/v1/messages"
@@ -1071,8 +1188,11 @@ class AnthropicHandlerMixin:
             )
             if input_event.messages is not None:
                 messages = input_event.messages
+                messages = _restore_provider_history(messages)
                 with stage_timer.measure("deep_copy"):
                     original_client_messages = copy.deepcopy(messages)
+            else:
+                messages = _restore_provider_history(messages)
             if input_event.tools is not None and not _claude_tool_search_active:
                 body["tools"] = input_event.tools
 
@@ -2185,6 +2305,7 @@ class AnthropicHandlerMixin:
                 if routed_event.messages is not None:
                     previous_optimized_messages = optimized_messages
                     optimized_messages = routed_event.messages
+                    optimized_messages = _restore_provider_history(optimized_messages)
                     if routed_event.messages is not previous_optimized_messages:
                         optimized_tokens = tokenizer.count_messages(optimized_messages)
                         tokens_saved = max(0, original_tokens - optimized_tokens)
@@ -2208,6 +2329,7 @@ class AnthropicHandlerMixin:
             if compressed_event.messages is not None:
                 previous_optimized_messages = optimized_messages
                 optimized_messages = compressed_event.messages
+                optimized_messages = _restore_provider_history(optimized_messages)
                 if compressed_event.messages is not previous_optimized_messages:
                     optimized_tokens = tokenizer.count_messages(optimized_messages)
                     tokens_saved = max(0, original_tokens - optimized_tokens)
@@ -2768,6 +2890,7 @@ class AnthropicHandlerMixin:
                 )
                 if remembered_event.messages is not None:
                     optimized_messages = remembered_event.messages
+                    optimized_messages = _restore_provider_history(optimized_messages)
                 if remembered_event.tools is not None and not _claude_tool_search_active:
                     tools = remembered_event.tools
                 if remembered_event.headers is not None:
@@ -2933,6 +3056,7 @@ class AnthropicHandlerMixin:
             previous_presend_messages = optimized_messages
             if presend_event.messages is not None:
                 optimized_messages = presend_event.messages
+                optimized_messages = _restore_provider_history(optimized_messages)
                 body["messages"] = optimized_messages
             if presend_event.tools is not None and not _claude_tool_search_active:
                 tools = self._tools_for_forwarding(
@@ -3063,6 +3187,7 @@ class AnthropicHandlerMixin:
                 run_request_hooks(_req_ctx, stream_safe_only=bool(stream))
                 if _req_ctx.messages is not optimized_messages:
                     optimized_messages = _req_ctx.messages
+                    optimized_messages = _restore_provider_history(optimized_messages)
                     body["messages"] = optimized_messages
                 if _req_ctx.tools is not body.get("tools") and not _claude_tool_search_active:
                     tools = _req_ctx.tools
@@ -3097,8 +3222,17 @@ class AnthropicHandlerMixin:
             # Nothing past this point mutates `body["tools"]` on the outbound path.
             from headroom.proxy.helpers import strip_unsupported_tool_search_blocks
 
+            def _active_continuation_messages(
+                candidate: list[dict[str, Any]],
+            ) -> list[dict[str, Any]]:
+                if not _claude_tool_search_active:
+                    return candidate
+                restored = _restore_provider_history(candidate)
+                repaired, _ = strip_unsupported_tool_search_blocks(restored, _locked_tools)
+                return repaired
+
             _ts_repaired, _ts_stripped = strip_unsupported_tool_search_blocks(
-                body.get("messages"), body.get("tools")
+                _restore_provider_history(body.get("messages")), body.get("tools")
             )
             if _ts_stripped:
                 body["messages"] = _ts_repaired
@@ -4064,6 +4198,7 @@ class AnthropicHandlerMixin:
                             async def api_call_fn(
                                 msgs: list[dict], tls: list[dict] | None
                             ) -> dict[str, Any]:
+                                msgs = _active_continuation_messages(msgs)
                                 continuation_body = {
                                     **body,
                                     "messages": msgs,
@@ -4245,10 +4380,13 @@ class AnthropicHandlerMixin:
                                         "content": tool_results,
                                     }
 
-                                    continuation_messages = optimized_messages + [
-                                        assistant_msg,
-                                        user_msg,
-                                    ]
+                                    continuation_messages = _active_continuation_messages(
+                                        optimized_messages
+                                        + [
+                                            assistant_msg,
+                                            user_msg,
+                                        ]
+                                    )
 
                                     # Make continuation API call
                                     continuation_body = {**body, "messages": continuation_messages}
@@ -4291,6 +4429,7 @@ class AnthropicHandlerMixin:
                             async def _turn_hook_call_model(
                                 hook_messages: list[dict[str, Any]],
                             ) -> dict[str, Any]:
+                                hook_messages = _active_continuation_messages(hook_messages)
                                 continuation_body = {**body, "messages": hook_messages}
                                 continuation_response = await self._retry_request(
                                     "POST",

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -1055,7 +1055,11 @@ class AnthropicHandlerMixin:
                 tuple[int, int, str | None, str | None, dict[str, Any]], ...
             ] = ()
 
-            def _restore_provider_history(candidate: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            def _restore_provider_history(
+                candidate: list[dict[str, Any]],
+                *,
+                preserve_extra_provider_blocks: bool = False,
+            ) -> list[dict[str, Any]]:
                 if not _claude_tool_search_active or not _provider_history_snapshot:
                     return candidate
                 provider_types = {"server_tool_use", "tool_search_tool_result"}
@@ -1070,7 +1074,10 @@ class AnthropicHandlerMixin:
                 ):
                     if message_index >= len(candidate):
                         continue
-                    if isinstance(candidate[message_index].get("content"), list):
+                    if (
+                        isinstance(candidate[message_index].get("content"), list)
+                        and candidate[message_index].get("role") == role
+                    ):
                         continue
                     candidate.insert(
                         message_index,
@@ -1134,19 +1141,20 @@ class AnthropicHandlerMixin:
                     else:
                         target_content.insert(content_index, block)
 
-                for current_message_index, message in enumerate(candidate):
-                    content = message.get("content")
-                    if not isinstance(content, list):
-                        continue
-                    for current_content_index in range(len(content) - 1, -1, -1):
-                        current_block = content[current_content_index]
-                        if (
-                            isinstance(current_block, dict)
-                            and current_block.get("type") in provider_types
-                            and (current_message_index, current_content_index)
-                            not in protected_paths
-                        ):
-                            del content[current_content_index]
+                if not preserve_extra_provider_blocks:
+                    for current_message_index, message in enumerate(candidate):
+                        content = message.get("content")
+                        if not isinstance(content, list):
+                            continue
+                        for current_content_index in range(len(content) - 1, -1, -1):
+                            current_block = content[current_content_index]
+                            if (
+                                isinstance(current_block, dict)
+                                and current_block.get("type") in provider_types
+                                and (current_message_index, current_content_index)
+                                not in protected_paths
+                            ):
+                                del content[current_content_index]
                 return candidate
 
             for message_index, message in enumerate(messages):
@@ -3227,7 +3235,10 @@ class AnthropicHandlerMixin:
             ) -> list[dict[str, Any]]:
                 if not _claude_tool_search_active:
                     return candidate
-                restored = _restore_provider_history(candidate)
+                restored = _restore_provider_history(
+                    candidate,
+                    preserve_extra_provider_blocks=True,
+                )
                 repaired, _ = strip_unsupported_tool_search_blocks(restored, _locked_tools)
                 return repaired
 

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -2343,7 +2343,11 @@ class AnthropicHandlerMixin:
                 or self.config.ccr_inject_system_instructions
                 or _claude_tool_search_active
             ) and not _bypass:
-                inject_system_instructions = self.config.ccr_inject_system_instructions
+                # Claude Tool Search owns the tools array, so do not advertise
+                # Headroom's retrieval tool in a system prompt it cannot call.
+                inject_system_instructions = (
+                    self.config.ccr_inject_system_instructions and not _claude_tool_search_active
+                )
                 if inject_system_instructions and frozen_message_count > 0:
                     logger.info(
                         f"[{request_id}] CCR: skipping system instruction injection "

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -2812,6 +2812,25 @@ def claude_code_tool_search_inactive(
     return not any(marker in beta for marker in _TOOL_SEARCH_BETA_MARKERS)
 
 
+def claude_code_tool_search_active(
+    *,
+    client: str | None,
+    tools: Any,
+    anthropic_beta: str | None,
+) -> bool:
+    """Return whether Claude Code sent an active Tool Search protocol marker."""
+    if client != "claude-code" or not isinstance(tools, list) or not tools:
+        return False
+    if any(
+        isinstance(tool, dict)
+        and str(tool.get("type", "")).startswith(_TOOL_SEARCH_TOOL_TYPE_PREFIX)
+        for tool in tools
+    ):
+        return True
+    beta = (anthropic_beta or "").lower()
+    return any(marker in beta for marker in _TOOL_SEARCH_BETA_MARKERS)
+
+
 def format_tool_search_disabled_hint(tools: list[Any]) -> str:
     """Build the one-time, actionable hint for issue #746.
 

--- a/tests/test_ccr_marker_resolution.py
+++ b/tests/test_ccr_marker_resolution.py
@@ -34,9 +34,19 @@ def test_resolve_markers_in_text_no_marker_is_noop():
     assert resolve_markers_in_text("plain text, no markers here") == "plain text, no markers here"
 
 
-def test_resolve_markers_in_text_replaces_hit():
+@pytest.mark.parametrize(
+    "marker_template",
+    [
+        "<<ccr:{hash},string,23.6KB>>",
+        "[100 items compressed to 10. Retrieve more: hash={hash}]",
+        "[Read content stale. Retrieve original: hash={hash}]",
+    ],
+)
+@pytest.mark.parametrize("uppercase", [False, True])
+def test_resolve_markers_in_text_replaces_all_supported_hits(marker_template: str, uppercase: bool):
     hash_key = _store_entry("the original uncompressed content")
-    text = f"before <<ccr:{hash_key},string,23.6KB>> after"
+    marker_hash = hash_key.upper() if uppercase else hash_key
+    text = f"before {marker_template.format(hash=marker_hash)} after"
 
     resolved = resolve_markers_in_text(text)
 
@@ -68,8 +78,18 @@ def test_resolve_markers_in_text_json_array_original_content():
     assert json.loads(resolved) == [1, 2, 3]
 
 
-def test_resolve_markers_in_text_miss_leaves_marker_with_reason():
-    text = "<<ccr:deadbeefdeadbeef,string,1KB>>"
+@pytest.mark.parametrize(
+    "marker_template",
+    [
+        "<<ccr:{hash},string,1KB>>",
+        "[100 items compressed to 10. Retrieve more: hash={hash}]",
+        "[Read content stale. Retrieve original: hash={hash}]",
+    ],
+)
+def test_resolve_markers_in_text_miss_leaves_all_supported_markers_with_reason(
+    marker_template: str,
+):
+    text = marker_template.format(hash="deadbeefdeadbeef")
 
     resolved = resolve_markers_in_text(text)
 

--- a/tests/test_integrations/agno/test_model.py
+++ b/tests/test_integrations/agno/test_model.py
@@ -19,11 +19,6 @@ try:
     AGNO_AVAILABLE = True
 except ImportError:
     AGNO_AVAILABLE = False
-else:
-    try:  # agno < 3: the per-message usage dataclass lived at agno.models.metrics
-        from agno.models.metrics import Metrics
-    except ImportError:  # agno >= 3 moved it to agno.metrics, renamed MessageMetrics
-        from agno.metrics import MessageMetrics as Metrics
 
 from headroom import HeadroomConfig, HeadroomMode
 

--- a/tests/test_issue_746_tool_search.py
+++ b/tests/test_issue_746_tool_search.py
@@ -19,6 +19,7 @@ from headroom.cli.wrap import (
     _normalize_tool_search_mode,
 )
 from headroom.proxy.helpers import (
+    claude_code_tool_search_active,
     claude_code_tool_search_inactive,
     format_tool_search_disabled_hint,
     reset_tool_search_hint_state,
@@ -141,6 +142,30 @@ def test_inactive_false_when_no_tools() -> None:
     assert not claude_code_tool_search_inactive(
         client="claude-code", tools=None, anthropic_beta=None
     )
+
+
+def test_active_requires_explicit_tool_search_protocol_marker() -> None:
+    assert claude_code_tool_search_active(
+        client="claude-code",
+        tools=[*_TOOLS, {"type": "tool_search_tool_regex_20251119"}],
+        anthropic_beta=None,
+    )
+    assert claude_code_tool_search_active(
+        client="claude-code",
+        tools=_TOOLS,
+        anthropic_beta="advanced-tool-use-2025-11-20",
+    )
+    assert not claude_code_tool_search_active(
+        client="claude-code",
+        tools=[{"name": "WaitForMcpServers"}],
+        anthropic_beta=None,
+    )
+
+
+def test_active_marker_boundary_value_zero_does_not_use_tool_name() -> None:
+    tools = [{"name": "WaitForMcpServers"}]
+    assert not claude_code_tool_search_active(client="claude-code", tools=tools, anthropic_beta="")
+    assert claude_code_tool_search_inactive(client="claude-code", tools=tools, anthropic_beta="")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proxy/test_anthropic_token_mode_tool_search.py
+++ b/tests/test_proxy/test_anthropic_token_mode_tool_search.py
@@ -19,7 +19,6 @@ def _tools() -> list[dict[str, Any]]:
         {
             "type": "tool_search_tool_regex_20251119",
             "name": "tool_search_tool_regex",
-            "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
         },
         {
             "name": "WaitForMcpServers",
@@ -54,20 +53,18 @@ def _messages(result: str | None = None) -> list[dict[str, Any]]:
             "type": "server_tool_use",
             "id": "search_1",
             "name": "tool_search_tool_regex",
-            "input": {"query": "Azure DevOps"},
+            "input": {"pattern": "Azure DevOps", "limit": 5},
         },
         {
             "type": "tool_search_tool_result",
             "tool_use_id": "search_1",
-            "content": [
-                {
-                    "type": "tool_search_tool_search_result",
-                    "tool_references": [
-                        {"type": "tool_reference", "tool_name": "WaitForMcpServers"},
-                        {"type": "tool_reference", "tool_name": "work_items"},
-                    ],
-                }
-            ],
+            "content": {
+                "type": "tool_search_tool_search_result",
+                "tool_references": [
+                    {"type": "tool_reference", "tool_name": "WaitForMcpServers"},
+                    {"type": "tool_reference", "tool_name": "work_items"},
+                ],
+            },
         },
         {
             "type": "tool_use",
@@ -442,7 +439,7 @@ def test_active_route_description_compaction_leaves_tools_unchanged(
     import headroom.proxy.tool_schema_compaction as compaction
 
     monkeypatch.setenv("HEADROOM_TOOL_DESC_MAX_CHARS", "20")
-    compaction._TOOL_DESC_MAX_CHARS = None
+    monkeypatch.setattr(compaction, "_TOOL_DESC_MAX_CHARS", None)
     inbound = _body(result=_workitems())
     inbound["tools"][1]["description"] = (
         "This description is deliberately much longer than twenty characters."

--- a/tests/test_proxy/test_anthropic_token_mode_tool_search.py
+++ b/tests/test_proxy/test_anthropic_token_mode_tool_search.py
@@ -218,12 +218,27 @@ def test_replacement_attempts_cannot_replace_active_tools() -> None:
 
 def test_active_route_injection_cannot_add_proxy_tools(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HEADROOM_TOOL_SEARCH", "true")
-    inbound = _body(result=_workitems())
-    with _client(
-        ccr_inject_tool=True,
-        ccr_inject_system_instructions=True,
-    ) as client:
-        outbound, _ = _capture(client, inbound)
+    marker_hash = "abc123def456abc123def456"
+    reset_compression_store()
+    get_compression_store().store(
+        original="expanded tool result",
+        compressed="[100 items compressed to 10]",
+        explicit_hash=marker_hash,
+    )
+    try:
+        inbound = _body(result=f"[100 items compressed to 10. Retrieve more: hash={marker_hash}]")
+        with _client(
+            ccr_inject_tool=True,
+            ccr_inject_system_instructions=True,
+        ) as client:
+            outbound, _ = _capture(client, inbound)
+    finally:
+        reset_compression_store()
+
+    serialized = json.dumps(outbound)
+    assert "headroom_retrieve" not in serialized
+    assert "expanded tool result" in serialized
+    assert "Retrieve more: hash=" not in serialized
     assert outbound["tools"] == inbound["tools"]
 
 

--- a/tests/test_proxy/test_anthropic_token_mode_tool_search.py
+++ b/tests/test_proxy/test_anthropic_token_mode_tool_search.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from headroom.cache.compression_store import get_compression_store, reset_compression_store
+from headroom.ccr.marker_resolution import resolve_markers_in_text
+from headroom.pipeline import PipelineStage
+from headroom.proxy.server import ProxyConfig, create_app
+from headroom.proxy.turn_hooks import TurnContext, clear_turn_hooks, register_turn_hook
+
+
+def _tools() -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "tool_search_tool_regex_20251119",
+            "name": "tool_search_tool_regex",
+            "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+        },
+        {
+            "name": "WaitForMcpServers",
+            "description": "Wait for MCP servers to become ready.",
+            "input_schema": {"type": "object", "properties": {"server": {"type": "string"}}},
+        },
+        {
+            "name": "work_items",
+            "description": "Read work items from Azure DevOps.",
+            "input_schema": {"type": "object", "properties": {"project": {"type": "string"}}},
+        },
+    ]
+
+
+def _workitems() -> str:
+    return json.dumps(
+        [
+            {
+                "id": index,
+                "rev": 1,
+                "fields": {"System.Title": f"work item {index}", "System.State": "New"},
+                "url": f"https://dev.azure.com/example/_apis/wit/workItems/{index}",
+            }
+            for index in range(150)
+        ]
+    )
+
+
+def _messages(result: str | None = None) -> list[dict[str, Any]]:
+    content: list[dict[str, Any]] = [
+        {
+            "type": "server_tool_use",
+            "id": "search_1",
+            "name": "tool_search_tool_regex",
+            "input": {"query": "Azure DevOps"},
+        },
+        {
+            "type": "tool_search_tool_result",
+            "tool_use_id": "search_1",
+            "content": [
+                {
+                    "type": "tool_search_tool_search_result",
+                    "tool_references": [
+                        {"type": "tool_reference", "tool_name": "WaitForMcpServers"},
+                        {"type": "tool_reference", "tool_name": "work_items"},
+                    ],
+                }
+            ],
+        },
+        {
+            "type": "tool_use",
+            "id": "work-1",
+            "name": "work_items",
+            "input": {"project": "example"},
+        },
+    ]
+    messages: list[dict[str, Any]] = [{"role": "assistant", "content": content}]
+    if result is not None:
+        messages.append(
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "work-1", "content": result}],
+            }
+        )
+    return messages
+
+
+def _body(
+    *, result: str | None = None, tools: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    return {
+        "model": "claude-sonnet-4-6",
+        "max_tokens": 64,
+        "messages": _messages(result),
+        "tools": copy.deepcopy(_tools() if tools is None else tools),
+    }
+
+
+def _response() -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "id": "msg_tool_search",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "ok"}],
+            "usage": {"input_tokens": 10, "output_tokens": 3},
+        },
+    )
+
+
+def _client(
+    *,
+    optimize: bool = True,
+    mode: str = "token",
+    ccr_inject_tool: bool = False,
+    ccr_inject_system_instructions: bool = False,
+) -> TestClient:
+    return TestClient(
+        create_app(
+            ProxyConfig(
+                optimize=optimize,
+                mode=mode,
+                cache_enabled=False,
+                rate_limit_enabled=False,
+                cost_tracking_enabled=False,
+                log_requests=False,
+                ccr_inject_tool=ccr_inject_tool,
+                ccr_inject_system_instructions=ccr_inject_system_instructions,
+                ccr_handle_responses=False,
+                ccr_context_tracking=False,
+                image_optimize=False,
+                pipeline_extensions=[],
+                discover_pipeline_extensions=False,
+            )
+        )
+    )
+
+
+def _capture(
+    client: TestClient, body: dict[str, Any], **headers: str
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    captured: dict[str, Any] = {}
+
+    async def fake_retry(
+        method: str,
+        url: str,
+        request_headers: dict[str, str],
+        request_body: dict[str, Any],
+        **kwargs: Any,
+    ) -> httpx.Response:
+        captured["body"] = copy.deepcopy(request_body)
+        captured["kwargs"] = kwargs
+        return _response()
+
+    client.app.state.proxy._retry_request = fake_retry
+    request_headers = {
+        "x-api-key": "test-key",
+        "anthropic-version": "2023-06-01",
+        "x-client": "claude-code",
+        **headers,
+    }
+    response = client.post("/v1/messages", headers=request_headers, json=body)
+    assert response.status_code == 200, response.text
+    return captured["body"], captured.get("kwargs", {})
+
+
+@pytest.fixture(autouse=True)
+def _clean_turn_hooks() -> None:
+    clear_turn_hooks()
+    yield
+    clear_turn_hooks()
+
+
+class _ReplacementExtension:
+    def on_pipeline_event(self, event: Any) -> Any:
+        if event.stage in {
+            PipelineStage.INPUT_RECEIVED,
+            PipelineStage.INPUT_REMEMBERED,
+            PipelineStage.PRE_SEND,
+        }:
+            event.tools = [{"name": "replacement", "input_schema": {"type": "object"}}]
+        return event
+
+
+def test_route_contract_preserves_tools_and_nested_history_while_compressing() -> None:
+    inbound = _body(result=_workitems())
+    with _client() as client:
+        outbound, _ = _capture(client, inbound)
+
+    assert outbound["tools"] == inbound["tools"]
+    assert outbound["messages"][0]["content"] == inbound["messages"][0]["content"]
+    result = outbound["messages"][1]["content"][0]["content"]
+    assert isinstance(result, str)
+    assert len(result) < len(_workitems())
+
+
+def test_string_tool_result_is_compressed() -> None:
+    inbound = _body(result=_workitems())
+    with _client() as client:
+        outbound, _ = _capture(client, inbound)
+    assert len(outbound["messages"][1]["content"][0]["content"]) < len(_workitems())
+
+
+def test_replacement_attempts_cannot_replace_active_tools() -> None:
+    class Hook:
+        name = "replace-tools"
+
+        def on_request(self, ctx: TurnContext) -> None:
+            ctx.tools = [{"name": "hook-replacement"}]
+
+    register_turn_hook(Hook())
+    inbound = _body(result=_workitems())
+    with _client() as client:
+        client.app.state.proxy.pipeline_extensions._extensions = [_ReplacementExtension()]
+        outbound, _ = _capture(client, inbound)
+    assert outbound["tools"] == inbound["tools"]
+
+
+def test_active_route_injection_cannot_add_proxy_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEADROOM_TOOL_SEARCH", "true")
+    inbound = _body(result=_workitems())
+    with _client() as client:
+        outbound, _ = _capture(client, inbound)
+    assert outbound["tools"] == inbound["tools"]
+
+
+def test_active_route_with_memory_enabled_keeps_memory_state_initialized() -> None:
+    class MemoryConfig:
+        inject_context = False
+        inject_tools = True
+        project_root_override = ""
+
+    class MemoryHandler:
+        config = MemoryConfig()
+        initialized = False
+        backend = None
+
+        def has_memory_tool_calls(self, response: dict[str, Any], provider: str) -> bool:
+            return False
+
+    inbound = _body(result=_workitems())
+    with _client() as client:
+        client.app.state.proxy.memory_handler = MemoryHandler()
+        outbound, _ = _capture(client, inbound, **{"x-headroom-user-id": "test-user"})
+    assert outbound["tools"] == inbound["tools"]
+
+
+@pytest.mark.parametrize(
+    "marker_template",
+    [
+        "<<ccr:{hash}>>",
+        "[100 items compressed to 10. Retrieve more: hash={hash}]",
+        "[Read content stale. Retrieve original: hash={hash}]",
+    ],
+)
+def test_direct_marker_resolver_supports_all_ccr_forms(marker_template: str) -> None:
+    marker_hash = "abc123def456abc123def456"
+    reset_compression_store()
+    get_compression_store().store(
+        original="expanded tool result",
+        compressed="[100 items compressed to 10]",
+        explicit_hash=marker_hash,
+    )
+    try:
+        resolved = resolve_markers_in_text(marker_template.format(hash=marker_hash))
+        assert resolved == "expanded tool result"
+    finally:
+        reset_compression_store()
+
+
+@pytest.mark.parametrize(
+    "marker_template",
+    [
+        "<<ccr:{hash}>>",
+        "[100 items compressed to 10. Retrieve more: hash={hash}]",
+        "[Read content stale. Retrieve original: hash={hash}]",
+    ],
+)
+def test_active_route_resolves_ccr_marker_without_adding_retrieve_tool(
+    marker_template: str,
+) -> None:
+    marker_hash = "abc123def456abc123def456"
+    reset_compression_store()
+    get_compression_store().store(
+        original="expanded tool result",
+        compressed="[100 items compressed to 10]",
+        explicit_hash=marker_hash,
+    )
+    try:
+        inbound = _body(result=marker_template.format(hash=marker_hash))
+        with _client(
+            ccr_inject_tool=False,
+            ccr_inject_system_instructions=False,
+        ) as client:
+            outbound, _ = _capture(client, inbound)
+        assert outbound["tools"] == inbound["tools"]
+        result = outbound["messages"][1]["content"][0]["content"]
+        assert "Retrieve more: hash=" not in result
+        assert "Retrieve original: hash=" not in result
+        assert result == "expanded tool result"
+    finally:
+        reset_compression_store()
+
+
+def test_provider_history_is_unchanged() -> None:
+    inbound = _body(result=_workitems())
+    with _client() as client:
+        outbound, _ = _capture(client, inbound)
+    assert outbound["messages"][0] == inbound["messages"][0]
+
+
+def test_text_list_tool_result_remains_compressible_and_list_shaped() -> None:
+    inbound = _body(result=None)
+    inbound["messages"].append(
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "work-1",
+                    "content": [{"type": "text", "text": _workitems()}],
+                }
+            ],
+        }
+    )
+    with _client() as client:
+        outbound, _ = _capture(client, inbound)
+    content = outbound["messages"][1]["content"][0]["content"]
+    assert isinstance(content, list)
+    assert all(block.get("type") == "text" for block in content)
+    assert len("".join(block["text"] for block in content)) < len(_workitems())
+
+
+def test_continuation_tools_use_locked_snapshot() -> None:
+    inbound = _body(result=_workitems())
+    continuation_capture: dict[str, Any] = {}
+
+    class FakeCcr:
+        def has_ccr_tool_calls(self, response: dict[str, Any], provider: str) -> bool:
+            return True
+
+        async def handle_response(
+            self,
+            response: dict[str, Any],
+            messages: list[dict[str, Any]],
+            tools: Any,
+            api_call_fn: Any,
+            provider: str,
+        ) -> dict[str, Any]:
+            await api_call_fn(messages, [{"name": "replacement"}])
+            return response
+
+        def residual_ccr_status(self, response: dict[str, Any], provider: str) -> None:
+            return None
+
+    class FakeHttpClient:
+        async def post(
+            self, url: str, *, content: bytes, headers: dict[str, str], timeout: Any
+        ) -> httpx.Response:
+            continuation_capture["body"] = json.loads(content)
+            return _response()
+
+        async def aclose(self) -> None:
+            return None
+
+    with _client() as client:
+        proxy = client.app.state.proxy
+        proxy.ccr_response_handler = FakeCcr()
+        proxy.http_client = FakeHttpClient()
+        outbound, _ = _capture(client, inbound)
+    assert outbound["tools"] == inbound["tools"]
+    assert continuation_capture["body"]["tools"] == inbound["tools"]
+
+
+def test_cache_mode_route_capture_keeps_active_token_lock_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HEADROOM_TOOL_SEARCH", "false")
+    inbound = _body(result=_workitems())
+    with _client(mode="cache") as client:
+        client.app.state.proxy.pipeline_extensions._extensions = [_ReplacementExtension()]
+        outbound, _ = _capture(client, inbound)
+    assert outbound["tools"] != inbound["tools"]
+    assert outbound["tools"][0]["name"] == "replacement"
+
+
+def test_custom_anthropic_upstream_strips_tool_search_without_lock_restore() -> None:
+    inbound = _body(result=_workitems())
+    with _client() as client:
+        outbound, _ = _capture(
+            client,
+            inbound,
+            **{"x-headroom-base-url": "https://api.deepseek.com/anthropic"},
+        )
+    assert all(
+        not str(tool.get("type", "")).startswith("tool_search_tool_") for tool in outbound["tools"]
+    )
+
+
+def test_active_route_keeps_tools_exact_when_ttl_repair_would_rewrite_tools() -> None:
+    inbound = _body(result=_workitems())
+    inbound["tools"][0]["cache_control"] = {"type": "ephemeral"}
+    inbound["messages"].append(
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "later",
+                    "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                }
+            ],
+        }
+    )
+    with _client() as client:
+        outbound, _ = _capture(client, inbound)
+    assert outbound["tools"] == inbound["tools"]
+
+
+def test_bypass_bytes_preserve_original_body() -> None:
+    raw = '{ "tools": [], "messages": [], "model": "claude-sonnet-4-6", "max_tokens": 1 }'
+    captured: dict[str, Any] = {}
+
+    async def fake_retry(
+        method: str, url: str, request_headers: dict[str, str], body: dict[str, Any], **kwargs: Any
+    ) -> httpx.Response:
+        captured.update(kwargs)
+        return _response()
+
+    with _client() as client:
+        client.app.state.proxy._retry_request = fake_retry
+        response = client.post(
+            "/v1/messages",
+            content=raw.encode(),
+            headers={
+                "x-api-key": "test-key",
+                "x-client": "claude-code",
+                "x-headroom-bypass": "true",
+                "content-type": "application/json",
+            },
+        )
+        assert response.status_code == 200, response.text
+    assert captured["original_body_bytes"] == raw.encode()

--- a/tests/test_proxy/test_anthropic_token_mode_tool_search.py
+++ b/tests/test_proxy/test_anthropic_token_mode_tool_search.py
@@ -9,7 +9,6 @@ import pytest
 from fastapi.testclient import TestClient
 
 from headroom.cache.compression_store import get_compression_store, reset_compression_store
-from headroom.ccr.marker_resolution import resolve_markers_in_text
 from headroom.pipeline import PipelineStage
 from headroom.proxy.server import ProxyConfig, create_app
 from headroom.proxy.turn_hooks import TurnContext, clear_turn_hooks, register_turn_hook
@@ -223,7 +222,10 @@ def test_replacement_attempts_cannot_replace_active_tools() -> None:
 def test_active_route_injection_cannot_add_proxy_tools(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HEADROOM_TOOL_SEARCH", "true")
     inbound = _body(result=_workitems())
-    with _client() as client:
+    with _client(
+        ccr_inject_tool=True,
+        ccr_inject_system_instructions=True,
+    ) as client:
         outbound, _ = _capture(client, inbound)
     assert outbound["tools"] == inbound["tools"]
 
@@ -242,6 +244,9 @@ def test_active_route_with_memory_enabled_keeps_memory_state_initialized() -> No
         def has_memory_tool_calls(self, response: dict[str, Any], provider: str) -> bool:
             return False
 
+        def compute_memory_tool_definitions(self, provider: str) -> list[dict[str, Any]]:
+            return [{"name": "memory_search", "input_schema": {"type": "object"}}]
+
     inbound = _body(result=_workitems())
     with _client() as client:
         client.app.state.proxy.memory_handler = MemoryHandler()
@@ -249,27 +254,20 @@ def test_active_route_with_memory_enabled_keeps_memory_state_initialized() -> No
     assert outbound["tools"] == inbound["tools"]
 
 
-@pytest.mark.parametrize(
-    "marker_template",
-    [
-        "<<ccr:{hash}>>",
-        "[100 items compressed to 10. Retrieve more: hash={hash}]",
-        "[Read content stale. Retrieve original: hash={hash}]",
-    ],
-)
-def test_direct_marker_resolver_supports_all_ccr_forms(marker_template: str) -> None:
-    marker_hash = "abc123def456abc123def456"
-    reset_compression_store()
-    get_compression_store().store(
-        original="expanded tool result",
-        compressed="[100 items compressed to 10]",
-        explicit_hash=marker_hash,
-    )
-    try:
-        resolved = resolve_markers_in_text(marker_template.format(hash=marker_hash))
-        assert resolved == "expanded tool result"
-    finally:
-        reset_compression_store()
+def test_active_route_beta_marker_locks_tools_without_tool_search_definition() -> None:
+    inbound = _body(result=_workitems())
+    inbound["tools"][0] = {
+        "name": "ordinary_tool",
+        "description": "A provider-owned tool.",
+        "input_schema": {"type": "object", "properties": {"value": {"type": "string"}}},
+    }
+    with _client() as client:
+        outbound, _ = _capture(
+            client,
+            inbound,
+            **{"anthropic-beta": "advanced-tool-use-2025-11-20"},
+        )
+    assert outbound["tools"] == inbound["tools"]
 
 
 @pytest.mark.parametrize(
@@ -374,6 +372,84 @@ def test_continuation_tools_use_locked_snapshot() -> None:
         outbound, _ = _capture(client, inbound)
     assert outbound["tools"] == inbound["tools"]
     assert continuation_capture["body"]["tools"] == inbound["tools"]
+
+
+def test_memory_continuation_uses_locked_snapshot() -> None:
+    inbound = _body(result=_workitems())
+
+    class MemoryConfig:
+        inject_context = False
+        inject_tools = True
+        project_root_override = ""
+
+    class FakeMemory:
+        config = MemoryConfig()
+        initialized = True
+        backend = object()
+
+        def has_memory_tool_calls(self, response: dict[str, Any], provider: str) -> bool:
+            return True
+
+        async def handle_memory_tool_calls(
+            self,
+            response: dict[str, Any],
+            user_id: str,
+            provider: str,
+            *,
+            request_context: Any,
+        ) -> list[dict[str, Any]]:
+            return [{"type": "tool_result", "content": "memory result"}]
+
+        def compute_memory_tool_definitions(self, provider: str) -> list[dict[str, Any]]:
+            return [{"name": "memory_search", "input_schema": {"type": "object"}}]
+
+    with _client() as client:
+        client.app.state.proxy.memory_handler = FakeMemory()
+        outbound, _ = _capture(client, inbound, **{"x-headroom-user-id": "test-user"})
+
+    assert outbound["tools"] == inbound["tools"]
+    assert outbound["messages"][-1]["content"] == [
+        {"type": "tool_result", "content": "memory result"}
+    ]
+
+
+def test_response_hook_continuation_uses_locked_snapshot() -> None:
+    inbound = _body(result=_workitems())
+
+    class ResponseHook:
+        name = "response-reload"
+
+        async def on_response(
+            self,
+            ctx: TurnContext,
+            response: dict[str, Any],
+            call_model: Any,
+        ) -> dict[str, Any]:
+            ctx.tools = [{"name": "response-hook-replacement"}]
+            return await call_model([{"role": "user", "content": "reload"}])
+
+    register_turn_hook(ResponseHook())
+    with _client() as client:
+        outbound, _ = _capture(client, inbound)
+
+    assert outbound["tools"] == inbound["tools"]
+    assert outbound["messages"] == [{"role": "user", "content": "reload"}]
+
+
+def test_active_route_description_compaction_leaves_tools_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import headroom.proxy.tool_schema_compaction as compaction
+
+    monkeypatch.setenv("HEADROOM_TOOL_DESC_MAX_CHARS", "20")
+    compaction._TOOL_DESC_MAX_CHARS = None
+    inbound = _body(result=_workitems())
+    inbound["tools"][1]["description"] = (
+        "This description is deliberately much longer than twenty characters."
+    )
+    with _client() as client:
+        outbound, _ = _capture(client, inbound)
+    assert outbound["tools"] == inbound["tools"]
 
 
 def test_cache_mode_route_capture_keeps_active_token_lock_off(

--- a/tests/test_proxy/test_anthropic_token_mode_tool_search.py
+++ b/tests/test_proxy/test_anthropic_token_mode_tool_search.py
@@ -379,6 +379,25 @@ def test_non_list_message_replacement_keeps_replacement_and_provider_history() -
     assert outbound["messages"][-1] == {"role": "user", "content": "replacement"}
 
 
+def test_list_message_replacement_preserves_provider_message_role() -> None:
+    class Extension:
+        def on_pipeline_event(self, event: Any) -> Any:
+            if event.stage == PipelineStage.INPUT_RECEIVED:
+                event.messages = [
+                    {"role": "user", "content": copy.deepcopy(event.messages[0]["content"])}
+                ]
+            return event
+
+    inbound = _body(result=_workitems())
+    with _client() as client:
+        client.app.state.proxy.pipeline_extensions._extensions = [Extension()]
+        outbound, _ = _capture(client, inbound)
+
+    assert outbound["messages"][0]["role"] == "assistant"
+    assert outbound["messages"][0]["content"] == inbound["messages"][0]["content"][:2]
+    assert outbound["messages"][-1]["role"] == "user"
+
+
 def test_text_list_tool_result_remains_compressible_and_list_shaped() -> None:
     inbound = _body(result=None)
     inbound["messages"].append(
@@ -420,6 +439,24 @@ def test_continuation_tools_use_locked_snapshot() -> None:
             mutated = copy.deepcopy(messages)
             mutated[0]["content"][0]["input"]["pattern"] = "ccr-mutated"
             mutated[0]["content"][1]["content"]["tool_references"][0]["tool_name"] = "ccr-mutated"
+            fresh_history = [
+                {
+                    "type": "server_tool_use",
+                    "id": "fresh-search",
+                    "name": "tool_search_tool_regex",
+                    "input": {"pattern": "fresh"},
+                },
+                {
+                    "type": "tool_search_tool_result",
+                    "tool_use_id": "fresh-search",
+                    "content": {
+                        "type": "tool_search_tool_search_result",
+                        "tool_references": [{"type": "tool_reference", "tool_name": "work_items"}],
+                    },
+                },
+            ]
+            continuation_capture["fresh_history"] = fresh_history
+            mutated.append({"role": "assistant", "content": fresh_history})
             await api_call_fn(mutated, [{"name": "replacement"}])
             return response
 
@@ -445,6 +482,10 @@ def test_continuation_tools_use_locked_snapshot() -> None:
     assert outbound["messages"][0] == inbound["messages"][0]
     assert continuation_capture["body"]["tools"] == inbound["tools"]
     assert continuation_capture["body"]["messages"][0] == inbound["messages"][0]
+    assert (
+        continuation_capture["body"]["messages"][-1]["content"]
+        == continuation_capture["fresh_history"]
+    )
 
 
 def test_continuation_reapplies_unsupported_history_repair() -> None:

--- a/tests/test_proxy/test_anthropic_token_mode_tool_search.py
+++ b/tests/test_proxy/test_anthropic_token_mode_tool_search.py
@@ -182,6 +182,28 @@ class _ReplacementExtension:
         return event
 
 
+class _ProviderHistoryMutationExtension:
+    def __init__(self) -> None:
+        self.stages: list[PipelineStage] = []
+
+    def on_pipeline_event(self, event: Any) -> Any:
+        if event.messages is not None:
+            self.stages.append(event.stage)
+            replaced = copy.deepcopy(event.messages)
+            provider_blocks = [
+                block
+                for message in replaced
+                for block in message.get("content", [])
+                if block.get("type") in {"server_tool_use", "tool_search_tool_result"}
+            ]
+            provider_blocks[0]["id"] = "mutated-id"
+            provider_blocks[0]["input"]["pattern"] = "mutated"
+            provider_blocks[1]["tool_use_id"] = "mutated-tool-use-id"
+            provider_blocks[1]["content"]["tool_references"][0]["tool_name"] = "mutated"
+            event.messages = replaced
+        return event
+
+
 def test_route_contract_preserves_tools_and_nested_history_while_compressing() -> None:
     inbound = _body(result=_workitems())
     with _client() as client:
@@ -207,6 +229,10 @@ def test_replacement_attempts_cannot_replace_active_tools() -> None:
 
         def on_request(self, ctx: TurnContext) -> None:
             ctx.tools = [{"name": "hook-replacement"}]
+            ctx.messages[0]["content"][0]["input"]["pattern"] = "hook-mutated"
+            ctx.messages[0]["content"][1]["content"]["tool_references"][0]["tool_name"] = (
+                "hook-mutated"
+            )
 
     register_turn_hook(Hook())
     inbound = _body(result=_workitems())
@@ -214,6 +240,7 @@ def test_replacement_attempts_cannot_replace_active_tools() -> None:
         client.app.state.proxy.pipeline_extensions._extensions = [_ReplacementExtension()]
         outbound, _ = _capture(client, inbound)
     assert outbound["tools"] == inbound["tools"]
+    assert outbound["messages"][0] == inbound["messages"][0]
 
 
 def test_active_route_injection_cannot_add_proxy_tools(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -323,6 +350,35 @@ def test_provider_history_is_unchanged() -> None:
     assert outbound["messages"][0] == inbound["messages"][0]
 
 
+def test_pipeline_history_mutations_restore_nested_provider_blocks() -> None:
+    inbound = _body(result=_workitems())
+    extension = _ProviderHistoryMutationExtension()
+    with _client() as client:
+        client.app.state.proxy.pipeline_extensions._extensions = [extension]
+        outbound, _ = _capture(client, inbound)
+
+    assert outbound["messages"][0]["content"] == inbound["messages"][0]["content"]
+    assert PipelineStage.INPUT_COMPRESSED in extension.stages
+    if PipelineStage.INPUT_ROUTED in extension.stages:
+        assert extension.stages.count(PipelineStage.INPUT_ROUTED) == 1
+
+
+def test_non_list_message_replacement_keeps_replacement_and_provider_history() -> None:
+    class Extension:
+        def on_pipeline_event(self, event: Any) -> Any:
+            if event.stage == PipelineStage.INPUT_RECEIVED:
+                event.messages = [{"role": "user", "content": "replacement"}]
+            return event
+
+    inbound = _body(result=_workitems())
+    with _client() as client:
+        client.app.state.proxy.pipeline_extensions._extensions = [Extension()]
+        outbound, _ = _capture(client, inbound)
+
+    assert outbound["messages"][0]["content"] == inbound["messages"][0]["content"][:2]
+    assert outbound["messages"][-1] == {"role": "user", "content": "replacement"}
+
+
 def test_text_list_tool_result_remains_compressible_and_list_shaped() -> None:
     inbound = _body(result=None)
     inbound["messages"].append(
@@ -361,7 +417,10 @@ def test_continuation_tools_use_locked_snapshot() -> None:
             api_call_fn: Any,
             provider: str,
         ) -> dict[str, Any]:
-            await api_call_fn(messages, [{"name": "replacement"}])
+            mutated = copy.deepcopy(messages)
+            mutated[0]["content"][0]["input"]["pattern"] = "ccr-mutated"
+            mutated[0]["content"][1]["content"]["tool_references"][0]["tool_name"] = "ccr-mutated"
+            await api_call_fn(mutated, [{"name": "replacement"}])
             return response
 
         def residual_ccr_status(self, response: dict[str, Any], provider: str) -> None:
@@ -383,7 +442,53 @@ def test_continuation_tools_use_locked_snapshot() -> None:
         proxy.http_client = FakeHttpClient()
         outbound, _ = _capture(client, inbound)
     assert outbound["tools"] == inbound["tools"]
+    assert outbound["messages"][0] == inbound["messages"][0]
     assert continuation_capture["body"]["tools"] == inbound["tools"]
+    assert continuation_capture["body"]["messages"][0] == inbound["messages"][0]
+
+
+def test_continuation_reapplies_unsupported_history_repair() -> None:
+    inbound = _body(result=_workitems())
+    inbound["tools"] = [
+        tool for tool in inbound["tools"] if tool.get("name") != "WaitForMcpServers"
+    ]
+    continuation_capture: dict[str, Any] = {}
+
+    class FakeCcr:
+        def has_ccr_tool_calls(self, response: dict[str, Any], provider: str) -> bool:
+            return True
+
+        async def handle_response(
+            self,
+            response: dict[str, Any],
+            messages: list[dict[str, Any]],
+            tools: Any,
+            api_call_fn: Any,
+            provider: str,
+        ) -> dict[str, Any]:
+            await api_call_fn(copy.deepcopy(messages), None)
+            return response
+
+        def residual_ccr_status(self, response: dict[str, Any], provider: str) -> None:
+            return None
+
+    class FakeHttpClient:
+        async def post(
+            self, url: str, *, content: bytes, headers: dict[str, str], timeout: Any
+        ) -> httpx.Response:
+            continuation_capture["body"] = json.loads(content)
+            return _response()
+
+        async def aclose(self) -> None:
+            return None
+
+    with _client() as client:
+        proxy = client.app.state.proxy
+        proxy.ccr_response_handler = FakeCcr()
+        proxy.http_client = FakeHttpClient()
+        _capture(client, inbound)
+
+    assert "WaitForMcpServers" not in json.dumps(continuation_capture["body"]["messages"])
 
 
 def test_memory_continuation_uses_locked_snapshot() -> None:
@@ -438,14 +543,21 @@ def test_response_hook_continuation_uses_locked_snapshot() -> None:
             call_model: Any,
         ) -> dict[str, Any]:
             ctx.tools = [{"name": "response-hook-replacement"}]
-            return await call_model([{"role": "user", "content": "reload"}])
+            replacement = copy.deepcopy(ctx.messages)
+            replacement[0]["content"][0]["input"]["pattern"] = "hook-mutated"
+            replacement[0]["content"][1]["content"]["tool_references"][0]["tool_name"] = (
+                "hook-mutated"
+            )
+            replacement.append({"role": "user", "content": "reload"})
+            return await call_model(replacement)
 
     register_turn_hook(ResponseHook())
     with _client() as client:
         outbound, _ = _capture(client, inbound)
 
     assert outbound["tools"] == inbound["tools"]
-    assert outbound["messages"] == [{"role": "user", "content": "reload"}]
+    assert outbound["messages"][0] == inbound["messages"][0]
+    assert outbound["messages"][-1] == {"role": "user", "content": "reload"}
 
 
 def test_active_route_description_compaction_leaves_tools_unchanged(


### PR DESCRIPTION
## Description

Standalone Claude Code sessions routed through `headroom proxy --mode token` can violate Anthropic's Tool Search request contract. Issue #2584 reports `400 Tool reference 'WaitForMcpServers' not found in available tools` without active deferral, then a non-completing turn with `ENABLE_TOOL_SEARCH=true`, including with the issue 1171 mitigation variables.

The direct Anthropic handler currently has several independent paths that can sort, compact, inject, or replace the inbound `tools` array and message history. Anthropic's Tool Search contract requires the complete array on every request and unchanged `server_tool_use` plus nested `tool_search_tool_result` history. The exact live mutation behind the reporter's 400 and hang remains unresolved because the issue contains no wire capture.

This fix scopes ownership to the standalone direct-Anthropic token-mode route. When Claude Code sends an explicit Tool Search marker, Headroom keeps the inbound `tools` array and provider-owned history unchanged through the initial request and continuations, including pipeline and turn-hook message seams. Ordinary string and text-list `tool_result` content remains eligible for the existing ContentRouter compression path. Cache mode, bypass, wrap and init behavior, cloud backends, plain API `HEADROOM_TOOL_SEARCH`, and issue 1171 controls retain their current behavior.

Closes #2584

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Treat the active standalone Claude Code token-mode request's inbound `tools` value as an opaque provider contract.
- Skip tool ordering, schema and description compaction, proxy-owned tool injection, and provider-owned message replacement at the active route's pipeline and turn-hook seams.
- Snapshot and restore `server_tool_use` and nested `tool_search_tool_result` blocks, including their roles and payloads, across request stages and CCR, memory, and response-hook continuations; retain fresh provider blocks produced by an upstream response.
- Reapply the existing unsupported Tool Search history repair to every active continuation before forwarding it.
- Preserve CCR marker scanning, workspace resolution, and tracking while suppressing proxy-owned system instructions on the active route; resolve active-route markers inline when the locked client tools cannot add `headroom_retrieve`.
- Run the active CCR marker-safety scan whenever the route owns the Claude Tool Search tools contract, including with both CCR tool and system-instruction injection flags false; keep proxy-owned tool and instruction mutations separately gated.
- Extend the existing `headroom/ccr/marker_resolution.py` CompressionStore resolver for bracketed `Retrieve more: hash=...` and `Retrieve original: hash=...` markers, retaining `<<ccr:...>>` behavior.
- Keep active classification first-party-only, preserve third-party Tool Search stripping, and prevent cache-control TTL repair from rewriting locked client tools.
- Keep ordinary string and all-text-list `tool_result.content` compression on the existing ContentRouter path while preserving the official nested Tool Search history.
- Replace name-based recovery tests with route-level outbound capture, actual compression evidence, continuation coverage, and a byte-faithful bypass control.
- Remove the obsolete module-level Agno compatibility imports; version-specific response usage construction remains localized in the helper and the repository lint gate stays clean.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality when applicable
- [x] Manual testing performed

### Test Output

```text
uv run --frozen pytest tests/test_proxy/test_anthropic_token_mode_tool_search.py tests/test_ccr_marker_resolution.py tests/test_issue_746_tool_search.py tests/test_providers/test_deepseek.py -q: 116 passed, 1 warning
uv run --frozen ruff check .: All checks passed!
uv run --frozen ruff format . --check: 1540 files already formatted
uv run --frozen ruff check headroom/proxy/handlers/anthropic.py headroom/proxy/helpers.py headroom/ccr/marker_resolution.py tests/test_proxy/test_anthropic_token_mode_tool_search.py tests/test_ccr_marker_resolution.py tests/test_issue_746_tool_search.py tests/test_integrations/agno/test_model.py: All checks passed!
uv run --frozen ruff format headroom/proxy/handlers/anthropic.py headroom/proxy/helpers.py headroom/ccr/marker_resolution.py tests/test_proxy/test_anthropic_token_mode_tool_search.py tests/test_ccr_marker_resolution.py tests/test_issue_746_tool_search.py tests/test_integrations/agno/test_model.py --check: 7 files already formatted
uv run --frozen mypy headroom/proxy/handlers/anthropic.py headroom/proxy/helpers.py headroom/ccr/marker_resolution.py: Success: no issues found in 3 source files
git diff --check: passed
```

## Real Behavior Proof

- Environment: Windows with Claude Code `2.1.238`, `ENABLE_TOOL_SEARCH=true`, Headroom's token and cache proxy modes, and a generated 150-record workload.
- Exact command / steps: run the standalone prompt through each proxy mode with `--memory --code-aware --log-messages`; inspect the client result and proxy request logs. Both runs used `ENABLE_TOOL_SEARCH=true`.
- Observed result: token mode completed in `9.9s`; cache mode completed in `10.4s`. The client answer was `svc-main appears in 100 vs svc-alt 50`. The workload assigned `svc-main` to ids `0-99` and `svc-alt` to ids `100-149`. Four requests completed in each mode, with no proxy errors. Local route tests cover CCR marker safety without adding `headroom_retrieve`, direct resolution of `<<ccr:...>>`, `Retrieve more`, and `Retrieve original` forms through the existing resolver, custom-upstream stripping, cache-mode capture, and cache-control tools exactness.
- Not tested: Claude Code `2.1.220` and unrelated cloud backends.

## Runtime Rollout Safety

- Rollout-managed feature(s): None; this is a request-shaping fix on the existing standalone Claude Code Tool Search route.
- Minimum rollout channel: Existing token-mode proxy deployments.
- Stable/default behavior changed: Active Claude Code Tool Search requests preserve provider-owned tools and history; other routes retain their current behavior.
- Kill switch / disable path: Route traffic through bypass mode while reverting or disabling the proxy deployment.
- Unsafe override required: No.
- Qualification impact: No migration or client qualification is required; the scoped route is covered by the focused regression suite and live token/cache checks.
- Rollback path: Revert this commit or deploy the previous Headroom version.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`; the release pipeline generates it from the Conventional Commit PR title

## Screenshots (if applicable)

Not applicable; this is a proxy request-shaping fix.

## Additional Notes

- Scope is the standalone direct-Anthropic Claude Code token-mode route. Cache mode, `headroom wrap`, `headroom init`, persistent installs, Bedrock, Vertex, Foundry, gateways, batch requests, and OpenAI routes remain outside this change.
- Plain API clients keep the existing `HEADROOM_TOOL_SEARCH` injection path.
- The issue 1171 variables remain orthogonal. They govern compression deadlines and off-path execution, while this change governs ownership of the inbound tools array.
- The live validation covers Claude Code `2.1.238` with the exact 150-item token and cache workloads. It makes no claim about Claude Code `2.1.220`.
