### PR TITLE
perf(memory/hnsw): pick eviction victims with heapq.nsmallest, not a full sort

### DIFF
--- a/headroom/memory/adapters/hnsw.py
+++ b/headroom/memory/adapters/hnsw.py
@@ -13,6 +13,7 @@ Or via headroom extras:
 
 from __future__ import annotations
 
+import heapq
 import json
 from dataclasses import dataclass
 from datetime import datetime
@@ -393,15 +394,19 @@ class HNSWVectorIndex:
         if not self._metadata:
             return 0
 
-        # Sort entries by importance (ascending), then by created_at (oldest first)
-        sorted_entries = sorted(
+        # Select the `count` lowest-importance (then oldest) entries. nsmallest
+        # is O(n log count); fully sorting all entries just to take the first
+        # `count` was O(n log n), and eviction runs on every insert once a
+        # bounded index is at capacity. The selection is identical.
+        lowest_entries = heapq.nsmallest(
+            count,
             self._metadata.items(),
             key=lambda x: (x[1].importance, x[1].created_at),
         )
 
         # Evict the lowest importance entries
         evicted = 0
-        for memory_id, _metadata in sorted_entries[:count]:
+        for memory_id, _metadata in lowest_entries:
             if memory_id not in self._memory_to_hnsw:
                 continue
 

--- a/tests/test_hnsw_only.py
+++ b/tests/test_hnsw_only.py
@@ -276,3 +276,58 @@ class TestHNSWVectorIndex:
         assert index2._max_entries == 50
         assert index2._eviction_batch_size == 10
         assert index2.size == 5
+
+
+class _StubHnswIndex:
+    """Minimal stand-in for the hnswlib index used by _evict_entries."""
+
+    def __init__(self) -> None:
+        self.deleted: list[int] = []
+
+    def mark_deleted(self, hnsw_id: int) -> None:
+        self.deleted.append(hnsw_id)
+
+
+def test_evict_entries_selects_lowest_importance_then_oldest() -> None:
+    """_evict_entries must remove the `count` lowest-importance (then oldest)
+    entries. This drives the selection logic directly (no hnswlib), locking in
+    the contract preserved when the full sort was replaced with heapq.nsmallest.
+    """
+    import types
+    from dataclasses import dataclass
+
+    from headroom.memory.adapters.hnsw import HNSWVectorIndex
+
+    @dataclass
+    class _Meta:
+        importance: float
+        created_at: float
+
+    # ids a..f: importance ascending; two ties (0.5) broken by created_at.
+    meta = {
+        "a": _Meta(0.1, 100.0),
+        "b": _Meta(0.2, 100.0),
+        "c": _Meta(0.5, 100.0),  # older of the 0.5 tie
+        "d": _Meta(0.5, 200.0),  # newer of the 0.5 tie
+        "e": _Meta(0.9, 100.0),
+        "f": _Meta(0.95, 100.0),
+    }
+    self = types.SimpleNamespace(
+        _metadata=dict(meta),
+        _memory_to_hnsw={k: i for i, k in enumerate(meta)},
+        _hnsw_to_memory=dict(enumerate(meta)),
+        _embeddings=dict.fromkeys(meta),
+        _index=_StubHnswIndex(),
+        _eviction_count=0,
+    )
+
+    evicted = HNSWVectorIndex._evict_entries(self, 3)
+
+    assert evicted == 3
+    # The three lowest by (importance, created_at): a, b, then c (older tie).
+    assert set(meta) - set(self._metadata) == {"a", "b", "c"}
+    assert "d" in self._metadata  # newer of the 0.5 tie survives
+    # Mappings and embeddings for evicted ids are cleaned up too.
+    assert "a" not in self._memory_to_hnsw
+    assert "a" not in self._embeddings
+    assert self._eviction_count == 3


### PR DESCRIPTION
## Description

`HNSWVectorIndex._evict_entries` (bounded-memory eviction) sorted **every** metadata entry just to keep the `count` lowest-importance ones:

```python
sorted_entries = sorted(
    self._metadata.items(),
    key=lambda x: (x[1].importance, x[1].created_at),
)
for memory_id, _metadata in sorted_entries[:count]:
    ...
```

That is O(n log n) over the whole index, but only the `count` smallest are used. Eviction is not rare: once a bounded index (`max_entries` set) is at capacity, `index()` calls `_evict_entries(eviction_batch_size)` on **every** insert (default batch 100). So a full sort of the entire index runs on each insert-at-capacity.

`heapq.nsmallest(count, ...)` selects exactly the same entries in O(n log count), which is much cheaper when `count << n` — the normal case (evict 100 out of 10k–100k).

Benchmark (10,000 entries, evicting 100, mean of 50 runs):

```
sorted()[:100]  : 3.88 ms
nsmallest(100)  : 0.93 ms   (4.2x faster)
same keys selected: True
```

The gap widens with index size (`log n` vs `log count`). The selection is identical: `nsmallest` uses the same `(importance, created_at)` key, so it evicts the lowest-importance entries, oldest first on ties — the documented eviction order.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/memory/adapters/hnsw.py`: `_evict_entries` now uses `heapq.nsmallest(count, self._metadata.items(), key=...)` instead of sorting all entries and slicing; added `import heapq`.
- `tests/test_hnsw_only.py`: added `test_evict_entries_selects_lowest_importance_then_oldest`, a hnswlib-free unit test that drives `_evict_entries` directly and asserts it removes the `count` lowest-importance (then oldest) entries and cleans up the mappings/embeddings. This locks in the selection contract the optimization preserves and runs even where the `hnswlib` C extension is unavailable.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
tests/test_hnsw_only.py::test_evict_entries_selects_lowest_importance_then_oldest  ->  passed
uvx ruff@0.16.2 check headroom/memory/adapters/hnsw.py tests/test_hnsw_only.py  ->  All checks passed!
uvx mypy@1.20.2 headroom/memory/adapters/hnsw.py  ->  Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.16.2 and mypy 1.20.2 via uvx.
- Exact command / steps: benchmarked `sorted(items, key)[:count]` vs `heapq.nsmallest(count, items, key)` on 10,000 synthetic `(importance, created_at)` entries (mean of 50 runs) -> 3.88ms vs 0.93ms, and confirmed the selected key-sequence is identical. Then drove the real `_evict_entries` with a stubbed hnsw index over 2,000 entries and confirmed the evicted set equals `sorted()[:count]` exactly.
- Observed result: identical eviction selection, ~4.2x less time in the selection step; the change is behavior-preserving.
- Not tested: the full `HNSWVectorIndex` eviction tests (`test_bounded_index_eviction`, `test_eviction_prefers_low_importance_then_old`) skip locally because `hnswlib` is not installed in this environment; they run on CI. The new unit test exercises the same selection logic without that dependency.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. This is an internal algorithmic change in the HNSW adapter's eviction, not a rollout-channel-gated runtime feature.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: no. Same entries are evicted (lowest importance, then oldest); only the selection is faster. Unbounded indexes (`max_entries=None`, the default) never evict and are unaffected.
- Kill switch / disable path: N/A.
- Unsafe override required: no.
- Qualification impact: bounded-memory HNSW indexes spend less time per insert-at-capacity; no behavioral change.
- Rollback path: revert this PR; `_evict_entries` returns to the full sort.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A: internal behavior, unchanged semantics)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

This mirrors the pattern the CCR compression store already uses next door (a heap for O(log n) eviction instead of an O(n) scan); the HNSW adapter was the outlier still doing a full sort. `nsmallest` is the right fit here because eviction removes a batch at once rather than one-at-a-time.

