### PR TITLE
fix(memory/vector): skip a corrupt vec_metadata row instead of aborting the search

### DIFF
--- a/headroom/memory/adapters/sqlite_vector.py
+++ b/headroom/memory/adapters/sqlite_vector.py
@@ -648,6 +648,42 @@ class SQLiteVectorIndex:
                 conn.commit()
                 return len(rowids)
 
+    def _row_to_metadata(self, row: Any) -> VectorMetadata | None:
+        """Build ``VectorMetadata`` from a ``vec_metadata`` row, skipping a bad row.
+
+        A single row with an unparseable ``created_at`` / ``valid_until`` or
+        malformed ``entity_refs`` / ``metadata_json`` JSON (schema drift across an
+        upgrade, a partially written row) otherwise raises mid-loop and aborts
+        the *whole* search, losing every other result. #2947 healed the
+        ``entity_refs`` shape for exactly this reason ("took down whole memory
+        searches rather than the one bad row"), but ``created_at`` and
+        ``metadata_json`` in this loop were left unguarded. Return ``None`` so
+        the caller skips just the offending row.
+        """
+        try:
+            created_at = datetime.fromisoformat(row["created_at"])
+            valid_until = datetime.fromisoformat(row["valid_until"]) if row["valid_until"] else None
+            entity_refs = normalize_entity_refs(json.loads(row["entity_refs"]))
+            metadata = json.loads(row["metadata_json"])
+        except (ValueError, TypeError):
+            logger.warning(
+                "Skipping unreadable vec_metadata row (memory_id=%s)",
+                row["memory_id"],
+            )
+            return None
+        return VectorMetadata(
+            memory_id=row["memory_id"],
+            user_id=row["user_id"],
+            session_id=row["session_id"],
+            agent_id=row["agent_id"],
+            importance=row["importance"],
+            created_at=created_at,
+            valid_until=valid_until,
+            entity_refs=entity_refs,
+            content=row["content"],
+            metadata=metadata,
+        )
+
     async def search(self, filter: VectorFilter) -> list[VectorSearchResult]:
         """Search for similar vectors.
 
@@ -722,23 +758,11 @@ class SQLiteVectorIndex:
                     if similarity < filter.min_similarity:
                         continue
 
-                    # Build metadata for filtering
-                    meta = VectorMetadata(
-                        memory_id=row["memory_id"],
-                        user_id=row["user_id"],
-                        session_id=row["session_id"],
-                        agent_id=row["agent_id"],
-                        importance=row["importance"],
-                        created_at=datetime.fromisoformat(row["created_at"]),
-                        valid_until=(
-                            datetime.fromisoformat(row["valid_until"])
-                            if row["valid_until"]
-                            else None
-                        ),
-                        entity_refs=json.loads(row["entity_refs"]),
-                        content=row["content"],
-                        metadata=json.loads(row["metadata_json"]),
-                    )
+                    # Build metadata for filtering. A single corrupt/legacy row
+                    # is skipped rather than aborting the whole search (#2947).
+                    meta = self._row_to_metadata(row)
+                    if meta is None:
+                        continue
 
                     # Apply filters
                     if not self._passes_filter(meta, filter):

--- a/tests/test_sqlite_vector_index.py
+++ b/tests/test_sqlite_vector_index.py
@@ -78,6 +78,36 @@ class TestSQLiteVectorIndex:
         assert results[0].similarity > 0.99  # Should be ~1.0 for exact match
 
     @pytest.mark.asyncio
+    async def test_search_skips_corrupt_row_instead_of_aborting(self, index):
+        """A single vec_metadata row with an unparseable created_at (or malformed
+        metadata_json) must not abort the whole search. #2947 healed the
+        entity_refs shape for this reason, but created_at/metadata_json in the
+        same loop were unguarded, so one bad row lost every other result."""
+        np.random.seed(1)
+        good = Memory(
+            content="good", user_id="alice", embedding=np.random.randn(384).astype(np.float32)
+        )
+        bad = Memory(
+            content="bad", user_id="alice", embedding=np.random.randn(384).astype(np.float32)
+        )
+        await index.index(good)
+        await index.index(bad)
+
+        # Simulate a schema-drift / partially written row on disk.
+        conn = index._get_conn()
+        conn.execute(
+            "UPDATE vec_metadata SET created_at=? WHERE memory_id=?", ("not-a-date", bad.id)
+        )
+        conn.commit()
+
+        filter = VectorFilter(query_vector=good.embedding, top_k=5, user_id="alice")
+        results = await index.search(filter)  # must not raise
+
+        ids = {r.memory.id for r in results}
+        assert good.id in ids  # the good result survives
+        assert bad.id not in ids  # the corrupt row is skipped, not fatal
+
+    @pytest.mark.asyncio
     async def test_true_delete(self, index):
         """Test that delete actually removes entries."""
         np.random.seed(42)


### PR DESCRIPTION
## Description

`SQLiteVectorIndex.search()` rebuilds a `VectorMetadata` for each candidate row directly from the `vec_metadata` columns, with unguarded deserialization:

```python
meta = VectorMetadata(
    ...
    created_at=datetime.fromisoformat(row["created_at"]),
    valid_until=(datetime.fromisoformat(row["valid_until"]) if row["valid_until"] else None),
    entity_refs=json.loads(row["entity_refs"]),
    content=row["content"],
    metadata=json.loads(row["metadata_json"]),
)
```

A single row with an unparseable `created_at` / `valid_until` (bad datetime) or malformed `entity_refs` / `metadata_json` (bad JSON) — schema drift across an upgrade, or a partially written row — raises `ValueError`/`JSONDecodeError` mid-loop and aborts the **entire** search, losing every other (good) result.

This is the exact failure #2947 named: dict-shaped `entity_refs` "took down whole memory searches rather than the one bad row." That fix added `normalize_entity_refs` to `VectorMetadata.from_json` and `Memory.from_dict`, but this search loop rebuilds metadata from **columns** (not `from_json`), so it never got the healing — and `created_at` / `metadata_json` in the same loop were left completely unguarded.

The fix routes the per-row construction through a new `_row_to_metadata` helper that skips an unreadable row (returns `None`, logs a warning) and normalizes `entity_refs`, so one corrupt/legacy row no longer takes down the whole search.

Reproduction:

```python
# index two memories, then corrupt one row on disk
conn.execute("UPDATE vec_metadata SET created_at=? WHERE memory_id=?", ("not-a-date", bad_id))
await index.search(VectorFilter(query_vector=good.embedding, top_k=5, user_id="alice"))
# before: raises ValueError -> zero results
# after:  returns the good result; the bad row is skipped
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/memory/adapters/sqlite_vector.py`: added `_row_to_metadata(row)` which builds `VectorMetadata` with guarded `datetime.fromisoformat` / `json.loads` (returns `None` and logs on failure) and runs `entity_refs` through `normalize_entity_refs` (matching `from_json`). `search()` now uses it and skips rows that return `None`.
- `tests/test_sqlite_vector_index.py`: added `test_search_skips_corrupt_row_instead_of_aborting` — index two memories, corrupt one row's `created_at` on disk, and assert `search()` returns the good result and skips the bad row instead of raising.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
tests/test_sqlite_vector_index.py::...::test_search_skips_corrupt_row_instead_of_aborting  ->  passed
uvx ruff@0.16.2 check headroom/memory/adapters/sqlite_vector.py tests/test_sqlite_vector_index.py  ->  All checks passed!
uvx mypy@1.20.2 headroom/memory/adapters/sqlite_vector.py  ->  Success: no issues found in 1 source file
```

(A pre-existing Windows-only teardown `PermissionError` — the fixture unlinks the db file while sqlite still holds it — and one pre-existing `test_data_persists_across_instances` failure are unrelated to this change; both are identical on clean main and pass on the Linux CI.)

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, `sqlite-vec` available, ruff 0.16.2 and mypy 1.20.2 via uvx.
- Exact command / steps: indexed two memories, `UPDATE vec_metadata SET created_at='not-a-date'` (and a malformed `metadata_json`) on one row, then `search()`. Before the fix it raised `ValueError` / `JSONDecodeError` and returned nothing; after, it logs `Skipping unreadable vec_metadata row (memory_id=...)`, returns the good result, and omits the bad row. Reverting the loop to the inline construction makes the new test fail (search raises); restoring it passes.
- Observed result: one corrupt row degrades to a skipped row; the rest of the search is unaffected.
- Not tested: an actual on-disk schema-drift upgrade; the corrupt row is injected directly, which is the exact shape the search loop consumes.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. This is defensive row deserialization in the sqlite-vec search path, not a rollout-channel-gated runtime feature.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: a corrupt/legacy `vec_metadata` row is now skipped (with a warning) instead of aborting the whole search. Well-formed rows are built exactly as before, and `entity_refs` are normalized (already the behavior downstream in the local backend).
- Kill switch / disable path: N/A.
- Unsafe override required: no.
- Qualification impact: memory vector search survives a single corrupt row instead of returning zero results.
- Rollback path: revert this PR; `search()` returns to the inline unguarded construction.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A: internal adapter behavior)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

This completes #2947's "one bad row must not take down the whole search" intent for the fields that fix did not reach on the column-based search path (`created_at`, `valid_until`, `metadata_json`), and keeps `entity_refs` consistent by routing it through the same `normalize_entity_refs` helper. It is independent of, and complementary to, the CCR-store row-tolerance fix in the sibling PR.
