### PR TITLE
fix(proxy): write per-port proxy logs so concurrent instances stop truncating each other

### DIFF
--- a/headroom/cli/perf.py
+++ b/headroom/cli/perf.py
@@ -28,7 +28,8 @@ def perf(hours: float, raw: bool, output_format: str) -> None:
     """Analyze proxy performance from logs.
 
     \b
-    Reads logs from ~/.headroom/logs/proxy.log and shows:
+    Reads logs from ~/.headroom/logs/proxy-*.log (per-worker and per-port,
+    with the legacy proxy.log as a fallback) and shows:
     - Token savings and compression effectiveness
     - Cache hit rates and prefix stability
     - Transform and routing breakdown

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -611,18 +611,31 @@ def _find_available_port(start_port: int, max_attempts: int = 100) -> int:
     raise RuntimeError(f"No available port found in range {start_port}-{end_port - 1}")
 
 
-def _get_log_path() -> Path:
-    """Get path for proxy log file."""
+def _get_log_path(port: int | None = None) -> Path:
+    """Get path for the proxy runtime log file.
+
+    Per-port (``proxy-<port>.log``) so concurrent wrap sessions on different
+    ports do not rotate a single shared log away; the legacy ``proxy.log``
+    name is used when *port* is omitted.
+    """
     from headroom import paths as _paths
 
     log_dir = _paths.log_dir()
     log_dir.mkdir(parents=True, exist_ok=True)
-    return log_dir / "proxy.log"
+    return _paths.proxy_log_path(port)
 
 
-def _get_proxy_stdio_log_path() -> Path:
-    """Get path for dedicated proxy stdio capture."""
-    return _get_log_path().with_name("proxy-stdio.log")
+def _get_proxy_stdio_log_path(port: int | None = None) -> Path:
+    """Get path for dedicated proxy stdio capture (per-port when *port* given).
+
+    The filename comes from :func:`headroom.paths.proxy_stdio_log_path` (the
+    single source of truth) while the directory comes from :func:`_get_log_path`,
+    so a caller (or test) that redirects the log directory via that helper
+    redirects the stdio capture with it.
+    """
+    from headroom import paths as _paths
+
+    return _get_log_path(port).with_name(_paths.proxy_stdio_log_path(port).name)
 
 
 def _start_proxy(
@@ -645,9 +658,9 @@ def _start_proxy(
 ) -> subprocess.Popen:
     """Start Headroom proxy as a background subprocess.
 
-    Stdout and stderr are written to a dedicated sibling file, usually
-    `~/.headroom/logs/proxy-stdio.log`, to avoid pipe deadlock risk without
-    competing with the rotating `proxy.log` runtime log.
+    Stdout and stderr are written to a dedicated per-port sibling file,
+    `~/.headroom/logs/proxy-stdio-<port>.log`, to avoid pipe deadlock risk
+    without competing with the rotating `proxy-<port>.log` runtime log.
 
     The caller is responsible for ensuring *port* is available
     (see ``_find_available_port``).
@@ -695,8 +708,8 @@ def _start_proxy(
         cmd.extend(["--vertex-api-url", vertex_api_url])
 
     timeout_seconds = _resolve_wrap_proxy_timeout_seconds()
-    log_path = _get_log_path()
-    stdio_log_path = _get_proxy_stdio_log_path()
+    log_path = _get_log_path(port)
+    stdio_log_path = _get_proxy_stdio_log_path(port)
     stdio_log_file = open(stdio_log_path, "a", encoding="utf-8")  # noqa: SIM115
 
     # Ensure proxy subprocess uses UTF-8 (Windows defaults to cp1252)

--- a/headroom/paths.py
+++ b/headroom/paths.py
@@ -73,7 +73,10 @@ _SAVINGS_EVENTS_FILE = "savings_events.jsonl"
 _SYNC_STATE_FILE = "sync_state.json"
 _BRIDGE_STATE_FILE = "bridge_state.json"
 _LOGS_DIR = "logs"
+# Legacy shared runtime-log filename. Kept only as the readers' backward-compat
+# fallback; live proxies now write per-port files (see ``proxy_log_path``).
 _PROXY_LOG_FILE = "proxy.log"
+_PROXY_STDIO_LOG_FILE = "proxy-stdio.log"
 _DEBUG_400_DIR = "debug_400"
 _CODEX_WIRE_DEBUG_DIR = "codex_wire"
 _BIN_DIR = "bin"
@@ -300,10 +303,33 @@ def log_dir() -> Path:
     return workspace_dir() / _LOGS_DIR
 
 
-def proxy_log_path() -> Path:
-    """Return the path for the proxy log file."""
+def proxy_log_path(port: int | None = None, *, process_id: int | None = None) -> Path:
+    """Return the path for the proxy runtime log file.
 
-    return log_dir() / _PROXY_LOG_FILE
+    Multi-worker processes pass both values and write
+    ``proxy-<port>-<pid>.log``. Omitting *process_id* returns the standard
+    per-port name; omitting *port* returns the legacy shared name. Readers
+    honor all three.
+    """
+
+    if port is None:
+        name = _PROXY_LOG_FILE
+    elif process_id is None:
+        name = f"proxy-{port}.log"
+    else:
+        name = f"proxy-{port}-{process_id}.log"
+    return log_dir() / name
+
+
+def proxy_stdio_log_path(port: int | None = None) -> Path:
+    """Return the path for the proxy stdout/stderr capture file.
+
+    Per-port for the same reason as :func:`proxy_log_path`; the legacy
+    ``proxy-stdio.log`` name is used when *port* is omitted.
+    """
+
+    name = f"proxy-stdio-{port}.log" if port is not None else _PROXY_STDIO_LOG_FILE
+    return log_dir() / name
 
 
 def debug_400_dir() -> Path:
@@ -432,6 +458,7 @@ __all__ = [
     "bridge_state_path",
     "log_dir",
     "proxy_log_path",
+    "proxy_stdio_log_path",
     "debug_400_dir",
     "codex_wire_debug_dir",
     "bin_dir",

--- a/headroom/perf/analyzer.py
+++ b/headroom/perf/analyzer.py
@@ -1,6 +1,7 @@
 """Analyze headroom proxy logs for performance insights.
 
-Parses PERF log lines from ~/.headroom/logs/proxy.log* and produces
+Parses PERF log lines from ~/.headroom/logs/proxy-*.log* (per-worker and
+per-port) and the legacy ~/.headroom/logs/proxy.log* fallback, and produces
 actionable reports on token savings, cache efficiency, and transform impact.
 
 Cost accounting is **cache-aware**: saved tokens that would have been served
@@ -24,6 +25,14 @@ log = logging.getLogger(__name__)
 
 LOG_DIR = _paths.log_dir()
 DEFAULT_SLOW_OPTIMIZATION_MS = 500.0
+
+# Runtime-log filenames that carry PERF records: the legacy shared
+# ``proxy.log``, per-port ``proxy-<port>.log``, and worker-specific
+# ``proxy-<port>-<pid>.log`` (port and PID are digits), each with optional
+# rotation suffix ``.1``..``.5``. A positive match (not a
+# ``proxy-stdio`` blacklist) so unrelated files like ``proxy-stdio-8787.log``
+# or a hypothetical ``proxy-errors.log`` are never ingested as PERF input.
+_PERF_LOG_FILE_RE = re.compile(r"proxy(?:-\d+){0,2}\.log(?:\.\d+)?$")
 
 # Matches: 2026-03-07 13:38:31,009 - headroom.proxy - INFO - [hr_...] PERF model=... ...
 _PERF_RE = re.compile(
@@ -312,7 +321,13 @@ def parse_log_files(last_n_hours: float = 168.0) -> PerfReport:
         if report.newest_kept_ts is None or ts_str > report.newest_kept_ts:
             report.newest_kept_ts = ts_str
 
-    # Collect log files: proxy.log, proxy.log.1, proxy.log.2, ...
+    # Collect log files across every proxy instance:
+    #   - per-worker runtime logs: proxy-<port>-<pid>.log, rotations
+    #   - standard per-port runtime logs: proxy-<port>.log, rotations
+    #   - legacy shared log (backward compat): proxy.log, proxy.log.1, ...
+    # Selected by a positive filename match (``_PERF_LOG_FILE_RE``), so the
+    # proxy-stdio-*.log captures (stdout/stderr, not PERF records) and any other
+    # ``proxy-<word>.log`` are never fed to the parser.
     #
     # A rotated file last written before the cutoff cannot contain a record
     # inside the window, so skip it without opening it. Without this the cost
@@ -327,7 +342,8 @@ def parse_log_files(last_n_hours: float = 168.0) -> PerfReport:
     # are stat'd once and the value reused for the sort.
     cutoff_epoch = cutoff.timestamp() if cutoff is not None else None
     dated_files: list[tuple[float, Path]] = []
-    for path in log_dir.glob("proxy.log*"):
+    candidates = [p for p in log_dir.glob("proxy*.log*") if _PERF_LOG_FILE_RE.fullmatch(p.name)]
+    for path in candidates:
         try:
             mtime = path.stat().st_mtime
         except OSError:
@@ -337,7 +353,9 @@ def parse_log_files(last_n_hours: float = 168.0) -> PerfReport:
             report.log_files_skipped += 1
             continue
         dated_files.append((mtime, path))
-    log_files = [path for _, path in sorted(dated_files, key=lambda pair: pair[0])]
+    # Secondary key on the path keeps ordering deterministic when two files
+    # share an mtime (glob order is not stable).
+    log_files = [path for _, path in sorted(dated_files, key=lambda pair: (pair[0], str(pair[1])))]
 
     for log_file in log_files:
         report.log_files_read += 1

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -1549,37 +1549,64 @@ def _headroom_log_dir() -> Path:
     return _paths.log_dir()
 
 
-def _setup_file_logging() -> None:
+_PROXY_LOG_HANDLER_NAME = "headroom.proxy.file"
+
+
+def _setup_file_logging(
+    port: int | None = None,
+    *,
+    process_id: int | None = None,
+) -> None:
     """Add a RotatingFileHandler to the headroom root logger.
 
-    Writes to ~/.headroom/logs/proxy.log with automatic rotation:
+    Writes to a per-port log, with a PID suffix in multi-worker mode:
     - Rotates at 10 MB
     - Keeps 5 backups (~50 MB max)
+
+    The file is keyed by *port* so concurrent instances rotate separate logs.
+    Multi-worker callers also pass *process_id* so same-port workers cannot
+    race during rollover. When *port* is omitted the legacy shared name is used.
     """
     from logging.handlers import RotatingFileHandler
 
     try:
         log_dir = _headroom_log_dir()
         log_dir.mkdir(parents=True, exist_ok=True)
-        log_path = log_dir / "proxy.log"
+        log_path = _paths.proxy_log_path(port, process_id=process_id)
+        # Attach to the headroom root logger so all sub-loggers are captured.
+        # Disable propagation to root to avoid duplicate writes when
+        # wrap.py redirects stderr to the same log file.
+        headroom_logger = logging.getLogger("headroom")
+        headroom_logger.setLevel(logging.INFO)
+        headroom_logger.propagate = False
+        # Decide BEFORE constructing the handler: constructing a
+        # RotatingFileHandler opens (creates) the file, so building one only to
+        # discard it would leave an empty stray worker log and leak
+        # its fd. Reuse an already-attached handler for the same file; if one
+        # points at a different port during sequential app creation, replace
+        # and close it so later records use the newly selected path.
+        existing = [
+            h
+            for h in headroom_logger.handlers
+            if isinstance(h, RotatingFileHandler) and h.name == _PROXY_LOG_HANDLER_NAME
+        ]
+        if any(Path(h.baseFilename) == log_path for h in existing):
+            return
         handler = RotatingFileHandler(
             log_path,
             maxBytes=10 * 1024 * 1024,  # 10 MB
             backupCount=5,
             encoding="utf-8",
         )
+        handler.set_name(_PROXY_LOG_HANDLER_NAME)
         handler.setLevel(logging.INFO)
         handler.setFormatter(
             logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
         )
-        # Attach to the headroom root logger so all sub-loggers are captured.
-        # Disable propagation to root to avoid duplicate writes when
-        # wrap.py redirects stderr to the same log file.
-        headroom_logger = logging.getLogger("headroom")
-        headroom_logger.setLevel(logging.INFO)
-        if not any(isinstance(h, RotatingFileHandler) for h in headroom_logger.handlers):
-            headroom_logger.addHandler(handler)
-        headroom_logger.propagate = False
+        for stale in existing:
+            headroom_logger.removeHandler(stale)
+            stale.close()
+        headroom_logger.addHandler(handler)
     except OSError:
         # Non-fatal: can't write logs (read-only fs, permissions, etc.)
         pass

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2719,13 +2719,23 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
 
     from contextlib import asynccontextmanager
 
+    # Resolve config before file logging so the log can be keyed by port
+    # (below). Tradeoff: any log record emitted while ``ProxyConfig`` is
+    # constructed on the no-config path (e.g. an invalid HEADROOM_QDRANT_PORT
+    # warning) predates the file handler and so is not captured in the file log;
+    # the port must be known first, and it is always present (``port`` defaults
+    # to 8787), so this is accepted.
+    config = config or ProxyConfig()
+
     # Always-on file logging to ~/.headroom/logs/ for `headroom perf` analysis.
     # Installed here (not at module import) so importing headroom.proxy.server
     # in tests or library contexts does not silently attach a RotatingFileHandler
-    # to the user's live proxy.log.
-    _setup_file_logging()
-
-    config = config or ProxyConfig()
+    # to the user's live proxy log. Multi-worker processes add their PID so
+    # same-port workers never share a RotatingFileHandler target.
+    _setup_file_logging(
+        config.port,
+        process_id=os.getpid() if config.worker_processes > 1 else None,
+    )
 
     # Defensive re-apply of file-backed settings for embedded/non-CLI callers
     # that construct the app without going through the `headroom` CLI entrypoint

--- a/tests/test_agent_savings.py
+++ b/tests/test_agent_savings.py
@@ -322,7 +322,7 @@ def test_start_proxy_does_not_inject_agent_savings_by_default(monkeypatch, tmp_p
     monkeypatch.setattr(wrap_module.subprocess, "Popen", popen)
     monkeypatch.setattr(wrap_module.time, "sleep", lambda seconds: None)
     monkeypatch.setattr(wrap_module, "_check_proxy", lambda port: True)
-    monkeypatch.setattr(wrap_module, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_module, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
 
     wrap_module._start_proxy(8787, agent_type="codex")
 
@@ -347,7 +347,7 @@ def test_start_proxy_injects_explicit_agent_savings_profile(monkeypatch, tmp_pat
     monkeypatch.setattr(wrap_module.subprocess, "Popen", popen)
     monkeypatch.setattr(wrap_module.time, "sleep", lambda seconds: None)
     monkeypatch.setattr(wrap_module, "_check_proxy", lambda port: True)
-    monkeypatch.setattr(wrap_module, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_module, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
 
     wrap_module._start_proxy(8787, agent_type="codex")
 

--- a/tests/test_cli/test_wrap_claude_vertex_proxy_env.py
+++ b/tests/test_cli/test_wrap_claude_vertex_proxy_env.py
@@ -434,7 +434,7 @@ def test_start_proxy_sets_vertex_target_env_for_proxy_subprocess(
     fake_proc = _FakeProxyProcess()
     captured: dict[str, Any] = {}
 
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
     monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
 
@@ -467,7 +467,7 @@ def test_start_proxy_clears_inherited_vertex_target_env(
     captured: dict[str, Any] = {}
 
     monkeypatch.setenv("VERTEX_TARGET_API_URL", "http://127.0.0.1:8787")
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
     monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
 
@@ -497,7 +497,7 @@ def test_start_proxy_sets_pythonsafepath_to_avoid_cwd_shadow(
     fake_proc = _FakeProxyProcess()
     captured: dict[str, Any] = {}
 
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
     monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
 

--- a/tests/test_cli/test_wrap_codex.py
+++ b/tests/test_cli/test_wrap_codex.py
@@ -1403,7 +1403,7 @@ def test_start_proxy_uses_separate_session_for_signal_isolation(
         popen_kwargs.update(kwargs)
         return FakeProc()
 
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda port: True)
     monkeypatch.setattr(wrap_mod.subprocess, "Popen", fake_popen)
 
@@ -1441,7 +1441,7 @@ def test_start_proxy_does_not_apply_agent_90_defaults(
         popen_kwargs.update(kwargs)
         return FakeProc()
 
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda port: True)
     monkeypatch.setattr(wrap_mod.subprocess, "Popen", fake_popen)
 
@@ -1473,7 +1473,7 @@ def test_start_proxy_preserves_explicit_savings_overrides(
 
     monkeypatch.setenv("HEADROOM_TARGET_RATIO", "0.20")
     monkeypatch.setenv("HEADROOM_MAX_ITEMS", "12")
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda port: True)
     monkeypatch.setattr(wrap_mod.subprocess, "Popen", fake_popen)
 

--- a/tests/test_cli/test_wrap_proxy_detach.py
+++ b/tests/test_cli/test_wrap_proxy_detach.py
@@ -44,7 +44,7 @@ def _capture_popen_kwargs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> di
     monkeypatch.setattr(wrap_cli.subprocess, "Popen", _fake_popen)
     monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: True)
     monkeypatch.setattr(wrap_cli.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_cli, "_resolve_wrap_proxy_timeout_seconds", lambda: 1)
 
     wrap_cli._start_proxy(8787)
@@ -98,7 +98,7 @@ def test_start_proxy_retries_without_breakaway_when_job_forbids_it(
     monkeypatch.setattr(wrap_cli.subprocess, "Popen", _flaky_popen)
     monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: True)
     monkeypatch.setattr(wrap_cli.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_cli, "_resolve_wrap_proxy_timeout_seconds", lambda: 1)
 
     wrap_cli._start_proxy(8787)
@@ -137,7 +137,7 @@ def test_start_proxy_closes_log_when_both_spawns_fail(
 
     monkeypatch.setattr(wrap_cli.subprocess, "Popen", _always_fails)
     monkeypatch.setattr(wrap_cli.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_cli, "_resolve_wrap_proxy_timeout_seconds", lambda: 1)
 
     with pytest.raises(OSError):

--- a/tests/test_cli_proxy_env.py
+++ b/tests/test_cli_proxy_env.py
@@ -65,7 +65,7 @@ class TestCLIWrapProxyTimeout:
 
         monkeypatch.delenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, raising=False)
         monkeypatch.setattr(wrap_mod, "_ml_wrap_extras_detected", lambda: False)
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda seconds: sleeps.append(seconds))
         monkeypatch.setattr(wrap_mod.subprocess, "Popen", lambda *args, **kwargs: fake_proc)
@@ -82,7 +82,7 @@ class TestCLIWrapProxyTimeout:
 
         monkeypatch.delenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, raising=False)
         monkeypatch.setattr(wrap_mod, "_ml_wrap_extras_detected", lambda: False)
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
 
@@ -115,7 +115,7 @@ class TestCLIWrapProxyTimeout:
         monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", "123")
         monkeypatch.delenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, raising=False)
         monkeypatch.setattr(wrap_mod, "_ml_wrap_extras_detected", lambda: False)
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
 
@@ -145,7 +145,11 @@ class TestCLIWrapProxyTimeout:
         logs: list[str] = []
 
         monkeypatch.delenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, raising=False)
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(
+            wrap_mod,
+            "_get_log_path",
+            lambda port=None: tmp_path / (f"proxy-{port}.log" if port is not None else "proxy.log"),
+        )
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
         monkeypatch.setattr(wrap_mod, "_ml_wrap_extras_detected", lambda: False)
@@ -161,9 +165,9 @@ class TestCLIWrapProxyTimeout:
 
         assert proc is fake_proc
         assert captured["kwargs"]["stdout"] is captured["kwargs"]["stderr"]
-        assert captured["kwargs"]["stdout"].name == str(tmp_path / "proxy-stdio.log")
-        assert captured["kwargs"]["stdout"].name != str(tmp_path / "proxy.log")
-        assert f"  Logs: {tmp_path / 'proxy.log'}" in logs
+        assert captured["kwargs"]["stdout"].name == str(tmp_path / "proxy-stdio-8787.log")
+        assert captured["kwargs"]["stdout"].name != str(tmp_path / "proxy-8787.log")
+        assert f"  Logs: {tmp_path / 'proxy-8787.log'}" in logs
 
     def test_env_timeout_allows_slow_start_proxy_to_succeed(self, monkeypatch, tmp_path):
         fake_proc = _FakeProxyProcess()
@@ -171,7 +175,7 @@ class TestCLIWrapProxyTimeout:
         checks = []
 
         monkeypatch.setenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, "4")
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda seconds: sleeps.append(seconds))
         monkeypatch.setattr(wrap_mod.subprocess, "Popen", lambda *args, **kwargs: fake_proc)
 
@@ -196,13 +200,13 @@ class TestCLIWrapProxyTimeout:
         fake_proc.poll = lambda: fake_proc.returncode
 
         monkeypatch.setenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, "2")
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
         monkeypatch.setattr(wrap_mod.subprocess, "Popen", lambda *args, **kwargs: fake_proc)
 
         (tmp_path / "proxy.log").write_text("canonical runtime log output")
-        (tmp_path / "proxy-stdio.log").write_text("proxy stdio startup output")
+        (tmp_path / "proxy-stdio-8787.log").write_text("proxy stdio startup output")
 
         with pytest.raises(RuntimeError) as excinfo:
             wrap_mod._start_proxy(8787, agent_type="codex")
@@ -216,7 +220,7 @@ class TestCLIWrapProxyTimeout:
         fake_proc = _FakeProxyProcess()
 
         monkeypatch.setenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, "2")
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
         monkeypatch.setattr(wrap_mod.subprocess, "Popen", lambda *args, **kwargs: fake_proc)

--- a/tests/test_perf_per_port_logs.py
+++ b/tests/test_perf_per_port_logs.py
@@ -1,0 +1,218 @@
+"""Per-port and per-worker proxy log files.
+
+Every proxy writes ``proxy-<port>.log``; multi-worker deployments add the PID
+so same-port workers do not share a ``RotatingFileHandler`` target and race
+during rollover. The perf reader aggregates worker files, per-port files, and
+the legacy shared ``proxy.log``.
+"""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+import pytest
+
+from headroom import paths as _paths
+from headroom.cli import wrap as wrap_cli
+from headroom.perf import analyzer
+from headroom.proxy import server
+from headroom.proxy.helpers import _setup_file_logging
+
+
+def _perf_line(ts: str, rid: str, model: str) -> str:
+    return (
+        f"{ts} - headroom.proxy - INFO - [{rid}] PERF "
+        f"model={model} msgs=3 tok_before=1000 tok_after=400 "
+        f"tok_saved=600 cache_read=0 cache_write=0 cache_hit_pct=0 "
+        f"opt_ms=1 transforms=agent90_smoke client=test"
+    )
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HEADROOM_WORKSPACE_DIR", str(tmp_path))
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def test_proxy_log_path_is_per_port() -> None:
+    a = _paths.proxy_log_path(8888)
+    b = _paths.proxy_log_path(8889)
+    assert a.name == "proxy-8888.log"
+    assert b.name == "proxy-8889.log"
+    assert a != b  # the core anti-collision property
+    # Legacy shared name preserved for the readers' fallback.
+    assert _paths.proxy_log_path().name == "proxy.log"
+
+
+def test_proxy_log_path_is_per_worker() -> None:
+    assert _paths.proxy_log_path(8888, process_id=1234).name == "proxy-8888-1234.log"
+    assert _paths.proxy_log_path(8888, process_id=5678).name == "proxy-8888-5678.log"
+
+
+def test_stdio_log_path_is_per_port() -> None:
+    assert _paths.proxy_stdio_log_path(8888).name == "proxy-stdio-8888.log"
+    assert _paths.proxy_stdio_log_path().name == "proxy-stdio.log"
+    # wrap helper agrees and keeps stdio beside the runtime log.
+    stdio = wrap_cli._get_proxy_stdio_log_path(8888)
+    assert stdio.name == "proxy-stdio-8888.log"
+    assert stdio.parent == wrap_cli._get_log_path(8888).parent
+
+
+def test_setup_file_logging_targets_per_port_file(workspace: Path) -> None:
+    logger = logging.getLogger("headroom")
+    original = list(logger.handlers)
+    for h in original:
+        if isinstance(h, RotatingFileHandler):
+            logger.removeHandler(h)
+    try:
+        _setup_file_logging(8888)
+        _setup_file_logging(8888)
+        rotating = [h for h in logger.handlers if isinstance(h, RotatingFileHandler)]
+        assert len(rotating) == 1
+        assert Path(rotating[-1].baseFilename).name == "proxy-8888.log"
+    finally:
+        for h in [x for x in logger.handlers if isinstance(x, RotatingFileHandler)]:
+            h.close()
+            logger.removeHandler(h)
+        for h in original:
+            logger.addHandler(h)
+
+
+def test_setup_file_logging_targets_worker_file(workspace: Path) -> None:
+    logger = logging.getLogger("headroom")
+    original = list(logger.handlers)
+    for handler in original:
+        if isinstance(handler, RotatingFileHandler):
+            logger.removeHandler(handler)
+    try:
+        _setup_file_logging(8888, process_id=1234)
+        rotating = [h for h in logger.handlers if isinstance(h, RotatingFileHandler)]
+        assert len(rotating) == 1
+        assert Path(rotating[0].baseFilename).name == "proxy-8888-1234.log"
+    finally:
+        for handler in [x for x in logger.handlers if isinstance(x, RotatingFileHandler)]:
+            handler.close()
+            logger.removeHandler(handler)
+        for handler in original:
+            logger.addHandler(handler)
+
+
+def test_setup_file_logging_reconfigures_for_sequential_port_change(
+    workspace: Path,
+) -> None:
+    """Sequential app creation closes the old handler and selects the new port.
+
+    Regression: when the ``RotatingFileHandler`` was constructed before the
+    dedup guard, the second ``_setup_file_logging(port)`` left an empty stray
+    ``proxy-<port>.log``, leaked the handler fd, and routed the new port's
+    records into the first port's file.
+    """
+    log_dir = workspace / "logs"
+    logger = logging.getLogger("headroom")
+    original = list(logger.handlers)
+    for h in original:
+        if isinstance(h, RotatingFileHandler):
+            logger.removeHandler(h)
+    try:
+        _setup_file_logging(8888)
+        logger.info("record-for-8888")
+        _setup_file_logging(9999)  # a second proxy/app in the same process
+        logger.info("record-for-9999")
+
+        # Exactly one file handler is ever attached, now pointing at 9999.
+        rotating = [h for h in logger.handlers if isinstance(h, RotatingFileHandler)]
+        assert len(rotating) == 1
+        assert Path(rotating[0].baseFilename).name == "proxy-9999.log"
+        rotating[0].flush()
+
+        text_8888 = (log_dir / "proxy-8888.log").read_text()
+        text_9999 = (log_dir / "proxy-9999.log").read_text()
+        # The records written before and after reconfiguration use their
+        # respective paths, and the first file is not an empty stray.
+        assert "record-for-8888" in text_8888 and "record-for-9999" not in text_8888
+        assert "record-for-9999" in text_9999 and "record-for-8888" not in text_9999
+    finally:
+        for h in [x for x in logger.handlers if isinstance(x, RotatingFileHandler)]:
+            h.close()
+            logger.removeHandler(h)
+        for h in original:
+            logger.addHandler(h)
+
+
+def test_setup_file_logging_preserves_external_rotating_handler(workspace: Path) -> None:
+    logger = logging.getLogger("headroom")
+    original = list(logger.handlers)
+    for handler in original:
+        logger.removeHandler(handler)
+    external = RotatingFileHandler(workspace / "logs" / "external.log")
+    logger.addHandler(external)
+    try:
+        _setup_file_logging(8888)
+        _setup_file_logging(9999)
+
+        assert external in logger.handlers
+    finally:
+        for handler in list(logger.handlers):
+            handler.close()
+            logger.removeHandler(handler)
+        for handler in original:
+            logger.addHandler(handler)
+
+
+def test_create_app_default_config_keys_logging_by_default_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[int, int | None]] = []
+    monkeypatch.setattr(
+        server,
+        "_setup_file_logging",
+        lambda port, process_id=None: calls.append((port, process_id)),
+    )
+
+    app = server.create_app()
+
+    assert app.state.proxy.config.port == 8787
+    assert calls == [(8787, None)]
+
+
+def test_create_app_keys_multi_worker_logging_by_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[int, int | None]] = []
+    monkeypatch.setattr(
+        server,
+        "_setup_file_logging",
+        lambda port, process_id=None: calls.append((port, process_id)),
+    )
+    monkeypatch.setattr(server.os, "getpid", lambda: 1234)
+
+    server.create_app(server.ProxyConfig(port=8888, worker_processes=2))
+
+    assert calls == [(8888, 1234)]
+
+
+def test_parse_log_files_aggregates_per_port_and_legacy(workspace: Path) -> None:
+    log_dir = workspace / "logs"
+    ts = "2026-08-22 10:00:00,000"
+    (log_dir / "proxy-8888-1111.log").write_text(_perf_line(ts, "hr_a", "model-A") + "\n")
+    (log_dir / "proxy-8888-2222.log").write_text(_perf_line(ts, "hr_b", "model-B") + "\n")
+    (log_dir / "proxy-8888-1111.log.1").write_text(_perf_line(ts, "hr_e", "model-E") + "\n")
+    (log_dir / "proxy-8889.log").write_text(_perf_line(ts, "hr_c", "model-C") + "\n")
+    (log_dir / "proxy.log").write_text(_perf_line(ts, "hr_d", "model-D") + "\n")
+    # stdio captures and any other non-PERF proxy-*.log are excluded by the
+    # positive filename filter, not just a proxy-stdio blacklist.
+    (log_dir / "proxy-stdio-8888.log").write_text(_perf_line(ts, "hr_stdio", "model-STDIO") + "\n")
+    (log_dir / "proxy-stdio.log").write_text(_perf_line(ts, "hr_stdio2", "model-STDIO2") + "\n")
+    (log_dir / "proxy-errors.log").write_text(_perf_line(ts, "hr_err", "model-ERR") + "\n")
+
+    report = analyzer.parse_log_files(last_n_hours=0.0)  # 0 => no cutoff, all data
+    models = {r.model for r in report.perf_records}
+    rids = {r.request_id for r in report.perf_records}
+
+    assert {"model-A", "model-B", "model-C", "model-D", "model-E"} <= models
+    # Non-PERF files never ingested.
+    assert models.isdisjoint({"model-STDIO", "model-STDIO2", "model-ERR"})
+    assert rids.isdisjoint({"hr_stdio", "hr_stdio2", "hr_err"})

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -327,8 +327,10 @@ headroom perf --raw
 | `--hours` | `168.0` | Time window in hours |
 | `--raw` | off | Print raw PERF records instead of the summarized report |
 
-The command reads `${HEADROOM_WORKSPACE_DIR}/logs/proxy.log` (defaults
-to `~/.headroom/logs/proxy.log` — see the
+The command reads each per-port runtime log
+`${HEADROOM_WORKSPACE_DIR}/logs/proxy-<port>.log` (defaults to
+`~/.headroom/logs/`) plus PID-qualified files from multi-worker deployments,
+aggregating them while still reading a legacy `proxy.log` when present — see the
 [Filesystem Contract](filesystem-contract.md)).
 
 ## `headroom inspect`


### PR DESCRIPTION
## Description

Every proxy instance wrote the same two fixed files: `~/.headroom/logs/proxy.log` (runtime log, via the `RotatingFileHandler` in `_setup_file_logging`) and `~/.headroom/logs/proxy-stdio.log` (subprocess stdout/stderr from `_start_proxy`). The name is a constant (`paths.py` `_PROXY_LOG_FILE = "proxy.log"`), so N concurrent proxies on different ports (wrapped copilot, droid, claude; plus any persistent `install agent` deployment) run N independent rotating handlers over the *same* file and truncate/rename each other's history.

This fix keys both files by port (`proxy-<port>.log`, `proxy-stdio-<port>.log`) so each proxy rotates only its own file. `headroom perf` aggregates every per-port file and still reads a lone legacy `proxy.log` when that is all that exists (backward compat); the `proxy-stdio-*` captures (raw stdout/stderr, not PERF records) are excluded from the parser.

This matters more now that wrap-spawned proxies self-exit after an idle grace (orphan-proxy watchdog, #3202): the process is gone, so its per-port log is the only forensic evidence and must survive an unrelated proxy's rotation.

Closes #3203

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `headroom/paths.py`: `proxy_log_path(port=None)` and new `proxy_stdio_log_path(port=None)` are the single source of truth for the filenames (`proxy-<port>.log` / `proxy-stdio-<port>.log` with a port, legacy names without). The `_PROXY_LOG_FILE` constant stays only as the readers' fallback name.
- `headroom/proxy/helpers.py`: `_setup_file_logging(port=None)` targets `proxy_log_path(port)`. The duplicate-handler guard runs BEFORE the `RotatingFileHandler` is constructed (construction opens the file), so a second `create_app` on a different port in one process cannot leave an empty stray `proxy-<port>.log` or leak an fd; a handler pointing at a different port is replaced and closed so per-port keying holds.
- `headroom/proxy/server.py`: `create_app` resolves `config` first, then calls `_setup_file_logging(config.port)` (the proxy always knows its own port).
- `headroom/cli/wrap.py`: `_get_log_path(port=None)` / `_get_proxy_stdio_log_path(port=None)` are per-port; `_start_proxy` passes its `port`. The stdio filename comes from `paths.proxy_stdio_log_path` (single source) and its directory from `_get_log_path`.
- `headroom/perf/analyzer.py`: `parse_log_files` selects PERF logs by a positive filename match (`_PERF_LOG_FILE_RE` = `proxy(-<digits>)?.log(.N)?`) rather than a `proxy-stdio` blacklist, so `proxy-stdio-*.log` and any other `proxy-<word>.log` are never ingested; ordering is deterministic (mtime, then path).
- `headroom/cli/perf.py`, `wiki/cli.md`: doc/help text updated for per-port + legacy.
- `tests/test_perf_per_port_logs.py` (new): per-port path helpers; a second `_setup_file_logging` on a new port reroutes cleanly with no cross-file leakage (regression for the guard-ordering bug); and `parse_log_files` aggregates per-port + legacy while excluding stdio and other non-PERF `proxy-*.log`.
- `tests/test_cli_proxy_env.py`, `tests/test_agent_savings.py`, `tests/test_cli/test_wrap_{codex,claude_vertex_proxy_env,proxy_detach}.py`: the `_get_log_path` monkeypatches take the new optional `port`, and the two stdio-filename assertions/fixtures in `test_cli_proxy_env.py` use the per-port name.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`) — plus `ruff format --check`
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ .venv/bin/python -m pytest tests/test_perf_per_port_logs.py tests/test_cli_proxy_env.py tests/test_agent_savings.py -q -p no:randomly
115 passed, 1 skipped in 4.44s

$ .venv/bin/python -m pytest tests/test_cli_perf_format.py tests/test_learn/test_analyzer.py -q
107 passed in 4.16s

$ .venv/bin/python -m pytest tests/test_cli/test_wrap_proxy_detach.py tests/test_cli/test_wrap_codex.py tests/test_cli/test_wrap_claude_vertex_proxy_env.py -q
120 passed in 171.19s

$ .venv/bin/ruff check <touched> && .venv/bin/ruff format --check <touched>
All checks passed!

$ .venv/bin/mypy headroom/paths.py headroom/cli/wrap.py headroom/proxy/helpers.py headroom/proxy/server.py headroom/perf/analyzer.py
Success: no issues found in 5 source files
```

Rust gate (`cargo clippy/test/fmt`) not run: Python-only change, no crate touched.

## Real Behavior Proof

- Environment: macOS 26.5 arm64, Python 3.13, local editable source build.
- Exact command / steps: `headroom proxy --port 8890` and `headroom proxy --port 8891` started concurrently; inspected `~/.headroom/logs/`; then `headroom perf --hours 1 --format json`.
- Observed result: each proxy wrote its own file (`proxy-8890.log`, `proxy-8891.log`, independent), the pre-existing shared `proxy.log` was not touched, and `headroom perf` reported `log_files_read: 4`, aggregating per-port + legacy with no error. `test_setup_file_logging_reroutes_on_port_change` additionally drives the production helper twice in one process and asserts each port's records land only in its own file.
- Not tested: Windows path semantics (filename construction is platform-independent `pathlib`); a legacy `proxy.log` written by an OLD binary running beside a new per-port one end to end (readers handle it, but not exercised live).

## Runtime Rollout Safety

- Rollout-managed feature(s): none.
- Minimum rollout channel: N/A (no flag; readers accept both layouts).
- Stable/default behavior changed: log filenames change from `proxy.log` to `proxy-<port>.log`; `headroom perf` reads both, so history is not orphaned.
- Kill switch / disable path: N/A (no flag).
- Unsafe override required: no.
- Qualification impact: none — readers stay backward compatible with a lone legacy `proxy.log`.
- Rollback path: revert; a downgraded binary writes legacy `proxy.log` again and readers still aggregate any per-port files left behind.

Disk growth: each per-port family keeps the prior bound (`maxBytes=10 MB × backupCount=5` = 60 MB), but there is now one family per distinct port used instead of one global family. Ports are usually stable (default 8787; wrap auto-selects a nearby free port), so in practice a handful of families; the theoretical worst case is bounded by the port scan (`_find_available_port`, ≤100) → ≤ ~6 GB. No automatic pruning; stale `proxy-<port>.log*` families can be deleted safely (perf reads whatever remains). A retention policy is intentionally out of scope.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — log-filename change; no UI.

## Additional Notes

Follow-up (separate SDK PR, not here): the TypeScript SDK helper `sdk/typescript/src/paths.ts::proxyLogPath()` still returns legacy `proxy.log` with no port argument and is pinned by `paths.test.ts`. It mirrors `paths.py`, so it should gain an optional port argument in an SDK PR (kept separate to stay one-surface, and because that package's vitest suite is the right gate for it).

