### PR TITLE
fix(proxy): acknowledge Claude local probe routes

### DIFF
--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -751,6 +751,59 @@ def register_provider_routes(app: FastAPI, proxy: Any) -> None:
             "gemini",
         )
 
+    @app.post("/api/event_logging/batch")
+    async def claude_event_logging_batch(request: Request):
+        """Acknowledge Claude Code telemetry locally instead of passthrough.
+
+        Claude Code emits background analytics to ``/api/event_logging/batch`` on
+        the local gateway. When Headroom is repointed so the Anthropic messages
+        route goes to a local OpenAI-compatible model endpoint, this unrelated
+        telemetry path falls through the generic passthrough and returns noisy
+        404s. Accept the batch locally so the inference route stays cleanly
+        isolated.
+        """
+        headers = dict(request.headers)
+        user_agent = (headers.get("user-agent") or headers.get("User-Agent") or "").lower()
+        service_name = (
+            headers.get("x-service-name") or headers.get("X-Service-Name") or ""
+        ).lower()
+        if "claude-code/" in user_agent or "claude-cli/" in user_agent or service_name == "claude-code":
+            await request.body()
+            return Response(status_code=204)
+        return await proxy.handle_passthrough(
+            request,
+            _select_passthrough_base_url(proxy, headers),
+        )
+
+    @app.api_route("/api/hello", methods=["GET", "HEAD"])
+    async def claude_api_hello(request: Request):
+        """Acknowledge Claude Code/Bun hello probes locally instead of passthrough.
+
+        When Claude Code is routed through a local Headroom bridge, Bun-based side
+        probes hit ``/api/hello`` on the gateway before or alongside real
+        inference traffic. Our local OpenAI-compatible upstream does not expose
+        that unrelated route, so generic passthrough produces noisy 404s even
+        though ``/readyz`` and ``/v1/messages`` are healthy. Accept those probes
+        locally so operator logs reflect real failures.
+        """
+        headers = dict(request.headers)
+        user_agent = (headers.get("user-agent") or headers.get("User-Agent") or "").lower()
+        service_name = (
+            headers.get("x-service-name") or headers.get("X-Service-Name") or ""
+        ).lower()
+        if (
+            user_agent.startswith("bun/")
+            or "claude-code/" in user_agent
+            or "claude-cli/" in user_agent
+            or service_name == "claude-code"
+        ):
+            await request.body()
+            return Response(status_code=200)
+        return await proxy.handle_passthrough(
+            request,
+            _select_passthrough_base_url(proxy, headers),
+        )
+
     @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
     async def passthrough(request: Request, path: str):
         custom_base = request.headers.get("x-headroom-base-url")

--- a/tests/test_proxy_claude_local_probe_routes.py
+++ b/tests/test_proxy_claude_local_probe_routes.py
@@ -1,0 +1,98 @@
+"""Regression tests for Claude-local probe routes on the proxy gateway."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi.responses import Response
+from fastapi.testclient import TestClient
+
+from headroom.proxy.server import ProxyConfig, create_app
+
+
+@pytest.fixture
+def app_and_client():
+    config = ProxyConfig(
+        optimize=False,
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+    )
+    app = create_app(config)
+    with TestClient(
+        app,
+        base_url="http://127.0.0.1",
+        client=("127.0.0.1", 12345),
+    ) as test_client:
+        yield app, test_client
+
+
+@pytest.fixture
+def passthrough_probe(monkeypatch, app_and_client):
+    app, client = app_and_client
+    proxy = app.state.proxy
+    calls: list[tuple[str, str]] = []
+
+    async def fake_handle_passthrough(request, *args, **kwargs):
+        calls.append((request.method, request.url.path))
+        return Response(status_code=599)
+
+    monkeypatch.setattr(proxy, "handle_passthrough", fake_handle_passthrough)
+    return client, calls
+
+
+def test_claude_event_logging_batch_is_acknowledged_locally(passthrough_probe):
+    client, calls = passthrough_probe
+
+    response = client.post(
+        "/api/event_logging/batch",
+        headers={
+            "User-Agent": "claude-code/2.0.77",
+            "X-Service-Name": "claude-code",
+            "Content-Type": "application/json",
+        },
+        json={"events": []},
+    )
+
+    assert response.status_code == 204
+    assert calls == []
+
+
+def test_non_claude_event_logging_batch_still_passthroughs(passthrough_probe):
+    client, calls = passthrough_probe
+
+    response = client.post(
+        "/api/event_logging/batch",
+        headers={"User-Agent": "curl/8.5.0", "Content-Type": "application/json"},
+        json={"events": []},
+    )
+
+    assert response.status_code == 599
+    assert calls == [("POST", "/api/event_logging/batch")]
+
+
+def test_bun_api_hello_probe_is_acknowledged_locally(passthrough_probe):
+    client, calls = passthrough_probe
+
+    response = client.head(
+        "/api/hello",
+        headers={"User-Agent": "Bun/1.4.0", "Accept": "*/*"},
+    )
+
+    assert response.status_code == 200
+    assert calls == []
+
+
+def test_non_claude_api_hello_still_passthroughs(passthrough_probe):
+    client, calls = passthrough_probe
+
+    response = client.get(
+        "/api/hello",
+        headers={"User-Agent": "curl/8.5.0", "Accept": "*/*"},
+    )
+
+    assert response.status_code == 599
+    assert calls == [("GET", "/api/hello")]


### PR DESCRIPTION
## Summary
- acknowledge Claude Code telemetry batches locally on the proxy bridge instead of letting them fall through to generic passthrough
- acknowledge Bun/Claude `/api/hello` probes locally so operator logs stop showing false 404s when the Anthropic bridge points at a local OpenAI-compatible upstream
- add focused regression tests proving Claude/Bun probe traffic short-circuits locally while non-Claude traffic still uses passthrough

## Why
When Headroom is repointed so Claude traffic is bridged into a local OpenAI-compatible model endpoint, unrelated Claude-side probe routes can fall through the generic passthrough path and generate noisy 404s even though `/readyz` and `/v1/messages` are healthy. This keeps those routes isolated without changing the actual inference path.

## Test Plan
- `uv run --extra dev python -m pytest -q tests/test_proxy_claude_local_probe_routes.py tests/test_proxy_debug_endpoints.py -k 'existing_health_routes_unchanged or claude_local_probe_routes'`
- Result: `5 passed, 25 deselected`
