### PR TITLE
fix(telemetry): release TOIN lock before auto-save disk write

### DIFF
--- a/headroom/telemetry/toin.py
+++ b/headroom/telemetry/toin.py
@@ -60,6 +60,7 @@ detection).
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -432,6 +433,10 @@ class ToolIntelligenceNetwork:
     Thread-safe for concurrent access.
     """
 
+    # Bounded re-snapshot passes when a mutation races a backend write; leftovers
+    # stay dirty and the next record_* trigger retries, so this only caps I/O.
+    _SAVE_PASSES = 2
+
     # ── Deprecation warning de-dupe (PR-B5) ───────────────────────────────
     # `get_recommendation` is retired as a per-request mutator. We emit
     # `DeprecationWarning` once per process; if every call warned, busy
@@ -482,6 +487,10 @@ class ToolIntelligenceNetwork:
         # Tracking
         self._last_save_time = time.time()
         self._dirty = False
+        # Bumped alongside every _dirty=True so save() can tell whether new
+        # data landed while its snapshot was being written (all mutators hold
+        # the lock, so the counter needs no lock of its own).
+        self._mutations = 0
 
         # Load existing data from backend
         if self._backend is not None:
@@ -708,6 +717,7 @@ class ToolIntelligenceNetwork:
             pattern.last_updated = time.time()
             pattern.confidence = self._calculate_confidence(pattern)
             self._dirty = True
+            self._mutations += 1
             self._prune_patterns_locked()
 
         # Auto-save if needed (outside lock)
@@ -1015,6 +1025,7 @@ class ToolIntelligenceNetwork:
 
             pattern.last_updated = time.time()
             self._dirty = True
+            self._mutations += 1
             self._prune_patterns_locked()
 
         self._maybe_auto_save()
@@ -1319,6 +1330,7 @@ class ToolIntelligenceNetwork:
 
             self._prune_patterns_locked()
             self._dirty = True
+            self._mutations += 1
 
     def _merge_patterns(self, existing: ToolPattern, imported: ToolPattern) -> None:
         """Merge imported pattern into existing."""
@@ -1506,39 +1518,47 @@ class ToolIntelligenceNetwork:
     def save(self) -> None:
         """Save TOIN data via the storage backend.
 
-        HIGH FIX: Serialize under lock but write outside lock to prevent
-        blocking other threads during slow file I/O.
+        Snapshot under lock, write outside it, so slow file I/O never blocks
+        record_* callers. The snapshot is a deep copy — to_dict() nests live
+        containers, and dumping those unlocked would race concurrent mutators.
+        A mutation landing mid-write bumps _mutations past the snapshot's
+        count; finalize then leaves _dirty armed and one bounded re-snapshot
+        pass persists the newer state, so nothing recorded is left unwritten.
         """
         if self._backend is None:
             return
 
-        # Step 1: Serialize under lock (fast in-memory operation)
-        with self._lock:
-            data = self.export_patterns()
-
-        # Step 2: Write outside lock (slow I/O operation)
-        try:
-            self._backend.save(data)
-
-            # Step 3: Update state under lock (fast)
+        for _pass in range(self._SAVE_PASSES):
             with self._lock:
-                self._dirty = False
-                self._last_save_time = time.time()
+                data = copy.deepcopy(self.export_patterns())
+                expected_mutations = self._mutations
 
-        except Exception as e:
-            # Surface storage failures structured so log aggregators can
-            # alert on `event=toin_save_failed` without false positives
-            # from generic exception lines. Per project memory
-            # `feedback_no_silent_fallbacks.md`: never swallow.
-            logger.warning(
-                "TOIN storage save failed",
-                extra={
-                    "event": "toin_save_failed",
-                    "backend": type(self._backend).__name__,
-                    "error_type": type(e).__name__,
-                    "error": str(e),
-                },
-            )
+            try:
+                self._backend.save(data)
+            except Exception as e:
+                # Surface storage failures structured so log aggregators can
+                # alert on `event=toin_save_failed` without false positives
+                # from generic exception lines. Per project memory
+                # `feedback_no_silent_fallbacks.md`: never swallow.
+                logger.warning(
+                    "TOIN storage save failed",
+                    extra={
+                        "event": "toin_save_failed",
+                        "backend": type(self._backend).__name__,
+                        "error_type": type(e).__name__,
+                        "error": str(e),
+                    },
+                )
+                return
+
+            with self._lock:
+                if self._mutations == expected_mutations:
+                    self._dirty = False
+                    self._last_save_time = time.time()
+                    return
+                # Newer data landed during the write — loop to include it.
+                # On pass exhaustion the dirty flag stays armed and the next
+                # record_* trigger retries from a fresh snapshot.
 
     def _load_from_backend(self) -> None:
         """Load TOIN data from the storage backend."""
@@ -1572,12 +1592,12 @@ class ToolIntelligenceNetwork:
     def _maybe_auto_save(self) -> None:
         """Auto-save if enough time has passed.
 
-        Check eligibility under lock, but call save() outside it — holding
-        the RLock across backend.save() made every concurrent record_* call
-        block for the whole disk write, defeating save()'s serialize-under /
-        write-outside design. A rare double-save from two threads passing
-        the same interval boundary is benign — serialization is locked and
-        the atomic last-write wins.
+        Eligibility is checked under lock, then save() runs outside it —
+        holding the RLock across backend.save() made every concurrent
+        record_* call block for the whole disk write, defeating save()'s
+        snapshot-under / write-outside design. Two threads passing the same
+        interval boundary may both save; each converges via save()'s
+        mutation counter, so this costs a duplicate write at worst.
         """
         if self._backend is None or not self._config.auto_save_interval:
             return

--- a/headroom/telemetry/toin.py
+++ b/headroom/telemetry/toin.py
@@ -1572,23 +1572,27 @@ class ToolIntelligenceNetwork:
     def _maybe_auto_save(self) -> None:
         """Auto-save if enough time has passed.
 
-        HIGH FIX: Check conditions under lock to prevent race where another
-        thread modifies _dirty or _last_save_time between check and save.
-        The save() method already acquires the lock, and we use RLock so
-        it's safe to hold the lock when calling save().
+        Check eligibility under lock, but call save() outside it — holding
+        the RLock across backend.save() made every concurrent record_* call
+        block for the whole disk write, defeating save()'s serialize-under /
+        write-outside design. A rare double-save from two threads passing
+        the same interval boundary is benign — serialization is locked and
+        the atomic last-write wins.
         """
         if self._backend is None or not self._config.auto_save_interval:
             return
 
-        # Check under lock to prevent race conditions
+        # Eligibility check stays under lock so a concurrent save cannot
+        # flip _dirty/_last_save_time between our check and our write.
         with self._lock:
             if not self._dirty:
                 return
 
             elapsed = time.time() - self._last_save_time
-            if elapsed >= self._config.auto_save_interval:
-                # save() uses the same RLock, so this is safe
-                self.save()
+            if elapsed < self._config.auto_save_interval:
+                return
+
+        self.save()
 
     def clear(self) -> None:
         """Clear all TOIN data. Mainly for testing."""

--- a/tests/test_toin_fixes.py
+++ b/tests/test_toin_fixes.py
@@ -12,6 +12,8 @@ This file tests all the fixes made to the TOIN implementation:
 
 import json
 import tempfile
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -690,3 +692,47 @@ class TestIntegration:
         if pattern:
             # Strategy should be tracked
             assert pattern.total_retrievals >= 1
+
+
+class TestAutoSaveLockScope:
+    """The periodic auto-save must not hold the instance lock across the write."""
+
+    def test_auto_save_writes_outside_the_instance_lock(self):
+        class _LockProbeBackend:
+            """Records whether the TOIN lock is free while save() performs I/O.
+
+            The probe runs on a second thread — a same-thread acquire can't
+            detect an RLock held reentrantly by the caller.
+            """
+
+            def __init__(self, lock: threading.RLock):
+                self._lock = lock
+                self.lock_free_during_write: bool | None = None
+
+            def save(self, data: dict) -> None:
+                acquired = []
+
+                def probe():
+                    got = self._lock.acquire(blocking=False)
+                    acquired.append(got)
+                    # An RLock may only be released by its owning thread.
+                    if got:
+                        self._lock.release()
+
+                t = threading.Thread(target=probe)
+                t.start()
+                t.join(timeout=5)
+                self.lock_free_during_write = acquired[0]
+
+            def load(self) -> None:
+                return None
+
+        toin = ToolIntelligenceNetwork(TOINConfig(auto_save_interval=600))
+        backend = _LockProbeBackend(toin._lock)
+        toin._backend = backend
+        toin._dirty = True
+        toin._last_save_time = time.time() - 2 * toin._config.auto_save_interval
+
+        toin._maybe_auto_save()
+
+        assert backend.lock_free_during_write is True

--- a/tests/test_toin_fixes.py
+++ b/tests/test_toin_fixes.py
@@ -710,22 +710,15 @@ class TestAutoSaveLockScope:
                 self.lock_free_during_write: bool | None = None
 
             def save(self, data: dict) -> None:
-                acquired = []
-
                 def probe():
-                    got = self._lock.acquire(blocking=False)
-                    acquired.append(got)
+                    self.lock_free_during_write = self._lock.acquire(blocking=False)
                     # An RLock may only be released by its owning thread.
-                    if got:
+                    if self.lock_free_during_write:
                         self._lock.release()
 
                 t = threading.Thread(target=probe)
                 t.start()
                 t.join(timeout=5)
-                self.lock_free_during_write = acquired[0]
-
-            def load(self) -> None:
-                return None
 
         toin = ToolIntelligenceNetwork(TOINConfig(auto_save_interval=600))
         backend = _LockProbeBackend(toin._lock)
@@ -736,3 +729,50 @@ class TestAutoSaveLockScope:
         toin._maybe_auto_save()
 
         assert backend.lock_free_during_write is True
+
+    def test_mutation_during_write_is_persisted_by_the_next_pass(self):
+        writes: list[dict] = []
+        first_write_started = threading.Event()
+        release_first_write = threading.Event()
+
+        class _BlockingBackend:
+            """Blocks the first write so a commit can race the snapshot."""
+
+            def save(self, data: dict) -> None:
+                writes.append(data)
+                if len(writes) == 1:
+                    first_write_started.set()
+                    release_first_write.wait(timeout=5)
+
+        toin = ToolIntelligenceNetwork(TOINConfig(auto_save_interval=600))
+        toin._backend = _BlockingBackend()
+        toin._dirty = True
+        toin._last_save_time = time.time() - 2 * toin._config.auto_save_interval
+
+        saver = threading.Thread(target=toin._maybe_auto_save)
+        saver.start()
+        assert first_write_started.wait(timeout=5)
+
+        # Commit while the first snapshot is mid-write. The interval flip keeps
+        # record_compression's own trailing auto-save from racing this test.
+        items = [{"id": i, "score": 100 - i} for i in range(20)]
+        signature = ToolSignature.from_items(items)
+        toin._config.auto_save_interval = 0
+        toin.record_compression(
+            tool_signature=signature,
+            original_count=20,
+            compressed_count=10,
+            original_tokens=2000,
+            compressed_tokens=1000,
+            strategy="smart_sample",
+            items=items,
+        )
+        assert toin._dirty is True
+
+        release_first_write.set()
+        saver.join(timeout=5)
+
+        # The convergence pass rewrote the snapshot including the late commit.
+        assert len(writes) == 2
+        assert any(signature.structure_hash in key for key in writes[1]["patterns"])
+        assert toin._dirty is False

--- a/tests/test_toin_fixes.py
+++ b/tests/test_toin_fixes.py
@@ -11,6 +11,7 @@ This file tests all the fixes made to the TOIN implementation:
 """
 
 import json
+import logging
 import tempfile
 import threading
 import time
@@ -776,3 +777,78 @@ class TestAutoSaveLockScope:
         assert len(writes) == 2
         assert any(signature.structure_hash in key for key in writes[1]["patterns"])
         assert toin._dirty is False
+
+    def test_save_failure_keeps_dirty_state_for_retry(self):
+        class _Capture(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.records: list[logging.LogRecord] = []
+
+            def emit(self, record: logging.LogRecord) -> None:
+                self.records.append(record)
+
+        class _FailingBackend:
+            def save(self, data: dict) -> None:
+                raise OSError("disk full")
+
+        toin = ToolIntelligenceNetwork(TOINConfig(auto_save_interval=600))
+        toin._backend = _FailingBackend()
+        toin._dirty = True
+        toin._last_save_time = time.time() - 2 * toin._config.auto_save_interval
+        before = toin._last_save_time
+
+        logger = logging.getLogger("headroom.telemetry.toin")
+        capture = _Capture()
+        logger.addHandler(capture)
+        try:
+            toin._maybe_auto_save()
+        finally:
+            logger.removeHandler(capture)
+
+        # Failed write must not advance the save clock — the next record_*
+        # trigger should retry from a fresh snapshot.
+        assert toin._dirty is True
+        assert toin._last_save_time == before
+        assert any(
+            record.levelno == logging.WARNING
+            and getattr(record, "event", None) == "toin_save_failed"
+            for record in capture.records
+        )
+
+    def test_mutations_on_every_pass_exhaust_and_stay_dirty(self):
+        writes: list[dict] = []
+
+        toin = ToolIntelligenceNetwork(TOINConfig(auto_save_interval=600))
+
+        class _MutatingBackend:
+            """Commits a new pattern during every write, racing each pass."""
+
+            def save(self, data: dict) -> None:
+                writes.append(data)
+                saved_interval = toin._config.auto_save_interval
+                # Silence the trailing auto-save inside the nested commit.
+                toin._config.auto_save_interval = 0
+                try:
+                    items = [{"id": len(writes), "score": 1}]
+                    toin.record_compression(
+                        tool_signature=ToolSignature.from_items(items),
+                        original_count=1,
+                        compressed_count=1,
+                        original_tokens=10,
+                        compressed_tokens=5,
+                        strategy="smart_sample",
+                        items=items,
+                    )
+                finally:
+                    toin._config.auto_save_interval = saved_interval
+
+        toin._backend = _MutatingBackend()
+        toin._dirty = True
+        toin._last_save_time = time.time() - 2 * 600
+
+        toin._maybe_auto_save()
+
+        # Both bounded passes wrote; neither could finalize because every pass
+        # was invalidated mid-write. Dirty stays armed for the next trigger.
+        assert len(writes) == toin._SAVE_PASSES
+        assert toin._dirty is True


### PR DESCRIPTION
## Description

TOIN's periodic auto-save held the instance `RLock` across the entire storage write. `_maybe_auto_save` called `self.save()` from inside `with self._lock:`, and because the lock is reentrant, `save()`'s own two lock acquisitions ("serialize under lock but write outside lock to prevent blocking other threads during slow file I/O", its own docstring) became no-ops. The backend write — full JSON serialization plus temp-file and atomic rename — therefore ran with the lock fully held, blocking every concurrent `record_compression` / `record_retrieval` call (the request-time API used by content routing and smart compression) for the whole file write.

Releasing the call from under the lock exposed two races the held-lock write had accidentally prevented, both fixed here:

1. `export_patterns()` nests live pattern containers (`query_pattern_frequency`, `strategy_success_rates`, `common_query_patterns`, …), so dumping them outside the lock raced concurrent mutators with `RuntimeError: dictionary changed size during iteration`, silently deferring saves via the broad failure log. The locked step now snapshots through `copy.deepcopy`.
2. A commit landing between snapshot and finalize was marked persisted without ever reaching disk (dirty cleared unconditionally; there is no shutdown flusher), stranding data until process exit. `save()` now reads a mutation counter alongside its snapshot and finalizes only when unchanged; otherwise it takes one bounded extra pass so late commits are persisted instead of lost.

Closes nothing on file — found by local code review of the telemetry lock paths (#21 in my contribution notes).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/telemetry/toin.py`:
  - `_maybe_auto_save`: eligibility check stays under the lock; `save()` is now called outside it.
  - `save()`: deep-copy snapshot under the lock, write outside, then conditional finalize gated on a `_mutations` counter bumped at every `_dirty = True` site (all mutators already hold the lock). One bounded re-snapshot pass (`_SAVE_PASSES = 2`) covers a commit racing the write; exhaustion leaves `_dirty` armed for the next trigger.
  - Docstrings corrected — they previously documented the reentrancy trap as intentional.
- `tests/test_toin_fixes.py`:
  - `TestAutoSaveLockScope::test_auto_save_writes_outside_the_instance_lock` — a fake backend probes whether the instance lock is acquirable from a **second thread** during the write (a same-thread acquire cannot detect an RLock held reentrantly).
  - `TestAutoSaveLockScope::test_mutation_during_write_is_persisted_by_the_next_pass` — a blocked first write, a real `record_compression` committed mid-write, asserting the convergence pass rewrites the snapshot including the late commit and clears the dirty flag only then.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_toin_fixes.py -q
15 passed, 8 skipped in 1.81s

$ ruff check headroom/telemetry/toin.py tests/test_toin_fixes.py
All checks passed!

$ ruff format --check headroom/telemetry/toin.py tests/test_toin_fixes.py
2 files already formatted

$ mypy headroom/telemetry/toin.py
Success: no issues found in 1 source file

Fail-before evidence (fix reverted to upstream/main, bytecode caches cleared):
$ python -m pytest "tests/test_toin_fixes.py::TestAutoSaveLockScope" -q
FAILED test_auto_save_writes_outside_the_instance_lock      # lock held during write
FAILED test_mutation_during_write_is_persisted_by_the_next_pass
    assert len(writes) == 1                                  # mid-write commit finalized away
```

The remaining failures in `tests/test_stateless_toin.py` (2) and `tests/test_toin_observation_only.py` (6) reproduce byte-for-byte on clean upstream/main `6262c28a` with this branch's changes stashed — pre-existing, unrelated to this patch.

## Real Behavior Proof

- Environment: macOS (arm64), CPython 3.13.13, project venv; branch based on upstream/main `6262c28a`.
- Exact command / steps: with the three touched files reverted to upstream/main and `__pycache__` cleared: `python -m pytest "tests/test_toin_fixes.py::TestAutoSaveLockScope" -q` (fail-before); re-applied the commits and re-ran the same command plus `ruff check`, `ruff format --check`, `mypy headroom/telemetry/toin.py`. Additional adversarial probes during review drove a commit mid-write through a blocking fake backend, injected a failure into a second pass, and raced two overlapping savers.
- Observed result: fail-before — the lock-scope test records `lock_free_during_write=False` (probe thread cannot acquire while the writer holds the RLock) and the convergence test records one write with `_dirty` cleared over an unwritten mid-write commit. After the fix — both pass (`17 passed`), the blocked-backend probe shows the late commit persisted by the second pass, a failing second pass leaves `dirty=True` with the save clock unadvanced and the structured `toin_save_failed` warning contained, and two overlapping savers converge on the newest state before returning.
- Not tested: Windows atomic-rename behavior of the backend (pre-existing coverage area); the Rust proxy path (this module is Python-only).

## Runtime Rollout Safety

- Rollout-managed feature(s): none changed — TOIN persistence behaves identically when uncontended.
- Minimum rollout channel: Stable.
- Stable/default behavior changed: timing only — request threads no longer block behind the periodic flush; on-disk format is untouched.
- Kill switch / disable path: unchanged (`auto_save_interval=0` disables auto-save).
- Unsafe override required: no.
- Qualification impact: none.
- Rollback path: revert the two commits; prior behavior restores (with the blocking write and the races it masked).

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)
