### PR TITLE
fix(proxy/responses): lift Codex >= 0.149.0 additional_tools into top-level tools

### DIFF
--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -778,6 +778,73 @@ def _compact_openai_responses_tools(
     return compact_tools(payload)
 
 
+def _codex_additional_tools_lift_enabled() -> bool:
+    from headroom.proxy import runtime_env
+
+    return (
+        runtime_env.getenv("HEADROOM_CODEX_ADDITIONAL_TOOLS_LIFT", "1") or "1"
+    ).strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _lift_codex_additional_tools(payload: dict[str, Any], *, request_id: str | None = None) -> int:
+    """Lift Codex ``additional_tools`` input items into top-level ``tools``.
+
+    Codex CLI 0.149.0 stopped sending a top-level ``tools`` array on
+    ``/v1/responses`` for models its capability cache flags (``gpt-5.6-sol``,
+    its current default): tool definitions ride inside ``input`` as items of
+    type ``additional_tools``. Every tools consumer downstream -- schema
+    compaction, the output-shaper stratum, tools token accounting -- reads
+    only ``payload["tools"]``, so those requests classified "notools" and
+    recorded zero tool-schema savings while forwarding normally (#3185).
+
+    Mutates *payload* in place: concatenates the items' ``tools`` arrays into
+    ``payload["tools"]`` and drops the carrier items from ``input``. Returns
+    the number of lifted tool definitions (0 = no-op). No-op when the payload
+    already carries top-level tools, so classic-encoding clients are
+    untouched and a future Codex reverting the change costs nothing. The
+    classic top-level encoding is accepted upstream for these models --
+    Codex <= 0.148 still sends it for ``gpt-5.6-sol`` -- verified against the
+    live ChatGPT Codex backend with executed tool calls. Disable with
+    ``HEADROOM_CODEX_ADDITIONAL_TOOLS_LIFT=0``.
+    """
+    if not isinstance(payload, dict) or payload.get("tools"):
+        return 0
+    items = payload.get("input")
+    if not isinstance(items, list):
+        return 0
+    if not any(isinstance(item, dict) and item.get("type") == "additional_tools" for item in items):
+        return 0
+    if not _codex_additional_tools_lift_enabled():
+        return 0
+    lifted: list[Any] = []
+    kept: list[Any] = []
+    for item in items:
+        if (
+            isinstance(item, dict)
+            and item.get("type") == "additional_tools"
+            and isinstance(item.get("tools"), list)
+            and item["tools"]
+        ):
+            lifted.extend(item["tools"])
+        else:
+            kept.append(item)
+    if not lifted:
+        return 0
+    payload["tools"] = lifted
+    payload["input"] = kept
+    logger.info(
+        "[%s] Lifted %d Codex additional_tools definitions to top-level tools",
+        request_id or "-",
+        len(lifted),
+    )
+    return len(lifted)
+
+
 def _allow_responses_memory_tools(is_chatgpt_auth: bool) -> bool:
     # Preserve the ChatGPT Codex route's existing store policy and memory-tool
     # exclusion while API Responses memory continuations stay stateless.
@@ -2869,6 +2936,20 @@ class OpenAIHandlerMixin:
         savings_tags: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], bool, int, list[str], str | None, int, int, int, dict[str, float]]:
         timing: dict[str, float] = {}
+
+        # Codex >= 0.149.0 nests tool definitions in `input` items of type
+        # additional_tools; normalize to the classic top-level array before
+        # shaping/compression so every downstream tools consumer engages.
+        # Runs once per pass, ahead of the executor closure, and never breaks
+        # forwarding.
+        try:
+            _lift_codex_additional_tools(payload, request_id=request_id)
+        except Exception:  # pragma: no cover - defensive; never break forwarding
+            logger.warning(
+                "[%s] additional_tools lift failed; continuing unlifted",
+                request_id,
+                exc_info=True,
+            )
 
         def _compress():  # noqa: ANN202
             # Output shaping (opt-in via HEADROOM_OUTPUT_SHAPER) runs before

--- a/tests/test_openai_responses_additional_tools.py
+++ b/tests/test_openai_responses_additional_tools.py
@@ -1,0 +1,150 @@
+"""Codex >= 0.149.0 ``additional_tools`` normalization (#3185).
+
+Codex CLI 0.149.0 sends tool definitions as ``input`` items of type
+``additional_tools`` instead of a top-level ``tools`` array for models its
+capability cache flags (``gpt-5.6-sol``). Without the lift, every tools
+consumer (schema compaction, output-shaper stratum, tools token accounting)
+sees a tool-less request and records zero tool-schema savings.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from headroom.proxy.handlers.openai import (
+    _compact_openai_responses_tools,
+    _lift_codex_additional_tools,
+)
+
+
+def _verbose_tool(name: str) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "name": name,
+        "description": " ".join(["Runs a shell command in the workspace."] * 30),
+        "parameters": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "title": name,
+            "properties": {
+                "command": {
+                    "type": "array",
+                    "title": "command",
+                    "items": {"type": "string"},
+                }
+            },
+            "required": ["command"],
+        },
+    }
+
+
+def _codex_0149_payload() -> dict[str, Any]:
+    return {
+        "model": "gpt-5.6-sol",
+        "include": ["reasoning.encrypted_content"],
+        "reasoning": {"effort": "low", "context": "all_turns"},
+        "tool_choice": "auto",
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "do the thing"}],
+            },
+            {
+                "type": "additional_tools",
+                "tools": [_verbose_tool("shell"), _verbose_tool("update_plan")],
+            },
+        ],
+    }
+
+
+def test_lift_moves_additional_tools_to_top_level() -> None:
+    payload = _codex_0149_payload()
+
+    lifted = _lift_codex_additional_tools(payload)
+
+    assert lifted == 2
+    assert [t["name"] for t in payload["tools"]] == ["shell", "update_plan"]
+    # The carrier item is dropped; every other input item survives in order.
+    assert [item["type"] for item in payload["input"]] == ["message"]
+
+
+def test_lift_concatenates_multiple_carrier_items() -> None:
+    payload = _codex_0149_payload()
+    payload["input"].append({"type": "additional_tools", "tools": [_verbose_tool("view_image")]})
+
+    lifted = _lift_codex_additional_tools(payload)
+
+    assert lifted == 3
+    assert [t["name"] for t in payload["tools"]] == ["shell", "update_plan", "view_image"]
+
+
+def test_lift_is_noop_when_top_level_tools_present() -> None:
+    payload = _codex_0149_payload()
+    payload["tools"] = [_verbose_tool("shell")]
+    before = copy.deepcopy(payload)
+
+    assert _lift_codex_additional_tools(payload) == 0
+    assert payload == before
+
+
+def test_lift_is_noop_without_carrier_items() -> None:
+    payload = _codex_0149_payload()
+    payload["input"] = [item for item in payload["input"] if item["type"] != "additional_tools"]
+    before = copy.deepcopy(payload)
+
+    assert _lift_codex_additional_tools(payload) == 0
+    assert payload == before
+
+    assert _lift_codex_additional_tools({"model": "gpt-5.6-sol", "input": "not-a-list"}) == 0
+    assert _lift_codex_additional_tools("not-a-dict") == 0  # type: ignore[arg-type]
+
+
+def test_lift_disabled_by_kill_switch(monkeypatch) -> None:
+    monkeypatch.setenv("HEADROOM_CODEX_ADDITIONAL_TOOLS_LIFT", "0")
+    payload = _codex_0149_payload()
+    before = copy.deepcopy(payload)
+
+    assert _lift_codex_additional_tools(payload) == 0
+    assert payload == before
+
+
+def test_lift_logs_with_request_id(caplog) -> None:
+    payload = _codex_0149_payload()
+
+    with caplog.at_level("INFO", logger="headroom.proxy"):
+        assert _lift_codex_additional_tools(payload, request_id="req_test") == 2
+
+    assert any(
+        "req_test" in message and "additional_tools" in message for message in caplog.messages
+    )
+
+
+def test_lift_preserves_empty_carrier_items() -> None:
+    payload = _codex_0149_payload()
+    payload["input"].append({"type": "additional_tools", "tools": []})
+
+    lifted = _lift_codex_additional_tools(payload)
+
+    # The empty carrier holds no definitions to lift; it is preserved rather
+    # than invented into an empty top-level array.
+    assert lifted == 2
+    assert [item["type"] for item in payload["input"]] == ["message", "additional_tools"]
+
+
+def test_lifted_tools_reach_schema_compaction() -> None:
+    payload = _codex_0149_payload()
+
+    # Without the lift: compaction sees no tools and returns unmodified —
+    # the exact production failure.
+    _, modified, _, _ = _compact_openai_responses_tools(copy.deepcopy(payload))
+    assert modified is False
+
+    _lift_codex_additional_tools(payload)
+    compacted, modified, before_bytes, after_bytes = _compact_openai_responses_tools(payload)
+
+    assert modified is True
+    assert after_bytes < before_bytes
+    # Compaction preserves the invocation shape the model needs.
+    assert [t["name"] for t in compacted["tools"]] == ["shell", "update_plan"]


### PR DESCRIPTION
## Description

Codex CLI 0.149.0 (npm `latest` since 2026-08-20 21:09 UTC) stopped sending a top-level `tools` array on `/v1/responses` for models its server-fetched capability cache flags (`gpt-5.6-sol`, its new default). Tool definitions now ride inside `input` as items of a new type:

```json
{"type": "additional_tools", "tools": [ {...}, {...} ]}
```

Every tools consumer in the proxy - `tool_schema_compaction`, the output-shaper stratum, the tools token accounting - reads only `payload["tools"]`, so these requests classify `notools` and record exactly zero tool-schema savings while forwarding and streaming normally. Users on Codex <= 0.148 are unaffected; users silently lose savings the moment their CLI updates. On our fleet the day after the Codex release, 42 of 54 codex-primary users active in a 12h window had savings frozen, and 0 of that day's codex new signups recorded any savings.

This PR normalizes the new encoding to the classic one before compression: `_lift_codex_additional_tools(payload)` concatenates the carrier items' `tools` arrays into `payload["tools"]` and drops the carriers from `input`, in place, once per compression pass - at the top of `_compress_openai_responses_payload_in_executor`, the single funnel every responses call site goes through (HTTP `/v1/responses`, WS first and subsequent frames, passthrough). It no-ops when top-level `tools` is already present, so classic-encoding clients pay nothing and a future Codex reverting the change costs nothing. Normalizing (rather than compacting inside the items and preserving the new wire shape) keeps every downstream consumer working without touching their accounting; the alternative shape is discussed in #3185.

Closes #3185

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/handlers/openai.py`: new module function `_lift_codex_additional_tools(payload, *, request_id=None)` plus `_codex_additional_tools_lift_enabled()` (env gate via `runtime_env.getenv`, hot-reloadable); called defensively at the top of `_compress_openai_responses_payload_in_executor` so a lift failure can never break forwarding.
- `tests/test_openai_responses_additional_tools.py`: 8 tests - lift shape, multi-carrier concatenation, no-op on classic encoding, no-op without carriers / non-dict / non-list input, kill switch, logging, empty-carrier preservation, and lift-then-compaction integration reproducing the exact production failure (compaction returns unmodified without the lift).

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run --frozen --extra dev pytest tests/test_openai_responses_additional_tools.py tests/test_openai_responses_context_compaction.py -q
==== 18 passed in 2.71s ====

$ uv run --frozen --extra dev pytest tests/test_proxy_openai.py -q   # adjacent handler suite
==== 31 passed, 1 warning in 26.36s ====

$ uv run --frozen ruff check headroom/proxy/handlers/openai.py tests/test_openai_responses_additional_tools.py
All checks passed!
$ uv run --frozen ruff format --check headroom/proxy/handlers/openai.py tests/test_openai_responses_additional_tools.py
2 files already formatted
$ uv run --frozen mypy headroom/proxy/handlers/openai.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: macOS 15 (arm64), headroom-ai 0.35.0 wheel in a fresh venv with empty state (`HOME` pointed at an empty dir), `headroom proxy --port 6799 --no-http2 --log-messages --no-ccr`; Codex CLI 0.149.0 (standalone npm install) and 0.142.4, ChatGPT-plan OAuth, routed via a `[model_providers]` block in `config.toml`.
- Exact command / steps: `CODEX_HOME=<test home> codex exec --skip-git-repo-check "Run the shell command: echo headroom-test-123. Then reply with exactly the output it printed."` against the proxy, before and after injecting the lift (via a sitecustomize carrying the same function); cross-checked Codex 0.142.4 default (gpt-5.5), 0.142.4 `-m gpt-5.6-sol`, and 0.149.0 `-m gpt-5.5`.
- Observed result: before - `/v1/responses compressed 59425->59425 bytes (0 tokens saved, transforms=['output_shaper:stratum:gpt|new_user_ask|m|notools', 'output_shaper:verbosity:L2'])` despite ~12k tokens of tool schemas in the request (Codex's own `tool_token_count` log field). After - `/v1/responses compressed 59437->58716 bytes (608 tokens saved, transforms=['output_shaper:stratum:gpt|new_user_ask|m|tools', 'output_shaper:verbosity:L2', 'openai:responses:tool_schema_compaction'])`; the shell tool call executed against the live ChatGPT Codex backend and returned its output, the follow-up turn classified `mechanical_continuation|m|tools`, and the prefix cache stayed hot (cache_hit_pct=100 on turn 2). The three cross-check matrix cells all compress, confirming the backend accepts the classic top-level encoding for these models and that the regression is 0.149.0's default-model path specifically.
- Not tested: Codex over the WebSocket transport (the verified setups pin `supports_websockets = false`; the lift sits in the shared executor those frames also funnel through, and unit tests cover the per-frame payload shapes); non-ChatGPT (API-key) Codex auth; models other than gpt-5.5/gpt-5.6-sol.

## Runtime Rollout Safety

- Rollout-managed feature(s): none - not wired to the rollout system.
- Minimum rollout channel: n/a.
- Stable/default behavior changed: only for requests carrying `additional_tools` input items with no top-level `tools` (the Codex >= 0.149.0 default-model encoding, which today gets zero compression); all other traffic is byte-identical.
- Kill switch / disable path: `HEADROOM_CODEX_ADDITIONAL_TOOLS_LIFT=0` (read through `runtime_env.getenv`, so hot-reload overrides apply without a restart).
- Unsafe override required: no.
- Qualification impact: none known.
- Rollback path: set the kill switch, or revert this single commit - the lift is self-contained (one function + one guarded call site).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

n/a - proxy log lines quoted under Real Behavior Proof.

## Additional Notes

- Documentation checklist item is unchecked because no user-facing docs describe the responses tools handling; happy to add a line wherever you track client-compat notes if you have a preferred spot.
- If you would rather preserve the new wire shape upstream (compact inside the carrier items instead of normalizing), I am happy to rework - trade-offs are laid out in #3185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
