### PR TITLE
fix(memory): tolerate None message content in inline memory parser

### DIFF
--- a/headroom/memory/inline_extractor.py
+++ b/headroom/memory/inline_extractor.py
@@ -56,9 +56,9 @@ Skip for greetings/small talk. If nothing: <memory>{"memories": []}</memory>"""
 class ParsedResponse:
     """Response with extracted memories."""
 
-    content: str  # The actual response (without memory block)
+    content: str | None  # The actual response (without memory block); None for tool-call turns
     memories: list[dict[str, Any]]  # Extracted memories
-    raw: str  # Original full response
+    raw: str | None  # Original full response
 
 
 def inject_memory_instruction(
@@ -101,17 +101,27 @@ def inject_memory_instruction(
     return messages
 
 
-def parse_response_with_memory(response_text: str) -> ParsedResponse:
+def parse_response_with_memory(response_text: str | None) -> ParsedResponse:
     """Parse LLM response to extract memories.
 
     Args:
-        response_text: Raw LLM response
+        response_text: Raw LLM response. May be ``None`` when the model answered
+            with tool/function calls instead of text.
 
     Returns:
         ParsedResponse with content and memories separated
     """
     memories: list[dict[str, Any]] = []
     content = response_text
+
+    # A chat completion's ``message.content`` is ``None`` whenever the model
+    # answers with tool/function calls instead of text, so the two call sites
+    # here forward ``None`` (and any non-str payload) straight in. ``re.search``
+    # on a non-str raises ``TypeError``, which crashed the whole request. Return
+    # the payload untouched — preserving ``None`` so a tool-call response is not
+    # coerced to text — with no memories to extract.
+    if not isinstance(response_text, str):
+        return ParsedResponse(content=response_text, memories=memories, raw=response_text)
 
     # Extract <memory> block
     memory_pattern = r"<memory>\s*(.*?)\s*</memory>"
@@ -179,7 +189,7 @@ class InlineMemoryWrapper:
         model: str = "gpt-4o-mini",
         short_instruction: bool = True,
         **kwargs: Any,
-    ) -> tuple[str, list[dict[str, Any]]]:
+    ) -> tuple[str | None, list[dict[str, Any]]]:
         """Send chat request and extract memories inline.
 
         Args:
@@ -213,7 +223,7 @@ class InlineMemoryWrapper:
         messages: list[dict[str, Any]],
         model: str = "gpt-4o-mini",
         **kwargs: Any,
-    ) -> tuple[Any, str, list[dict[str, Any]]]:
+    ) -> tuple[Any, str | None, list[dict[str, Any]]]:
         """Send chat request and return full response object.
 
         Args:

--- a/tests/test_memory_wrapper.py
+++ b/tests/test_memory_wrapper.py
@@ -224,3 +224,17 @@ def test_parse_response_with_memory_tolerates_non_object_memory_block() -> None:
     )
     assert parsed.memories == [{"content": "User likes Python"}]
     assert parsed.content == "text"
+
+
+def test_parse_response_with_memory_tolerates_none_content() -> None:
+    from headroom.memory.inline_extractor import parse_response_with_memory
+
+    # `chat.completions` returns `message.content == None` whenever the model
+    # answers with tool/function calls instead of text. The callers forward that
+    # `None` straight in, where `re.search(pattern, None)` used to raise
+    # `TypeError` and crash the whole request. It must degrade gracefully and
+    # preserve `None` (not coerce a tool-call turn to text).
+    parsed = parse_response_with_memory(None)
+    assert parsed.content is None
+    assert parsed.memories == []
+    assert parsed.raw is None


### PR DESCRIPTION
## Description

`InlineMemoryWrapper.chat` / `.chat_with_response` read `response.choices[0].message.content` and hand it straight to `parse_response_with_memory`, which immediately does `re.search(pattern, response_text, ...)`:

```python
raw_content = response.choices[0].message.content   # str | None
parsed = parse_response_with_memory(raw_content)
...
match = re.search(memory_pattern, response_text, re.DOTALL | re.IGNORECASE)
```

A chat completion's `message.content` is `None` whenever the model answers with tool/function calls instead of text. `re.search` on `None` raises `TypeError: expected string or bytes-like object, got 'NoneType'`, crashing the whole request. So enabling tools on any request routed through the inline memory wrapper turns the first tool-call turn into an unhandled exception.

This is the same robustness class the function already guards for the `<memory>` block payload (a non-object / non-list JSON is tolerated at `inline_extractor.py:132`-`:143`); `None` content was the remaining gap, one level up.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/memory/inline_extractor.py`: `parse_response_with_memory` now returns early when `response_text` is not a `str`, preserving the payload unchanged (so a `None` tool-call turn is not coerced to text) with no memories extracted. Widened its parameter to `str | None` and `ParsedResponse.content` / `.raw` and the two `chat*` return types to `str | None` to match what a chat completion actually yields.
- `tests/test_memory_wrapper.py`: added `test_parse_response_with_memory_tolerates_none_content` next to the existing non-object-block regression.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
tests/test_memory_wrapper.py  ->  7 passed in 0.78s
uvx ruff@0.16.2 check headroom/memory/inline_extractor.py tests/test_memory_wrapper.py  ->  All checks passed!
uvx mypy@1.20.2 headroom/memory/inline_extractor.py  ->  Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.16.2 and mypy 1.20.2 via uvx.
- Exact command / steps: before the fix, `parse_response_with_memory(None)` raised `TypeError: expected string or bytes-like object, got 'NoneType'`. After the fix, the same call returns `ParsedResponse(content=None, memories=[], raw=None)`, and a normal text response with a `<memory>` block still parses (`content == "hello  world"`, memories extracted).
- Observed result: `None` content degrades gracefully and stays `None`; the string path is byte-for-byte unchanged.
- Not tested: no live `chat.completions.create` tool-call round trip (the wrapper takes an injected client); the `None` content a tool-call turn produces is reproduced directly.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. `InlineMemoryWrapper` is an SDK-side convenience wrapper (`headroom.memory`), not a rollout-channel-gated runtime feature.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: no. Non-`None` string inputs take exactly the previous path; only the previously-crashing `None` case changes, from `TypeError` to a graceful no-op parse.
- Kill switch / disable path: N/A.
- Unsafe override required: no.
- Qualification impact: none; text responses are handled identically.
- Rollback path: revert this PR; the parser returns to assuming a `str`.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A: internal behavior, unchanged semantics)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`
