### PR TITLE
fix(kimi): route managed Kimi Code through the proxy

### DIFF
--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -4386,14 +4386,10 @@ def _launch_tool(
         port_holder[0] = actual_port
         _push_runtime_env(actual_port, no_proxy)
 
-        # If port fell back, update env URLs to point at the actual port
+        # If port fell back, update environment URLs to point at the actual port.
         if actual_port != port:
             for k, v in dict(env).items():
                 env[k] = v.replace(f"127.0.0.1:{port}", f"127.0.0.1:{actual_port}")
-            env_vars_display[:] = [
-                value.replace(f"127.0.0.1:{port}", f"127.0.0.1:{actual_port}")
-                for value in env_vars_display
-            ]
 
         if configure_launch is not None:
             args, env, env_vars_display = configure_launch(actual_port, args, env, env_vars_display)
@@ -6320,9 +6316,20 @@ def kimi(
         click.echo("Install Kimi CLI: https://github.com/MoonshotAI/kimi-cli")
         raise SystemExit(1)
 
-    env, env_vars_display = _build_kimi_launch_env(
-        port, os.environ, project=_project_name_from_cwd()
-    )
+    project = _project_name_from_cwd()
+    env, env_vars_display = _build_kimi_launch_env(port, os.environ, project=project)
+
+    def configure_kimi_launch(
+        actual_port: int,
+        current_args: tuple,
+        current_env: dict[str, str],
+        current_display: list[str],
+    ) -> tuple[tuple, dict[str, str], list[str]]:
+        del current_display
+        updated_env, updated_display = _build_kimi_launch_env(
+            actual_port, current_env, project=project
+        )
+        return current_args, updated_env, updated_display
 
     _launch_tool(
         binary=kimi_bin,
@@ -6337,6 +6344,7 @@ def kimi(
         agent_type="kimi",
         code_graph=code_graph,
         openai_api_url=kimi_api_url,
+        configure_launch=configure_kimi_launch,
     )
 
 

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -6295,9 +6295,10 @@ def kimi(
     """Launch Kimi CLI through Headroom proxy.
 
     \b
-    Sets KIMI_BASE_URL to route Kimi's OpenAI-compatible /chat/completions
-    traffic through Headroom. Kimi's own OAuth bearer is forwarded upstream,
-    so no extra login is required — run `kimi` once to authenticate first.
+    Sets KIMI_CODE_BASE_URL for managed Kimi Code and KIMI_BASE_URL for legacy
+    kimi-cli to route OpenAI-compatible /chat/completions traffic through
+    Headroom. Kimi's own OAuth bearer is forwarded upstream, so no extra login
+    is required — run `kimi` once to authenticate first.
 
     \b
     Examples:

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -4390,6 +4390,10 @@ def _launch_tool(
         if actual_port != port:
             for k, v in dict(env).items():
                 env[k] = v.replace(f"127.0.0.1:{port}", f"127.0.0.1:{actual_port}")
+            env_vars_display[:] = [
+                value.replace(f"127.0.0.1:{port}", f"127.0.0.1:{actual_port}")
+                for value in env_vars_display
+            ]
 
         if configure_launch is not None:
             args, env, env_vars_display = configure_launch(actual_port, args, env, env_vars_display)
@@ -6297,8 +6301,8 @@ def kimi(
     \b
     Sets KIMI_CODE_BASE_URL for managed Kimi Code and KIMI_BASE_URL for legacy
     kimi-cli to route OpenAI-compatible /chat/completions traffic through
-    Headroom. Kimi's own OAuth bearer is forwarded upstream, so no extra login
-    is required — run `kimi` once to authenticate first.
+    Headroom. Managed Kimi Code needs one `/login` after the proxy URL changes
+    so its OAuth slot matches that URL; legacy kimi-cli keeps its existing login.
 
     \b
     Examples:

--- a/headroom/providers/kimi/runtime.py
+++ b/headroom/providers/kimi/runtime.py
@@ -18,8 +18,9 @@ def build_launch_env(
 
     Kimi CLI (``kimi`` / ``kimi-cli``) talks to its managed coding endpoint with
     an OpenAI-compatible ``/chat/completions`` client (``kosong``'s ``Kimi``
-    provider wraps ``AsyncOpenAI``). Its base URL is overridable via the
-    ``KIMI_BASE_URL`` environment variable, so we point it at the local proxy.
+    provider wraps ``AsyncOpenAI``). Its base URL is overridable via
+    ``KIMI_CODE_BASE_URL`` for the managed client and ``KIMI_BASE_URL`` for
+    legacy clients, so both point at the local proxy.
     The proxy forwards the request — including Kimi's own OAuth ``Authorization``
     bearer (passthrough auth mode) — to the real upstream configured by
     ``--openai-api-url`` (``https://api.kimi.com/coding/v1``).
@@ -30,5 +31,9 @@ def build_launch_env(
     """
     env = dict(environ or os.environ)
     base_url = with_project_prefix(codex_proxy_base_url(port), project)
+    env["KIMI_CODE_BASE_URL"] = base_url
     env["KIMI_BASE_URL"] = base_url
-    return env, [f"KIMI_BASE_URL={base_url}"]
+    return env, [
+        f"KIMI_CODE_BASE_URL={base_url}",
+        f"KIMI_BASE_URL={base_url}",
+    ]

--- a/headroom/providers/kimi/runtime.py
+++ b/headroom/providers/kimi/runtime.py
@@ -22,8 +22,9 @@ def build_launch_env(
     ``KIMI_CODE_BASE_URL`` for the managed client and ``KIMI_BASE_URL`` for
     legacy clients, so both point at the local proxy.
     The proxy forwards the request — including Kimi's own OAuth ``Authorization``
-    bearer (passthrough auth mode) — to the real upstream configured by
-    ``--openai-api-url`` (``https://api.kimi.com/coding/v1``).
+    bearer after the managed client completes its proxy-scoped ``/login`` — to
+    the real upstream configured by ``--openai-api-url``
+    (``https://api.kimi.com/coding/v1``).
 
     ``project`` (the wrap launch directory) is encoded as a ``/p/<name>``
     base-URL prefix because the Kimi base-URL override cannot carry custom

--- a/tests/test_cli/test_wrap_kimi.py
+++ b/tests/test_cli/test_wrap_kimi.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
@@ -42,10 +44,20 @@ def test_environment_precedence() -> None:
 
 def test_managed_route_reproduction() -> None:
     direct = "https://api.kimi.com/coding/v1"
-    configured = {"base_url": direct, "oauth": {"key": "oauth/kimi-code"}}
     env, _ = build_launch_env(8787, {"KIMI_BASE_URL": direct}, project="repo")
 
-    selected_url = env.get("KIMI_CODE_BASE_URL") or configured["base_url"]
+    child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os; print(os.environ.get('KIMI_CODE_BASE_URL') or os.environ.get('KIMI_BASE_URL') or '')",
+        ],
+        env=env,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    selected_url = child.stdout.strip()
 
     assert selected_url == "http://127.0.0.1:8787/p/repo/v1"
     assert selected_url != direct
@@ -148,21 +160,28 @@ def test_legacy_stale_config(
     config.write_text('base_url = "https://api.kimi.com/coding/v1"\n', encoding="utf-8")
     monkeypatch.setenv("HOME", str(tmp_path))
     before = config.read_text(encoding="utf-8")
-    captured: dict[str, Any] = {}
-
-    def fake_launch_tool(**kwargs: Any) -> None:  # noqa: ANN003
-        captured.update(kwargs)
 
     def fake_which(name: str) -> str | None:
         return "/usr/local/bin/kimi-cli" if name == "kimi-cli" else None
 
-    with patch.object(wrap_mod.shutil, "which", side_effect=fake_which):
-        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
-            result = runner.invoke(main, ["wrap", "kimi"])
+    completed = Mock(returncode=0)
+    with (
+        patch.object(wrap_mod.shutil, "which", side_effect=fake_which),
+        patch.object(wrap_mod, "_make_cleanup", return_value=lambda: None),
+        patch.object(wrap_mod.signal, "signal"),
+        patch.object(wrap_mod, "_register_proxy_client"),
+        patch.object(wrap_mod, "_ensure_proxy", return_value=(None, 8787)),
+        patch.object(wrap_mod, "_push_runtime_env"),
+        patch.object(wrap_mod, "_configure_quiet_cli_env", return_value=[]),
+        patch.object(wrap_mod, "subprocess") as subprocess_mod,
+    ):
+        subprocess_mod.run.return_value = completed
+        result = runner.invoke(main, ["wrap", "kimi"])
 
     assert result.exit_code == 0, result.output
-    assert captured["binary"] == "/usr/local/bin/kimi-cli"
-    assert captured["env"]["KIMI_TEST_UNRELATED"] == "preserved"
+    subprocess_mod.run.assert_called_once()
+    assert subprocess_mod.run.call_args.args[0][0] == "/usr/local/bin/kimi-cli"
+    assert subprocess_mod.run.call_args.kwargs["env"]["KIMI_TEST_UNRELATED"] == "preserved"
     assert config.read_text(encoding="utf-8") == before
 
 

--- a/tests/test_cli/test_wrap_kimi.py
+++ b/tests/test_cli/test_wrap_kimi.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-import subprocess
+import os
 import sys
 from pathlib import Path
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
 from headroom.cli import wrap as wrap_mod
 from headroom.cli.main import main
-from headroom.providers.kimi.runtime import build_launch_env
 
 
 @pytest.fixture
@@ -21,46 +20,66 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
-def test_environment_precedence() -> None:
-    source = {
-        "KIMI_CODE_BASE_URL": "https://managed.example/v1",
-        "KIMI_BASE_URL": "https://legacy.example/v1",
-        "KEEP_ME": "yes",
-    }
-
-    env, display = build_launch_env(8787, source, project="my project")
-
-    expected = "http://127.0.0.1:8787/p/my%20project/v1"
-    assert env["KIMI_CODE_BASE_URL"] == expected
-    assert env["KIMI_BASE_URL"] == expected
-    assert env["KEEP_ME"] == "yes"
-    assert source == {
-        "KIMI_CODE_BASE_URL": "https://managed.example/v1",
-        "KIMI_BASE_URL": "https://legacy.example/v1",
-        "KEEP_ME": "yes",
-    }
-    assert display == [f"KIMI_CODE_BASE_URL={expected}", f"KIMI_BASE_URL={expected}"]
-
-
-def test_managed_route_reproduction() -> None:
+def test_managed_route_reproduction(
+    runner: CliRunner,
+    capfd: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The production launcher passes the managed endpoint to an exact-contract child."""
     direct = "https://api.kimi.com/coding/v1"
-    env, _ = build_launch_env(8787, {"KIMI_BASE_URL": direct}, project="repo")
+    monkeypatch.setenv("KIMI_BASE_URL", direct)
+    monkeypatch.setenv("KIMI_TEST_UNRELATED", "preserved")
+    monkeypatch.setattr(wrap_mod, "_project_name_from_cwd", lambda: "repo")
+    captured: dict[str, Any] = {}
 
-    child = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            "import os; print(os.environ.get('KIMI_CODE_BASE_URL') or os.environ.get('KIMI_BASE_URL') or '')",
-        ],
-        env=env,
-        capture_output=True,
-        check=True,
-        text=True,
+    def fake_launch_tool(**kwargs: Any) -> None:  # noqa: ANN003
+        captured.update(kwargs)
+
+    with patch.object(wrap_mod.shutil, "which", return_value=sys.executable):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            result = runner.invoke(main, ["wrap", "kimi", "--port", "8787"])
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    display = captured["env_vars_display"]
+    configure_launch = captured["configure_launch"]
+    child_result = tmp_path / "kimi-child.txt"
+    child = (
+        "import os, sys; from pathlib import Path; Path(r'"
+        f"{child_result}"
+        "').write_text('CHILD|' + os.environ['KIMI_CODE_BASE_URL'] + '|' + "
+        "os.environ['KIMI_BASE_URL'] + '|' + os.environ['KIMI_TEST_UNRELATED'] + '|' + sys.argv[1])"
     )
-    selected_url = child.stdout.strip()
 
-    assert selected_url == "http://127.0.0.1:8787/p/repo/v1"
-    assert selected_url != direct
+    with (
+        patch.object(wrap_mod, "_make_cleanup", return_value=lambda: None),
+        patch.object(wrap_mod.signal, "signal"),
+        patch.object(wrap_mod, "_register_proxy_client"),
+        patch.object(wrap_mod, "_ensure_proxy", return_value=(None, 9001)),
+        patch.object(wrap_mod, "_unregister_proxy_client"),
+        patch.object(wrap_mod, "_push_runtime_env"),
+        patch.object(wrap_mod, "_configure_quiet_cli_env", return_value=[]),
+    ):
+        with pytest.raises(SystemExit) as raised:
+            wrap_mod._launch_tool(
+                binary=os.fspath(Path(sys.executable)),
+                args=("-c", child, "child-arg"),
+                env=env,
+                port=8787,
+                no_proxy=False,
+                tool_label="KIMI",
+                env_vars_display=display,
+                configure_launch=configure_launch,
+            )
+
+    assert raised.value.code == 0
+    output = result.output + capfd.readouterr().out
+    expected = "http://127.0.0.1:9001/p/repo/v1"
+    assert f"KIMI_CODE_BASE_URL={expected}" in output
+    assert f"KIMI_BASE_URL={expected}" in output
+    assert child_result.read_text() == f"CHILD|{expected}|{expected}|preserved|child-arg"
+    assert direct not in output
 
 
 def test_wrap_kimi_launch(
@@ -91,6 +110,7 @@ def test_wrap_kimi_launch(
     assert captured["agent_type"] == "kimi"
     assert captured["args"] == ("-m", "kimi-for-coding")
     assert captured["openai_api_url"] == "https://api.kimi.com/coding/v1"
+    assert callable(captured["configure_launch"])
     assert env["KIMI_CODE_BASE_URL"] == "http://127.0.0.1:9000/v1"
     assert env["KIMI_BASE_URL"] == "http://127.0.0.1:9000/v1"
 
@@ -147,77 +167,6 @@ def test_wrap_kimi_cli_fallback(
     assert captured["binary"] == "/usr/local/bin/kimi-cli"
 
 
-def test_legacy_stale_config(
-    runner: CliRunner,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
-    monkeypatch.setenv("KIMI_TEST_UNRELATED", "preserved")
-    config = tmp_path / ".kimi-code" / "config.toml"
-    config.parent.mkdir()
-    config.write_text('base_url = "https://api.kimi.com/coding/v1"\n', encoding="utf-8")
-    monkeypatch.setenv("HOME", str(tmp_path))
-    before = config.read_text(encoding="utf-8")
-
-    def fake_which(name: str) -> str | None:
-        return "/usr/local/bin/kimi-cli" if name == "kimi-cli" else None
-
-    completed = Mock(returncode=0)
-    with (
-        patch.object(wrap_mod.shutil, "which", side_effect=fake_which),
-        patch.object(wrap_mod, "_make_cleanup", return_value=lambda: None),
-        patch.object(wrap_mod.signal, "signal"),
-        patch.object(wrap_mod, "_register_proxy_client"),
-        patch.object(wrap_mod, "_ensure_proxy", return_value=(None, 8787)),
-        patch.object(wrap_mod, "_push_runtime_env"),
-        patch.object(wrap_mod, "_configure_quiet_cli_env", return_value=[]),
-        patch.object(wrap_mod, "subprocess") as subprocess_mod,
-    ):
-        subprocess_mod.run.return_value = completed
-        result = runner.invoke(main, ["wrap", "kimi"])
-
-    assert result.exit_code == 0, result.output
-    subprocess_mod.run.assert_called_once()
-    assert subprocess_mod.run.call_args.args[0][0] == "/usr/local/bin/kimi-cli"
-    assert subprocess_mod.run.call_args.kwargs["env"]["KIMI_TEST_UNRELATED"] == "preserved"
-    assert config.read_text(encoding="utf-8") == before
-
-
-def test_subprocess_launch_environment() -> None:
-    env, display = build_launch_env(8787, {"KIMI_TEST_UNRELATED": "preserved"})
-    completed = Mock(returncode=0)
-
-    with (
-        patch.object(wrap_mod, "_make_cleanup", return_value=lambda: None),
-        patch.object(wrap_mod.signal, "signal"),
-        patch.object(wrap_mod, "_register_proxy_client"),
-        patch.object(wrap_mod, "_ensure_proxy", return_value=(None, 8787)),
-        patch.object(wrap_mod, "_push_runtime_env"),
-        patch.object(wrap_mod, "_configure_quiet_cli_env", return_value=[]),
-        patch.object(wrap_mod, "subprocess") as subprocess_mod,
-    ):
-        subprocess_mod.run.return_value = completed
-        with pytest.raises(SystemExit) as raised:
-            wrap_mod._launch_tool(
-                binary="kimi",
-                args=("--version",),
-                env=env,
-                port=8787,
-                no_proxy=False,
-                tool_label="KIMI",
-                env_vars_display=display,
-            )
-
-    assert raised.value.code == 0
-    subprocess_mod.run.assert_called_once_with(["kimi", "--version"], env=env)
-    actual_env = subprocess_mod.run.call_args.kwargs["env"]
-    assert actual_env["KIMI_CODE_BASE_URL"] == "http://127.0.0.1:8787/v1"
-    assert actual_env["KIMI_BASE_URL"] == "http://127.0.0.1:8787/v1"
-    assert subprocess_mod.run.call_args.kwargs["env"]["KIMI_TEST_UNRELATED"] == "preserved"
-
-
 def test_wrap_kimi_not_found(
     runner: CliRunner,
     tmp_path: Path,
@@ -260,9 +209,17 @@ def test_port_fallback(
     assert captured["env"]["KIMI_BASE_URL"] == "http://127.0.0.1:9999/v1"
 
 
-def test_port_fallback_rewrites_both_urls() -> None:
-    env, display = build_launch_env(8787, {}, project="repo")
-    completed = Mock(returncode=0)
+def test_non_kimi_fallback_display_is_unchanged(
+    capfd: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    env = {**os.environ, "OTHER_BASE_URL": "http://127.0.0.1:8787/v1"}
+    display = ["OTHER_BASE_URL=http://127.0.0.1:8787/v1"]
+    child_result = tmp_path / "other-child.txt"
+    child = (
+        "import os; from pathlib import Path; Path(r'"
+        f"{child_result}"
+        "').write_text('CHILD|' + os.environ['OTHER_BASE_URL'])"
+    )
 
     with (
         patch.object(wrap_mod, "_make_cleanup", return_value=lambda: None),
@@ -272,28 +229,22 @@ def test_port_fallback_rewrites_both_urls() -> None:
         patch.object(wrap_mod, "_unregister_proxy_client"),
         patch.object(wrap_mod, "_push_runtime_env"),
         patch.object(wrap_mod, "_configure_quiet_cli_env", return_value=[]),
-        patch.object(wrap_mod, "subprocess") as subprocess_mod,
     ):
-        subprocess_mod.run.return_value = completed
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as raised:
             wrap_mod._launch_tool(
-                binary="kimi",
-                args=(),
+                binary=os.fspath(Path(sys.executable)),
+                args=("-c", child),
                 env=env,
                 port=8787,
                 no_proxy=False,
-                tool_label="KIMI",
+                tool_label="OTHER",
                 env_vars_display=display,
             )
 
-    actual_env = subprocess_mod.run.call_args.kwargs["env"]
-    expected = "http://127.0.0.1:9001/p/repo/v1"
-    assert actual_env["KIMI_CODE_BASE_URL"] == expected
-    assert actual_env["KIMI_BASE_URL"] == expected
-    assert display == [
-        f"KIMI_CODE_BASE_URL={expected}",
-        f"KIMI_BASE_URL={expected}",
-    ]
+    assert raised.value.code == 0
+    output = capfd.readouterr().out
+    assert "OTHER_BASE_URL=http://127.0.0.1:8787/v1" in output
+    assert child_result.read_text() == "CHILD|http://127.0.0.1:9001/v1"
 
 
 def test_wrap_kimi_custom_api_url(

--- a/tests/test_cli/test_wrap_kimi.py
+++ b/tests/test_cli/test_wrap_kimi.py
@@ -4,18 +4,50 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
 
 from headroom.cli import wrap as wrap_mod
 from headroom.cli.main import main
+from headroom.providers.kimi.runtime import build_launch_env
 
 
 @pytest.fixture
 def runner() -> CliRunner:
     return CliRunner()
+
+
+def test_environment_precedence() -> None:
+    source = {
+        "KIMI_CODE_BASE_URL": "https://managed.example/v1",
+        "KIMI_BASE_URL": "https://legacy.example/v1",
+        "KEEP_ME": "yes",
+    }
+
+    env, display = build_launch_env(8787, source, project="my project")
+
+    expected = "http://127.0.0.1:8787/p/my%20project/v1"
+    assert env["KIMI_CODE_BASE_URL"] == expected
+    assert env["KIMI_BASE_URL"] == expected
+    assert env["KEEP_ME"] == "yes"
+    assert source == {
+        "KIMI_CODE_BASE_URL": "https://managed.example/v1",
+        "KIMI_BASE_URL": "https://legacy.example/v1",
+        "KEEP_ME": "yes",
+    }
+    assert display == [f"KIMI_CODE_BASE_URL={expected}", f"KIMI_BASE_URL={expected}"]
+
+
+def test_managed_route_reproduction() -> None:
+    direct = "https://api.kimi.com/coding/v1"
+    env, _ = build_launch_env(8787, {"KIMI_BASE_URL": direct}, project="repo")
+
+    selected_url = env.get("KIMI_CODE_BASE_URL", direct)
+
+    assert selected_url == "http://127.0.0.1:8787/p/repo/v1"
+    assert selected_url != direct
 
 
 def test_wrap_kimi_launch(
@@ -46,15 +78,16 @@ def test_wrap_kimi_launch(
     assert captured["agent_type"] == "kimi"
     assert captured["args"] == ("-m", "kimi-for-coding")
     assert captured["openai_api_url"] == "https://api.kimi.com/coding/v1"
+    assert env["KIMI_CODE_BASE_URL"] == "http://127.0.0.1:9000/v1"
     assert env["KIMI_BASE_URL"] == "http://127.0.0.1:9000/v1"
 
 
-def test_wrap_kimi_with_project_name(
+def test_project_name(
     runner: CliRunner,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Project name is encoded in KIMI_BASE_URL when run from a project directory."""
+    """Project name is encoded in both Kimi endpoint variables."""
     project_dir = tmp_path / "my-project"
     project_dir.mkdir()
     monkeypatch.chdir(project_dir)
@@ -71,6 +104,7 @@ def test_wrap_kimi_with_project_name(
 
     assert result.exit_code == 0, result.output
     env = captured["env"]
+    assert env["KIMI_CODE_BASE_URL"] == "http://127.0.0.1:7000/p/my-project/v1"
     assert env["KIMI_BASE_URL"] == "http://127.0.0.1:7000/p/my-project/v1"
 
 
@@ -100,6 +134,66 @@ def test_wrap_kimi_cli_fallback(
     assert captured["binary"] == "/usr/local/bin/kimi-cli"
 
 
+def test_legacy_stale_config(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    monkeypatch.setenv("KIMI_TEST_UNRELATED", "preserved")
+    config = tmp_path / "config.toml"
+    config.write_text('base_url = "https://api.kimi.com/coding/v1"\n', encoding="utf-8")
+    before = config.read_text(encoding="utf-8")
+    captured: dict[str, Any] = {}
+
+    def fake_launch_tool(**kwargs: Any) -> None:  # noqa: ANN003
+        captured.update(kwargs)
+
+    def fake_which(name: str) -> str | None:
+        return "/usr/local/bin/kimi-cli" if name == "kimi-cli" else None
+
+    with patch.object(wrap_mod.shutil, "which", side_effect=fake_which):
+        with patch.object(wrap_mod, "_launch_tool", side_effect=fake_launch_tool):
+            result = runner.invoke(main, ["wrap", "kimi"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["binary"] == "/usr/local/bin/kimi-cli"
+    assert captured["env"]["KIMI_TEST_UNRELATED"] == "preserved"
+    assert config.read_text(encoding="utf-8") == before
+
+
+def test_subprocess_launch_environment() -> None:
+    env, display = build_launch_env(8787, {"KIMI_TEST_UNRELATED": "preserved"})
+    completed = Mock(returncode=0)
+
+    with (
+        patch.object(wrap_mod, "_make_cleanup", return_value=lambda: None),
+        patch.object(wrap_mod.signal, "signal"),
+        patch.object(wrap_mod, "_register_proxy_client"),
+        patch.object(wrap_mod, "_ensure_proxy", return_value=(None, 8787)),
+        patch.object(wrap_mod, "_push_runtime_env"),
+        patch.object(wrap_mod, "_configure_quiet_cli_env", return_value=[]),
+        patch.object(wrap_mod, "subprocess") as subprocess_mod,
+    ):
+        subprocess_mod.run.return_value = completed
+        with pytest.raises(SystemExit) as raised:
+            wrap_mod._launch_tool(
+                binary="kimi",
+                args=("--version",),
+                env=env,
+                port=8787,
+                no_proxy=False,
+                tool_label="KIMI",
+                env_vars_display=display,
+            )
+
+    assert raised.value.code == 0
+    subprocess_mod.run.assert_called_once_with(["kimi", "--version"], env=env)
+    assert subprocess_mod.run.call_args.kwargs["env"]["KIMI_CODE_BASE_URL"] == env["KIMI_BASE_URL"]
+    assert subprocess_mod.run.call_args.kwargs["env"]["KIMI_TEST_UNRELATED"] == "preserved"
+
+
 def test_wrap_kimi_not_found(
     runner: CliRunner,
     tmp_path: Path,
@@ -117,12 +211,12 @@ def test_wrap_kimi_not_found(
     assert "https://github.com/MoonshotAI/kimi-cli" in result.output
 
 
-def test_wrap_kimi_custom_port(
+def test_port_fallback(
     runner: CliRunner,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Custom --port is passed to _launch_tool and appears in KIMI_BASE_URL."""
+    """Custom --port is passed to _launch_tool and appears in both URLs."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
 
@@ -138,7 +232,40 @@ def test_wrap_kimi_custom_port(
 
     assert result.exit_code == 0, result.output
     assert captured["port"] == 9999
+    assert captured["env"]["KIMI_CODE_BASE_URL"] == "http://127.0.0.1:9999/v1"
     assert captured["env"]["KIMI_BASE_URL"] == "http://127.0.0.1:9999/v1"
+
+
+def test_port_fallback_rewrites_both_urls() -> None:
+    env, display = build_launch_env(8787, {}, project="repo")
+    completed = Mock(returncode=0)
+
+    with (
+        patch.object(wrap_mod, "_make_cleanup", return_value=lambda: None),
+        patch.object(wrap_mod.signal, "signal"),
+        patch.object(wrap_mod, "_register_proxy_client"),
+        patch.object(wrap_mod, "_ensure_proxy", return_value=(None, 9001)),
+        patch.object(wrap_mod, "_unregister_proxy_client"),
+        patch.object(wrap_mod, "_push_runtime_env"),
+        patch.object(wrap_mod, "_configure_quiet_cli_env", return_value=[]),
+        patch.object(wrap_mod, "subprocess") as subprocess_mod,
+    ):
+        subprocess_mod.run.return_value = completed
+        with pytest.raises(SystemExit):
+            wrap_mod._launch_tool(
+                binary="kimi",
+                args=(),
+                env=env,
+                port=8787,
+                no_proxy=False,
+                tool_label="KIMI",
+                env_vars_display=display,
+            )
+
+    actual_env = subprocess_mod.run.call_args.kwargs["env"]
+    expected = "http://127.0.0.1:9001/p/repo/v1"
+    assert actual_env["KIMI_CODE_BASE_URL"] == expected
+    assert actual_env["KIMI_BASE_URL"] == expected
 
 
 def test_wrap_kimi_custom_api_url(

--- a/tests/test_cli/test_wrap_kimi.py
+++ b/tests/test_cli/test_wrap_kimi.py
@@ -42,9 +42,10 @@ def test_environment_precedence() -> None:
 
 def test_managed_route_reproduction() -> None:
     direct = "https://api.kimi.com/coding/v1"
+    configured = {"base_url": direct, "oauth": {"key": "oauth/kimi-code"}}
     env, _ = build_launch_env(8787, {"KIMI_BASE_URL": direct}, project="repo")
 
-    selected_url = env.get("KIMI_CODE_BASE_URL", direct)
+    selected_url = env.get("KIMI_CODE_BASE_URL") or configured["base_url"]
 
     assert selected_url == "http://127.0.0.1:8787/p/repo/v1"
     assert selected_url != direct
@@ -142,8 +143,10 @@ def test_legacy_stale_config(
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
     monkeypatch.setenv("KIMI_TEST_UNRELATED", "preserved")
-    config = tmp_path / "config.toml"
+    config = tmp_path / ".kimi-code" / "config.toml"
+    config.parent.mkdir()
     config.write_text('base_url = "https://api.kimi.com/coding/v1"\n', encoding="utf-8")
+    monkeypatch.setenv("HOME", str(tmp_path))
     before = config.read_text(encoding="utf-8")
     captured: dict[str, Any] = {}
 
@@ -190,7 +193,9 @@ def test_subprocess_launch_environment() -> None:
 
     assert raised.value.code == 0
     subprocess_mod.run.assert_called_once_with(["kimi", "--version"], env=env)
-    assert subprocess_mod.run.call_args.kwargs["env"]["KIMI_CODE_BASE_URL"] == env["KIMI_BASE_URL"]
+    actual_env = subprocess_mod.run.call_args.kwargs["env"]
+    assert actual_env["KIMI_CODE_BASE_URL"] == "http://127.0.0.1:8787/v1"
+    assert actual_env["KIMI_BASE_URL"] == "http://127.0.0.1:8787/v1"
     assert subprocess_mod.run.call_args.kwargs["env"]["KIMI_TEST_UNRELATED"] == "preserved"
 
 
@@ -266,6 +271,10 @@ def test_port_fallback_rewrites_both_urls() -> None:
     expected = "http://127.0.0.1:9001/p/repo/v1"
     assert actual_env["KIMI_CODE_BASE_URL"] == expected
     assert actual_env["KIMI_BASE_URL"] == expected
+    assert display == [
+        f"KIMI_CODE_BASE_URL={expected}",
+        f"KIMI_BASE_URL={expected}",
+    ]
 
 
 def test_wrap_kimi_custom_api_url(


### PR DESCRIPTION
## Description

Managed Kimi Code reads KIMI_CODE_BASE_URL while headroom wrap kimi previously supplied only KIMI_BASE_URL. The managed client can therefore keep its direct endpoint while the wrapper appears healthy. Emit both provider-owned keys and recompute them through the existing launch callback at the proxy's actual port. Preserve the legacy route and unrelated wrappers. Closes #3207

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (feature that would cause existing behavior to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Set KIMI_CODE_BASE_URL and KIMI_BASE_URL from one project-aware proxy URL.
- Recompute both values and their display lines through the Kimi configure_launch callback after port fallback.
- Remove the generic display rewrite from _launch_tool so other wrappers retain their base behavior.
- Add production-boundary child, fallback-port, legacy-preservation, and non-Kimi negative-space tests.

## Testing

- [x] Unit tests pass (`uv run pytest tests/test_cli/test_wrap_kimi.py -q`)
- [x] Linting passes (`uv run ruff check .`)
- [ ] Type checking passes (`uv run mypy headroom`)
- [x] New tests added for the regression
- [x] Manual testing performed through the production subprocess boundary

### Test Output

```text
uv run pytest tests/test_cli/test_wrap_kimi.py -q
10 passed in 0.40s
uv run pytest tests/test_cli/test_wrap_grok.py -q
2 passed
uv run ruff check .
All checks passed!
uv run ruff format . --check
1534 files already formatted
git diff --check
```

## Real Behavior Proof

- Environment: Windows, isolated Kimi wrapper subprocess harness.
- Exact command / steps: launch a contract-compatible child through the Kimi wrapper; exercise requested and fallback ports, project prefixes, legacy selection, and a non-Kimi wrapper.
- Observed result: the child receives the effective project-aware proxy URL in both Kimi keys; the displayed URL matches it after fallback; legacy and non-Kimi behavior remain unchanged.
- Not tested: live authenticated Kimi Code managed request

## Runtime Rollout Safety

- Rollout-managed feature(s): None; managed Kimi Code routing is selected by the existing wrapper mode.
- Minimum rollout channel: Stable; no staged rollout mechanism exists for this wrapper path.
- Stable/default behavior changed: Yes, managed Kimi Code launches now receive the effective proxy URL in both provider-owned keys.
- Kill switch / disable path: Stop using the managed Kimi wrapper path or revert the release commit.
- Unsafe override required: No.
- Qualification impact: None.
- Rollback path: Revert the release commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md if applicable

## Additional Notes

Kimi Code owns OAuth credentials and the /login flow. Headroom does not read or modify Kimi config or credential files. The changelog is generated by the release pipeline.
