### PR TITLE
fix(mcp): add explicit Serena reconciliation

### DIFF
--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -184,9 +184,10 @@ Install Headroom so it's globally on PATH — `uv tool install "headroom-ai[mcp]
 | Cursor | Supported | Add to Cursor MCP settings |
 | Codex | If supported | Configure MCP server |
 | Any MCP host | Yes | Point to `headroom mcp serve` |
-| Serena reconciliation | User-managed drift | `headroom mcp reconcile [--acknowledge|--adopt|--clear]` |
 
 ## Architecture
+
+For user-managed Serena drift, run `headroom mcp reconcile` to inspect the current recommendation. Use `--acknowledge`, `--adopt`, or `--clear` for the explicit action.
 
 ### MCP only (no proxy)
 

--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -184,6 +184,7 @@ Install Headroom so it's globally on PATH — `uv tool install "headroom-ai[mcp]
 | Cursor | Supported | Add to Cursor MCP settings |
 | Codex | If supported | Configure MCP server |
 | Any MCP host | Yes | Point to `headroom mcp serve` |
+| Serena reconciliation | User-managed drift | `headroom mcp reconcile [--acknowledge|--adopt|--clear]` |
 
 ## Architecture
 

--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -187,7 +187,7 @@ Install Headroom so it's globally on PATH — `uv tool install "headroom-ai[mcp]
 
 ## Architecture
 
-For user-managed Serena drift, run `headroom mcp reconcile` to inspect the current recommendation. Use `--acknowledge`, `--adopt`, or `--clear` for the explicit action.
+For user-managed Serena drift, run `headroom mcp reconcile` to inspect the current recommendation. Add `--adopt` only when you want Headroom to replace the Serena entry.
 
 ### MCP only (no proxy)
 

--- a/headroom/cli/mcp.py
+++ b/headroom/cli/mcp.py
@@ -222,6 +222,7 @@ def mcp_reconcile(adopt: bool) -> None:
     """Inspect or explicitly reconcile a user-managed Serena MCP entry."""
     from headroom.mcp_registry import (
         CLAUDE_SERENA_CONTEXT,
+        ClaudeConfigMutationError,
         ClaudeRegistrar,
         RegisterStatus,
         build_serena_spec,
@@ -240,8 +241,9 @@ def mcp_reconcile(adopt: bool) -> None:
 
     if adopt:
         try:
+            registrar.validate_configs_for_mutation()
             validate_ledger_for_mutation()
-        except LedgerMutationError as exc:
+        except (ClaudeConfigMutationError, LedgerMutationError) as exc:
             raise click.ClickException(str(exc)) from exc
     if adopt:
         result = registrar.register_server(recommended, force=True)

--- a/headroom/cli/mcp.py
+++ b/headroom/cli/mcp.py
@@ -216,6 +216,86 @@ def mcp_uninstall() -> None:
         click.echo("Headroom MCP is not configured. Nothing to uninstall.")
 
 
+@mcp.command("reconcile")
+@click.option(
+    "--agent",
+    type=click.Choice(["claude", "codex", "grok", "opencode"]),
+    default="claude",
+    show_default=True,
+)
+@click.option("--server", default="serena", show_default=True)
+@click.option("--acknowledge", is_flag=True, help="Acknowledge the current observed Serena drift.")
+@click.option("--adopt", is_flag=True, help="Replace only the Serena entry with Headroom's spec.")
+@click.option("--clear", "clear_ack", is_flag=True, help="Clear the Serena drift acknowledgement.")
+def mcp_reconcile(
+    agent: str,
+    server: str,
+    acknowledge: bool,
+    adopt: bool,
+    clear_ack: bool,
+) -> None:
+    """Inspect or explicitly reconcile a user-managed Serena MCP entry."""
+    if server != "serena":
+        raise click.ClickException("only --server serena is supported")
+    actions = sum((acknowledge, adopt, clear_ack))
+    if actions > 1:
+        raise click.ClickException("choose at most one of --acknowledge, --adopt, or --clear")
+
+    from headroom.mcp_registry import (
+        ClaudeRegistrar,
+        RegisterStatus,
+        build_serena_spec_for_agent,
+        get_all_registrars,
+    )
+    from headroom.mcp_registry.ledger import (
+        acknowledgement_matches,
+        clear_acknowledgement,
+        record_acknowledgement,
+        record_install,
+    )
+
+    registrar = (
+        ClaudeRegistrar()
+        if agent == "claude"
+        else next((item for item in get_all_registrars() if item.name == agent), None)
+    )
+    if registrar is None or not registrar.detect():
+        raise click.ClickException(f"{agent} is not detected")
+    recommended = build_serena_spec_for_agent(agent)
+    observed = registrar.get_server(server)
+    current_ack = acknowledgement_matches(agent, server, recommended, observed)
+
+    if clear_ack:
+        clear_acknowledgement(agent, server)
+        click.echo(f"Cleared Serena acknowledgement for {agent}.")
+        return
+    if acknowledge:
+        if observed is None:
+            raise click.ClickException("cannot acknowledge an absent Serena entry")
+        record_acknowledgement(agent, server, recommended, observed)
+        click.echo(f"Acknowledged current Serena configuration for {agent}.")
+        return
+    if adopt:
+        result = registrar.register_server(recommended, force=True)
+        if result.status not in (RegisterStatus.REGISTERED, RegisterStatus.ALREADY):
+            raise click.ClickException(result.detail or "could not adopt Serena configuration")
+        record_install(agent, recommended)
+        clear_acknowledgement(agent, server)
+        click.echo(
+            f"Adopted Headroom's Serena configuration for {agent}; unrelated config preserved."
+        )
+        return
+
+    click.echo(f"Serena reconciliation for {agent}")
+    click.echo(f"  observed: {'absent' if observed is None else 'present'}")
+    click.echo(f"  recommendation: {recommended.command} {' '.join(recommended.args)}")
+    click.echo(f"  acknowledgement: {'current' if current_ack else 'none/stale'}")
+    if observed is not None and observed != recommended:
+        click.echo(
+            "  action: use --acknowledge to suppress this current drift or --adopt to replace it"
+        )
+
+
 @mcp.command("status")
 def mcp_status() -> None:
     """Check Headroom MCP configuration status.

--- a/headroom/cli/mcp.py
+++ b/headroom/cli/mcp.py
@@ -217,86 +217,42 @@ def mcp_uninstall() -> None:
 
 
 @mcp.command("reconcile")
-@click.option(
-    "--agent",
-    type=click.Choice(["claude"]),
-    default="claude",
-    show_default=True,
-)
-@click.option("--server", default="serena", show_default=True)
-@click.option("--acknowledge", is_flag=True, help="Acknowledge the current observed Serena drift.")
 @click.option("--adopt", is_flag=True, help="Replace only the Serena entry with Headroom's spec.")
-@click.option("--clear", "clear_ack", is_flag=True, help="Clear the Serena drift acknowledgement.")
-def mcp_reconcile(
-    agent: str,
-    server: str,
-    acknowledge: bool,
-    adopt: bool,
-    clear_ack: bool,
-) -> None:
+def mcp_reconcile(adopt: bool) -> None:
     """Inspect or explicitly reconcile a user-managed Serena MCP entry."""
-    if server != "serena":
-        raise click.ClickException("only --server serena is supported")
-    actions = sum((acknowledge, adopt, clear_ack))
-    if actions > 1:
-        raise click.ClickException("choose at most one of --acknowledge, --adopt, or --clear")
-
-    from headroom.mcp_registry import (
-        ClaudeRegistrar,
-        RegisterStatus,
-        build_serena_spec_for_agent,
-    )
+    from headroom.mcp_registry import ClaudeRegistrar, RegisterStatus, build_serena_spec
     from headroom.mcp_registry.ledger import (
         LedgerMutationError,
-        acknowledgement_matches,
-        clear_acknowledgement,
-        record_acknowledgement,
         record_install,
         validate_ledger_for_mutation,
     )
 
     registrar = ClaudeRegistrar()
-    if registrar is None or not registrar.detect():
-        raise click.ClickException(f"{agent} is not detected")
-    recommended = build_serena_spec_for_agent(agent)
-    observed = registrar.get_server(server)
-    current_ack = acknowledgement_matches(agent, server, recommended, observed)
+    if not registrar.detect():
+        raise click.ClickException("claude is not detected")
+    recommended = build_serena_spec("claude-code")
+    observed = registrar.get_server("serena")
 
-    if acknowledge or adopt or clear_ack:
+    if adopt:
         try:
             validate_ledger_for_mutation()
         except LedgerMutationError as exc:
             raise click.ClickException(str(exc)) from exc
-
-    if clear_ack:
-        clear_acknowledgement(agent, server)
-        click.echo(f"Cleared Serena acknowledgement for {agent}.")
-        return
-    if acknowledge:
-        if observed is None:
-            raise click.ClickException("cannot acknowledge an absent Serena entry")
-        record_acknowledgement(agent, server, recommended, observed)
-        click.echo(f"Acknowledged current Serena configuration for {agent}.")
-        return
     if adopt:
         result = registrar.register_server(recommended, force=True)
         if result.status not in (RegisterStatus.REGISTERED, RegisterStatus.ALREADY):
             raise click.ClickException(result.detail or "could not adopt Serena configuration")
-        record_install(agent, recommended)
-        clear_acknowledgement(agent, server)
+        record_install("claude", recommended)
         click.echo(
-            f"Adopted Headroom's Serena configuration for {agent}; unrelated config preserved."
+            "Adopted Headroom's Serena configuration for Claude; unrelated config preserved."
         )
         return
 
-    click.echo(f"Serena reconciliation for {agent}")
+    click.echo("Serena reconciliation for Claude")
     click.echo(f"  observed: {'absent' if observed is None else 'present'}")
     click.echo(f"  recommendation: {recommended.command} {' '.join(recommended.args)}")
-    click.echo(f"  acknowledgement: {'current' if current_ack else 'none/stale'}")
     if observed is not None and observed != recommended:
-        click.echo(
-            "  action: use --acknowledge to suppress this current drift or --adopt to replace it"
-        )
+        click.echo("  action: use --adopt to replace it")
 
 
 @mcp.command("status")

--- a/headroom/cli/mcp.py
+++ b/headroom/cli/mcp.py
@@ -220,7 +220,12 @@ def mcp_uninstall() -> None:
 @click.option("--adopt", is_flag=True, help="Replace only the Serena entry with Headroom's spec.")
 def mcp_reconcile(adopt: bool) -> None:
     """Inspect or explicitly reconcile a user-managed Serena MCP entry."""
-    from headroom.mcp_registry import ClaudeRegistrar, RegisterStatus, build_serena_spec
+    from headroom.mcp_registry import (
+        CLAUDE_SERENA_CONTEXT,
+        ClaudeRegistrar,
+        RegisterStatus,
+        build_serena_spec,
+    )
     from headroom.mcp_registry.ledger import (
         LedgerMutationError,
         record_install,
@@ -230,7 +235,7 @@ def mcp_reconcile(adopt: bool) -> None:
     registrar = ClaudeRegistrar()
     if not registrar.detect():
         raise click.ClickException("claude is not detected")
-    recommended = build_serena_spec("claude-code")
+    recommended = build_serena_spec(CLAUDE_SERENA_CONTEXT)
     observed = registrar.get_server("serena")
 
     if adopt:

--- a/headroom/cli/mcp.py
+++ b/headroom/cli/mcp.py
@@ -219,7 +219,7 @@ def mcp_uninstall() -> None:
 @mcp.command("reconcile")
 @click.option(
     "--agent",
-    type=click.Choice(["claude", "codex", "grok", "opencode"]),
+    type=click.Choice(["claude"]),
     default="claude",
     show_default=True,
 )
@@ -245,25 +245,28 @@ def mcp_reconcile(
         ClaudeRegistrar,
         RegisterStatus,
         build_serena_spec_for_agent,
-        get_all_registrars,
     )
     from headroom.mcp_registry.ledger import (
+        LedgerMutationError,
         acknowledgement_matches,
         clear_acknowledgement,
         record_acknowledgement,
         record_install,
+        validate_ledger_for_mutation,
     )
 
-    registrar = (
-        ClaudeRegistrar()
-        if agent == "claude"
-        else next((item for item in get_all_registrars() if item.name == agent), None)
-    )
+    registrar = ClaudeRegistrar()
     if registrar is None or not registrar.detect():
         raise click.ClickException(f"{agent} is not detected")
     recommended = build_serena_spec_for_agent(agent)
     observed = registrar.get_server(server)
     current_ack = acknowledgement_matches(agent, server, recommended, observed)
+
+    if acknowledge or adopt or clear_ack:
+        try:
+            validate_ledger_for_mutation()
+        except LedgerMutationError as exc:
+            raise click.ClickException(str(exc)) from exc
 
     if clear_ack:
         clear_acknowledgement(agent, server)

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -2041,7 +2041,11 @@ def _setup_serena_mcp(
         result,
         label="Serena MCP",
         verbose=verbose,
-        overwrite_hint="run headroom mcp reconcile --adopt",
+        overwrite_hint=(
+            "run headroom mcp reconcile --adopt"
+            if registrar.name == "claude"
+            else "update or remove the existing serena MCP entry, then rerun headroom wrap"
+        ),
         restart_hint=f"restart {registrar.display_name} if it was already running",
     )
     if line is not None:

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -2018,17 +2018,18 @@ def _setup_serena_mcp(
 
     spec = build_serena_spec(context)
     result = registrar.register_server(spec, force=force)
+    owned_drift = (
+        result.status == RegisterStatus.MISMATCH
+        and not force
+        and headroom_installed_matching(registrar.name, registrar.get_server("serena"))
+    )
 
     # Migrate a stale Headroom-installed entry. register_server won't overwrite
     # a differing spec without force, so an older Headroom Serena entry would
     # otherwise persist across re-wraps. Force-update it only when the ledger
     # proves Headroom installed the entry that's currently on disk — never a
     # user-managed Serena.
-    if (
-        result.status == RegisterStatus.MISMATCH
-        and not force
-        and headroom_installed_matching(registrar.name, registrar.get_server("serena"))
-    ):
+    if result.status == RegisterStatus.MISMATCH and not force and owned_drift:
         result = registrar.register_server(spec, force=True)
         if result.status == RegisterStatus.REGISTERED:
             click.echo("  Serena MCP: migrated previously-installed entry to current spec")
@@ -2042,7 +2043,9 @@ def _setup_serena_mcp(
         label="Serena MCP",
         verbose=verbose,
         overwrite_hint=(
-            "run headroom mcp reconcile --adopt"
+            "run headroom wrap again"
+            if owned_drift
+            else "run headroom mcp reconcile --adopt"
             if registrar.name == "claude"
             else "update or remove the existing serena MCP entry, then rerun headroom wrap"
         ),
@@ -4936,11 +4939,11 @@ def claude(
             click.echo("  Skipping MCP retrieve tool (--no-mcp)")
 
         # Coding-task compressor: Serena (retires any legacy tokensave entry).
-        from headroom.mcp_registry import ClaudeRegistrar
+        from headroom.mcp_registry import CLAUDE_SERENA_CONTEXT, ClaudeRegistrar
 
         _setup_coding_compressor(
             ClaudeRegistrar(),
-            serena_context="claude-code",
+            serena_context=CLAUDE_SERENA_CONTEXT,
             serena=serena,
             no_serena=no_serena,
             no_tokensave=no_tokensave,

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -2002,7 +2002,7 @@ def _setup_serena_mcp(
     """
     from headroom.mcp_registry import (
         acknowledgement_matches,
-        build_serena_spec_for_agent,
+        build_serena_spec,
         format_result,
         serena_context_for_agent,
     )
@@ -2025,7 +2025,7 @@ def _setup_serena_mcp(
     if agent_context is None:
         click.echo(f"  Serena MCP: unsupported agent {registrar.name} — skipping")
         return
-    spec = build_serena_spec_for_agent(registrar.name)
+    spec = build_serena_spec(agent_context)
     result = registrar.register_server(spec, force=force)
 
     # Migrate a stale Headroom-installed entry. register_server won't overwrite
@@ -2055,7 +2055,7 @@ def _setup_serena_mcp(
         result,
         label="Serena MCP",
         verbose=verbose,
-        overwrite_hint="update or remove the existing serena MCP entry, then rerun headroom wrap",
+        overwrite_hint=f"run headroom mcp reconcile --agent {registrar.name} --server serena",
         restart_hint=f"restart {registrar.display_name} if it was already running",
     )
     if line is not None:

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -1986,7 +1986,7 @@ def _index_serena_project(*, verbose: bool = False) -> None:
 
 
 def _setup_serena_mcp(
-    registrar: Any, *, context: str | None = None, verbose: bool = False, force: bool = False
+    registrar: Any, *, context: str, verbose: bool = False, force: bool = False
 ) -> None:
     """Register Serena MCP with the given agent (idempotent).
 
@@ -2000,13 +2000,8 @@ def _setup_serena_mcp(
     user-managed Serena (absent from our ledger) is left untouched and the
     mismatch is reported as before.
     """
-    from headroom.mcp_registry import (
-        acknowledgement_matches,
-        build_serena_spec,
-        format_result,
-        serena_context_for_agent,
-    )
-    from headroom.mcp_registry.base import RegisterResult, RegisterStatus
+    from headroom.mcp_registry import build_serena_spec, format_result
+    from headroom.mcp_registry.base import RegisterStatus
     from headroom.mcp_registry.ledger import headroom_installed_matching, record_install
 
     if not registrar.detect():
@@ -2021,11 +2016,7 @@ def _setup_serena_mcp(
     # Serena is a real launch now — make sure it won't pop a browser tab.
     _ensure_serena_dashboard_disabled(verbose=verbose)
 
-    agent_context = serena_context_for_agent(registrar.name) or context
-    if agent_context is None:
-        click.echo(f"  Serena MCP: unsupported agent {registrar.name} — skipping")
-        return
-    spec = build_serena_spec(agent_context)
+    spec = build_serena_spec(context)
     result = registrar.register_server(spec, force=force)
 
     # Migrate a stale Headroom-installed entry. register_server won't overwrite
@@ -2042,11 +2033,6 @@ def _setup_serena_mcp(
         if result.status == RegisterStatus.REGISTERED:
             click.echo("  Serena MCP: migrated previously-installed entry to current spec")
 
-    if result.status == RegisterStatus.MISMATCH and acknowledgement_matches(
-        registrar.name, "serena", spec, registrar.get_server("serena")
-    ):
-        result = RegisterResult(RegisterStatus.ALREADY, "acknowledged current mismatch")
-
     if result.status == RegisterStatus.REGISTERED:
         record_install(registrar.name, spec)
 
@@ -2055,7 +2041,7 @@ def _setup_serena_mcp(
         result,
         label="Serena MCP",
         verbose=verbose,
-        overwrite_hint=f"run headroom mcp reconcile --agent {registrar.name} --server serena",
+        overwrite_hint="run headroom mcp reconcile --adopt",
         restart_hint=f"restart {registrar.display_name} if it was already running",
     )
     if line is not None:

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -1986,7 +1986,7 @@ def _index_serena_project(*, verbose: bool = False) -> None:
 
 
 def _setup_serena_mcp(
-    registrar: Any, *, context: str, verbose: bool = False, force: bool = False
+    registrar: Any, *, context: str | None = None, verbose: bool = False, force: bool = False
 ) -> None:
     """Register Serena MCP with the given agent (idempotent).
 
@@ -2000,8 +2000,13 @@ def _setup_serena_mcp(
     user-managed Serena (absent from our ledger) is left untouched and the
     mismatch is reported as before.
     """
-    from headroom.mcp_registry import build_serena_spec, format_result
-    from headroom.mcp_registry.base import RegisterStatus
+    from headroom.mcp_registry import (
+        acknowledgement_matches,
+        build_serena_spec_for_agent,
+        format_result,
+        serena_context_for_agent,
+    )
+    from headroom.mcp_registry.base import RegisterResult, RegisterStatus
     from headroom.mcp_registry.ledger import headroom_installed_matching, record_install
 
     if not registrar.detect():
@@ -2016,7 +2021,11 @@ def _setup_serena_mcp(
     # Serena is a real launch now — make sure it won't pop a browser tab.
     _ensure_serena_dashboard_disabled(verbose=verbose)
 
-    spec = build_serena_spec(context)
+    agent_context = serena_context_for_agent(registrar.name) or context
+    if agent_context is None:
+        click.echo(f"  Serena MCP: unsupported agent {registrar.name} — skipping")
+        return
+    spec = build_serena_spec_for_agent(registrar.name)
     result = registrar.register_server(spec, force=force)
 
     # Migrate a stale Headroom-installed entry. register_server won't overwrite
@@ -2032,6 +2041,11 @@ def _setup_serena_mcp(
         result = registrar.register_server(spec, force=True)
         if result.status == RegisterStatus.REGISTERED:
             click.echo("  Serena MCP: migrated previously-installed entry to current spec")
+
+    if result.status == RegisterStatus.MISMATCH and acknowledgement_matches(
+        registrar.name, "serena", spec, registrar.get_server("serena")
+    ):
+        result = RegisterResult(RegisterStatus.ALREADY, "acknowledged current mismatch")
 
     if result.status == RegisterStatus.REGISTERED:
         record_install(registrar.name, spec)

--- a/headroom/mcp_registry/__init__.py
+++ b/headroom/mcp_registry/__init__.py
@@ -14,7 +14,7 @@ without changing the calling code.
 from __future__ import annotations
 
 from .base import MCPRegistrar, RegisterResult, RegisterStatus, ServerSpec
-from .claude import ClaudeRegistrar
+from .claude import ClaudeConfigMutationError, ClaudeRegistrar
 from .codex import CodexRegistrar
 from .display import any_succeeded, format_result, format_results
 from .grok import GrokRegistrar
@@ -32,6 +32,7 @@ from .server_json import build_server_json, render_server_json
 __all__ = [
     "DEFAULT_PROXY_URL",
     "CLAUDE_SERENA_CONTEXT",
+    "ClaudeConfigMutationError",
     "ClaudeRegistrar",
     "CodexRegistrar",
     "GrokRegistrar",

--- a/headroom/mcp_registry/__init__.py
+++ b/headroom/mcp_registry/__init__.py
@@ -20,10 +20,19 @@ from .display import any_succeeded, format_result, format_results
 from .grok import GrokRegistrar
 from .install import (
     DEFAULT_PROXY_URL,
+    SERENA_CONTEXT_BY_AGENT,
     build_headroom_spec,
     build_serena_spec,
+    build_serena_spec_for_agent,
     get_all_registrars,
     install_everywhere,
+    serena_context_for_agent,
+)
+from .ledger import (
+    acknowledgement_matches,
+    clear_acknowledgement,
+    get_acknowledgement,
+    record_acknowledgement,
 )
 from .opencode import OpencodeRegistrar
 from .server_json import build_server_json, render_server_json
@@ -39,12 +48,19 @@ __all__ = [
     "RegisterStatus",
     "ServerSpec",
     "any_succeeded",
+    "acknowledgement_matches",
+    "clear_acknowledgement",
+    "get_acknowledgement",
+    "record_acknowledgement",
     "build_headroom_spec",
     "build_serena_spec",
+    "build_serena_spec_for_agent",
     "build_server_json",
     "format_result",
     "format_results",
     "get_all_registrars",
     "install_everywhere",
+    "SERENA_CONTEXT_BY_AGENT",
+    "serena_context_for_agent",
     "render_server_json",
 ]

--- a/headroom/mcp_registry/__init__.py
+++ b/headroom/mcp_registry/__init__.py
@@ -20,19 +20,10 @@ from .display import any_succeeded, format_result, format_results
 from .grok import GrokRegistrar
 from .install import (
     DEFAULT_PROXY_URL,
-    SERENA_CONTEXT_BY_AGENT,
     build_headroom_spec,
     build_serena_spec,
-    build_serena_spec_for_agent,
     get_all_registrars,
     install_everywhere,
-    serena_context_for_agent,
-)
-from .ledger import (
-    acknowledgement_matches,
-    clear_acknowledgement,
-    get_acknowledgement,
-    record_acknowledgement,
 )
 from .opencode import OpencodeRegistrar
 from .server_json import build_server_json, render_server_json
@@ -48,19 +39,12 @@ __all__ = [
     "RegisterStatus",
     "ServerSpec",
     "any_succeeded",
-    "acknowledgement_matches",
-    "clear_acknowledgement",
-    "get_acknowledgement",
-    "record_acknowledgement",
     "build_headroom_spec",
     "build_serena_spec",
-    "build_serena_spec_for_agent",
     "build_server_json",
     "format_result",
     "format_results",
     "get_all_registrars",
     "install_everywhere",
-    "SERENA_CONTEXT_BY_AGENT",
-    "serena_context_for_agent",
     "render_server_json",
 ]

--- a/headroom/mcp_registry/__init__.py
+++ b/headroom/mcp_registry/__init__.py
@@ -19,6 +19,7 @@ from .codex import CodexRegistrar
 from .display import any_succeeded, format_result, format_results
 from .grok import GrokRegistrar
 from .install import (
+    CLAUDE_SERENA_CONTEXT,
     DEFAULT_PROXY_URL,
     build_headroom_spec,
     build_serena_spec,
@@ -30,6 +31,7 @@ from .server_json import build_server_json, render_server_json
 
 __all__ = [
     "DEFAULT_PROXY_URL",
+    "CLAUDE_SERENA_CONTEXT",
     "ClaudeRegistrar",
     "CodexRegistrar",
     "GrokRegistrar",

--- a/headroom/mcp_registry/claude.py
+++ b/headroom/mcp_registry/claude.py
@@ -26,6 +26,10 @@ from .base import MCPRegistrar, RegisterResult, RegisterStatus, ServerSpec
 logger = logging.getLogger(__name__)
 
 
+class ClaudeConfigMutationError(ValueError):
+    """Raised when a Claude config cannot be safely changed."""
+
+
 class ClaudeRegistrar(MCPRegistrar):
     """Register MCP servers with Claude Code."""
 
@@ -83,6 +87,34 @@ class ClaudeRegistrar(MCPRegistrar):
             if entry is not None:
                 return entry
         return None
+
+    def validate_configs_for_mutation(self) -> None:
+        """Validate every Claude config root before an explicit mutation."""
+        seen: set[Path] = set()
+        for config_path in (self._modern_config, self._legacy_config):
+            if config_path in seen or not config_path.exists():
+                continue
+            seen.add(config_path)
+            try:
+                raw = config_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                raise ClaudeConfigMutationError(
+                    f"could not read Claude config {config_path}: {exc}"
+                ) from exc
+            try:
+                config = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ClaudeConfigMutationError(
+                    f"Claude config {config_path} is not valid JSON; refusing to mutate"
+                ) from exc
+            if not isinstance(config, dict):
+                raise ClaudeConfigMutationError(
+                    f"Claude config {config_path} must contain a JSON object"
+                )
+            if "mcpServers" in config and not isinstance(config["mcpServers"], dict):
+                raise ClaudeConfigMutationError(
+                    f"Claude config {config_path} has a non-object mcpServers; refusing to mutate"
+                )
 
     def register_server(self, spec: ServerSpec, *, force: bool = False) -> RegisterResult:
         existing = self.get_server(spec.name)

--- a/headroom/mcp_registry/install.py
+++ b/headroom/mcp_registry/install.py
@@ -14,6 +14,7 @@ from .opencode import OpencodeRegistrar
 
 #: Default proxy URL used when none is given.
 DEFAULT_PROXY_URL = "http://127.0.0.1:8787"
+CLAUDE_SERENA_CONTEXT = "claude-code"
 
 
 def get_all_registrars() -> list[MCPRegistrar]:

--- a/headroom/mcp_registry/install.py
+++ b/headroom/mcp_registry/install.py
@@ -15,27 +15,6 @@ from .opencode import OpencodeRegistrar
 #: Default proxy URL used when none is given.
 DEFAULT_PROXY_URL = "http://127.0.0.1:8787"
 
-SERENA_CONTEXT_BY_AGENT = {
-    "claude": "claude-code",
-    "codex": "codex",
-    "grok": "grok",
-    "opencode": "agent",
-}
-
-
-def serena_context_for_agent(agent: str) -> str | None:
-    """Return the supported Serena context for a registered agent."""
-    return SERENA_CONTEXT_BY_AGENT.get(agent)
-
-
-def build_serena_spec_for_agent(agent: str) -> ServerSpec:
-    """Build the canonical Serena spec for a supported agent."""
-    try:
-        context = SERENA_CONTEXT_BY_AGENT[agent]
-    except KeyError as exc:
-        raise ValueError(f"unsupported Serena agent: {agent}") from exc
-    return build_serena_spec(context)
-
 
 def get_all_registrars() -> list[MCPRegistrar]:
     """Return one instance of every registrar implemented today.

--- a/headroom/mcp_registry/install.py
+++ b/headroom/mcp_registry/install.py
@@ -15,6 +15,27 @@ from .opencode import OpencodeRegistrar
 #: Default proxy URL used when none is given.
 DEFAULT_PROXY_URL = "http://127.0.0.1:8787"
 
+SERENA_CONTEXT_BY_AGENT = {
+    "claude": "claude-code",
+    "codex": "codex",
+    "grok": "grok",
+    "opencode": "agent",
+}
+
+
+def serena_context_for_agent(agent: str) -> str | None:
+    """Return the supported Serena context for a registered agent."""
+    return SERENA_CONTEXT_BY_AGENT.get(agent)
+
+
+def build_serena_spec_for_agent(agent: str) -> ServerSpec:
+    """Build the canonical Serena spec for a supported agent."""
+    try:
+        context = SERENA_CONTEXT_BY_AGENT[agent]
+    except KeyError as exc:
+        raise ValueError(f"unsupported Serena agent: {agent}") from exc
+    return build_serena_spec(context)
+
 
 def get_all_registrars() -> list[MCPRegistrar]:
     """Return one instance of every registrar implemented today.

--- a/headroom/mcp_registry/ledger.py
+++ b/headroom/mcp_registry/ledger.py
@@ -19,7 +19,6 @@ from headroom import paths
 from .base import ServerSpec
 
 _LEDGER_FILE = "mcp_installs.json"
-_ACKNOWLEDGEMENTS = "acknowledgements"
 
 
 class LedgerMutationError(ValueError):
@@ -74,76 +73,6 @@ def clear_install(agent: str, server_name: str, *, path: Path | None = None) -> 
     _write_ledger(ledger_file, data)
 
 
-def record_acknowledgement(
-    agent: str,
-    server_name: str,
-    recommended: ServerSpec,
-    observed: ServerSpec,
-    *,
-    path: Path | None = None,
-) -> None:
-    """Remember a user's acknowledgement without changing install ownership."""
-    ledger_file = path or ledger_path()
-    data = _read_ledger(ledger_file, for_mutation=True)
-    acknowledgements = data.setdefault(_ACKNOWLEDGEMENTS, {})
-    agent_entry = acknowledgements.setdefault(agent, {})
-    agent_entry[server_name] = {
-        "recommended_fingerprint": spec_fingerprint(recommended),
-        "observed_fingerprint": spec_fingerprint(observed),
-        "acknowledged_at": datetime.now(timezone.utc).isoformat(),
-    }
-    _write_ledger(ledger_file, data)
-
-
-def get_acknowledgement(
-    agent: str, server_name: str, *, path: Path | None = None
-) -> dict[str, Any] | None:
-    """Return the acknowledgement record, if one exists."""
-    data = _read_ledger(path or ledger_path())
-    try:
-        record = data[_ACKNOWLEDGEMENTS][agent][server_name]
-    except (KeyError, TypeError):
-        return None
-    return record if isinstance(record, dict) else None
-
-
-def acknowledgement_matches(
-    agent: str,
-    server_name: str,
-    recommended: ServerSpec,
-    observed: ServerSpec | None,
-    *,
-    path: Path | None = None,
-) -> bool:
-    """Return true only when both sides still match the acknowledged pair."""
-    if observed is None:
-        return False
-    record = get_acknowledgement(agent, server_name, path=path)
-    return bool(
-        record
-        and record.get("recommended_fingerprint") == spec_fingerprint(recommended)
-        and record.get("observed_fingerprint") == spec_fingerprint(observed)
-    )
-
-
-def clear_acknowledgement(agent: str, server_name: str, *, path: Path | None = None) -> None:
-    """Clear acknowledgement state while leaving install ownership intact."""
-    ledger_file = path or ledger_path()
-    data = _read_ledger(ledger_file, for_mutation=True)
-    acknowledgements = data.get(_ACKNOWLEDGEMENTS)
-    if not isinstance(acknowledgements, dict):
-        return
-    agent_entry = acknowledgements.get(agent)
-    if not isinstance(agent_entry, dict) or server_name not in agent_entry:
-        return
-    del agent_entry[server_name]
-    if not agent_entry:
-        del acknowledgements[agent]
-    if not acknowledgements:
-        data.pop(_ACKNOWLEDGEMENTS, None)
-    _write_ledger(ledger_file, data)
-
-
 def headroom_installed_matching(
     agent: str,
     current_spec: ServerSpec | None,
@@ -185,12 +114,19 @@ def _read_ledger(path: Path, *, for_mutation: bool = False) -> dict[str, Any]:
             raise LedgerMutationError("MCP install ledger must contain a JSON object")
         return {}
     if for_mutation:
-        for section in ("agents", _ACKNOWLEDGEMENTS):
+        for section in ("agents",):
             section_data = data.get(section)
             if section_data is None:
                 continue
             if not isinstance(section_data, dict) or any(
-                not isinstance(entry, dict) for entry in section_data.values()
+                not isinstance(agent_entry, dict)
+                or any(
+                    not isinstance(server_entry, dict)
+                    or not isinstance(server_entry.get("fingerprint"), str)
+                    or not isinstance(server_entry.get("installed_at"), str)
+                    for server_entry in agent_entry.values()
+                )
+                for agent_entry in section_data.values()
             ):
                 raise LedgerMutationError(f"MCP install ledger section {section!r} is malformed")
     return data

--- a/headroom/mcp_registry/ledger.py
+++ b/headroom/mcp_registry/ledger.py
@@ -48,8 +48,14 @@ def record_install(agent: str, spec: ServerSpec, *, path: Path | None = None) ->
     # Automatic installs must recover from a stale or damaged ledger. The
     # explicit reconcile route performs strict validation before config writes.
     data = _read_ledger(ledger_file)
-    agents = data.setdefault("agents", {})
-    agent_entry = agents.setdefault(agent, {})
+    agents = data.get("agents")
+    if not isinstance(agents, dict):
+        agents = {}
+        data["agents"] = agents
+    agent_entry = agents.get(agent)
+    if not isinstance(agent_entry, dict):
+        agent_entry = {}
+        agents[agent] = agent_entry
     agent_entry[spec.name] = {
         "fingerprint": spec_fingerprint(spec),
         "installed_at": datetime.now(timezone.utc).isoformat(),
@@ -118,8 +124,6 @@ def _read_ledger(path: Path, *, for_mutation: bool = False) -> dict[str, Any]:
     if for_mutation:
         for section in ("agents",):
             section_data = data.get(section)
-            if section_data is None:
-                continue
             if not isinstance(section_data, dict) or any(
                 not isinstance(agent_entry, dict)
                 or any(

--- a/headroom/mcp_registry/ledger.py
+++ b/headroom/mcp_registry/ledger.py
@@ -19,6 +19,7 @@ from headroom import paths
 from .base import ServerSpec
 
 _LEDGER_FILE = "mcp_installs.json"
+_ACKNOWLEDGEMENTS = "acknowledgements"
 
 
 def ledger_path() -> Path:
@@ -66,6 +67,76 @@ def clear_install(agent: str, server_name: str, *, path: Path | None = None) -> 
         del agents[agent]
     if not agents:
         data.pop("agents", None)
+    _write_ledger(ledger_file, data)
+
+
+def record_acknowledgement(
+    agent: str,
+    server_name: str,
+    recommended: ServerSpec,
+    observed: ServerSpec,
+    *,
+    path: Path | None = None,
+) -> None:
+    """Remember a user's acknowledgement without changing install ownership."""
+    ledger_file = path or ledger_path()
+    data = _read_ledger(ledger_file)
+    acknowledgements = data.setdefault(_ACKNOWLEDGEMENTS, {})
+    agent_entry = acknowledgements.setdefault(agent, {})
+    agent_entry[server_name] = {
+        "recommended_fingerprint": spec_fingerprint(recommended),
+        "observed_fingerprint": spec_fingerprint(observed),
+        "acknowledged_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _write_ledger(ledger_file, data)
+
+
+def get_acknowledgement(
+    agent: str, server_name: str, *, path: Path | None = None
+) -> dict[str, Any] | None:
+    """Return the acknowledgement record, if one exists."""
+    data = _read_ledger(path or ledger_path())
+    try:
+        record = data[_ACKNOWLEDGEMENTS][agent][server_name]
+    except (KeyError, TypeError):
+        return None
+    return record if isinstance(record, dict) else None
+
+
+def acknowledgement_matches(
+    agent: str,
+    server_name: str,
+    recommended: ServerSpec,
+    observed: ServerSpec | None,
+    *,
+    path: Path | None = None,
+) -> bool:
+    """Return true only when both sides still match the acknowledged pair."""
+    if observed is None:
+        return False
+    record = get_acknowledgement(agent, server_name, path=path)
+    return bool(
+        record
+        and record.get("recommended_fingerprint") == spec_fingerprint(recommended)
+        and record.get("observed_fingerprint") == spec_fingerprint(observed)
+    )
+
+
+def clear_acknowledgement(agent: str, server_name: str, *, path: Path | None = None) -> None:
+    """Clear acknowledgement state while leaving install ownership intact."""
+    ledger_file = path or ledger_path()
+    data = _read_ledger(ledger_file)
+    acknowledgements = data.get(_ACKNOWLEDGEMENTS)
+    if not isinstance(acknowledgements, dict):
+        return
+    agent_entry = acknowledgements.get(agent)
+    if not isinstance(agent_entry, dict) or server_name not in agent_entry:
+        return
+    del agent_entry[server_name]
+    if not agent_entry:
+        del acknowledgements[agent]
+    if not acknowledgements:
+        data.pop(_ACKNOWLEDGEMENTS, None)
     _write_ledger(ledger_file, data)
 
 

--- a/headroom/mcp_registry/ledger.py
+++ b/headroom/mcp_registry/ledger.py
@@ -22,6 +22,10 @@ _LEDGER_FILE = "mcp_installs.json"
 _ACKNOWLEDGEMENTS = "acknowledgements"
 
 
+class LedgerMutationError(ValueError):
+    """Raised when a ledger cannot be safely updated."""
+
+
 def ledger_path() -> Path:
     """Return the Headroom MCP install ledger path."""
     return paths.workspace_dir() / _LEDGER_FILE
@@ -42,7 +46,7 @@ def spec_fingerprint(spec: ServerSpec) -> str:
 def record_install(agent: str, spec: ServerSpec, *, path: Path | None = None) -> None:
     """Record that Headroom installed ``spec`` for ``agent``."""
     ledger_file = path or ledger_path()
-    data = _read_ledger(ledger_file)
+    data = _read_ledger(ledger_file, for_mutation=True)
     agents = data.setdefault("agents", {})
     agent_entry = agents.setdefault(agent, {})
     agent_entry[spec.name] = {
@@ -55,7 +59,7 @@ def record_install(agent: str, spec: ServerSpec, *, path: Path | None = None) ->
 def clear_install(agent: str, server_name: str, *, path: Path | None = None) -> None:
     """Remove one ledger entry if present."""
     ledger_file = path or ledger_path()
-    data = _read_ledger(ledger_file)
+    data = _read_ledger(ledger_file, for_mutation=True)
     agents = data.get("agents")
     if not isinstance(agents, dict):
         return
@@ -80,7 +84,7 @@ def record_acknowledgement(
 ) -> None:
     """Remember a user's acknowledgement without changing install ownership."""
     ledger_file = path or ledger_path()
-    data = _read_ledger(ledger_file)
+    data = _read_ledger(ledger_file, for_mutation=True)
     acknowledgements = data.setdefault(_ACKNOWLEDGEMENTS, {})
     agent_entry = acknowledgements.setdefault(agent, {})
     agent_entry[server_name] = {
@@ -125,7 +129,7 @@ def acknowledgement_matches(
 def clear_acknowledgement(agent: str, server_name: str, *, path: Path | None = None) -> None:
     """Clear acknowledgement state while leaving install ownership intact."""
     ledger_file = path or ledger_path()
-    data = _read_ledger(ledger_file)
+    data = _read_ledger(ledger_file, for_mutation=True)
     acknowledgements = data.get(_ACKNOWLEDGEMENTS)
     if not isinstance(acknowledgements, dict):
         return
@@ -160,16 +164,36 @@ def headroom_installed_matching(
     return entry.get("fingerprint") == spec_fingerprint(current_spec)
 
 
-def _read_ledger(path: Path) -> dict[str, Any]:
+def validate_ledger_for_mutation(path: Path | None = None) -> None:
+    """Reject malformed ledger structure before a config mutation."""
+    _read_ledger(path or ledger_path(), for_mutation=True)
+
+
+def _read_ledger(path: Path, *, for_mutation: bool = False) -> dict[str, Any]:
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError:
         return {}
     try:
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        if for_mutation:
+            raise LedgerMutationError(f"MCP install ledger is invalid JSON: {path}") from exc
         return {}
-    return data if isinstance(data, dict) else {}
+    if not isinstance(data, dict):
+        if for_mutation:
+            raise LedgerMutationError("MCP install ledger must contain a JSON object")
+        return {}
+    if for_mutation:
+        for section in ("agents", _ACKNOWLEDGEMENTS):
+            section_data = data.get(section)
+            if section_data is None:
+                continue
+            if not isinstance(section_data, dict) or any(
+                not isinstance(entry, dict) for entry in section_data.values()
+            ):
+                raise LedgerMutationError(f"MCP install ledger section {section!r} is malformed")
+    return data
 
 
 def _write_ledger(path: Path, data: dict[str, Any]) -> None:

--- a/headroom/mcp_registry/ledger.py
+++ b/headroom/mcp_registry/ledger.py
@@ -45,7 +45,9 @@ def spec_fingerprint(spec: ServerSpec) -> str:
 def record_install(agent: str, spec: ServerSpec, *, path: Path | None = None) -> None:
     """Record that Headroom installed ``spec`` for ``agent``."""
     ledger_file = path or ledger_path()
-    data = _read_ledger(ledger_file, for_mutation=True)
+    # Automatic installs must recover from a stale or damaged ledger. The
+    # explicit reconcile route performs strict validation before config writes.
+    data = _read_ledger(ledger_file)
     agents = data.setdefault("agents", {})
     agent_entry = agents.setdefault(agent, {})
     agent_entry[spec.name] = {
@@ -58,7 +60,7 @@ def record_install(agent: str, spec: ServerSpec, *, path: Path | None = None) ->
 def clear_install(agent: str, server_name: str, *, path: Path | None = None) -> None:
     """Remove one ledger entry if present."""
     ledger_file = path or ledger_path()
-    data = _read_ledger(ledger_file, for_mutation=True)
+    data = _read_ledger(ledger_file)
     agents = data.get("agents")
     if not isinstance(agents, dict):
         return

--- a/headroom/mcp_registry/ledger.py
+++ b/headroom/mcp_registry/ledger.py
@@ -109,7 +109,11 @@ def validate_ledger_for_mutation(path: Path | None = None) -> None:
 def _read_ledger(path: Path, *, for_mutation: bool = False) -> dict[str, Any]:
     try:
         raw = path.read_text(encoding="utf-8")
-    except OSError:
+    except FileNotFoundError:
+        return {}
+    except OSError as exc:
+        if for_mutation:
+            raise LedgerMutationError(f"MCP install ledger is unreadable: {path}") from exc
         return {}
     try:
         data = json.loads(raw)

--- a/tests/fixtures/headroom-issue-3054.json
+++ b/tests/fixtures/headroom-issue-3054.json
@@ -1,0 +1,26 @@
+{
+  "issue": 3054,
+  "url": "https://github.com/headroomlabs-ai/headroom/issues/3054",
+  "old_serena_args": [
+    "--from",
+    "git+https://github.com/oraios/serena",
+    "serena",
+    "start-mcp-server",
+    "--project-from-cwd",
+    "--context",
+    "claude-code",
+    "--open-web-dashboard",
+    "False"
+  ],
+  "recommended_serena_args": [
+    "--from",
+    "serena-agent",
+    "serena",
+    "start-mcp-server",
+    "--project-from-cwd",
+    "--context",
+    "claude-code",
+    "--open-web-dashboard",
+    "False"
+  ]
+}

--- a/tests/test_cli/test_mcp_reconcile.py
+++ b/tests/test_cli/test_mcp_reconcile.py
@@ -92,6 +92,16 @@ def test_malformed_ledger_is_treated_as_unacknowledged(monkeypatch, tmp_path: Pa
     assert "none/stale" in result.output
 
 
+def test_malformed_ledger_rejects_mutation_before_adopt(monkeypatch, tmp_path: Path):
+    config, _ = _setup(monkeypatch, tmp_path)
+    before = config.read_bytes()
+    (tmp_path / "ledger.json").write_text(json.dumps({"acknowledgements": []}))
+    result = CliRunner().invoke(main, ["mcp", "reconcile", "--adopt"])
+    assert result.exit_code != 0
+    assert "ledger section 'acknowledgements' is malformed" in result.output
+    assert config.read_bytes() == before
+
+
 def test_ordinary_install_forwards_force_without_reconcile(monkeypatch, tmp_path: Path):
     _setup(monkeypatch, tmp_path)
     monkeypatch.setitem(sys.modules, "mcp", object())

--- a/tests/test_cli/test_mcp_reconcile.py
+++ b/tests/test_cli/test_mcp_reconcile.py
@@ -84,7 +84,16 @@ def test_adopt_preserves_unrelated_config_and_records_ownership(monkeypatch, tmp
 
 
 @pytest.mark.parametrize(
-    "contents", ["not json", "[]", '{"agents": []}', '{"agents": {"claude": []}}']
+    "contents",
+    [
+        "not json",
+        "[]",
+        '{"agents": null}',
+        '{"agents": []}',
+        '{"agents": {"claude": null}}',
+        '{"agents": {"claude": []}}',
+        '{"agents": {"claude": {"serena": null}}}',
+    ],
 )
 def test_malformed_ledger_blocks_adopt_before_config_write(
     monkeypatch, tmp_path: Path, contents: str
@@ -103,6 +112,29 @@ def test_corrupt_ledger_is_tolerated_by_read_only(monkeypatch, tmp_path: Path):
     ledger.write_text('{"agents": []}')
     result = CliRunner().invoke(main, ["mcp", "reconcile"])
     assert result.exit_code == 0, result.output
+
+
+def test_reconcile_rejects_absent_claude(monkeypatch, tmp_path: Path):
+    _, _ = _setup(monkeypatch, tmp_path)
+    registrar = ClaudeRegistrar(claude_cli=None, home_dir=tmp_path)
+    monkeypatch.setattr(registrar, "detect", lambda: False)
+    monkeypatch.setattr("headroom.mcp_registry.ClaudeRegistrar", lambda: registrar)
+
+    result = CliRunner().invoke(main, ["mcp", "reconcile", "--adopt"])
+
+    assert result.exit_code != 0
+    assert "claude is not detected" in result.output
+
+
+def test_reconcile_adopt_preserves_malformed_config(monkeypatch, tmp_path: Path):
+    config, _ = _setup(monkeypatch, tmp_path)
+    config.write_text("not json")
+    before = config.read_bytes()
+
+    result = CliRunner().invoke(main, ["mcp", "reconcile", "--adopt"])
+
+    assert result.exit_code != 0
+    assert config.read_bytes() == before
 
 
 @pytest.mark.parametrize("state", ["absent", "matching", "user-drift", "headroom-drift"])
@@ -182,3 +214,16 @@ def test_ordinary_install_does_not_adopt_serena(monkeypatch, tmp_path: Path):
     assert after["mcpServers"]["serena"] == before_data["mcpServers"]["serena"]
     assert after["mcpServers"]["headroom"]["args"] == ["mcp", "serve"]
     assert "mcp reconcile --adopt" not in result.output
+
+
+def test_mcp_install_force_preserves_user_managed_serena(monkeypatch, tmp_path: Path):
+    config, _ = _setup(monkeypatch, tmp_path)
+    before = json.loads(config.read_text())["mcpServers"]["serena"]
+    monkeypatch.setitem(sys.modules, "mcp", object())
+    registrar = ClaudeRegistrar(claude_cli=None, home_dir=tmp_path)
+    monkeypatch.setattr("headroom.mcp_registry.install.get_all_registrars", lambda: [registrar])
+
+    result = CliRunner().invoke(main, ["mcp", "install", "--agent", "claude", "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(config.read_text())["mcpServers"]["serena"] == before

--- a/tests/test_cli/test_mcp_reconcile.py
+++ b/tests/test_cli/test_mcp_reconcile.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+from headroom.mcp_registry import ClaudeRegistrar, build_serena_spec_for_agent
+
+
+def _setup(monkeypatch, tmp_path: Path):
+    config = tmp_path / ".claude.json"
+    config.write_text(
+        json.dumps(
+            {
+                "oauthAccount": {"email": "user@example.com"},
+                "mcpServers": {
+                    "serena": {"command": "uvx", "args": ["--from", "old-serena"]},
+                    "other": {"command": "other", "args": []},
+                },
+                "projects": {"/repo": {"trust": True}},
+            }
+        )
+    )
+    registrar = ClaudeRegistrar(claude_cli=None, home_dir=tmp_path)
+    monkeypatch.setattr("headroom.mcp_registry.ClaudeRegistrar", lambda: registrar)
+    monkeypatch.setattr(
+        "headroom.mcp_registry.ledger.ledger_path", lambda: tmp_path / "ledger.json"
+    )
+    return config, registrar
+
+
+def test_read_only_does_not_write_claude_config(monkeypatch, tmp_path: Path):
+    config, _ = _setup(monkeypatch, tmp_path)
+    before = config.read_bytes()
+    result = CliRunner().invoke(main, ["mcp", "reconcile"])
+    assert result.exit_code == 0, result.output
+    assert config.read_bytes() == before
+    assert "--adopt" in result.output
+
+
+def test_adopt_preserves_unrelated_config_and_records_ownership(monkeypatch, tmp_path: Path):
+    config, _ = _setup(monkeypatch, tmp_path)
+    result = CliRunner().invoke(main, ["mcp", "reconcile", "--adopt"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(config.read_text())
+    assert data["oauthAccount"] == {"email": "user@example.com"}
+    assert data["projects"] == {"/repo": {"trust": True}}
+    assert data["mcpServers"]["other"] == {"command": "other", "args": []}
+    assert data["mcpServers"]["serena"]["args"] == list(build_serena_spec_for_agent("claude").args)
+    ledger = json.loads((tmp_path / "ledger.json").read_text())
+    assert ledger["agents"]["claude"]["serena"]["fingerprint"]
+
+
+def test_validation_rejects_multiple_actions(monkeypatch, tmp_path: Path):
+    _setup(monkeypatch, tmp_path)
+    result = CliRunner().invoke(main, ["mcp", "reconcile", "--acknowledge", "--clear"])
+    assert result.exit_code != 0
+    assert "at most one" in result.output
+
+
+def test_ordinary_install_has_no_reconcile_flags():
+    result = CliRunner().invoke(main, ["mcp", "install", "--help"])
+    assert result.exit_code == 0
+    assert "reconcile" not in result.output

--- a/tests/test_cli/test_mcp_reconcile.py
+++ b/tests/test_cli/test_mcp_reconcile.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from headroom.cli.main import main
-from headroom.mcp_registry import ClaudeRegistrar, build_serena_spec_for_agent
-from headroom.mcp_registry.base import RegisterResult, RegisterStatus
+from headroom.mcp_registry import ClaudeRegistrar, build_serena_spec
+
+FIXTURE = Path(__file__).parents[1] / "fixtures" / "headroom-issue-3054.json"
 
 
 def _setup(monkeypatch, tmp_path: Path):
@@ -18,7 +21,10 @@ def _setup(monkeypatch, tmp_path: Path):
             {
                 "oauthAccount": {"email": "user@example.com"},
                 "mcpServers": {
-                    "serena": {"command": "uvx", "args": ["--from", "old-serena"]},
+                    "serena": {
+                        "command": "uvx",
+                        "args": json.loads(FIXTURE.read_text())["old_serena_args"],
+                    },
                     "other": {"command": "other", "args": []},
                 },
                 "projects": {"/repo": {"trust": True}},
@@ -27,101 +33,117 @@ def _setup(monkeypatch, tmp_path: Path):
     )
     registrar = ClaudeRegistrar(claude_cli=None, home_dir=tmp_path)
     monkeypatch.setattr("headroom.mcp_registry.ClaudeRegistrar", lambda: registrar)
-    monkeypatch.setattr(
-        "headroom.mcp_registry.ledger.ledger_path", lambda: tmp_path / "ledger.json"
-    )
-    return config, registrar
+    ledger = tmp_path / "ledger.json"
+    monkeypatch.setattr("headroom.mcp_registry.ledger.ledger_path", lambda: ledger)
+    return config, ledger
 
 
-def test_read_only_does_not_write_claude_config(monkeypatch, tmp_path: Path):
+def test_issue_fixture_reconcile_is_base_fail_head_pass(monkeypatch, tmp_path: Path):
     config, _ = _setup(monkeypatch, tmp_path)
-    before = config.read_bytes()
+    fixture = json.loads(FIXTURE.read_text())
+    recommended = build_serena_spec("claude-code")
+    assert list(recommended.args) == fixture["recommended_serena_args"]
+    assert CliRunner().invoke(main, ["mcp", "reconcile"]).exit_code == 0
+    adopted = CliRunner().invoke(main, ["mcp", "reconcile", "--adopt"])
+    assert adopted.exit_code == 0, adopted.output
+    assert json.loads(config.read_text())["mcpServers"]["serena"]["args"] == list(recommended.args)
+
+
+def test_read_only_preserves_config_and_ledger_bytes_and_mtimes(monkeypatch, tmp_path: Path):
+    config, ledger = _setup(monkeypatch, tmp_path)
+    ledger.write_text("not json")
+    before = (
+        config.read_bytes(),
+        ledger.read_bytes(),
+        os.stat(config).st_mtime_ns,
+        os.stat(ledger).st_mtime_ns,
+    )
     result = CliRunner().invoke(main, ["mcp", "reconcile"])
     assert result.exit_code == 0, result.output
-    assert config.read_bytes() == before
+    after = (
+        config.read_bytes(),
+        ledger.read_bytes(),
+        os.stat(config).st_mtime_ns,
+        os.stat(ledger).st_mtime_ns,
+    )
+    assert after == before
     assert "--adopt" in result.output
 
 
 def test_adopt_preserves_unrelated_config_and_records_ownership(monkeypatch, tmp_path: Path):
-    config, _ = _setup(monkeypatch, tmp_path)
+    config, ledger = _setup(monkeypatch, tmp_path)
     result = CliRunner().invoke(main, ["mcp", "reconcile", "--adopt"])
     assert result.exit_code == 0, result.output
     data = json.loads(config.read_text())
     assert data["oauthAccount"] == {"email": "user@example.com"}
     assert data["projects"] == {"/repo": {"trust": True}}
     assert data["mcpServers"]["other"] == {"command": "other", "args": []}
-    assert data["mcpServers"]["serena"]["args"] == list(build_serena_spec_for_agent("claude").args)
-    ledger = json.loads((tmp_path / "ledger.json").read_text())
-    assert ledger["agents"]["claude"]["serena"]["fingerprint"]
+    assert data["mcpServers"]["serena"]["args"] == list(build_serena_spec("claude-code").args)
+    assert json.loads(ledger.read_text())["agents"]["claude"]["serena"]["fingerprint"]
 
 
-def test_validation_rejects_multiple_actions(monkeypatch, tmp_path: Path):
-    _setup(monkeypatch, tmp_path)
-    result = CliRunner().invoke(main, ["mcp", "reconcile", "--acknowledge", "--clear"])
-    assert result.exit_code != 0
-    assert "at most one" in result.output
-
-
-def test_validation_rejects_unknown_server(monkeypatch, tmp_path: Path):
-    _setup(monkeypatch, tmp_path)
-    result = CliRunner().invoke(main, ["mcp", "reconcile", "--server", "other"])
-    assert result.exit_code != 0
-    assert "only --server serena" in result.output
-
-
-def test_clear_acknowledgement_and_reject_absent_entry(monkeypatch, tmp_path: Path):
-    config, _ = _setup(monkeypatch, tmp_path)
-    acknowledged = CliRunner().invoke(main, ["mcp", "reconcile", "--acknowledge"])
-    assert acknowledged.exit_code == 0, acknowledged.output
-    cleared = CliRunner().invoke(main, ["mcp", "reconcile", "--clear"])
-    assert cleared.exit_code == 0, cleared.output
-
-    data = json.loads(config.read_text())
-    del data["mcpServers"]["serena"]
-    config.write_text(json.dumps(data))
-    absent = CliRunner().invoke(main, ["mcp", "reconcile", "--acknowledge"])
-    assert absent.exit_code != 0
-    assert "absent Serena entry" in absent.output
-
-
-def test_malformed_ledger_is_treated_as_unacknowledged(monkeypatch, tmp_path: Path):
-    _setup(monkeypatch, tmp_path)
-    (tmp_path / "ledger.json").write_text("not json")
-    result = CliRunner().invoke(main, ["mcp", "reconcile"])
-    assert result.exit_code == 0, result.output
-    assert "none/stale" in result.output
-
-
-def test_malformed_ledger_rejects_mutation_before_adopt(monkeypatch, tmp_path: Path):
-    config, _ = _setup(monkeypatch, tmp_path)
+@pytest.mark.parametrize(
+    "contents", ["not json", "[]", '{"agents": []}', '{"agents": {"claude": []}}']
+)
+def test_malformed_ledger_blocks_adopt_before_config_write(
+    monkeypatch, tmp_path: Path, contents: str
+):
+    config, ledger = _setup(monkeypatch, tmp_path)
     before = config.read_bytes()
-    (tmp_path / "ledger.json").write_text(json.dumps({"acknowledgements": []}))
+    ledger.write_text(contents)
     result = CliRunner().invoke(main, ["mcp", "reconcile", "--adopt"])
     assert result.exit_code != 0
-    assert "ledger section 'acknowledgements' is malformed" in result.output
+    assert "ledger" in result.output.lower()
     assert config.read_bytes() == before
 
 
-def test_ordinary_install_forwards_force_without_reconcile(monkeypatch, tmp_path: Path):
-    _setup(monkeypatch, tmp_path)
-    monkeypatch.setitem(sys.modules, "mcp", object())
-    calls: list[dict] = []
-
-    def fake_install_everywhere(**kwargs):
-        calls.append(kwargs)
-        return [RegisterResult(RegisterStatus.REGISTERED, "installed")]
-
-    monkeypatch.setattr("headroom.mcp_registry.install_everywhere", fake_install_everywhere)
-    monkeypatch.setattr(
-        "headroom.mcp_registry.format_results", lambda results, **kwargs: ["installed"]
-    )
-    monkeypatch.setattr("headroom.mcp_registry.any_succeeded", lambda results: True)
-    result = CliRunner().invoke(main, ["mcp", "install", "--agent", "claude", "--force"])
+def test_corrupt_ledger_is_tolerated_by_read_only(monkeypatch, tmp_path: Path):
+    _, ledger = _setup(monkeypatch, tmp_path)
+    ledger.write_text('{"agents": []}')
+    result = CliRunner().invoke(main, ["mcp", "reconcile"])
     assert result.exit_code == 0, result.output
-    assert calls == [{"proxy_url": "http://127.0.0.1:8787", "agents": ["claude"], "force": True}]
 
 
-def test_ordinary_install_has_no_reconcile_flags():
-    result = CliRunner().invoke(main, ["mcp", "install", "--help"])
+@pytest.mark.parametrize("state", ["absent", "matching", "user-drift", "headroom-drift"])
+@pytest.mark.parametrize("adopt", [False, True])
+def test_reconcile_state_matrix(monkeypatch, tmp_path: Path, state: str, adopt: bool):
+    config, ledger = _setup(monkeypatch, tmp_path)
+    data = json.loads(config.read_text())
+    recommended = build_serena_spec("claude-code")
+    if state == "absent":
+        del data["mcpServers"]["serena"]
+    elif state == "matching":
+        data["mcpServers"]["serena"] = {
+            "command": recommended.command,
+            "args": list(recommended.args),
+        }
+    elif state == "headroom-drift":
+        from headroom.mcp_registry.ledger import record_install
+
+        record_install("claude", recommended, path=ledger)
+    config.write_text(json.dumps(data))
+    result = CliRunner().invoke(main, ["mcp", "reconcile"] + (["--adopt"] if adopt else []))
+    assert result.exit_code == 0, result.output
+
+
+def test_only_adopt_is_a_reconcile_mutation(monkeypatch, tmp_path: Path):
+    _setup(monkeypatch, tmp_path)
+    result = CliRunner().invoke(main, ["mcp", "reconcile", "--help"])
     assert result.exit_code == 0
-    assert "reconcile" not in result.output
+    assert "--adopt" in result.output
+    for option in ("--acknowledge", "--clear", "--agent", "--server"):
+        assert option not in result.output
+
+
+def test_ordinary_install_does_not_adopt_serena(monkeypatch, tmp_path: Path):
+    config, _ = _setup(monkeypatch, tmp_path)
+    before = config.read_bytes()
+    monkeypatch.setitem(sys.modules, "mcp", object())
+    monkeypatch.setattr(
+        "headroom.mcp_registry.install_everywhere", lambda **kwargs: {"codex": object()}
+    )
+    monkeypatch.setattr("headroom.mcp_registry.format_results", lambda *args, **kwargs: [])
+    monkeypatch.setattr("headroom.mcp_registry.any_succeeded", lambda results: True)
+    result = CliRunner().invoke(main, ["mcp", "install", "--agent", "codex"])
+    assert result.exit_code == 0, result.output
+    assert config.read_bytes() == before

--- a/tests/test_cli/test_mcp_reconcile.py
+++ b/tests/test_cli/test_mcp_reconcile.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from headroom.cli.main import main
 from headroom.mcp_registry import ClaudeRegistrar, build_serena_spec_for_agent
+from headroom.mcp_registry.base import RegisterResult, RegisterStatus
 
 
 def _setup(monkeypatch, tmp_path: Path):
@@ -58,6 +60,55 @@ def test_validation_rejects_multiple_actions(monkeypatch, tmp_path: Path):
     result = CliRunner().invoke(main, ["mcp", "reconcile", "--acknowledge", "--clear"])
     assert result.exit_code != 0
     assert "at most one" in result.output
+
+
+def test_validation_rejects_unknown_server(monkeypatch, tmp_path: Path):
+    _setup(monkeypatch, tmp_path)
+    result = CliRunner().invoke(main, ["mcp", "reconcile", "--server", "other"])
+    assert result.exit_code != 0
+    assert "only --server serena" in result.output
+
+
+def test_clear_acknowledgement_and_reject_absent_entry(monkeypatch, tmp_path: Path):
+    config, _ = _setup(monkeypatch, tmp_path)
+    acknowledged = CliRunner().invoke(main, ["mcp", "reconcile", "--acknowledge"])
+    assert acknowledged.exit_code == 0, acknowledged.output
+    cleared = CliRunner().invoke(main, ["mcp", "reconcile", "--clear"])
+    assert cleared.exit_code == 0, cleared.output
+
+    data = json.loads(config.read_text())
+    del data["mcpServers"]["serena"]
+    config.write_text(json.dumps(data))
+    absent = CliRunner().invoke(main, ["mcp", "reconcile", "--acknowledge"])
+    assert absent.exit_code != 0
+    assert "absent Serena entry" in absent.output
+
+
+def test_malformed_ledger_is_treated_as_unacknowledged(monkeypatch, tmp_path: Path):
+    _setup(monkeypatch, tmp_path)
+    (tmp_path / "ledger.json").write_text("not json")
+    result = CliRunner().invoke(main, ["mcp", "reconcile"])
+    assert result.exit_code == 0, result.output
+    assert "none/stale" in result.output
+
+
+def test_ordinary_install_forwards_force_without_reconcile(monkeypatch, tmp_path: Path):
+    _setup(monkeypatch, tmp_path)
+    monkeypatch.setitem(sys.modules, "mcp", object())
+    calls: list[dict] = []
+
+    def fake_install_everywhere(**kwargs):
+        calls.append(kwargs)
+        return [RegisterResult(RegisterStatus.REGISTERED, "installed")]
+
+    monkeypatch.setattr("headroom.mcp_registry.install_everywhere", fake_install_everywhere)
+    monkeypatch.setattr(
+        "headroom.mcp_registry.format_results", lambda results, **kwargs: ["installed"]
+    )
+    monkeypatch.setattr("headroom.mcp_registry.any_succeeded", lambda results: True)
+    result = CliRunner().invoke(main, ["mcp", "install", "--agent", "claude", "--force"])
+    assert result.exit_code == 0, result.output
+    assert calls == [{"proxy_url": "http://127.0.0.1:8787", "agents": ["claude"], "force": True}]
 
 
 def test_ordinary_install_has_no_reconcile_flags():

--- a/tests/test_cli/test_mcp_reconcile.py
+++ b/tests/test_cli/test_mcp_reconcile.py
@@ -137,6 +137,68 @@ def test_reconcile_adopt_preserves_malformed_config(monkeypatch, tmp_path: Path)
     assert config.read_bytes() == before
 
 
+def test_adopt_rejects_malformed_modern_before_touching_valid_legacy(monkeypatch, tmp_path: Path):
+    modern = tmp_path / ".claude.json"
+    legacy = tmp_path / ".claude" / "mcp.json"
+    legacy.parent.mkdir()
+    modern.write_text("not json")
+    legacy.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "serena": {"command": "uvx", "args": ["--from", "user"]},
+                    "other": {"command": "other"},
+                }
+            }
+        )
+    )
+    registrar = ClaudeRegistrar(claude_cli=None, home_dir=tmp_path)
+    monkeypatch.setattr("headroom.mcp_registry.ClaudeRegistrar", lambda: registrar)
+    ledger = tmp_path / "ledger.json"
+    monkeypatch.setattr("headroom.mcp_registry.ledger.ledger_path", lambda: ledger)
+    before = (modern.read_bytes(), legacy.read_bytes())
+
+    result = CliRunner().invoke(main, ["mcp", "reconcile", "--adopt"])
+
+    assert result.exit_code != 0
+    assert "not valid JSON" in result.output
+    assert (modern.read_bytes(), legacy.read_bytes()) == before
+
+
+def test_adopt_rejects_non_dict_mcp_servers_in_legacy_root(monkeypatch, tmp_path: Path):
+    modern, _ = _setup(monkeypatch, tmp_path)
+    legacy = tmp_path / ".claude" / "mcp.json"
+    legacy.parent.mkdir()
+    legacy.write_text(json.dumps({"mcpServers": []}))
+    before = (modern.read_bytes(), legacy.read_bytes())
+
+    result = CliRunner().invoke(main, ["mcp", "reconcile", "--adopt"])
+
+    assert result.exit_code != 0
+    assert "non-object mcpServers" in result.output
+    assert (modern.read_bytes(), legacy.read_bytes()) == before
+
+
+def test_unreadable_ledger_blocks_adopt_without_partial_mutation(monkeypatch, tmp_path: Path):
+    config, ledger = _setup(monkeypatch, tmp_path)
+    ledger.write_text(json.dumps({"agents": {}}))
+    before = (config.read_bytes(), ledger.read_bytes())
+    original_read_text = Path.read_text
+
+    def unreadable(path: Path, *args, **kwargs):
+        if path == ledger:
+            raise PermissionError("test unreadable ledger")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", unreadable)
+
+    result = CliRunner().invoke(main, ["mcp", "reconcile", "--adopt"])
+
+    assert result.exit_code != 0
+    assert "unreadable" in result.output
+    assert (config.read_bytes(), ledger.read_bytes()) == before
+
+
 @pytest.mark.parametrize("state", ["absent", "matching", "user-drift", "headroom-drift"])
 @pytest.mark.parametrize("adopt", [False, True])
 def test_reconcile_state_matrix(monkeypatch, tmp_path: Path, state: str, adopt: bool):

--- a/tests/test_cli/test_mcp_reconcile.py
+++ b/tests/test_cli/test_mcp_reconcile.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from headroom.cli.main import main
 from headroom.mcp_registry import ClaudeRegistrar, build_serena_spec
+from headroom.mcp_registry.ledger import headroom_installed_matching
 
 FIXTURE = Path(__file__).parents[1] / "fixtures" / "headroom-issue-3054.json"
 
@@ -110,6 +111,7 @@ def test_reconcile_state_matrix(monkeypatch, tmp_path: Path, state: str, adopt: 
     config, ledger = _setup(monkeypatch, tmp_path)
     data = json.loads(config.read_text())
     recommended = build_serena_spec("claude-code")
+    owned_spec = None
     if state == "absent":
         del data["mcpServers"]["serena"]
     elif state == "matching":
@@ -117,13 +119,45 @@ def test_reconcile_state_matrix(monkeypatch, tmp_path: Path, state: str, adopt: 
             "command": recommended.command,
             "args": list(recommended.args),
         }
+    elif state == "user-drift":
+        data["mcpServers"]["serena"]["args"] = ["--from", "user-managed"]
     elif state == "headroom-drift":
         from headroom.mcp_registry.ledger import record_install
 
-        record_install("claude", recommended, path=ledger)
+        stale = build_serena_spec("claude-code")
+        stale.args = ("--from", "headroom-installed-old")
+        owned_spec = stale
+        data["mcpServers"]["serena"] = {
+            "command": stale.command,
+            "args": list(stale.args),
+        }
+        record_install("claude", stale, path=ledger)
     config.write_text(json.dumps(data))
+    if owned_spec is not None:
+        assert headroom_installed_matching("claude", owned_spec, path=ledger)
     result = CliRunner().invoke(main, ["mcp", "reconcile"] + (["--adopt"] if adopt else []))
     assert result.exit_code == 0, result.output
+    observed = json.loads(config.read_text())["mcpServers"].get("serena")
+    ownership = observed is not None and headroom_installed_matching(
+        "claude",
+        build_serena_spec("claude-code") if observed["args"] == list(recommended.args) else None,
+        path=ledger,
+    )
+    if adopt:
+        assert observed == {
+            "command": recommended.command,
+            "args": list(recommended.args),
+        }
+        assert ownership
+        assert "Adopted Headroom" in result.output
+    elif state == "headroom-drift":
+        assert observed["args"] == ["--from", "headroom-installed-old"]
+        assert headroom_installed_matching("claude", owned_spec, path=ledger)
+        assert ownership is False
+        assert "observed: present" in result.output
+    else:
+        assert not ownership
+        assert "Serena reconciliation for Claude" in result.output
 
 
 def test_only_adopt_is_a_reconcile_mutation(monkeypatch, tmp_path: Path):
@@ -139,11 +173,12 @@ def test_ordinary_install_does_not_adopt_serena(monkeypatch, tmp_path: Path):
     config, _ = _setup(monkeypatch, tmp_path)
     before = config.read_bytes()
     monkeypatch.setitem(sys.modules, "mcp", object())
-    monkeypatch.setattr(
-        "headroom.mcp_registry.install_everywhere", lambda **kwargs: {"codex": object()}
-    )
-    monkeypatch.setattr("headroom.mcp_registry.format_results", lambda *args, **kwargs: [])
-    monkeypatch.setattr("headroom.mcp_registry.any_succeeded", lambda results: True)
-    result = CliRunner().invoke(main, ["mcp", "install", "--agent", "codex"])
+    registrar = ClaudeRegistrar(claude_cli=None, home_dir=tmp_path)
+    monkeypatch.setattr("headroom.mcp_registry.install.get_all_registrars", lambda: [registrar])
+    result = CliRunner().invoke(main, ["mcp", "install", "--agent", "claude"])
     assert result.exit_code == 0, result.output
-    assert config.read_bytes() == before
+    after = json.loads(config.read_text())
+    before_data = json.loads(before)
+    assert after["mcpServers"]["serena"] == before_data["mcpServers"]["serena"]
+    assert after["mcpServers"]["headroom"]["args"] == ["mcp", "serve"]
+    assert "mcp reconcile --adopt" not in result.output

--- a/tests/test_cli/test_serena_reconcile.py
+++ b/tests/test_cli/test_serena_reconcile.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from headroom.cli import wrap as wrap_cli
-from headroom.mcp_registry import ClaudeRegistrar, build_serena_spec_for_agent
+from headroom.mcp_registry import build_serena_spec
 from headroom.mcp_registry.base import RegisterResult, RegisterStatus, ServerSpec
-from headroom.mcp_registry.ledger import record_acknowledgement
+from headroom.mcp_registry.ledger import headroom_installed_matching, record_install
 
 
 class _Registrar:
     name = "claude"
     display_name = "Claude Code"
 
-    def __init__(self, current: ServerSpec):
+    def __init__(self, current: ServerSpec | None):
         self.current = current
+        self.force_calls: list[bool] = []
 
     def detect(self) -> bool:
         return True
@@ -23,15 +23,16 @@ class _Registrar:
         return self.current if name == "serena" else None
 
     def register_server(self, spec: ServerSpec, *, force: bool = False) -> RegisterResult:
+        self.force_calls.append(force)
         if self.current == spec:
             return RegisterResult(RegisterStatus.ALREADY, "matches")
-        if not force:
+        if self.current is not None and not force:
             return RegisterResult(RegisterStatus.MISMATCH, "different")
         self.current = spec
         return RegisterResult(RegisterStatus.REGISTERED, "updated")
 
 
-def _quiet_serena_side_effects(monkeypatch):
+def _quiet(monkeypatch):
     monkeypatch.setattr(wrap_cli, "_ensure_serena_dashboard_disabled", lambda **kwargs: None)
     monkeypatch.setattr(wrap_cli, "_inject_serena_instructions", lambda *args, **kwargs: None)
     monkeypatch.setattr(wrap_cli, "_serena_project_skip_reason", lambda root: "test")
@@ -39,70 +40,33 @@ def _quiet_serena_side_effects(monkeypatch):
     monkeypatch.setattr(wrap_cli.shutil, "which", lambda name: "uvx" if name == "uvx" else None)
 
 
-def test_reproduction_acknowledgement_suppresses_current_drift_without_mutation(
-    tmp_path: Path, monkeypatch, capsys
+def test_automatic_wrap_migrates_owned_drift_and_recurs_to_noop(
+    monkeypatch, tmp_path: Path, capsys
 ):
-    _quiet_serena_side_effects(monkeypatch)
-    ledger = tmp_path / "mcp_installs.json"
-    monkeypatch.setattr("headroom.mcp_registry.ledger.ledger_path", lambda: ledger)
-    fixture = json.loads(
-        (Path(__file__).parents[1] / "fixtures" / "headroom-issue-3054.json").read_text()
+    _quiet(monkeypatch)
+    monkeypatch.setattr(
+        "headroom.mcp_registry.ledger.ledger_path", lambda: tmp_path / "ledger.json"
     )
-    recommended = build_serena_spec_for_agent("claude")
-    observed = ServerSpec(name="serena", command="uvx", args=tuple(fixture["old_serena_args"]))
-    assert list(recommended.args) == fixture["recommended_serena_args"]
-    config = tmp_path / ".claude.json"
-    config.write_text(
-        json.dumps(
-            {
-                "oauthAccount": {"email": "user@example.com"},
-                "mcpServers": {
-                    "serena": {"command": observed.command, "args": list(observed.args)},
-                    "other": {"command": "other", "args": []},
-                },
-                "projects": {"/repo": {"trust": True}},
-            }
-        )
+    stale = ServerSpec("serena", "uvx", ("--from", "old"))
+    record_install("claude", stale)
+    registrar = _Registrar(stale)
+    wrap_cli._setup_serena_mcp(registrar, context="claude-code", verbose=True)
+    assert registrar.current == build_serena_spec("claude-code")
+    assert registrar.force_calls == [False, True]
+    assert headroom_installed_matching("claude", registrar.current)
+    capsys.readouterr()
+    wrap_cli._setup_serena_mcp(registrar, context="claude-code", verbose=True)
+    assert registrar.force_calls == [False, True, False]
+
+
+def test_automatic_wrap_preserves_user_managed_warning(monkeypatch, tmp_path: Path, capsys):
+    _quiet(monkeypatch)
+    monkeypatch.setattr(
+        "headroom.mcp_registry.ledger.ledger_path", lambda: tmp_path / "ledger.json"
     )
-    before = config.read_bytes()
-    registrar = ClaudeRegistrar(claude_cli=None, home_dir=tmp_path)
-    assert registrar.get_server("serena") == observed
-
-    wrap_cli._setup_serena_mcp(registrar, verbose=True)
-    assert "existing config differs" in capsys.readouterr().out
-
-    record_acknowledgement("claude", "serena", recommended, observed)
-    wrap_cli._setup_serena_mcp(registrar, verbose=True)
-    output = capsys.readouterr().out
-    assert "existing config differs" not in output
-    assert registrar.get_server("serena") == observed
-    assert config.read_bytes() == before
-
-
-def test_context_map_recommendation_moved_rearms_acknowledgement(
-    tmp_path: Path, monkeypatch, capsys
-):
-    _quiet_serena_side_effects(monkeypatch)
-    ledger = tmp_path / "mcp_installs.json"
-    monkeypatch.setattr("headroom.mcp_registry.ledger.ledger_path", lambda: ledger)
-    observed = ServerSpec(name="serena", command="uvx", args=("--from", "old-serena"))
-    old_recommended = ServerSpec(
-        name="serena", command="uvx", args=("--from", "old-recommendation")
-    )
-    record_acknowledgement("claude", "serena", old_recommended, observed)
-
-    wrap_cli._setup_serena_mcp(_Registrar(observed), verbose=True)
-    assert "existing config differs" in capsys.readouterr().out
-
-
-def test_user_edit_after_acknowledgement_rearms_warning(tmp_path: Path, monkeypatch, capsys):
-    _quiet_serena_side_effects(monkeypatch)
-    ledger = tmp_path / "mcp_installs.json"
-    monkeypatch.setattr("headroom.mcp_registry.ledger.ledger_path", lambda: ledger)
-    recommended = build_serena_spec_for_agent("claude")
-    observed = ServerSpec(name="serena", command="uvx", args=("--from", "old-serena"))
-    record_acknowledgement("claude", "serena", recommended, observed)
-
-    edited = ServerSpec(name="serena", command="uvx", args=("--from", "edited"))
-    wrap_cli._setup_serena_mcp(_Registrar(edited), verbose=True)
+    user = ServerSpec("serena", "uvx", ("--from", "user"))
+    registrar = _Registrar(user)
+    wrap_cli._setup_serena_mcp(registrar, context="claude-code", verbose=True)
+    assert registrar.current == user
+    assert registrar.force_calls == [False]
     assert "existing config differs" in capsys.readouterr().out

--- a/tests/test_cli/test_serena_reconcile.py
+++ b/tests/test_cli/test_serena_reconcile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from headroom.cli import wrap as wrap_cli
@@ -44,8 +45,12 @@ def test_reproduction_acknowledgement_suppresses_current_drift_without_mutation(
     _quiet_serena_side_effects(monkeypatch)
     ledger = tmp_path / "mcp_installs.json"
     monkeypatch.setattr("headroom.mcp_registry.ledger.ledger_path", lambda: ledger)
+    fixture = json.loads(
+        (Path(__file__).parents[1] / "fixtures" / "headroom-issue-3054.json").read_text()
+    )
     recommended = build_serena_spec_for_agent("claude")
-    observed = ServerSpec(name="serena", command="uvx", args=("--from", "old-serena"))
+    observed = ServerSpec(name="serena", command="uvx", args=tuple(fixture["old_serena_args"]))
+    assert list(recommended.args) == fixture["recommended_serena_args"]
     registrar = _Registrar(observed)
 
     wrap_cli._setup_serena_mcp(registrar, verbose=True)

--- a/tests/test_cli/test_serena_reconcile.py
+++ b/tests/test_cli/test_serena_reconcile.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from headroom.cli import wrap as wrap_cli
+from headroom.mcp_registry import build_serena_spec_for_agent
+from headroom.mcp_registry.base import RegisterResult, RegisterStatus, ServerSpec
+from headroom.mcp_registry.ledger import record_acknowledgement
+
+
+class _Registrar:
+    name = "claude"
+    display_name = "Claude Code"
+
+    def __init__(self, current: ServerSpec):
+        self.current = current
+
+    def detect(self) -> bool:
+        return True
+
+    def get_server(self, name: str) -> ServerSpec | None:
+        return self.current if name == "serena" else None
+
+    def register_server(self, spec: ServerSpec, *, force: bool = False) -> RegisterResult:
+        if self.current == spec:
+            return RegisterResult(RegisterStatus.ALREADY, "matches")
+        if not force:
+            return RegisterResult(RegisterStatus.MISMATCH, "different")
+        self.current = spec
+        return RegisterResult(RegisterStatus.REGISTERED, "updated")
+
+
+def _quiet_serena_side_effects(monkeypatch):
+    monkeypatch.setattr(wrap_cli, "_ensure_serena_dashboard_disabled", lambda **kwargs: None)
+    monkeypatch.setattr(wrap_cli, "_inject_serena_instructions", lambda *args, **kwargs: None)
+    monkeypatch.setattr(wrap_cli, "_serena_project_skip_reason", lambda root: "test")
+    monkeypatch.setattr(wrap_cli, "_index_serena_project", lambda **kwargs: None)
+    monkeypatch.setattr(wrap_cli.shutil, "which", lambda name: "uvx" if name == "uvx" else None)
+
+
+def test_reproduction_acknowledgement_suppresses_current_drift_without_mutation(
+    tmp_path: Path, monkeypatch, capsys
+):
+    _quiet_serena_side_effects(monkeypatch)
+    ledger = tmp_path / "mcp_installs.json"
+    monkeypatch.setattr("headroom.mcp_registry.ledger.ledger_path", lambda: ledger)
+    recommended = build_serena_spec_for_agent("claude")
+    observed = ServerSpec(name="serena", command="uvx", args=("--from", "old-serena"))
+    registrar = _Registrar(observed)
+
+    wrap_cli._setup_serena_mcp(registrar, verbose=True)
+    assert "existing config differs" in capsys.readouterr().out
+
+    record_acknowledgement("claude", "serena", recommended, observed)
+    wrap_cli._setup_serena_mcp(registrar, verbose=True)
+    output = capsys.readouterr().out
+    assert "existing config differs" not in output
+    assert registrar.current == observed
+
+
+def test_context_map_recommendation_moved_rearms_acknowledgement(
+    tmp_path: Path, monkeypatch, capsys
+):
+    _quiet_serena_side_effects(monkeypatch)
+    ledger = tmp_path / "mcp_installs.json"
+    monkeypatch.setattr("headroom.mcp_registry.ledger.ledger_path", lambda: ledger)
+    observed = ServerSpec(name="serena", command="uvx", args=("--from", "old-serena"))
+    old_recommended = ServerSpec(
+        name="serena", command="uvx", args=("--from", "old-recommendation")
+    )
+    record_acknowledgement("claude", "serena", old_recommended, observed)
+
+    wrap_cli._setup_serena_mcp(_Registrar(observed), verbose=True)
+    assert "existing config differs" in capsys.readouterr().out
+
+
+def test_user_edit_after_acknowledgement_rearms_warning(tmp_path: Path, monkeypatch, capsys):
+    _quiet_serena_side_effects(monkeypatch)
+    ledger = tmp_path / "mcp_installs.json"
+    monkeypatch.setattr("headroom.mcp_registry.ledger.ledger_path", lambda: ledger)
+    recommended = build_serena_spec_for_agent("claude")
+    observed = ServerSpec(name="serena", command="uvx", args=("--from", "old-serena"))
+    record_acknowledgement("claude", "serena", recommended, observed)
+
+    edited = ServerSpec(name="serena", command="uvx", args=("--from", "edited"))
+    wrap_cli._setup_serena_mcp(_Registrar(edited), verbose=True)
+    assert "existing config differs" in capsys.readouterr().out

--- a/tests/test_cli/test_serena_reconcile.py
+++ b/tests/test_cli/test_serena_reconcile.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from headroom.cli import wrap as wrap_cli
-from headroom.mcp_registry import build_serena_spec_for_agent
+from headroom.mcp_registry import ClaudeRegistrar, build_serena_spec_for_agent
 from headroom.mcp_registry.base import RegisterResult, RegisterStatus, ServerSpec
 from headroom.mcp_registry.ledger import record_acknowledgement
 
@@ -51,7 +51,22 @@ def test_reproduction_acknowledgement_suppresses_current_drift_without_mutation(
     recommended = build_serena_spec_for_agent("claude")
     observed = ServerSpec(name="serena", command="uvx", args=tuple(fixture["old_serena_args"]))
     assert list(recommended.args) == fixture["recommended_serena_args"]
-    registrar = _Registrar(observed)
+    config = tmp_path / ".claude.json"
+    config.write_text(
+        json.dumps(
+            {
+                "oauthAccount": {"email": "user@example.com"},
+                "mcpServers": {
+                    "serena": {"command": observed.command, "args": list(observed.args)},
+                    "other": {"command": "other", "args": []},
+                },
+                "projects": {"/repo": {"trust": True}},
+            }
+        )
+    )
+    before = config.read_bytes()
+    registrar = ClaudeRegistrar(claude_cli=None, home_dir=tmp_path)
+    assert registrar.get_server("serena") == observed
 
     wrap_cli._setup_serena_mcp(registrar, verbose=True)
     assert "existing config differs" in capsys.readouterr().out
@@ -60,7 +75,8 @@ def test_reproduction_acknowledgement_suppresses_current_drift_without_mutation(
     wrap_cli._setup_serena_mcp(registrar, verbose=True)
     output = capsys.readouterr().out
     assert "existing config differs" not in output
-    assert registrar.current == observed
+    assert registrar.get_server("serena") == observed
+    assert config.read_bytes() == before
 
 
 def test_context_map_recommendation_moved_rearms_acknowledgement(

--- a/tests/test_cli/test_serena_reconcile.py
+++ b/tests/test_cli/test_serena_reconcile.py
@@ -9,10 +9,10 @@ from headroom.mcp_registry.ledger import headroom_installed_matching, record_ins
 
 
 class _Registrar:
-    name = "claude"
     display_name = "Claude Code"
 
-    def __init__(self, current: ServerSpec | None):
+    def __init__(self, current: ServerSpec | None, *, name: str = "claude"):
+        self.name = name
         self.current = current
         self.force_calls: list[bool] = []
 
@@ -70,3 +70,31 @@ def test_automatic_wrap_preserves_user_managed_warning(monkeypatch, tmp_path: Pa
     assert registrar.current == user
     assert registrar.force_calls == [False]
     assert "existing config differs" in capsys.readouterr().out
+
+
+def test_automatic_wrap_recovers_from_malformed_ledger(monkeypatch, tmp_path: Path):
+    _quiet(monkeypatch)
+    ledger = tmp_path / "ledger.json"
+    ledger.write_text("not json")
+    monkeypatch.setattr("headroom.mcp_registry.ledger.ledger_path", lambda: ledger)
+    registrar = _Registrar(None)
+
+    wrap_cli._setup_serena_mcp(registrar, context="claude-code", verbose=True)
+
+    current = registrar.get_server("serena")
+    assert current == build_serena_spec("claude-code")
+    assert headroom_installed_matching("claude", current)
+
+
+def test_non_claude_wrap_keeps_usable_remediation_hint(monkeypatch, tmp_path: Path, capsys):
+    _quiet(monkeypatch)
+    monkeypatch.setattr(
+        "headroom.mcp_registry.ledger.ledger_path", lambda: tmp_path / "ledger.json"
+    )
+    registrar = _Registrar(ServerSpec("serena", "uvx", ("--from", "user")), name="codex")
+
+    wrap_cli._setup_serena_mcp(registrar, context="codex", verbose=True)
+
+    output = capsys.readouterr().out
+    assert "update or remove the existing serena MCP entry" in output
+    assert "mcp reconcile --adopt" not in output

--- a/tests/test_cli/test_serena_reconcile.py
+++ b/tests/test_cli/test_serena_reconcile.py
@@ -59,6 +59,30 @@ def test_automatic_wrap_migrates_owned_drift_and_recurs_to_noop(
     assert registrar.force_calls == [False, True, False]
 
 
+def test_automatic_wrap_owned_drift_suggests_rerun_wrap(monkeypatch, tmp_path: Path, capsys):
+    _quiet(monkeypatch)
+    monkeypatch.setattr(
+        "headroom.mcp_registry.ledger.ledger_path", lambda: tmp_path / "ledger.json"
+    )
+    stale = ServerSpec("serena", "uvx", ("--from", "old"))
+    record_install("claude", stale)
+
+    class _FailedMigrationRegistrar(_Registrar):
+        def register_server(self, spec, *, force=False):
+            if force:
+                self.force_calls.append(force)
+                return RegisterResult(RegisterStatus.MISMATCH, "still different")
+            return super().register_server(spec, force=force)
+
+    wrap_cli._setup_serena_mcp(
+        _FailedMigrationRegistrar(stale), context="claude-code", verbose=True
+    )
+
+    output = capsys.readouterr().out
+    assert "run headroom wrap again" in output
+    assert "mcp reconcile --adopt" not in output
+
+
 def test_automatic_wrap_preserves_user_managed_warning(monkeypatch, tmp_path: Path, capsys):
     _quiet(monkeypatch)
     monkeypatch.setattr(

--- a/tests/test_mcp_registry/test_ledger.py
+++ b/tests/test_mcp_registry/test_ledger.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from headroom.mcp_registry.base import ServerSpec
 from headroom.mcp_registry.ledger import (
+    acknowledgement_matches,
+    clear_acknowledgement,
     clear_install,
+    get_acknowledgement,
     headroom_installed_matching,
+    record_acknowledgement,
     record_install,
     spec_fingerprint,
 )
@@ -51,3 +55,18 @@ def test_spec_fingerprint_stable_for_env_order():
     b = ServerSpec(name="serena", command="uvx", env={"A": "1", "B": "2"})
 
     assert spec_fingerprint(a) == spec_fingerprint(b)
+
+
+def test_authorship_acknowledgement_is_separate_from_install_ownership(tmp_path):
+    ledger = tmp_path / "mcp_installs.json"
+    recommended = _spec(command="recommended")
+    observed = _spec(command="user-managed")
+
+    record_acknowledgement("claude", "serena", recommended, observed, path=ledger)
+
+    assert acknowledgement_matches("claude", "serena", recommended, observed, path=ledger)
+    assert headroom_installed_matching("claude", observed, path=ledger) is False
+    assert get_acknowledgement("claude", "serena", path=ledger) is not None
+
+    clear_acknowledgement("claude", "serena", path=ledger)
+    assert get_acknowledgement("claude", "serena", path=ledger) is None

--- a/tests/test_mcp_registry/test_ledger.py
+++ b/tests/test_mcp_registry/test_ledger.py
@@ -34,7 +34,19 @@ def test_spec_fingerprint_is_stable_for_env_order():
     assert spec_fingerprint(a) == spec_fingerprint(b)
 
 
-@pytest.mark.parametrize("value", ["not json", [], {"agents": []}, {"agents": {"claude": []}}])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not json",
+        [],
+        {"agents": None},
+        {"agents": []},
+        {"agents": {"claude": None}},
+        {"agents": {"claude": []}},
+        {"agents": {"claude": {"serena": None}}},
+        {"agents": {"claude": {"serena": {"fingerprint": "only"}}}},
+    ],
+)
 def test_mutation_preflight_rejects_unsafe_shapes(tmp_path, value):
     ledger = tmp_path / "mcp_installs.json"
     ledger.write_text(value if isinstance(value, str) else json.dumps(value))
@@ -56,3 +68,13 @@ def test_record_install_recovers_from_corrupt_ledger(tmp_path):
     record_install("claude", spec, path=ledger)
 
     assert headroom_installed_matching("claude", spec, path=ledger)
+
+
+@pytest.mark.parametrize("contents", ['{"agents": null}', '{"agents": {"claude": null}}'])
+def test_record_install_recovers_from_unsafe_ledger_shape(tmp_path, contents):
+    ledger = tmp_path / "mcp_installs.json"
+    ledger.write_text(contents)
+
+    record_install("claude", _spec(), path=ledger)
+
+    assert headroom_installed_matching("claude", _spec(), path=ledger)

--- a/tests/test_mcp_registry/test_ledger.py
+++ b/tests/test_mcp_registry/test_ledger.py
@@ -46,3 +46,13 @@ def test_read_matching_tolerates_corrupt_ledger(tmp_path):
     ledger = tmp_path / "mcp_installs.json"
     ledger.write_text("not json")
     assert not headroom_installed_matching("claude", _spec(), path=ledger)
+
+
+def test_record_install_recovers_from_corrupt_ledger(tmp_path):
+    ledger = tmp_path / "mcp_installs.json"
+    ledger.write_text("not json")
+    spec = _spec()
+
+    record_install("claude", spec, path=ledger)
+
+    assert headroom_installed_matching("claude", spec, path=ledger)

--- a/tests/test_mcp_registry/test_ledger.py
+++ b/tests/test_mcp_registry/test_ledger.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+import headroom.mcp_registry.ledger as ledger_module
 from headroom.mcp_registry.base import ServerSpec
 from headroom.mcp_registry.ledger import (
     LedgerMutationError,
@@ -51,6 +52,22 @@ def test_mutation_preflight_rejects_unsafe_shapes(tmp_path, value):
     ledger = tmp_path / "mcp_installs.json"
     ledger.write_text(value if isinstance(value, str) else json.dumps(value))
     with pytest.raises(LedgerMutationError):
+        validate_ledger_for_mutation(ledger)
+
+
+def test_mutation_preflight_rejects_unreadable_ledger(monkeypatch, tmp_path):
+    ledger = tmp_path / "mcp_installs.json"
+    ledger.write_text('{"agents": {}}')
+    original_read_text = ledger_module.Path.read_text
+
+    def unreadable(path, *args, **kwargs):
+        if path == ledger:
+            raise PermissionError("test unreadable ledger")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(ledger_module.Path, "read_text", unreadable)
+
+    with pytest.raises(LedgerMutationError, match="unreadable"):
         validate_ledger_for_mutation(ledger)
 
 

--- a/tests/test_mcp_registry/test_ledger.py
+++ b/tests/test_mcp_registry/test_ledger.py
@@ -1,72 +1,48 @@
 from __future__ import annotations
 
+import json
+
+import pytest
+
 from headroom.mcp_registry.base import ServerSpec
 from headroom.mcp_registry.ledger import (
-    acknowledgement_matches,
-    clear_acknowledgement,
+    LedgerMutationError,
     clear_install,
-    get_acknowledgement,
     headroom_installed_matching,
-    record_acknowledgement,
     record_install,
     spec_fingerprint,
+    validate_ledger_for_mutation,
 )
 
 
 def _spec(command: str = "uvx") -> ServerSpec:
-    return ServerSpec(
-        name="serena",
-        command=command,
-        args=("--from", "git+https://github.com/oraios/serena", "serena"),
-    )
+    return ServerSpec("serena", command, ("--from", "serena-agent", "serena"))
 
 
-def test_ledger_records_matching_install(tmp_path):
-    ledger = tmp_path / "mcp_installs.json"
-    spec = _spec()
-
-    record_install("claude", spec, path=ledger)
-
-    assert headroom_installed_matching("claude", spec, path=ledger) is True
-
-
-def test_ledger_rejects_changed_spec(tmp_path):
-    ledger = tmp_path / "mcp_installs.json"
-
-    record_install("claude", _spec(), path=ledger)
-
-    assert (
-        headroom_installed_matching("claude", _spec(command="/custom/serena"), path=ledger) is False
-    )
-
-
-def test_clear_install_removes_entry(tmp_path):
+def test_ledger_records_and_clears_matching_install(tmp_path):
     ledger = tmp_path / "mcp_installs.json"
     spec = _spec()
     record_install("claude", spec, path=ledger)
-
+    assert headroom_installed_matching("claude", spec, path=ledger)
     clear_install("claude", "serena", path=ledger)
+    assert not headroom_installed_matching("claude", spec, path=ledger)
 
-    assert headroom_installed_matching("claude", spec, path=ledger) is False
 
-
-def test_spec_fingerprint_stable_for_env_order():
-    a = ServerSpec(name="serena", command="uvx", env={"B": "2", "A": "1"})
-    b = ServerSpec(name="serena", command="uvx", env={"A": "1", "B": "2"})
-
+def test_spec_fingerprint_is_stable_for_env_order():
+    a = ServerSpec("serena", "uvx", env={"B": "2", "A": "1"})
+    b = ServerSpec("serena", "uvx", env={"A": "1", "B": "2"})
     assert spec_fingerprint(a) == spec_fingerprint(b)
 
 
-def test_authorship_acknowledgement_is_separate_from_install_ownership(tmp_path):
+@pytest.mark.parametrize("value", ["not json", [], {"agents": []}, {"agents": {"claude": []}}])
+def test_mutation_preflight_rejects_unsafe_shapes(tmp_path, value):
     ledger = tmp_path / "mcp_installs.json"
-    recommended = _spec(command="recommended")
-    observed = _spec(command="user-managed")
+    ledger.write_text(value if isinstance(value, str) else json.dumps(value))
+    with pytest.raises(LedgerMutationError):
+        validate_ledger_for_mutation(ledger)
 
-    record_acknowledgement("claude", "serena", recommended, observed, path=ledger)
 
-    assert acknowledgement_matches("claude", "serena", recommended, observed, path=ledger)
-    assert headroom_installed_matching("claude", observed, path=ledger) is False
-    assert get_acknowledgement("claude", "serena", path=ledger) is not None
-
-    clear_acknowledgement("claude", "serena", path=ledger)
-    assert get_acknowledgement("claude", "serena", path=ledger) is None
+def test_read_matching_tolerates_corrupt_ledger(tmp_path):
+    ledger = tmp_path / "mcp_installs.json"
+    ledger.write_text("not json")
+    assert not headroom_installed_matching("claude", _spec(), path=ledger)


### PR DESCRIPTION
## Description

Headroom repeatedly warns about user-managed Serena drift but has no scoped remediation command. Add a Claude-only read-only mcp reconcile command with explicit --adopt consent, using the canonical Serena spec and existing Claude registrar. Adoption validates every relevant ledger and Claude config root before mutation, writes only the Serena entry, and records ownership after the config write succeeds. Automatic wrap migration and ordinary install remain unchanged. Closes #3054

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (feature that would cause existing behavior to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add Claude-only `headroom mcp reconcile`, read-only by default, with `--adopt` as its only mutation action.
- Reuse the shared `CLAUDE_SERENA_CONTEXT` and canonical Claude Serena spec builder.
- Fail closed on malformed or unreadable ledger/config state before adoption.
- Preserve automatic wrap recovery, user-managed warnings, ordinary `mcp install --force`, unrelated Claude config, and corrupt-ledger tolerance outside explicit adoption.
- Record Headroom ownership only after a successful registrar write.

## Testing

- [x] Unit tests pass (`uv run pytest tests/test_cli/test_mcp_reconcile.py tests/test_cli/test_serena_reconcile.py tests/test_mcp_registry/test_ledger.py`)
- [x] Linting passes (`uv run ruff check .`)
- [ ] Type checking passes (`uv run mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed through the file-backed Claude registrar

### Test Output

```text
uv run pytest tests/test_cli/test_mcp_reconcile.py tests/test_mcp_registry/test_ledger.py tests/test_cli/test_serena_reconcile.py tests/test_mcp_registry/test_claude_registrar.py tests/test_mcp_registry/test_install.py -q
102 passed in 0.70s
uv run ruff check headroom/mcp_registry/ledger.py headroom/cli/wrap.py tests/test_mcp_registry/test_ledger.py tests/test_cli/test_serena_reconcile.py tests/test_cli/test_mcp_reconcile.py
All checks passed!
uv run ruff format --check headroom/mcp_registry/ledger.py headroom/cli/wrap.py tests/test_mcp_registry/test_ledger.py tests/test_cli/test_serena_reconcile.py tests/test_cli/test_mcp_reconcile.py
5 files already formatted
git diff --check
```

## Real Behavior Proof

- Environment: Windows, file-backed Claude configuration and isolated MCP ledger.
- Exact command / steps: run the stale user-managed Serena fixture from `tests/fixtures/headroom-issue-3054.json`; run read-only reconcile; run `mcp reconcile --adopt`; rerun wrap and ordinary `mcp install --force`; exercise malformed JSON, non-dict `mcpServers`, null ledger agents, and unreadable-ledger adoption.
- Observed result: read-only reconciliation leaves config and ledger bytes unchanged; adoption updates only Claude Serena and records ownership after a successful write; automatic wrap remains lenient; unsafe adoption inputs leave all files unchanged; ordinary install does not adopt Serena.
- Not tested: live Claude CLI acceptance and Serena stdio handshake

## Runtime Rollout Safety

- Rollout-managed feature(s): None; explicit `mcp reconcile --adopt` is the only mutation path.
- Minimum rollout channel: Stable; no staged rollout mechanism exists for this command.
- Stable/default behavior changed: No, read-only reconcile is the default and automatic wrap plus ordinary install remain unchanged.
- Kill switch / disable path: Do not invoke `--adopt` or revert the release commit.
- Unsafe override required: No.
- Qualification impact: None.
- Rollback path: Revert the release commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

The changelog is generated by the release pipeline. This change is limited to Claude Serena reconciliation and does not add a new persistent acknowledgement state or a multi-provider adoption route.
