### PR TITLE
fix(auth): match the Bearer auth scheme case-insensitively (RFC 7235)

### DIFF
--- a/headroom/proxy/auth_policy.py
+++ b/headroom/proxy/auth_policy.py
@@ -71,8 +71,15 @@ def classify_auth_signals(signals: AuthSignals) -> AuthMode:
             return AuthMode.SUBSCRIPTION
 
     auth = signals.authorization
-    if auth.startswith("Bearer "):
-        token = auth[len("Bearer ") :]
+    # The auth-scheme token ("Bearer") is case-insensitive per RFC 7235 §2.1,
+    # so a client sending `Authorization: bearer sk-...` must classify the same
+    # as `Bearer`. A case-sensitive `startswith("Bearer ")` sent such a request
+    # to the `elif auth:` (OAUTH) fallthrough, misclassifying a PAYG API key —
+    # which mis-routes compression policy and mislabels cost/TOIN auth_mode.
+    # Only the scheme is case-folded; the credential itself stays case-sensitive.
+    scheme, sep, credentials = auth.partition(" ")
+    if sep and scheme.lower() == "bearer":
+        token = credentials
         if token.startswith("sk-ant-oat"):
             return AuthMode.OAUTH
         if token.startswith("sk-ant-api") or token.startswith("sk-"):

--- a/tests/test_auth_policy.py
+++ b/tests/test_auth_policy.py
@@ -60,3 +60,34 @@ def test_codex_stamp_only_for_unidentified_responses_callers() -> None:
         is False
     )
     assert should_stamp_codex_client_signals("/v1/chat/completions", AuthSignals()) is False
+
+
+def test_bearer_scheme_is_case_insensitive() -> None:
+    # RFC 7235 §2.1: the auth-scheme token is case-insensitive. A lowercase or
+    # mixed-case "bearer" carrying a PAYG key must classify as PAYG, not fall
+    # through to the non-Bearer OAUTH branch.
+    for scheme in ("bearer", "BEARER", "Bearer", "BeArEr"):
+        signals = AuthSignals(authorization=f"{scheme} sk-ant-api03-abc")
+        assert classify_auth_signals(signals) is AuthMode.PAYG, scheme
+
+
+def test_bearer_case_insensitive_preserves_oauth_and_jwt_shapes() -> None:
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.signature"
+    assert classify_auth_signals(AuthSignals(authorization="bearer sk-ant-oat01-abc")) is (
+        AuthMode.OAUTH
+    )
+    assert classify_auth_signals(AuthSignals(authorization=f"bearer {jwt}")) is AuthMode.OAUTH
+
+
+def test_credential_case_is_not_folded() -> None:
+    # Only the scheme is case-folded; the token keeps its case, so a PAYG
+    # `sk-...` prefix still matches exactly (it is lowercase by construction).
+    signals = AuthSignals(authorization="Bearer sk-PROJ-Abc123")
+    assert classify_auth_signals(signals) is AuthMode.PAYG
+
+
+def test_non_bearer_scheme_still_oauth() -> None:
+    # AWS SigV4 (Bedrock) and any other non-Bearer scheme keep the OAUTH
+    # passthrough-prefer classification.
+    signals = AuthSignals(authorization="AWS4-HMAC-SHA256 Credential=AKIA/...")
+    assert classify_auth_signals(signals) is AuthMode.OAUTH


### PR DESCRIPTION
## Description

`classify_auth_signals` (`headroom/proxy/auth_policy.py`) gated PAYG/OAUTH
token-shape detection on a case-sensitive check:

```python
if auth.startswith("Bearer "):
    ...classify sk-ant-oat / sk-ant-api / sk- / jwt...
elif auth:
    return AuthMode.OAUTH
```

RFC 7235 §2.1 defines the auth-scheme token as **case-insensitive**. A client
sending `Authorization: bearer sk-ant-api03-...` (lowercase scheme) therefore
skipped the Bearer branch and fell through to `elif auth:` → `OAUTH`,
misclassifying a PAYG API key.

Auth mode is not cosmetic: it routes compression policy (`classify_auth_mode`
feeds the compression-policy decision) and labels the cost/TOIN `auth_mode`
aggregation key, so the misclassification silently changes how a request is
compressed and how its spend is attributed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Compare the auth scheme case-insensitively via `str.partition(" ")`; only
  the scheme is folded, the credential keeps its original case (tokens are
  case-sensitive, and PAYG `sk-` prefixes are lowercase by construction).
- Non-Bearer schemes (AWS SigV4 / Bedrock, etc.) keep the existing OAUTH
  passthrough-prefer classification.
- Added regression tests for lowercase/mixed-case `bearer`, OAuth/JWT shapes
  under a lowercase scheme, credential-case preservation, and non-Bearer.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom --ignore-missing-imports`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_auth_policy.py tests/test_auth_mode.py -q
36 passed, 1 warning

# The case-insensitivity regression test fails before the fix:
$ git stash push -- headroom/proxy/auth_policy.py && \
  python -m pytest tests/test_auth_policy.py -q -k "case_insensitive"
FAILED tests/test_auth_policy.py::test_bearer_scheme_is_case_insensitive
1 failed, ...

$ python -m ruff check headroom/proxy/auth_policy.py tests/test_auth_policy.py
All checks passed!
$ mypy headroom --ignore-missing-imports
Success: no issues found in 527 source files
```

## Real Behavior Proof

- Environment: macOS (Darwin arm64), Python 3.13. Classify an inbound request whose header is `Authorization: bearer sk-ant-api03-...` (lowercase scheme) through the header-facing entrypoint `headroom.proxy.auth_mode.classify_auth_mode`.
- Exact command / steps: call `classify_auth_mode({"authorization": "bearer sk-ant-api03-REALKEYSHAPE"})` once with the fix stashed (before) and once applied (after).
- Observed result: BEFORE the fix the PAYG key is classified `oauth`; AFTER the fix it is classified `payg`.
  ```text
  header: {'authorization': 'bearer sk-ant-api03-REALKEYSHAPE'}
  --- BEFORE fix ---  classified auth_mode: oauth   (wrong)
  --- AFTER fix ----  classified auth_mode: payg    (correct)
  ```
- Not tested: a live end-to-end proxied request from a client that lowercases the scheme (the pure classifier that every request routes through is exercised directly above).

## Runtime Rollout Safety

- Rollout-managed feature(s): none — pure classification correctness fix.
- Minimum rollout channel: N/A
- Stable/default behavior changed: only for requests whose scheme is not exactly `Bearer` (e.g. `bearer`); `Bearer ...` and non-Bearer schemes classify exactly as before.
- Kill switch / disable path: N/A
- Unsafe override required: no
- Qualification impact: none
- Rollback path: revert this commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A — the classify_auth_mode docstring already describes the intended Bearer behavior)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`
