### PR TITLE
fix(toin): address /v1/toin/patterns by tool-signature hash, not composite key

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -181,7 +181,7 @@ from headroom.subscription.tracker import (
 )
 from headroom.telemetry import get_telemetry_collector
 from headroom.telemetry.beacon import is_telemetry_enabled
-from headroom.telemetry.toin import get_toin
+from headroom.telemetry.toin import get_toin, pattern_key_sig_hash
 from headroom.transforms import (
     CacheAligner,
     CodeAwareCompressor,
@@ -4969,7 +4969,11 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
 
             patterns_list.append(
                 {
-                    "hash": sig_hash[:12],
+                    # `sig_hash` here is the full "auth|model|hash" aggregation
+                    # key; the identifier must be the tool-signature component,
+                    # not a prefix of the whole key (which collides across every
+                    # pattern sharing an auth mode and model family).
+                    "hash": pattern_key_sig_hash(sig_hash)[:12],
                     "compressions": total_compressions,
                     "retrievals": total_retrievals,
                     "retrieval_rate": f"{retrieval_rate:.1%}",
@@ -5005,9 +5009,13 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
         exported = toin.export_patterns()
         patterns_data = exported.get("patterns", {})
 
-        # Search for pattern with matching hash prefix
+        # Search for the pattern whose tool-signature hash matches the prefix.
+        # Match on the signature component of the composite key so the
+        # identifier from /v1/toin/patterns round-trips here; matching the whole
+        # "auth|model|hash" key would resolve an "unknown" prefix to an
+        # arbitrary pattern.
         for sig_hash, pattern_dict in patterns_data.items():
-            if sig_hash.startswith(hash_prefix):
+            if pattern_key_sig_hash(sig_hash).startswith(hash_prefix):
                 # Keep this response aligned with /v1/toin/patterns while
                 # excluding query text, field semantics, and other internal
                 # learning state from the detail endpoint.

--- a/headroom/telemetry/toin.py
+++ b/headroom/telemetry/toin.py
@@ -156,6 +156,20 @@ def _deserialize_pattern_key(serialized: str) -> PatternKey:
     return (DEFAULT_AUTH_MODE, DEFAULT_MODEL_FAMILY, serialized)
 
 
+def pattern_key_sig_hash(serialized: str) -> str:
+    """Extract the tool-signature hash from a serialized aggregation key.
+
+    The aggregation key is encoded as ``"auth_mode|model_family|sig_hash"``
+    (see `_serialize_pattern_key`); only the third component is the tool
+    signature hash. Callers that identify or address a pattern by its
+    signature — e.g. the `/v1/toin/patterns` diagnostic endpoints — must use
+    this component, not a prefix of the whole composite key, which would
+    collide across every pattern sharing an auth mode and model family.
+    Legacy bare-hash keys are handled by `_deserialize_pattern_key`.
+    """
+    return _deserialize_pattern_key(serialized)[2]
+
+
 def get_default_toin_storage_path() -> str:
     """Get the default TOIN storage path.
 

--- a/tests/test_proxy_loopback_gating.py
+++ b/tests/test_proxy_loopback_gating.py
@@ -112,7 +112,9 @@ def test_toin_pattern_detail_whitelists_learned_payload(monkeypatch: pytest.Monk
             }
 
     monkeypatch.setattr("headroom.proxy.server.get_toin", lambda: FakeTOIN())
-    response = _loopback_client().get("/v1/toin/pattern/unknown")
+    # The detail endpoint addresses a pattern by its tool-signature hash (the
+    # third "auth|model|hash" component), not a prefix of the composite key.
+    response = _loopback_client().get("/v1/toin/pattern/abc123")
 
     assert response.status_code == 200
     assert response.json() == {
@@ -123,6 +125,58 @@ def test_toin_pattern_detail_whitelists_learned_payload(monkeypatch: pytest.Monk
         "skip_recommended": False,
         "optimal_max_items": 20,
     }
+
+
+def test_toin_patterns_hash_identifies_signature_not_composite_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Two patterns sharing auth_mode and model_family but with distinct tool
+    # signatures. Truncating the whole "auth|model|hash" key reported the same
+    # "unknown|unkn" identifier for both; the identifier must be the signature
+    # component so the two remain addressable.
+    class FakeTOIN:
+        def export_patterns(self):
+            return {
+                "patterns": {
+                    "unknown|unknown|aaaa1111bbbb": {"sample_size": 10},
+                    "unknown|unknown|cccc2222dddd": {"sample_size": 5},
+                }
+            }
+
+    monkeypatch.setattr("headroom.proxy.server.get_toin", lambda: FakeTOIN())
+    body = _loopback_client().get("/v1/toin/patterns").json()
+
+    hashes = [entry["hash"] for entry in body]
+    assert hashes == ["aaaa1111bbbb", "cccc2222dddd"]  # sorted by sample_size
+    assert len(set(hashes)) == 2, "distinct patterns must not share an identifier"
+
+
+def test_toin_pattern_hash_round_trips_to_detail(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The identifier from /v1/toin/patterns must resolve to the *same* pattern
+    # at /v1/toin/pattern/{hash}, not an arbitrary first-iterated one.
+    class FakeTOIN:
+        def export_patterns(self):
+            return {
+                "patterns": {
+                    "unknown|unknown|aaaa1111bbbb": {
+                        "sample_size": 10,
+                        "total_compressions": 8,
+                    },
+                    "unknown|unknown|cccc2222dddd": {
+                        "sample_size": 5,
+                        "total_compressions": 3,
+                    },
+                }
+            }
+
+    monkeypatch.setattr("headroom.proxy.server.get_toin", lambda: FakeTOIN())
+    client = _loopback_client()
+
+    listed = client.get("/v1/toin/patterns").json()
+    second = next(e for e in listed if e["hash"] == "cccc2222dddd")
+    detail = client.get(f"/v1/toin/pattern/{second['hash']}").json()
+
+    assert detail["compressions"] == 3  # the second pattern, not the first
 
 
 # Mutating routes reachable from loopback. `require_loopback` cannot stop a

--- a/tests/test_toin.py
+++ b/tests/test_toin.py
@@ -834,3 +834,27 @@ class TestTOINRecommendationUpdates:
         pattern = toin.get_pattern(sig_hash)
         # Field should be marked to preserve
         assert len(pattern.preserve_fields) > 0
+
+
+class TestPatternKeySigHash:
+    """`pattern_key_sig_hash` returns the signature component (issue #2928)."""
+
+    def test_extracts_third_component(self):
+        from headroom.telemetry.toin import pattern_key_sig_hash
+
+        assert pattern_key_sig_hash("payg|claude|deadbeef") == "deadbeef"
+        assert pattern_key_sig_hash("unknown|unknown|abc123") == "abc123"
+
+    def test_distinct_signatures_do_not_collide(self):
+        from headroom.telemetry.toin import pattern_key_sig_hash
+
+        a = pattern_key_sig_hash("unknown|unknown|aaaa1111")
+        b = pattern_key_sig_hash("unknown|unknown|bbbb2222")
+        assert a != b
+
+    def test_legacy_bare_hash_key(self):
+        # Pre-B5 dumps stored a bare sig_hash with no separator; the helper must
+        # return it unchanged rather than raising on the missing pipes.
+        from headroom.telemetry.toin import pattern_key_sig_hash
+
+        assert pattern_key_sig_hash("barehash123") == "barehash123"


### PR DESCRIPTION
## Description

`/v1/toin/patterns` reported each pattern's identifier as `sig_hash[:12]`,
but `sig_hash` is **not** a hash — it is the full aggregation key
`"auth_mode|model_family|hash"` produced by `_serialize_pattern_key`
(documented at `telemetry/toin.py`). So the first 12 characters are the
`auth_mode` and part of `model_family`, not the tool signature the field
name and docstring ("Truncated tool signature hash (12 chars)") promise.

Consequences:

- Every pattern that shares an auth mode and model family collides on the
  same identifier. When both are `unknown` (the common case) **all**
  patterns report the identical `"unknown|unkn"`.
- `/v1/toin/pattern/{hash_prefix}` matched that prefix against the whole
  composite key with `startswith` and returned on the first hit, so a
  lookup resolved to an **arbitrary** pattern and the identifier from the
  list endpoint could not round-trip to the detail endpoint.

Net effect: the two diagnostic endpoints cannot inspect a specific
pattern — which is their entire purpose.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `pattern_key_sig_hash()` in `telemetry/toin.py` to extract the
  tool-signature component of a serialized aggregation key (legacy
  bare-hash keys handled via the existing `_deserialize_pattern_key`).
- `/v1/toin/patterns` now reports `pattern_key_sig_hash(sig_hash)[:12]`.
- `/v1/toin/pattern/{hash_prefix}` now matches the prefix against the
  signature component, so the list → detail round trip is exact.
- Tests: updated the existing detail test (which addressed a pattern by
  the composite prefix), added endpoint tests for distinct identifiers +
  round-trip, and unit tests for the helper.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom --ignore-missing-imports`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_toin.py tests/test_toin_fixes.py \
    tests/test_toin_observation_only.py tests/test_toin_publish.py \
    tests/test_toin_integration.py tests/test_stateless_toin.py \
    tests/test_proxy_loopback_gating.py -q
175 passed, 15 skipped, 2 warnings

# The three endpoint tests fail before the fix:
$ git stash push -- headroom/proxy/server.py headroom/telemetry/toin.py && \
  python -m pytest tests/test_proxy_loopback_gating.py -q \
    -k "toin_patterns_hash_identifies or toin_pattern_hash_round_trips or toin_pattern_detail_whitelists"
FAILED ...::test_toin_pattern_detail_whitelists_learned_payload
FAILED ...::test_toin_patterns_hash_identifies_signature_not_composite_key
FAILED ...::test_toin_pattern_hash_round_trips_to_detail
3 failed, 98 deselected

$ python -m ruff check . && mypy headroom --ignore-missing-imports
All checks passed!
Success: no issues found in 527 source files
```

## Real Behavior Proof

- Environment: macOS (Darwin arm64), Python 3.13, Rust `_core` built locally with `maturin develop --release` (toolchain 1.95.0). Seeded a real TOIN store with two patterns that share `unknown|unknown` but have distinct signature hashes (`aaaa1111bbbbcccc`, `dddd2222eeeeffff`) via the real `record_compression` API.
- Exact command / steps: boot the actual proxy with `uvicorn --factory headroom.proxy.server:create_app --host 127.0.0.1 --port 8799` against `HEADROOM_TOIN_PATH=<seed>`, then `curl -s http://127.0.0.1:8799/v1/toin/patterns` and feed the second returned `hash` back to `curl -s http://127.0.0.1:8799/v1/toin/pattern/<hash>`. Run once with the fix stashed (before) and once applied (after).
- Observed result: BEFORE the fix both patterns reported the identical `"unknown|unkn"` and the detail lookup resolved an arbitrary pattern; AFTER the fix the identifiers are distinct and the list → detail round trip is exact.
  ```text
  BEFORE fix — GET /v1/toin/patterns:
    [{"hash": "unknown|unkn", ...}, {"hash": "unknown|unkn", ...}]
    GET /v1/toin/pattern/unknown  -> returns an arbitrary first-iterated pattern

  AFTER fix — GET /v1/toin/patterns:
    [{"hash": "aaaa1111bbbb", "compressions": 3, ...},
     {"hash": "dddd2222eeee", "compressions": 3, ...}]
    GET /v1/toin/pattern/dddd2222eeee ->
    {"compressions": 3, "retrievals": 0, "retrieval_rate": 0.0,
     "confidence": 0.03, "skip_recommended": false, "optimal_max_items": 20}
  ```
- Not tested: collisions between two distinct tool signatures that share a 12-char prefix remain possible by construction (truncated identifier); this restores the documented short-identifier contract rather than widening it.

## Runtime Rollout Safety

- Rollout-managed feature(s): none — loopback-only diagnostic endpoints, observation-only (TOIN never alters compression).
- Minimum rollout channel: N/A
- Stable/default behavior changed: the `hash` field value and the detail-endpoint matching key change shape; no compression or request behavior changes.
- Kill switch / disable path: N/A
- Unsafe override required: no
- Qualification impact: none
- Rollback path: revert this commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A — endpoint docstring already described the intended contract)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`
