### PR TITLE
fix(proxy): reset the cc-switch upstream when Claude Official is selected

### DIFF
--- a/headroom/proxy/cc_switch_reconciler.py
+++ b/headroom/proxy/cc_switch_reconciler.py
@@ -162,7 +162,20 @@ class CCSwitchReconciler:
                 self._atomic_write(data)
                 logger.info("cc-switch reconciler: official -> route via Headroom")
                 return True
-            return False  # leave official direct (default, safe for OAuth)
+            # Leaving official direct (default, safe for OAuth) still has to
+            # drop a previously captured third-party upstream. The upstream is
+            # process-wide (``HeadroomProxy.ANTHROPIC_API_URL`` is a class
+            # attr), so a stale DeepSeek/Kimi endpoint would keep receiving
+            # this proxy's Anthropic traffic from every client still routed
+            # through it -- with Anthropic credentials attached.
+            if self.current_upstream not in (None, self.default_upstream):
+                logger.info(
+                    "cc-switch reconciler: official -> upstream reset to %s",
+                    self.default_upstream,
+                )
+                self.current_upstream = self.default_upstream
+                self._set_upstream(self.default_upstream)
+            return False
 
         # Already pointing at us: nothing to do (loop guard).
         if url.rstrip("/") == self.proxy_url:

--- a/tests/test_proxy/test_cc_switch_reconciler.py
+++ b/tests/test_proxy/test_cc_switch_reconciler.py
@@ -115,6 +115,33 @@ def test_official_left_direct_by_default(tmp_path, monkeypatch):
     assert json.loads(sf.read_text())["env"] == {}
 
 
+def test_official_resets_a_captured_third_party_upstream(tmp_path, monkeypatch):
+    monkeypatch.delenv("HEADROOM_CC_SWITCH_ROUTE_OFFICIAL", raising=False)
+    r, sf, captured = _make(tmp_path)
+    _write(sf, {"env": {"ANTHROPIC_BASE_URL": "https://api.kimi.com/anthropic"}})
+    assert r.tick() is True
+    assert captured[-1] == "https://api.kimi.com/anthropic"
+
+    # Switching back to Claude Official leaves settings.json direct, but the
+    # process-wide upstream must not stay on Kimi -- otherwise Anthropic OAuth
+    # traffic from any client still routed through this proxy is sent there.
+    _write(sf, {"env": {}})
+    assert r.tick() is False
+    assert json.loads(sf.read_text())["env"] == {}
+    assert captured[-1] == DEFAULT
+    assert r.current_upstream == DEFAULT
+
+
+def test_official_does_not_reset_upstream_when_never_captured(tmp_path, monkeypatch):
+    monkeypatch.delenv("HEADROOM_CC_SWITCH_ROUTE_OFFICIAL", raising=False)
+    r, sf, captured = _make(tmp_path)
+    _write(sf, {"env": {}})
+    assert r.tick() is False
+    # Nothing was captured, so nothing to reset: an operator-configured
+    # upstream must not be clobbered by a passing official tick.
+    assert captured == []
+
+
 def test_official_routed_when_opted_in(tmp_path, monkeypatch):
     monkeypatch.setenv("HEADROOM_CC_SWITCH_ROUTE_OFFICIAL", "1")
     r, sf, captured = _make(tmp_path)


### PR DESCRIPTION
## Description

The cc-switch reconciler (#1030) captures a third-party `ANTHROPIC_BASE_URL` as the proxy's upstream and points Claude Code back at Headroom. The "Claude Official" branch (cc-switch writes `{"env": {}}`) returned early without dropping that captured upstream.

`HeadroomProxy.ANTHROPIC_API_URL` is a **process-wide class attr** read per request, so switching back to Official left the previous provider live. Any Anthropic client still routed through that proxy - a second Claude Code instance, the VS Code connector, a desktop app that re-asserts `ANTHROPIC_BASE_URL` on launch - kept reaching e.g. `api.deepseek.com`, now with Anthropic OAuth credentials attached.

Related: #1264 (Anthropic-compatible third-party upstream support).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cc_switch_reconciler.tick()`: before leaving Official direct, reset a captured third-party upstream back to `default_upstream`.
- Guarded on `self.current_upstream not in (None, self.default_upstream)`, so nothing captured means nothing reset - an operator-configured upstream is not clobbered by a passing official tick.
- `tick()` still returns `False` for the direct-official case: `settings.json` is not rewritten, only the in-process upstream is corrected.
- Two regression tests.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ uv run --frozen --extra dev pytest tests/test_proxy/test_cc_switch_reconciler.py -q
collected 16 items
tests/test_proxy/test_cc_switch_reconciler.py ................           [100%]
16 passed in 0.82s

$ uv run --frozen --extra dev ruff check headroom/proxy/cc_switch_reconciler.py tests/test_proxy/test_cc_switch_reconciler.py
All checks passed!

$ uv run --frozen --extra dev ruff format --check headroom/proxy/cc_switch_reconciler.py tests/test_proxy/test_cc_switch_reconciler.py
2 files already formatted

$ uv run --frozen --extra dev mypy headroom/proxy/cc_switch_reconciler.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: macOS 24.6.0, Python 3.10.18, pytest 9.0.3, branch off `main` @ 5e0ce242 (0.36.2).
- Exact command / steps: applied the source hunk in reverse (`git show HEAD -- headroom/proxy/cc_switch_reconciler.py | git apply -R -`), re-ran the suite, then restored the fix and re-ran.
- Observed result: without the fix, `test_official_resets_a_captured_third_party_upstream` fails with `- https://api.anthropic.com` / `+ https://api.kimi.com/anthropic` (1 failed, 15 passed) - the captured Kimi upstream stayed live after the switch back to Official. With the fix, 16 passed.
- Not tested: no live end-to-end run against a real cc-switch install or a real third-party provider. The reconciler is gated behind `HEADROOM_CC_SWITCH_RECONCILE=1`, which is off by default, so the change is inert for anyone not opted in. Verified at the `tick()` level only.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. The cc-switch reconciler is gated by the `HEADROOM_CC_SWITCH_RECONCILE` env flag (off by default), not by a rollout channel.
- Minimum rollout channel: N/A - not rollout-managed.
- Stable/default behavior changed: no. With the flag unset the reconciler never starts and the changed branch is unreachable. With it set, the change only corrects the in-process upstream attr; `settings.json` is not touched and `tick()` still returns `False` on that path.
- Kill switch / disable path: unset `HEADROOM_CC_SWITCH_RECONCILE` (the default), which stops the whole reconciler including this branch.
- Unsafe override required: none.
- Qualification impact: none. No new config surface, no wire/schema change, no new dependency, no persisted state.
- Rollback path: revert the commit. Behavior returns to the previous sticky-upstream state; nothing to migrate or clean up.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
