### PR TITLE
fix(binaries): fail closed on HEADROOM_BINARIES_ALLOW_UNVERIFIED=0/false

### DIFF
--- a/headroom/binaries.py
+++ b/headroom/binaries.py
@@ -42,6 +42,19 @@ from headroom._subprocess import run
 
 logger = logging.getLogger(__name__)
 
+# Affirmative values for the sha256-verification bypass. This is a security
+# control (supply-chain integrity), so it must fail CLOSED: only an explicit
+# affirmative disables verification. A bare presence check treated
+# `HEADROOM_BINARIES_ALLOW_UNVERIFIED=0` / `=false` — the natural way to say
+# "keep verifying" — as truthy and silently skipped verification.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _allow_unverified_binaries() -> bool:
+    """Whether sha256 verification of fetched binaries is bypassed."""
+    return os.environ.get("HEADROOM_BINARIES_ALLOW_UNVERIFIED", "").strip().lower() in _TRUTHY
+
+
 __all__ = [
     "BinaryError",
     "BinaryFetchError",
@@ -311,7 +324,7 @@ def _sha256_file(path: Path) -> str:
 
 
 def _verify_sha256(path: Path, expected: str | None) -> None:
-    if os.environ.get("HEADROOM_BINARIES_ALLOW_UNVERIFIED"):
+    if _allow_unverified_binaries():
         logger.warning(
             "skipping sha256 verification for %s (HEADROOM_BINARIES_ALLOW_UNVERIFIED=1)",
             path.name,
@@ -347,7 +360,7 @@ def verify_download_bytes(data: bytes, *, url: str, name: str) -> None:
     the bytes against the tools.json pin for ``url`` and refuses an unpinned URL
     unless HEADROOM_BINARIES_ALLOW_UNVERIFIED=1.
     """
-    if os.environ.get("HEADROOM_BINARIES_ALLOW_UNVERIFIED"):
+    if _allow_unverified_binaries():
         logger.warning(
             "skipping sha256 verification for %s (HEADROOM_BINARIES_ALLOW_UNVERIFIED=1)", name
         )

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -382,3 +382,47 @@ def test_status_reports_every_registered_tool(monkeypatch):
     assert {"difft", "scc", "ast-grep"} <= names
     for r in rows:
         assert r["state"] in ("on-path", "cached", "missing", "unsupported-platform")
+
+
+# -------- HEADROOM_BINARIES_ALLOW_UNVERIFIED (security: fail closed) ------- #
+
+
+def _write(tmp_path, data: bytes):
+    p = tmp_path / "asset.bin"
+    p.write_bytes(data)
+    return p
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "  "])
+def test_allow_unverified_non_affirmative_still_verifies(monkeypatch, tmp_path, value):
+    # A security bypass must fail CLOSED: only an explicit affirmative disables
+    # verification. Setting the var to "0"/"false" (the natural way to say "keep
+    # verifying") previously passed a bare presence check and silently skipped
+    # sha256 verification of the downloaded binary.
+    monkeypatch.setenv("HEADROOM_BINARIES_ALLOW_UNVERIFIED", value)
+    path = _write(tmp_path, b"payload")
+    with pytest.raises(binaries.Sha256Mismatch):
+        binaries._verify_sha256(path, "deadbeef" * 8)  # wrong pin
+
+
+def test_allow_unverified_unset_still_verifies(monkeypatch, tmp_path):
+    monkeypatch.delenv("HEADROOM_BINARIES_ALLOW_UNVERIFIED", raising=False)
+    path = _write(tmp_path, b"payload")
+    with pytest.raises(binaries.Sha256Mismatch):
+        binaries._verify_sha256(path, "deadbeef" * 8)
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_allow_unverified_affirmative_skips_verification(monkeypatch, tmp_path, value):
+    monkeypatch.setenv("HEADROOM_BINARIES_ALLOW_UNVERIFIED", value)
+    path = _write(tmp_path, b"payload")
+    # Wrong pin, but an explicit affirmative bypass returns without raising.
+    binaries._verify_sha256(path, "deadbeef" * 8)
+
+
+def test_verify_download_bytes_zero_still_verifies(monkeypatch):
+    # Same fail-closed contract on the in-memory installer path.
+    monkeypatch.setenv("HEADROOM_BINARIES_ALLOW_UNVERIFIED", "0")
+    monkeypatch.setattr(binaries, "sha256_for_url", lambda _url: "deadbeef" * 8)
+    with pytest.raises(binaries.Sha256Mismatch):
+        binaries.verify_download_bytes(b"payload", url="https://x/y", name="y")


### PR DESCRIPTION
## Description

The sha256-verification bypass for fetched tool binaries is a supply-chain
integrity control, but both call sites gated it on a bare presence check:

```python
if os.environ.get("HEADROOM_BINARIES_ALLOW_UNVERIFIED"):
    ...skip sha256 verification...
```

Any non-empty value is truthy — including `0`, `false`, `no`, `off`. An
operator who set `HEADROOM_BINARIES_ALLOW_UNVERIFIED=0` (the natural way to
say "keep verification on") therefore **silently disabled** sha256
verification of every fetched binary (`difft`, `scc`, and the in-memory
`rtk` / `lean-ctx` / `codebase-memory-mcp` installer path via
`verify_download_bytes`). The failure direction is backwards for a security
control: it fails **open**.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Parse `HEADROOM_BINARIES_ALLOW_UNVERIFIED` as an affirmative flag
  (`1`/`true`/`yes`/`on`) via a shared `_allow_unverified_binaries()` helper,
  used by both `_verify_sha256` and `verify_download_bytes`.
- Every non-affirmative value — and an unset or empty variable — now
  **enforces** verification (fail closed). Matches the truthy-set parsing
  already used across the codebase (`onnx_runtime`, `cold_prefix`,
  `ttl_observations`, `qdrant_env`).
- Added regression tests over the env-value matrix on both call sites.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom --ignore-missing-imports`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_binaries.py -q
35 passed, 1 warning in 1.15s

# New tests fail before the fix (0/false/no/off/whitespace + in-memory path):
$ git stash push -- headroom/binaries.py && \
  python -m pytest tests/test_binaries.py -q -k "allow_unverified or verify_download_bytes_zero"
FAILED ...::test_allow_unverified_non_affirmative_still_verifies[0]
FAILED ...::test_allow_unverified_non_affirmative_still_verifies[false]
FAILED ...::test_allow_unverified_non_affirmative_still_verifies[no]
FAILED ...::test_allow_unverified_non_affirmative_still_verifies[off]
FAILED ...::test_allow_unverified_non_affirmative_still_verifies[  ]
FAILED ...::test_verify_download_bytes_zero_still_verifies
6 failed, 7 passed, 22 deselected

$ python -m ruff check headroom/binaries.py tests/test_binaries.py && mypy headroom --ignore-missing-imports
All checks passed!
Success: no issues found in 527 source files
```

## Real Behavior Proof

- Environment: macOS (Darwin arm64), Python 3.13. Operator sets `HEADROOM_BINARIES_ALLOW_UNVERIFIED=0` (intending to keep verification enabled). A tampered binary whose bytes do not match the registry-pinned sha256 is passed to `binaries._verify_sha256`.
- Exact command / steps: write a file containing `b"TAMPERED-BINARY-CONTENT"`, then call `binaries._verify_sha256(path, <wrong pin>)` under `HEADROOM_BINARIES_ALLOW_UNVERIFIED=0`, once with the fix stashed (before) and once applied (after).
- Observed result: BEFORE the fix the mismatched binary is accepted (verification skipped); AFTER the fix it is rejected with `Sha256Mismatch`.
  ```text
  ### HEADROOM_BINARIES_ALLOW_UNVERIFIED=0 (operator intent: keep verifying)
  --- BEFORE fix ---
  skipping sha256 verification for difft (HEADROOM_BINARIES_ALLOW_UNVERIFIED=1)
  RESULT: verification SKIPPED — tampered binary ACCEPTED  (fail-open)
  --- AFTER fix ----
  RESULT: Sha256Mismatch raised — tampered binary REJECTED  (fail-closed)
  ```
- Not tested: a live end-to-end download of difft/scc from GitHub releases (network-dependent); the verification function that gates every such download is exercised directly above with a real byte payload.

## Runtime Rollout Safety

- Rollout-managed feature(s): none — unconditional hardening of an existing security control.
- Minimum rollout channel: N/A
- Stable/default behavior changed: only for non-affirmative env values that previously bypassed verification; `=1`/`true`/`yes`/`on` still bypass exactly as before, and the default (unset) still verifies.
- Kill switch / disable path: `HEADROOM_BINARIES_ALLOW_UNVERIFIED=1` still bypasses verification for operators who genuinely need it.
- Unsafe override required: no
- Qualification impact: none
- Rollback path: revert this commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation (N/A — behavior now matches the existing `=1` docstrings)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`
