### PR TITLE
fix(savings): record tool-schema dollars disjointly beside the folded headline

### DIFF
--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -434,6 +434,8 @@ def _normalize_history_entry(entry: Any) -> dict[str, Any] | None:
     total_input_cost_usd = 0.0
     output_tokens_saved = 0
     output_savings_usd = 0.0
+    tool_tokens_saved = 0
+    tool_schema_savings_usd = 0.0
     provider = PROVIDER_UNKNOWN
     model = MODEL_UNKNOWN
 
@@ -450,6 +452,8 @@ def _normalize_history_entry(entry: Any) -> dict[str, Any] | None:
         total_input_cost_usd = _coerce_float(entry.get("total_input_cost_usd"))
         output_tokens_saved = _coerce_int(entry.get("output_tokens_saved"))
         output_savings_usd = _coerce_float(entry.get("output_savings_usd"))
+        tool_tokens_saved = _coerce_int(entry.get("tool_tokens_saved"))
+        tool_schema_savings_usd = _coerce_float(entry.get("tool_schema_savings_usd"))
         provider = _normalize_provider(entry.get("provider"))
         model = _normalize_model(entry.get("model"))
     elif isinstance(entry, list | tuple) and len(entry) >= 2:
@@ -479,6 +483,8 @@ def _normalize_history_entry(entry: Any) -> dict[str, Any] | None:
         "total_input_cost_usd": round(total_input_cost_usd, 6),
         "output_tokens_saved": output_tokens_saved,
         "output_savings_usd": round(output_savings_usd, 6),
+        "tool_tokens_saved": tool_tokens_saved,
+        "tool_schema_savings_usd": round(tool_schema_savings_usd, 6),
     }
 
 
@@ -487,6 +493,8 @@ def _empty_display_session() -> dict[str, Any]:
         "requests": 0,
         "tokens_saved": 0,
         "compression_savings_usd": 0.0,
+        "tool_tokens_saved": 0,
+        "tool_schema_savings_usd": 0.0,
         "cache_read_tokens": 0,
         "cache_savings_usd": 0.0,
         "total_input_tokens": 0,
@@ -607,6 +615,11 @@ def _normalize_display_session(entry: Any) -> dict[str, Any]:
         "tokens_saved": tokens_saved,
         "compression_savings_usd": round(
             _coerce_float(entry.get("compression_savings_usd")),
+            6,
+        ),
+        "tool_tokens_saved": _coerce_int(entry.get("tool_tokens_saved")),
+        "tool_schema_savings_usd": round(
+            _coerce_float(entry.get("tool_schema_savings_usd")),
             6,
         ),
         "cache_read_tokens": _coerce_int(entry.get("cache_read_tokens")),
@@ -821,6 +834,17 @@ class SavingsTracker:
             if priced is not None
             else _estimate_cache_savings_usd(model, delta_cache_read_tokens)
         )
+        # The same figure that was just folded into ``delta_savings_usd``, kept
+        # as its own delta so the layer is also recorded disjointly below. A
+        # consumer can then recover message-only dollars by subtraction --
+        # without this, checkpoint dollars (folded) over checkpoint tokens
+        # (message-only) imply a $/token inflated by 1 + tool/message, which on
+        # tool-heavy traffic (ratios of 5x+ observed) exceeds the model's own
+        # input price. Without the priced breakdown nothing was folded either,
+        # so 0.0 keeps the disjoint field consistent with the sum.
+        delta_tool_savings_usd = (
+            max(_coerce_float(priced.get("tool_schema")), 0.0) if priced is not None else 0.0
+        )
         delta_input_cost_usd = _estimate_input_cost_usd(
             model,
             delta_input_tokens,
@@ -880,6 +904,11 @@ class SavingsTracker:
                 lifetime.get("output_savings_usd", 0.0) + delta_output_savings_usd,
                 6,
             )
+            lifetime["tool_tokens_saved"] += delta_tool_tokens_saved
+            lifetime["tool_schema_savings_usd"] = round(
+                lifetime["tool_schema_savings_usd"] + delta_tool_savings_usd,
+                6,
+            )
 
             session = self._state["display_session"]
             last_activity = _parse_timestamp(session.get("last_activity_at"))
@@ -895,6 +924,11 @@ class SavingsTracker:
             session["tokens_saved"] += delta_tokens_saved
             session["compression_savings_usd"] = round(
                 session["compression_savings_usd"] + delta_savings_usd,
+                6,
+            )
+            session["tool_tokens_saved"] += delta_tool_tokens_saved
+            session["tool_schema_savings_usd"] = round(
+                session["tool_schema_savings_usd"] + delta_tool_savings_usd,
                 6,
             )
             session["cache_read_tokens"] += delta_cache_read_tokens
@@ -946,6 +980,7 @@ class SavingsTracker:
                 delta_tokens_saved > 0
                 or delta_cache_read_tokens > 0
                 or delta_output_tokens_saved > 0
+                or delta_tool_tokens_saved > 0
             ):
                 self._state["history"].append(
                     {
@@ -960,6 +995,8 @@ class SavingsTracker:
                         "total_input_cost_usd": lifetime["total_input_cost_usd"],
                         "output_tokens_saved": lifetime.get("output_tokens_saved", 0),
                         "output_savings_usd": lifetime.get("output_savings_usd", 0.0),
+                        "tool_tokens_saved": lifetime["tool_tokens_saved"],
+                        "tool_schema_savings_usd": lifetime["tool_schema_savings_usd"],
                     }
                 )
                 self._trim_history_locked(reference_time=timestamp_dt)
@@ -1255,6 +1292,8 @@ class SavingsTracker:
                 "total_input_cost_usd",
                 "output_tokens_saved_delta",
                 "output_savings_usd_delta",
+                "tool_tokens_saved_delta",
+                "tool_schema_savings_usd_delta",
             ]
 
         buffer = StringIO()
@@ -1292,6 +1331,8 @@ class SavingsTracker:
                 "requests": 0,
                 "tokens_saved": 0,
                 "compression_savings_usd": 0.0,
+                "tool_tokens_saved": 0,
+                "tool_schema_savings_usd": 0.0,
                 "cache_read_tokens": 0,
                 "cache_savings_usd": 0.0,
                 "total_input_tokens": 0,
@@ -1354,6 +1395,8 @@ class SavingsTracker:
         lifetime_requests = 0
         lifetime_tokens_saved = 0
         lifetime_savings_usd = 0.0
+        lifetime_tool_tokens_saved = 0
+        lifetime_tool_savings_usd = 0.0
         lifetime_cache_read_tokens = 0
         lifetime_cache_savings_usd = 0.0
         lifetime_input_tokens = 0
@@ -1362,6 +1405,8 @@ class SavingsTracker:
             lifetime_requests = _coerce_int(lifetime_raw.get("requests"))
             lifetime_tokens_saved = _coerce_int(lifetime_raw.get("tokens_saved"))
             lifetime_savings_usd = _coerce_float(lifetime_raw.get("compression_savings_usd"))
+            lifetime_tool_tokens_saved = _coerce_int(lifetime_raw.get("tool_tokens_saved"))
+            lifetime_tool_savings_usd = _coerce_float(lifetime_raw.get("tool_schema_savings_usd"))
             lifetime_cache_read_tokens = _coerce_int(lifetime_raw.get("cache_read_tokens"))
             lifetime_cache_savings_usd = _coerce_float(lifetime_raw.get("cache_savings_usd"))
             lifetime_input_tokens = _coerce_int(lifetime_raw.get("total_input_tokens"))
@@ -1376,6 +1421,14 @@ class SavingsTracker:
             lifetime_savings_usd = max(
                 lifetime_savings_usd,
                 _coerce_float(last["compression_savings_usd"]),
+            )
+            lifetime_tool_tokens_saved = max(
+                lifetime_tool_tokens_saved,
+                _coerce_int(last.get("tool_tokens_saved")),
+            )
+            lifetime_tool_savings_usd = max(
+                lifetime_tool_savings_usd,
+                _coerce_float(last.get("tool_schema_savings_usd")),
             )
             lifetime_input_tokens = max(
                 lifetime_input_tokens,
@@ -1392,6 +1445,8 @@ class SavingsTracker:
                 "requests": lifetime_requests,
                 "tokens_saved": lifetime_tokens_saved,
                 "compression_savings_usd": round(lifetime_savings_usd, 6),
+                "tool_tokens_saved": lifetime_tool_tokens_saved,
+                "tool_schema_savings_usd": round(lifetime_tool_savings_usd, 6),
                 "cache_read_tokens": lifetime_cache_read_tokens,
                 "cache_savings_usd": round(lifetime_cache_savings_usd, 6),
                 "total_input_tokens": lifetime_input_tokens,
@@ -1675,6 +1730,8 @@ class SavingsTracker:
         prev_total_input_cost_usd = 0.0
         prev_output_tokens = 0
         prev_output_usd = 0.0
+        prev_tool_tokens = 0
+        prev_tool_usd = 0.0
 
         for point in history:
             timestamp = _parse_timestamp(point["timestamp"])
@@ -1690,6 +1747,8 @@ class SavingsTracker:
             total_input_cost_usd = _coerce_float(point.get("total_input_cost_usd"))
             total_output_tokens = _coerce_int(point.get("output_tokens_saved"))
             total_output_usd = _coerce_float(point.get("output_savings_usd"))
+            total_tool_tokens = _coerce_int(point.get("tool_tokens_saved"))
+            total_tool_usd = _coerce_float(point.get("tool_schema_savings_usd"))
             delta_tokens = max(total_tokens_saved - prev_total_tokens, 0)
             delta_usd = max(total_usd - prev_total_usd, 0.0)
             delta_input_tokens = max(total_input_tokens - prev_total_input_tokens, 0)
@@ -1700,6 +1759,8 @@ class SavingsTracker:
 
             delta_output_tokens = max(total_output_tokens - prev_output_tokens, 0)
             delta_output_usd = max(total_output_usd - prev_output_usd, 0.0)
+            delta_tool_tokens = max(total_tool_tokens - prev_tool_tokens, 0)
+            delta_tool_usd = max(total_tool_usd - prev_tool_usd, 0.0)
 
             prev_total_tokens = total_tokens_saved
             prev_total_usd = total_usd
@@ -1707,6 +1768,8 @@ class SavingsTracker:
             prev_total_input_cost_usd = total_input_cost_usd
             prev_output_tokens = total_output_tokens
             prev_output_usd = total_output_usd
+            prev_tool_tokens = total_tool_tokens
+            prev_tool_usd = total_tool_usd
 
             entry = aggregated.setdefault(
                 bucket_key,
@@ -1722,6 +1785,10 @@ class SavingsTracker:
                     "total_input_cost_usd": total_input_cost_usd,
                     "output_tokens_saved_delta": 0,
                     "output_savings_usd_delta": 0.0,
+                    "tool_tokens_saved_delta": 0,
+                    "tool_schema_savings_usd_delta": 0.0,
+                    "tool_tokens_saved": total_tool_tokens,
+                    "tool_schema_savings_usd": total_tool_usd,
                     "by_provider": {},
                     "by_model": {},
                 },
@@ -1745,6 +1812,13 @@ class SavingsTracker:
                 entry["output_savings_usd_delta"] + delta_output_usd,
                 6,
             )
+            entry["tool_tokens_saved_delta"] += delta_tool_tokens
+            entry["tool_schema_savings_usd_delta"] = round(
+                entry["tool_schema_savings_usd_delta"] + delta_tool_usd,
+                6,
+            )
+            entry["tool_tokens_saved"] = total_tool_tokens
+            entry["tool_schema_savings_usd"] = round(total_tool_usd, 6)
 
             # Attribute this checkpoint's delta to the provider that produced
             # it. Each checkpoint comes from a single request, so its delta is

--- a/tests/test_persistent_metrics_persistence.py
+++ b/tests/test_persistent_metrics_persistence.py
@@ -63,7 +63,13 @@ def test_savings_tracker_migrates_v4_lifetime_to_v5_metrics_and_preserves_legacy
     tracker.flush()
     saved = json.loads(path.read_text(encoding="utf-8"))
     assert saved["schema_version"] == 5
-    assert saved["lifetime"] == legacy_state["lifetime"]
+    # Legacy values survive verbatim; the disjoint tool-schema fields are new
+    # and default to zero for state written before they existed.
+    assert saved["lifetime"] == {
+        **legacy_state["lifetime"],
+        "tool_tokens_saved": 0,
+        "tool_schema_savings_usd": 0.0,
+    }
     assert saved["display_session"]["requests"] == 2
     assert saved["projects"]["keep-me"]["requests"] == 1
     assert saved["lifetime_metrics"]["models"]["other"]["input_tokens"] == 80

--- a/tests/test_proxy_savings_history.py
+++ b/tests/test_proxy_savings_history.py
@@ -84,6 +84,8 @@ def test_savings_tracker_helpers_normalize_inputs_and_paths(tmp_path, monkeypatc
         "total_input_cost_usd": 0.0,
         "output_tokens_saved": 0,
         "output_savings_usd": 0.0,
+        "tool_tokens_saved": 0,
+        "tool_schema_savings_usd": 0.0,
     }
     assert savings_tracker_module._normalize_history_entry({"timestamp": "bad"}) is None
     assert savings_tracker_module._normalize_history_entry(object()) is None
@@ -130,6 +132,8 @@ def test_savings_tracker_sanitizes_legacy_state_and_applies_retention(tmp_path):
         "requests": 0,
         "tokens_saved": 30,
         "compression_savings_usd": pytest.approx(0.03),
+        "tool_tokens_saved": 0,
+        "tool_schema_savings_usd": 0.0,
         "cache_read_tokens": 0,
         "cache_savings_usd": 0.0,
         "total_input_tokens": 0,
@@ -149,6 +153,8 @@ def test_savings_tracker_sanitizes_legacy_state_and_applies_retention(tmp_path):
             "total_input_cost_usd": 0.0,
             "output_tokens_saved": 0,
             "output_savings_usd": 0.0,
+            "tool_tokens_saved": 0,
+            "tool_schema_savings_usd": 0.0,
         }
     ]
     assert snapshot["retention"] == {
@@ -169,6 +175,8 @@ def test_non_dict_savings_state_resets_to_default(tmp_path):
         "requests": 0,
         "tokens_saved": 0,
         "compression_savings_usd": 0.0,
+        "tool_tokens_saved": 0,
+        "tool_schema_savings_usd": 0.0,
         "cache_read_tokens": 0,
         "cache_savings_usd": 0.0,
         "total_input_tokens": 0,
@@ -634,6 +642,8 @@ def test_display_session_rolls_after_inactivity_and_counts_zero_savings_requests
         "requests": 2,
         "tokens_saved": 20,
         "compression_savings_usd": pytest.approx(0.02),
+        "tool_tokens_saved": 0,
+        "tool_schema_savings_usd": 0.0,
         "cache_read_tokens": 0,
         "cache_savings_usd": 0.0,
         "total_input_tokens": 200,
@@ -668,6 +678,8 @@ def test_display_session_rolls_after_inactivity_and_counts_zero_savings_requests
         "requests": 1,
         "tokens_saved": 5,
         "compression_savings_usd": pytest.approx(0.005),
+        "tool_tokens_saved": 0,
+        "tool_schema_savings_usd": 0.0,
         "cache_read_tokens": 0,
         "cache_savings_usd": 0.0,
         "total_input_tokens": 50,
@@ -1295,7 +1307,8 @@ def test_stats_history_csv_export_is_frontend_friendly(tmp_path, monkeypatch):
             "timestamp,tokens_saved,compression_savings_usd_delta,total_tokens_saved,"
             "compression_savings_usd,total_input_tokens_delta,total_input_tokens,"
             "total_input_cost_usd_delta,total_input_cost_usd,"
-            "output_tokens_saved_delta,output_savings_usd_delta"
+            "output_tokens_saved_delta,output_savings_usd_delta,"
+            "tool_tokens_saved_delta,tool_schema_savings_usd_delta"
         )
         assert len(lines) >= 2
         assert "total_tokens_saved" in lines[0]

--- a/tests/test_tool_schema_savings_split.py
+++ b/tests/test_tool_schema_savings_split.py
@@ -1,0 +1,203 @@
+"""Tool-schema dollars must be recorded disjointly, not only folded.
+
+Reported by a desktop consumer of the persisted savings state. Since the
+attribution unification, ``record_request`` folds the tool-schema layer's
+dollars into ``compression_savings_usd`` (lifetime, display_session, and every
+history checkpoint) while ``total_tokens_saved`` on the same checkpoint stays
+message-only. Any consumer deriving a $/token rate from a checkpoint therefore
+reads a figure inflated by ``1 + tool/message``:
+
+- Traffic: message compression 3,299,618 tokens next to 18,435,490 tokens of
+  tool-schema deferral (ratio 5.59x) on one real install.
+- Implied rate: a $4.99/M blended savings rate became $32.88/M after the fold,
+  which exceeds the input list price of every model in the mix.
+- Reader impact: consumers that accumulated ``compression_savings_usd`` before
+  the fold shipped had the field's meaning widened underneath them.
+
+Same resolution shape as the per-model token fix: keep the folded headline
+exactly as it is, and record the layer disjointly beside it --
+``tool_tokens_saved`` / ``tool_schema_savings_usd`` on lifetime,
+display_session, and checkpoints, with matching ``_delta`` fields on rollup
+buckets -- so message-only dollars are recoverable by subtraction.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from headroom.proxy.savings_tracker import SavingsTracker, _normalize_history_entry
+
+MODEL = "claude-opus-5"
+
+
+def _tracker(tmp_path) -> SavingsTracker:
+    return SavingsTracker(
+        path=str(tmp_path / "proxy_savings.json"),
+        max_history_points=100,
+        max_history_age_days=30,
+    )
+
+
+def _record(
+    tracker: SavingsTracker,
+    *,
+    tokens_saved: int = 100,
+    tool_search_saved: int = 500,
+    compression_usd: float = 1.0,
+    tool_usd: float = 5.0,
+    timestamp: str = "2026-08-21T09:10:00Z",
+) -> None:
+    tracker.record_request(
+        model=MODEL,
+        input_tokens=1_000,
+        tokens_saved=tokens_saved,
+        tool_search_saved=tool_search_saved,
+        estimated_savings_usd={
+            "compression": compression_usd,
+            "tool_schema": tool_usd,
+            "output_shaping": 0.0,
+            "provider_cache": 0.0,
+        },
+        timestamp=timestamp,
+    )
+
+
+def test_lifetime_and_session_record_tool_schema_disjointly(tmp_path):
+    tracker = _tracker(tmp_path)
+    _record(tracker)
+
+    snapshot = tracker.snapshot()
+    for block in (snapshot["lifetime"], snapshot["display_session"]):
+        # The folded headline is unchanged: compression + tool_schema.
+        assert block["compression_savings_usd"] == 6.0
+        # The disjoint record makes message-only dollars recoverable.
+        assert block["tool_schema_savings_usd"] == 5.0
+        assert block["compression_savings_usd"] - block["tool_schema_savings_usd"] == 1.0
+        assert block["tool_tokens_saved"] == 500
+
+
+def test_checkpoints_carry_the_layer_and_survive_reload(tmp_path):
+    tracker = _tracker(tmp_path)
+    _record(tracker)
+    tracker.flush()
+
+    point = tracker.snapshot()["history"][-1]
+    assert point["tool_tokens_saved"] == 500
+    assert point["tool_schema_savings_usd"] == 5.0
+    # Checkpoint tokens stay message-only; the disjoint dollar field is what
+    # lets a consumer pair a consistent numerator with that denominator.
+    assert point["total_tokens_saved"] == 100
+
+    # A fresh tracker on the same file must not zero the layer (the output
+    # fields historically reset on every restart; these must not).
+    reloaded = SavingsTracker(
+        path=str(tmp_path / "proxy_savings.json"),
+        max_history_points=100,
+        max_history_age_days=30,
+    )
+    lifetime = reloaded.snapshot()["lifetime"]
+    assert lifetime["tool_tokens_saved"] == 500
+    assert lifetime["tool_schema_savings_usd"] == 5.0
+
+
+def test_state_written_before_the_fields_existed_defaults_to_zero(tmp_path):
+    path = tmp_path / "proxy_savings.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 5,
+                "lifetime": {
+                    "requests": 3,
+                    "tokens_saved": 900,
+                    "compression_savings_usd": 0.9,
+                    "cache_read_tokens": 0,
+                    "cache_savings_usd": 0.0,
+                    "total_input_tokens": 5_000,
+                    "total_input_cost_usd": 0.05,
+                },
+                "display_session": {},
+                "history": [
+                    {
+                        "timestamp": "2026-08-20T10:00:00Z",
+                        "total_tokens_saved": 900,
+                        "compression_savings_usd": 0.9,
+                        "total_input_tokens": 5_000,
+                        "total_input_cost_usd": 0.05,
+                    }
+                ],
+                "projects": {},
+                "by_model": {},
+            }
+        )
+    )
+
+    tracker = SavingsTracker(path=str(path), max_history_points=100, max_history_age_days=30)
+    lifetime = tracker.snapshot()["lifetime"]
+    assert lifetime["tool_tokens_saved"] == 0
+    assert lifetime["tool_schema_savings_usd"] == 0.0
+    assert lifetime["tokens_saved"] == 900
+
+    # Legacy tuple-shaped history entries normalize the same way.
+    normalized = _normalize_history_entry(["2026-08-20T10:00:00Z", 900, 0.9])
+    assert normalized is not None
+    assert normalized["tool_tokens_saved"] == 0
+    assert normalized["tool_schema_savings_usd"] == 0.0
+
+
+def test_tool_only_request_appends_a_checkpoint(tmp_path):
+    tracker = _tracker(tmp_path)
+    # Deferral with zero message compression: real on tool-heavy traffic, and
+    # previously invisible to the history because the append gate only looked
+    # at message/cache/output deltas.
+    _record(tracker, tokens_saved=0, compression_usd=0.0)
+
+    history = tracker.snapshot()["history"]
+    assert len(history) == 1
+    assert history[-1]["tool_tokens_saved"] == 500
+    assert history[-1]["tool_schema_savings_usd"] == 5.0
+    assert history[-1]["total_tokens_saved"] == 0
+
+
+def test_rollups_expose_tool_schema_deltas(tmp_path):
+    tracker = _tracker(tmp_path)
+    _record(tracker, timestamp="2026-08-21T09:10:00Z")
+    _record(tracker, tool_search_saved=250, tool_usd=2.5, timestamp="2026-08-21T09:40:00Z")
+    _record(tracker, tool_search_saved=1_000, tool_usd=10.0, timestamp="2026-08-21T10:05:00Z")
+
+    hourly = tracker.history_response()["series"]["hourly"]
+    assert [point["timestamp"] for point in hourly] == [
+        "2026-08-21T09:00:00Z",
+        "2026-08-21T10:00:00Z",
+    ]
+
+    first, second = hourly
+    # Deltas start from a zero baseline, so the series' first checkpoint
+    # contributes its full cumulative -- the same convention as every other
+    # rollup delta in this module. Bucket one therefore carries 500 + 250.
+    assert first["tool_tokens_saved_delta"] == 750
+    assert first["tool_schema_savings_usd_delta"] == 7.5
+    assert first["tool_tokens_saved"] == 750
+    assert second["tool_tokens_saved_delta"] == 1_000
+    assert second["tool_schema_savings_usd_delta"] == 10.0
+    assert second["tool_tokens_saved"] == 1_750
+
+    # The subtraction identity the split exists for: folded minus disjoint
+    # equals message-only dollars, bucket by bucket (two $1 records, then one).
+    assert first["compression_savings_usd_delta"] - first[
+        "tool_schema_savings_usd_delta"
+    ] == pytest.approx(2.0)
+    assert second["compression_savings_usd_delta"] - second[
+        "tool_schema_savings_usd_delta"
+    ] == pytest.approx(1.0)
+
+
+def test_rollup_csv_exports_the_delta_columns(tmp_path):
+    tracker = _tracker(tmp_path)
+    _record(tracker, timestamp="2026-08-21T09:10:00Z")
+    _record(tracker, timestamp="2026-08-21T09:40:00Z")
+
+    header = tracker.export_csv(series="hourly").splitlines()[0]
+    assert "tool_tokens_saved_delta" in header
+    assert "tool_schema_savings_usd_delta" in header

--- a/tests/test_tool_schema_savings_split.py
+++ b/tests/test_tool_schema_savings_split.py
@@ -24,12 +24,35 @@ buckets -- so message-only dollars are recoverable by subtraction.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 from headroom.proxy.savings_tracker import SavingsTracker, _normalize_history_entry
 
 MODEL = "claude-opus-5"
+
+
+def _iso(moment: datetime) -> str:
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _recent() -> str:
+    """A timestamp inside the display-session window, anchored to wall clock.
+
+    ``_display_session_snapshot_locked`` expires the session against
+    ``_utc_now()``, not against the recorded timestamp, so a frozen literal
+    silently stops populating ``display_session`` once it ages past
+    ``DEFAULT_DISPLAY_SESSION_INACTIVITY_MINUTES``. This suite was written with
+    a hardcoded date and went red three weeks later for exactly that reason.
+    """
+    return _iso(datetime.now(timezone.utc) - timedelta(minutes=1))
+
+
+def _hour_base() -> datetime:
+    """A whole hour safely in the past, so derived buckets are stable and never future-dated."""
+    now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    return now - timedelta(hours=3)
 
 
 def _tracker(tmp_path) -> SavingsTracker:
@@ -47,7 +70,7 @@ def _record(
     tool_search_saved: int = 500,
     compression_usd: float = 1.0,
     tool_usd: float = 5.0,
-    timestamp: str = "2026-08-21T09:10:00Z",
+    timestamp: str | None = None,
 ) -> None:
     tracker.record_request(
         model=MODEL,
@@ -60,7 +83,7 @@ def _record(
             "output_shaping": 0.0,
             "provider_cache": 0.0,
         },
-        timestamp=timestamp,
+        timestamp=timestamp or _recent(),
     )
 
 
@@ -162,14 +185,25 @@ def test_tool_only_request_appends_a_checkpoint(tmp_path):
 
 def test_rollups_expose_tool_schema_deltas(tmp_path):
     tracker = _tracker(tmp_path)
-    _record(tracker, timestamp="2026-08-21T09:10:00Z")
-    _record(tracker, tool_search_saved=250, tool_usd=2.5, timestamp="2026-08-21T09:40:00Z")
-    _record(tracker, tool_search_saved=1_000, tool_usd=10.0, timestamp="2026-08-21T10:05:00Z")
+    base = _hour_base()
+    _record(tracker, timestamp=_iso(base + timedelta(minutes=10)))
+    _record(
+        tracker,
+        tool_search_saved=250,
+        tool_usd=2.5,
+        timestamp=_iso(base + timedelta(minutes=40)),
+    )
+    _record(
+        tracker,
+        tool_search_saved=1_000,
+        tool_usd=10.0,
+        timestamp=_iso(base + timedelta(minutes=65)),
+    )
 
     hourly = tracker.history_response()["series"]["hourly"]
     assert [point["timestamp"] for point in hourly] == [
-        "2026-08-21T09:00:00Z",
-        "2026-08-21T10:00:00Z",
+        _iso(base),
+        _iso(base + timedelta(hours=1)),
     ]
 
     first, second = hourly
@@ -195,8 +229,9 @@ def test_rollups_expose_tool_schema_deltas(tmp_path):
 
 def test_rollup_csv_exports_the_delta_columns(tmp_path):
     tracker = _tracker(tmp_path)
-    _record(tracker, timestamp="2026-08-21T09:10:00Z")
-    _record(tracker, timestamp="2026-08-21T09:40:00Z")
+    base = _hour_base()
+    _record(tracker, timestamp=_iso(base + timedelta(minutes=10)))
+    _record(tracker, timestamp=_iso(base + timedelta(minutes=40)))
 
     header = tracker.export_csv(series="hourly").splitlines()[0]
     assert "tool_tokens_saved_delta" in header


### PR DESCRIPTION
## Description

Since the attribution unification (#2976, refined by #3123), `record_request` folds the tool-schema layer's dollars into `compression_savings_usd` — on the lifetime block, the display session, and every history checkpoint — while `total_tokens_saved` on those same checkpoints stays message-only. The two halves of one checkpoint now disagree about what "saved" means, and any consumer that derives a $/token rate from a checkpoint reads a figure inflated by `1 + tool/message`.

That inflation is not hypothetical. On one real install, message compression was 3,299,618 tokens next to 18,435,490 tokens of tool-schema deferral (a 5.59x ratio — far from the 0.24x in the sample #2976 cites, this ratio varies wildly by workload). The blended savings rate a downstream consumer derived went from $4.99/M to $32.88/M — above the input list price of every model in the mix, a rate no genuine input-token saving can reach.

There is also a smaller correctness gap: a request whose only saving is deferral (`tokens_saved == 0`, common on tool-heavy turns) appended no checkpoint at all, so its folded dollars landed in whichever later bucket happened to checkpoint next.

#3155 fixed the token half of this per model, and stated the principle this PR extends to dollars: kept as its own bucket rather than widened in place, so the persisted meaning of an existing field never changes under a reader that predates it. This PR is deliberately **additive** — `compression_savings_usd` keeps its current folded semantics everywhere, so the dashboard, PERF headline, and every existing reader are unchanged. The layer is simply also recorded disjointly beside it, so message-only dollars are recoverable by subtraction and the checkpoint's token/dollar pair can be read consistently.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Record `tool_tokens_saved` / `tool_schema_savings_usd` on the lifetime block and display session, wired through `_default_state`, `_sanitize_state` (including the history-recovery max), and both normalizers — the fields survive restarts rather than resetting the way the ad-hoc output fields do.
- Carry both fields on every history checkpoint, and extend the checkpoint append gate so a deferral-only request checkpoints too.
- Expose `tool_tokens_saved_delta` / `tool_schema_savings_usd_delta` (plus cumulatives) on rollup buckets, following the exact delta convention of the existing series, and add the delta columns to the rollup CSV export.
- State files written before these fields existed load with both at 0; legacy tuple-shaped history entries normalize the same way.
- New test module `tests/test_tool_schema_savings_split.py` (6 tests) pinning the disjoint recording, reload durability, legacy-state defaults, the deferral-only checkpoint, the rollup deltas, and the subtraction identity; existing shape assertions in `tests/test_proxy_savings_history.py` updated for the two new fields.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
$ uv run --frozen --extra dev pytest tests/test_proxy_savings_history.py \
    tests/test_tool_schema_savings_split.py tests/test_per_model_tool_savings.py \
    tests/test_savings_tool_search_aggregation.py tests/test_savings_tracker_zero_price.py \
    tests/test_agent_savings.py
======================== 103 passed, 1 warning in 7.36s ========================

$ uv run --frozen --extra dev pytest tests/test_stats_new_input_savings_rate.py \
    tests/test_dashboard_token_savings.py tests/test_proxy_project_savings.py \
    tests/test_output_savings.py tests/test_savings_ledger.py
=================== 76 passed, 2 skipped, 1 warning in 8.15s ===================

$ uv run --frozen ruff check headroom/proxy/savings_tracker.py tests/test_tool_schema_savings_split.py tests/test_proxy_savings_history.py
All checks passed!
$ uv run --frozen ruff format --check headroom/proxy/savings_tracker.py tests/test_tool_schema_savings_split.py tests/test_proxy_savings_history.py
3 files already formatted
$ uv run --frozen mypy headroom/proxy/savings_tracker.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: macOS, Python 3.10 venv via `uv run --frozen`, this branch.
- Exact command / steps: one `record_request` shaped like the reporting install's traffic (100 message tokens saved, 559 deferred schema tokens, claude-opus-5 pricing at $5/M input), then derive $/token from the appended checkpoint both ways.
- Observed result: the naive checkpoint-derived rate reproduces the impossible $32.88/M seen in the field almost exactly, and subtracting the new disjoint field recovers the model's actual input rate:

```text
checkpoint: total_tokens_saved=100 compression_savings_usd=0.003295 tool_tokens_saved=559 tool_schema_savings_usd=0.002795
folded-dollars / message-tokens rate: $32.95/M  (input list price is $5/M)
after subtracting the disjoint field:  $5.00/M
```

- Not tested: a long-lived multi-process proxy soak, and the downstream consumer's subtraction path itself (that lands with the consumer release that reads the new fields).

## Runtime Rollout Safety

- Rollout-managed feature(s): None -- persisted savings accounting only; no rollout-gated runtime behavior is touched.
- Minimum rollout channel: N/A
- Stable/default behavior changed: No. Additive fields beside existing ones; `compression_savings_usd` keeps its current folded semantics, so every existing reader sees identical values.
- Kill switch / disable path: None needed -- old readers ignore the new fields, and state files written before them load with both at 0 (covered by tests).
- Unsafe override required: No
- Qualification impact: None beyond the unit suites run above; displayed figures are unchanged.
- Rollback path: `git revert` -- the fields stop being written and remain optional on read, so state files produced while this was live stay loadable.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

Related: #3155 (token half of the same split), #3171 (companion PR on what the tool-schema bucket should be priced at — independent; either lands without the other).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
