### PR TITLE
fix: strip x-openai-internal-* headers when proxying to upstreams

### DIFF
--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -3112,6 +3112,8 @@ class OpenAIHandlerMixin:
         # Cloudflare Workers forward "br, zstd" which OpenAI may honor;
         # if httpx lacks brotli support the response body is undecipherable → 502.
         headers.pop("accept-encoding", None)
+        from headroom.proxy.helpers import strip_openai_internal_headers
+        headers = strip_openai_internal_headers(headers)
         tags = extract_tags(headers)
         from headroom.proxy.savings_attribution import bind_scope
 
@@ -5109,6 +5111,8 @@ class OpenAIHandlerMixin:
         # plain. Leaving a stale content-encoding header makes the upstream try
         # to decompress already-decoded JSON and reject it with HTTP 400 (#1542).
         headers.pop("content-encoding", None)
+        from headroom.proxy.helpers import strip_openai_internal_headers
+        headers = strip_openai_internal_headers(headers)
         tags = extract_tags(headers)
         from headroom.proxy.savings_attribution import bind_scope
 
@@ -9619,6 +9623,8 @@ class OpenAIHandlerMixin:
         headers = dict(request.headers.items())
         headers.pop("host", None)
         headers.pop("accept-encoding", None)
+        from headroom.proxy.helpers import strip_openai_internal_headers
+        headers = strip_openai_internal_headers(headers)
         client = classify_client(headers)
         tags = extract_tags(headers)
         # PR-A5 (P5-49): strip internal x-headroom-* before forwarding upstream.

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -1602,6 +1602,16 @@ def _strip_internal_headers(headers: dict[str, str]) -> dict[str, str]:
     return strip_internal_headers(headers, mode=get_strip_internal_headers_mode())
 
 
+def strip_openai_internal_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Strip internal x-openai-internal-* headers that cause upstreams to reject requests."""
+    cleaned = dict(headers)
+    for k in list(cleaned.keys()):
+        if k.lower().startswith("x-openai-internal-"):
+            cleaned.pop(k, None)
+    return cleaned
+
+
+
 def merge_extra_headers(
     headers: dict[str, str],
     extra: dict[str, str] | None,

--- a/tests/test_proxy_handler_helpers.py
+++ b/tests/test_proxy_handler_helpers.py
@@ -1255,3 +1255,19 @@ def test_handle_streaming_passthrough_client_disconnect():
         )
     )
     assert response.status_code == 204
+
+
+def test_strip_openai_internal_headers():
+    from headroom.proxy.helpers import strip_openai_internal_headers
+    headers = {
+        "Host": "api.openai.com",
+        "X-OpenAI-Internal-Codex-Responses-Lite": "true",
+        "x-openai-internal-another-header": "value",
+        "Authorization": "Bearer key"
+    }
+    cleaned = strip_openai_internal_headers(headers)
+    assert "Host" in cleaned
+    assert "Authorization" in cleaned
+    assert "X-OpenAI-Internal-Codex-Responses-Lite" not in cleaned
+    assert "x-openai-internal-another-header" not in cleaned
+


### PR DESCRIPTION
## Description

This PR prevents upstreams from rejecting proxied requests when internal headers like `X-OpenAI-Internal-Codex-Responses-Lite` are forwarded by the client. These headers are stripped case-insensitively before proxying.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Added `strip_openai_internal_headers(headers)` utility function to case-insensitively pop all `x-openai-internal-*` headers.
- Integrated the stripping utility into the main proxy pathways in `headroom/proxy/handlers/openai.py`:
  - `openai_chat_completions` (chat path)
  - `openai_completions` (legacy text path)
  - `v1_responses` (passthrough path)
- Created the corresponding unit test `test_strip_openai_internal_headers` in `tests/test_proxy_handler_helpers.py` to assert header scrubbing correctness.

## Testing

- [x] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
pytest tests/test_proxy_handler_helpers.py
...
✔ test_strip_openai_internal_headers passes (1.02ms)
