### PR TITLE
fix(savings): price tool-schema deferral at the cache-read rate

### DIFF
--- a/headroom/proxy/cost.py
+++ b/headroom/proxy/cost.py
@@ -12,6 +12,7 @@ import importlib.util
 import logging
 import math
 from collections import deque
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -169,6 +170,35 @@ def _bucket_by_cache_mix(
     read_part = tokens * max(0, cache_read_tokens) / billed_in
     write_part = tokens * max(0, cache_write_tokens) / billed_in
     return read_part, write_part, tokens - read_part - write_part
+
+
+def _cache_input_rates(
+    info: Mapping[str, Any], *, long_context: bool = False
+) -> tuple[float, float, float] | None:
+    """``(cache_read, cache_write, list)`` per-token rates from a catalog entry.
+
+    The single fallback policy for every consumer of LiteLLM cache pricing
+    (``CostTracker._get_cache_prices`` here, ``savings_tracker``'s tool-schema
+    estimator there), so two surfaces cannot quote different prices for the same
+    tokens of the same request. A model that publishes no cache pricing bills
+    its cache traffic at list, so an absent ``cache_read_input_token_cost`` /
+    ``cache_creation_input_token_cost`` reads as ``input_cost_per_token`` —
+    never as a hardcoded provider multiplier, which goes stale per model and
+    per context tier and would overstate a non-Anthropic provider's savings.
+
+    Returns ``None`` only when the list price itself is unknown; a real ``0.0``
+    is a genuinely free model and prices as free.
+    """
+    uncached = info.get("input_cost_per_token")
+    if uncached is None:
+        return None
+    cache_read = info.get("cache_read_input_token_cost", uncached)
+    cache_write = info.get("cache_creation_input_token_cost", uncached)
+    if long_context:
+        uncached = info.get("input_cost_per_token_above_200k_tokens") or uncached
+        cache_read = info.get("cache_read_input_token_cost_above_200k_tokens") or cache_read
+        cache_write = info.get("cache_creation_input_token_cost_above_200k_tokens") or cache_write
+    return (float(cache_read), float(cache_write), float(uncached))
 
 
 def _summarize_transforms(transforms: list[str]) -> str:
@@ -1294,20 +1324,13 @@ class CostTracker:
         try:
             from headroom.pricing.litellm_pricing import resolve_litellm_model
 
-            resolved = resolve_litellm_model(model)
-            info = litellm.model_cost.get(resolved, {})
-            uncached = info.get("input_cost_per_token")
-            if not uncached:
+            info = litellm.model_cost.get(resolve_litellm_model(model), {})
+            # A free model (a real 0.0) has always read as "no pricing" here and
+            # the callers below all skip it; keep that, and let
+            # _cache_input_rates own the rate/fallback policy itself.
+            if not info.get("input_cost_per_token"):
                 return None
-            cache_read = info.get("cache_read_input_token_cost", uncached)
-            cache_write = info.get("cache_creation_input_token_cost", uncached)
-            if long_context:
-                uncached = info.get("input_cost_per_token_above_200k_tokens") or uncached
-                cache_read = info.get("cache_read_input_token_cost_above_200k_tokens") or cache_read
-                cache_write = (
-                    info.get("cache_creation_input_token_cost_above_200k_tokens") or cache_write
-                )
-            return (cache_read, cache_write, uncached)
+            return _cache_input_rates(info, long_context=long_context)
         except Exception:
             return None
 

--- a/headroom/proxy/prometheus_metrics.py
+++ b/headroom/proxy/prometheus_metrics.py
@@ -788,6 +788,8 @@ class PrometheusMetrics:
             tool_schema_tokens_saved=tool_search_saved,
             output_tokens_saved=output_tokens_saved,
             cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            uncached_tokens=uncached_input_tokens,
         )
         async with self._lock:
             self.requests_total += 1

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from headroom import paths as _paths
 from headroom.proxy import project_name_policy
-from headroom.proxy.cost import _bucket_by_cache_mix
+from headroom.proxy.cost import _bucket_by_cache_mix, _cache_input_rates
 from headroom.proxy.persistent_metrics import PersistentMetricsState
 
 PROJECT_NAME_MAX_LENGTH = project_name_policy.PROJECT_NAME_MAX_LENGTH
@@ -330,46 +330,31 @@ def _estimate_cache_savings_usd(model: str, cache_read_tokens: int) -> float:
         return 0.0
 
 
-# Multipliers used only when litellm knows a model's list price but not its
-# cache prices. Anthropic bills cache reads at 0.1x input and cold writes at
-# 1.25x; OpenAI and Gemini read between 0.1x and 0.25x. Reads take the
-# conservative (cheapest) end so an unknown cache price cannot inflate savings.
-_CACHE_READ_MULTIPLIER = 0.1
-_CACHE_WRITE_MULTIPLIER = 1.25
-
-
 def _model_input_rates(model: str) -> tuple[float, float, float]:
     """``(cache_read, cache_write, list)`` per-token input rates for ``model``.
 
-    Mirrors ``_estimate_compression_savings_usd``'s fallback rules: an
-    unavailable litellm or an unpriced model falls back to
-    ``DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN``, and a legitimately free model
-    (a real ``0.0``) prices as free rather than as "unknown".
+    Rates and the missing-cache-price fallback come from ``cost.py``'s
+    ``_cache_input_rates``, the same policy the cost card prices real requests
+    with, so the two surfaces cannot disagree about what a deferred token would
+    have cost. Only the catalog lookup is local, because this module resolves
+    model names through its own alias-aware ``_resolve_litellm_model``.
+
+    Mirrors ``_estimate_compression_savings_usd``'s outer rules: an unavailable
+    litellm or an unpriced model falls back to
+    ``DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN`` for all three rates, and a
+    legitimately free model (a real ``0.0``) prices as free rather than as
+    "unknown".
     """
     litellm = _get_litellm_module()
+    if litellm is not None:
+        try:
+            rates = _cache_input_rates(litellm.model_cost.get(_resolve_litellm_model(model), {}))
+        except Exception:
+            rates = None
+        if rates is not None:
+            return rates
     fallback = float(DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN)
-    default = (
-        fallback * _CACHE_READ_MULTIPLIER,
-        fallback * _CACHE_WRITE_MULTIPLIER,
-        fallback,
-    )
-    if litellm is None:
-        return default
-    try:
-        info = litellm.model_cost.get(_resolve_litellm_model(model), {})
-        list_cost = info.get("input_cost_per_token")
-        if list_cost is None:
-            raise RuntimeError("input cost unavailable")
-        list_rate = float(list_cost)
-        read_cost = info.get("cache_read_input_token_cost")
-        write_cost = info.get("cache_creation_input_token_cost")
-        return (
-            float(read_cost) if read_cost is not None else list_rate * _CACHE_READ_MULTIPLIER,
-            float(write_cost) if write_cost is not None else list_rate * _CACHE_WRITE_MULTIPLIER,
-            list_rate,
-        )
-    except Exception:
-        return default
+    return (fallback, fallback, fallback)
 
 
 def _estimate_tool_schema_savings_usd(

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from headroom import paths as _paths
 from headroom.proxy import project_name_policy
+from headroom.proxy.cost import _bucket_by_cache_mix
 from headroom.proxy.persistent_metrics import PersistentMetricsState
 
 PROJECT_NAME_MAX_LENGTH = project_name_policy.PROJECT_NAME_MAX_LENGTH
@@ -329,6 +330,86 @@ def _estimate_cache_savings_usd(model: str, cache_read_tokens: int) -> float:
         return 0.0
 
 
+# Multipliers used only when litellm knows a model's list price but not its
+# cache prices. Anthropic bills cache reads at 0.1x input and cold writes at
+# 1.25x; OpenAI and Gemini read between 0.1x and 0.25x. Reads take the
+# conservative (cheapest) end so an unknown cache price cannot inflate savings.
+_CACHE_READ_MULTIPLIER = 0.1
+_CACHE_WRITE_MULTIPLIER = 1.25
+
+
+def _model_input_rates(model: str) -> tuple[float, float, float]:
+    """``(cache_read, cache_write, list)`` per-token input rates for ``model``.
+
+    Mirrors ``_estimate_compression_savings_usd``'s fallback rules: an
+    unavailable litellm or an unpriced model falls back to
+    ``DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN``, and a legitimately free model
+    (a real ``0.0``) prices as free rather than as "unknown".
+    """
+    litellm = _get_litellm_module()
+    fallback = float(DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN)
+    default = (
+        fallback * _CACHE_READ_MULTIPLIER,
+        fallback * _CACHE_WRITE_MULTIPLIER,
+        fallback,
+    )
+    if litellm is None:
+        return default
+    try:
+        info = litellm.model_cost.get(_resolve_litellm_model(model), {})
+        list_cost = info.get("input_cost_per_token")
+        if list_cost is None:
+            raise RuntimeError("input cost unavailable")
+        list_rate = float(list_cost)
+        read_cost = info.get("cache_read_input_token_cost")
+        write_cost = info.get("cache_creation_input_token_cost")
+        return (
+            float(read_cost) if read_cost is not None else list_rate * _CACHE_READ_MULTIPLIER,
+            float(write_cost) if write_cost is not None else list_rate * _CACHE_WRITE_MULTIPLIER,
+            list_rate,
+        )
+    except Exception:
+        return default
+
+
+def _estimate_tool_schema_savings_usd(
+    model: str,
+    tokens_saved: int,
+    *,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    uncached_tokens: int = 0,
+) -> float:
+    """Estimate tool-schema deferral savings in USD, priced by the cache mix.
+
+    Deferred schemas are byte-stable prompt-prefix content. Had they been sent
+    they would have ridden the SAME region of the request as everything else in
+    the prefix: cold-written once, read at the cache-read discount on warm
+    turns, re-written when the TTL expired. Pricing the whole layer at the full
+    input rate (as message compression correctly is) therefore overstates it by
+    roughly 10x on cache-heavy traffic -- enough to push a blended $/token
+    figure past the input list price of every model in the mix, a rate no real
+    input saving can reach.
+
+    Splits by the request's own observed mix with ``cost.py``'s
+    ``_bucket_by_cache_mix``, the same helper the cost card uses for exactly
+    this counterfactual, so the two surfaces cannot drift into quoting
+    different prices for the same deferred tokens. A request with no billed
+    input breakdown falls back to list price for the whole amount, matching
+    that helper's documented behaviour.
+    """
+    if tokens_saved <= 0:
+        return 0.0
+    read_share, write_share, list_share = _bucket_by_cache_mix(
+        tokens_saved,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+        uncached_tokens=uncached_tokens,
+    )
+    read_rate, write_rate, list_rate = _model_input_rates(model)
+    return read_share * read_rate + write_share * write_rate + list_share * list_rate
+
+
 def estimate_request_savings_usd(
     model: str,
     *,
@@ -336,6 +417,8 @@ def estimate_request_savings_usd(
     tool_schema_tokens_saved: int = 0,
     output_tokens_saved: int = 0,
     cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    uncached_tokens: int = 0,
 ) -> dict[str, float]:
     """Price one request's distinct savings layers for external telemetry.
 
@@ -348,8 +431,12 @@ def estimate_request_savings_usd(
         "compression": _estimate_compression_savings_usd(
             model, max(_coerce_int(compression_tokens_saved), 0)
         ),
-        "tool_schema": _estimate_compression_savings_usd(
-            model, max(_coerce_int(tool_schema_tokens_saved), 0)
+        "tool_schema": _estimate_tool_schema_savings_usd(
+            model,
+            max(_coerce_int(tool_schema_tokens_saved), 0),
+            cache_read_tokens=max(_coerce_int(cache_read_tokens), 0),
+            cache_write_tokens=max(_coerce_int(cache_write_tokens), 0),
+            uncached_tokens=max(_coerce_int(uncached_tokens), 0),
         ),
         "output_shaping": _estimate_output_savings_usd(
             model, max(_coerce_int(output_tokens_saved), 0)

--- a/tests/test_tool_schema_pricing.py
+++ b/tests/test_tool_schema_pricing.py
@@ -1,0 +1,195 @@
+"""Tool-schema deferral must be priced by the request's cache mix, not at list.
+
+Reported from a real install: pricing deferral with
+``_estimate_compression_savings_usd`` (full ``input_cost_per_token``) pushed the
+blended $/token savings figure from $4.99/M to $32.88/M on traffic where
+deferral ran 5.59x message compression -- a rate above the input list price of
+every model in the mix, which no genuine input-token saving can reach.
+
+Deferred schemas are byte-stable prompt-prefix content, so the counterfactual is
+the prefix's own billing rhythm: cold-written once, read at the cache-read
+discount on warm turns, re-written on TTL expiry. ``cost.py`` already models
+exactly that for the cost card via ``_bucket_by_cache_mix``; this module reuses
+that helper rather than keeping a second, differently-shaped estimate of the
+same tokens.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from headroom.proxy import savings_tracker as st
+from headroom.proxy.savings_tracker import (
+    _CACHE_READ_MULTIPLIER,
+    _CACHE_WRITE_MULTIPLIER,
+    DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN,
+    _estimate_tool_schema_savings_usd,
+    estimate_request_savings_usd,
+)
+
+LIST = 5.0 / 1_000_000
+READ = 0.5 / 1_000_000
+WRITE = 6.25 / 1_000_000
+MODEL = "claude-opus-5"
+
+
+def _fake_litellm(model_cost: dict) -> types.SimpleNamespace:
+    # cost_per_token succeeding makes _resolve_litellm_model return the name as-is.
+    return types.SimpleNamespace(
+        model_cost=model_cost,
+        cost_per_token=lambda **_kw: (0.0, 0.0),
+    )
+
+
+@pytest.fixture
+def priced(monkeypatch):
+    monkeypatch.setattr(
+        st,
+        "_get_litellm_module",
+        lambda: _fake_litellm(
+            {
+                MODEL: {
+                    "input_cost_per_token": LIST,
+                    "cache_read_input_token_cost": READ,
+                    "cache_creation_input_token_cost": WRITE,
+                }
+            }
+        ),
+    )
+
+
+def test_a_fully_warm_request_prices_deferral_at_the_cache_read_rate(priced):
+    got = _estimate_tool_schema_savings_usd(MODEL, 1_000_000, cache_read_tokens=100_000)
+    assert got == pytest.approx(1_000_000 * READ)
+    # The rate this replaces would have claimed the full input price -- 10x.
+    assert got * 10 == pytest.approx(1_000_000 * LIST)
+
+
+def test_a_cold_request_prices_deferral_at_the_cache_write_rate(priced):
+    got = _estimate_tool_schema_savings_usd(MODEL, 1_000_000, cache_write_tokens=100_000)
+    assert got == pytest.approx(1_000_000 * WRITE)
+
+
+def test_a_mixed_request_splits_by_its_own_observed_mix(priced):
+    # 50k read / 30k write / 20k uncached -> the deferred tokens are assumed to
+    # have ridden the same prefix in the same proportions.
+    got = _estimate_tool_schema_savings_usd(
+        MODEL,
+        100_000,
+        cache_read_tokens=50_000,
+        cache_write_tokens=30_000,
+        uncached_tokens=20_000,
+    )
+    expected = 50_000 * READ + 30_000 * WRITE + 20_000 * LIST
+    assert got == pytest.approx(expected)
+
+
+def test_no_billed_breakdown_falls_back_to_list_price(priced):
+    # Matches _bucket_by_cache_mix's documented behaviour, so the cost card and
+    # this estimator cannot disagree about the same request.
+    assert _estimate_tool_schema_savings_usd(MODEL, 1_000_000) == pytest.approx(1_000_000 * LIST)
+
+
+def test_missing_cache_prices_derive_from_the_models_list_price(monkeypatch):
+    monkeypatch.setattr(
+        st,
+        "_get_litellm_module",
+        lambda: _fake_litellm({"some-model": {"input_cost_per_token": LIST}}),
+    )
+    read = _estimate_tool_schema_savings_usd("some-model", 1_000_000, cache_read_tokens=1)
+    write = _estimate_tool_schema_savings_usd("some-model", 1_000_000, cache_write_tokens=1)
+    assert read == pytest.approx(1_000_000 * LIST * _CACHE_READ_MULTIPLIER)
+    assert write == pytest.approx(1_000_000 * LIST * _CACHE_WRITE_MULTIPLIER)
+
+
+def test_free_model_prices_as_zero(monkeypatch):
+    monkeypatch.setattr(
+        st,
+        "_get_litellm_module",
+        lambda: _fake_litellm(
+            {
+                "free-model": {
+                    "input_cost_per_token": 0.0,
+                    "cache_read_input_token_cost": 0.0,
+                    "cache_creation_input_token_cost": 0.0,
+                }
+            }
+        ),
+    )
+    assert _estimate_tool_schema_savings_usd("free-model", 1_000_000, cache_read_tokens=1) == 0.0
+
+
+@pytest.mark.parametrize("litellm", [None, "empty"])
+def test_unpriced_model_falls_back_to_the_default_rate(monkeypatch, litellm):
+    monkeypatch.setattr(
+        st,
+        "_get_litellm_module",
+        (lambda: None) if litellm is None else (lambda: _fake_litellm({})),
+    )
+    got = _estimate_tool_schema_savings_usd("unknown-model", 1_000_000, cache_read_tokens=1)
+    expected = 1_000_000 * _CACHE_READ_MULTIPLIER * DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN
+    assert got == pytest.approx(expected)
+
+
+def test_zero_and_negative_token_counts_price_as_zero(priced):
+    assert _estimate_tool_schema_savings_usd(MODEL, 0, cache_read_tokens=100) == 0.0
+    assert _estimate_tool_schema_savings_usd(MODEL, -5, cache_read_tokens=100) == 0.0
+
+
+def test_priced_buckets_separate_message_and_deferral_rates(priced):
+    result = estimate_request_savings_usd(
+        MODEL,
+        compression_tokens_saved=1_000_000,
+        tool_schema_tokens_saved=1_000_000,
+        cache_read_tokens=100_000,
+    )
+    # Message compression removes tokens that would have billed at full input
+    # rate; deferral removes prefix tokens billed at the cache-read rate.
+    assert result["compression"] == pytest.approx(1_000_000 * LIST)
+    assert result["tool_schema"] == pytest.approx(1_000_000 * READ)
+
+
+@pytest.mark.asyncio
+async def test_record_request_forwards_the_requests_cache_mix(monkeypatch, priced):
+    """The estimator only helps if the real path hands it the mix.
+
+    ``record_request`` already receives ``cache_write_tokens`` and
+    ``uncached_input_tokens``; before this change it passed only
+    ``cache_read_tokens`` on, so every deferred token priced as list no matter
+    how warm the request actually was.
+    """
+    from headroom.proxy.prometheus_metrics import PrometheusMetrics
+
+    seen: dict = {}
+    real = st.estimate_request_savings_usd
+
+    def _capture(model, **kwargs):
+        seen.update(kwargs)
+        return real(model, **kwargs)
+
+    monkeypatch.setattr("headroom.proxy.prometheus_metrics.estimate_request_savings_usd", _capture)
+
+    await PrometheusMetrics().record_request(
+        provider="anthropic",
+        model=MODEL,
+        input_tokens=100_000,
+        output_tokens=100,
+        tokens_saved=0,
+        latency_ms=1.0,
+        cache_read_tokens=50_000,
+        cache_write_tokens=30_000,
+        uncached_input_tokens=20_000,
+        tool_search_saved=100_000,
+    )
+
+    assert seen["cache_read_tokens"] == 50_000
+    assert seen["cache_write_tokens"] == 30_000
+    assert seen["uncached_tokens"] == 20_000
+    # Priced by that mix, not at list: list would have been 100_000 * LIST.
+    assert real(
+        MODEL,
+        tool_schema_tokens_saved=100_000,
+        **{k: seen[k] for k in ("cache_read_tokens", "cache_write_tokens", "uncached_tokens")},
+    )["tool_schema"] == pytest.approx(50_000 * READ + 30_000 * WRITE + 20_000 * LIST)

--- a/tests/test_tool_schema_pricing.py
+++ b/tests/test_tool_schema_pricing.py
@@ -20,10 +20,9 @@ import types
 
 import pytest
 
+from headroom.proxy import cost
 from headroom.proxy import savings_tracker as st
 from headroom.proxy.savings_tracker import (
-    _CACHE_READ_MULTIPLIER,
-    _CACHE_WRITE_MULTIPLIER,
     DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN,
     _estimate_tool_schema_savings_usd,
     estimate_request_savings_usd,
@@ -92,16 +91,28 @@ def test_no_billed_breakdown_falls_back_to_list_price(priced):
     assert _estimate_tool_schema_savings_usd(MODEL, 1_000_000) == pytest.approx(1_000_000 * LIST)
 
 
-def test_missing_cache_prices_derive_from_the_models_list_price(monkeypatch):
-    monkeypatch.setattr(
-        st,
-        "_get_litellm_module",
-        lambda: _fake_litellm({"some-model": {"input_cost_per_token": LIST}}),
-    )
-    read = _estimate_tool_schema_savings_usd("some-model", 1_000_000, cache_read_tokens=1)
-    write = _estimate_tool_schema_savings_usd("some-model", 1_000_000, cache_write_tokens=1)
-    assert read == pytest.approx(1_000_000 * LIST * _CACHE_READ_MULTIPLIER)
-    assert write == pytest.approx(1_000_000 * LIST * _CACHE_WRITE_MULTIPLIER)
+def test_missing_cache_prices_price_exactly_as_the_cost_card_does(monkeypatch):
+    """Both real pricing paths, on a catalog entry with no cache rates at all.
+
+    A hardcoded provider multiplier here would have quoted $0.50/M for a fully
+    read-cached request while ``CostTracker`` quoted $5/M for the same tokens of
+    the same request -- and would have overstated savings for any provider that
+    does not bill cache like Anthropic. Both sides now read the absent rate as
+    the list price, via the one shared policy in ``cost._cache_input_rates``.
+    """
+    catalog = {"some-model": {"input_cost_per_token": LIST}}
+    monkeypatch.setattr(st, "_get_litellm_module", lambda: _fake_litellm(catalog))
+    monkeypatch.setattr(cost, "_get_litellm_module", lambda: _fake_litellm(catalog))
+    monkeypatch.setattr("headroom.pricing.litellm_pricing.resolve_litellm_model", lambda m: m)
+    st._resolve_litellm_model.cache_clear()
+
+    card = cost.CostTracker()._get_cache_prices("some-model")
+    assert card == (LIST, LIST, LIST)
+    for mix, card_rate in zip(
+        ("cache_read_tokens", "cache_write_tokens", "uncached_tokens"), card, strict=True
+    ):
+        got = _estimate_tool_schema_savings_usd("some-model", 1_000_000, **{mix: 1})
+        assert got == pytest.approx(1_000_000 * card_rate)
 
 
 def test_free_model_prices_as_zero(monkeypatch):
@@ -128,9 +139,9 @@ def test_unpriced_model_falls_back_to_the_default_rate(monkeypatch, litellm):
         "_get_litellm_module",
         (lambda: None) if litellm is None else (lambda: _fake_litellm({})),
     )
+    st._resolve_litellm_model.cache_clear()
     got = _estimate_tool_schema_savings_usd("unknown-model", 1_000_000, cache_read_tokens=1)
-    expected = 1_000_000 * _CACHE_READ_MULTIPLIER * DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN
-    assert got == pytest.approx(expected)
+    assert got == pytest.approx(1_000_000 * DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN)
 
 
 def test_zero_and_negative_token_counts_price_as_zero(priced):


### PR DESCRIPTION
## Description

`estimate_request_savings_usd` prices the tool-schema deferral layer with `_estimate_compression_savings_usd`, i.e. at the full `input_cost_per_token` rate, the same rate message compression uses. That is the wrong counterfactual. Deferred schemas are byte-stable prompt-prefix content, so had they been sent they would have ridden the SAME region of the request as the rest of the prefix: cold-written once, billed at the cache-read discount on every warm turn after, re-written when the TTL expired.

On one real install where deferral ran 5.59x message compression, the blended savings rate read $32.88/M against $4.99/M actual, which is above the input list price of every model in the mix. No genuine input-token saving can reach that: a saved input token cannot be worth more than sending it would have cost.

**This branch was rewritten on 2026-09-09.** It previously proposed a flat 0.1x-of-input fraction. Since then #3351 merged `_bucket_by_cache_mix` into `cost.py` to model exactly this counterfactual for the full-savings cost card. Keeping a separate rule here would leave two surfaces quoting different prices for the same deferred tokens, so this now reuses that helper instead.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `headroom/proxy/savings_tracker.py`: new `_estimate_tool_schema_savings_usd`, which splits the layer with `cost.py`'s `_bucket_by_cache_mix` by the request's own observed read/write/uncached mix and prices each share at its own rate. A request with no billed input breakdown falls back to list price for the whole amount, matching that helper's documented behaviour, so the two surfaces cannot disagree about the same request.
- `headroom/proxy/savings_tracker.py`: new `_model_input_rates`, which resolves `(cache_read, cache_write, list)` per-token rates. Models litellm prices without cache rates derive them from the list price (0.1x read, 1.25x write) rather than silently pricing a cached token at list. Follows the module's existing fallback rules: an unavailable litellm or unpriced model falls back to `DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN`, and a legitimately free model (a real `0.0`) prices as free rather than as "unknown".
- `headroom/proxy/savings_tracker.py`: `estimate_request_savings_usd` gains `cache_write_tokens` and `uncached_tokens`.
- `headroom/proxy/prometheus_metrics.py`: `record_request` already received both and forwarded only `cache_read_tokens`, so the mix could never reach the estimator. Both are now passed.
- `tests/test_tool_schema_pricing.py`: rewritten for the mix-based rule (11 tests) - per-mix pricing, the no-breakdown fallback, derived cache rates, free models, unpriced models, zero/negative counts, bucket separation, and the call-site wiring through the real `PrometheusMetrics.record_request` path.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
uv run --frozen --extra dev pytest $(grep -rln "tool_search_saved\|tool_schema\|estimate_request_savings_usd" tests/) -q
309 passed, 2 warnings in 33.13s

uvx ruff check headroom/proxy/savings_tracker.py headroom/proxy/prometheus_metrics.py tests/test_tool_schema_pricing.py
All checks passed!

uv run --frozen --extra dev mypy headroom/proxy/savings_tracker.py headroom/proxy/prometheus_metrics.py
Success: no issues found in 2 source files
```

## Real Behavior Proof

- Environment: macOS 15, Python 3.11.13, branch rebased onto `e67b3c8a`.
- Exact command / steps: call `estimate_request_savings_usd(model, compression_tokens_saved=1_000_000, tool_schema_tokens_saved=1_000_000, **mix)` across four cache mixes and three models.
- Observed result: the deferral bucket now tracks the request's mix instead of always reading as the message rate.

```text
                                 message   deferral
claude-opus-5
  fully warm (100% cache read)    $5.00     $0.50
  mixed 50/30/20                  $5.00     $3.12
  cold (100% write)               $5.00     $6.25
  no breakdown                    $5.00     $5.00
gpt-5.2
  fully warm (100% cache read)    $1.75     $0.17
  mixed 50/30/20                  $1.75     $1.09
  cold (100% write)               $1.75     $2.19
  no breakdown                    $1.75     $1.75
gemini-3-pro
  fully warm (100% cache read)    $3.00     $0.30
  mixed 50/30/20                  $3.00     $1.88
  cold (100% write)               $3.00     $3.75
  no breakdown                    $3.00     $3.00
```

- Worth reading carefully: this is NOT a uniform reduction. A cold request prices deferral ABOVE the message rate ($6.25 vs $5.00 on opus), because cache writes bill at a 1.25x premium. The old flat-rate treatment was wrong in both directions; it happened to be wrong in the expensive direction on the cache-heavy traffic that prompted the report.
- Not tested: installs without litellm beyond the unit-tested fallback path; dashboard rendering of the re-priced bucket on a long-lived live proxy.

## Runtime Rollout Safety

- Rollout-managed feature(s): None - pricing estimator only, no rollout-gated runtime behavior touched.
- Minimum rollout channel: N/A
- Stable/default behavior changed: Yes, deliberately. The `tool_schema` bucket now prices by cache mix, so reported tool-schema dollars fall on warm traffic and rise slightly on cold traffic. No control flow, wire format, or persistence shape changes.
- Kill switch / disable path: None - pure function change; reverting the commit restores input-rate pricing exactly.
- Unsafe override required: No
- Qualification impact: Savings dollars shown on the dashboard and `/stats` drop on tool-heavy cache-warm traffic. A correction, not a regression. Token counts untouched.
- Rollback path: `git revert` - no persisted state depends on the rate that produced a recorded dollar figure.

## Review Readiness

- [x] I performed a self-review
- [x] PR is ready for human review

Related: #3170 records tool-schema dollars disjointly so consumers can tell the layers apart. Independent; either lands without the other. Together they make the headline both legible and honest.
