### PR TITLE
fix(transforms): drop trailing empty spreadsheet rows and stray CR in CSV render

### DIFF
--- a/headroom/transforms/spreadsheet_ingest.py
+++ b/headroom/transforms/spreadsheet_ingest.py
@@ -18,11 +18,30 @@ from pathlib import Path
 __all__ = ["load_spreadsheet"]
 
 
+def _is_blank_row(row: list[object]) -> bool:
+    return all(cell is None or str(cell).strip() == "" for cell in row)
+
+
 def _rows_to_csv(rows: list[list[object]]) -> str:
-    """Render rows to CSV text, dropping fully empty trailing rows."""
+    """Render rows to CSV text, dropping fully empty trailing rows.
+
+    openpyxl's ``iter_rows`` walks the sheet's *used range*, which routinely
+    extends past the last data row (leftover formatting, a cleared cell), so a
+    real sheet commonly ends in ``(None, None, ...)`` tuples. Those were written
+    out as blank ``,`` rows — contradicting this function's own contract — so the
+    trailing empties are dropped here first.
+
+    ``lineterminator="\\n"`` is load-bearing: ``csv.writer`` defaults to
+    ``\\r\\n``, and the old ``.strip("\\n")`` removed only the ``\\n``, leaving a
+    dangling ``\\r`` on the final line (and ``,\\r`` residue behind each undropped
+    empty row). Using ``\\n`` makes the strip clean.
+    """
+    last = len(rows)
+    while last > 0 and _is_blank_row(rows[last - 1]):
+        last -= 1
     buf = io.StringIO()
-    writer = csv.writer(buf)
-    for row in rows:
+    writer = csv.writer(buf, lineterminator="\n")
+    for row in rows[:last]:
         writer.writerow(["" if cell is None else cell for cell in row])
     return buf.getvalue().strip("\n")
 

--- a/tests/test_transforms_tabular.py
+++ b/tests/test_transforms_tabular.py
@@ -322,6 +322,29 @@ def test_router_respects_disable_flag() -> None:
 # Binary spreadsheet ingestion -----------------------------------------------
 
 
+def test_rows_to_csv_drops_trailing_empty_rows_and_has_no_dangling_cr() -> None:
+    """Trailing all-empty rows are dropped and the output has no stray ``\\r``.
+
+    openpyxl's used-range routinely extends past the last data row, so a sheet
+    commonly ends in ``(None, None, ...)`` tuples. Those were emitted as blank
+    ``,`` rows, and ``csv.writer``'s default ``\\r\\n`` terminator combined with
+    ``.strip("\\n")`` left a dangling ``\\r`` — noise fed straight to the LLM.
+    """
+    from headroom.transforms.spreadsheet_ingest import _rows_to_csv
+
+    rendered = _rows_to_csv(
+        [["Name", "Age"], ["Alice", "30"], [None, None], ["", "  "], [None, None]]
+    )
+    assert rendered == "Name,Age\nAlice,30"
+    assert "\r" not in rendered
+
+    # Interior empty rows are preserved (only the trailing run is dropped).
+    assert _rows_to_csv([["a", "b"], [None, None], ["c", "d"], [None, None]]) == "a,b\n,\nc,d"
+
+    # A fully empty sheet renders to the empty string.
+    assert _rows_to_csv([[None, None], ["", ""]]) == ""
+
+
 @pytest.mark.skipif(not _HAS_OPENPYXL, reason="openpyxl not installed")
 def test_load_and_compress_xlsx(tmp_path) -> None:
     import openpyxl


### PR DESCRIPTION
## Description

`_rows_to_csv` in the binary spreadsheet ingester does not do what its own docstring ("dropping fully empty trailing rows") says, and emits a stray carriage return:

```python
def _rows_to_csv(rows: list[list[object]]) -> str:
    """Render rows to CSV text, dropping fully empty trailing rows."""
    buf = io.StringIO()
    writer = csv.writer(buf)                 # default lineterminator = "\r\n"
    for row in rows:                         # trailing empty rows are NOT dropped
        writer.writerow(["" if cell is None else cell for cell in row])
    return buf.getvalue().strip("\n")        # strips "\n" only, leaving a dangling "\r"
```

Two problems, both hit in normal use:

1. **Trailing empty rows are not dropped.** openpyxl's `iter_rows` walks the sheet's *used range*, which routinely extends past the last data row (leftover formatting, a cleared cell), so a real sheet commonly ends in `(None, None, …)` tuples. Those get written out as blank `,` rows.
2. **A dangling `\r` is left on the output.** `csv.writer` defaults to a `\r\n` terminator, and `.strip("\n")` removes only the `\n`, so the last line ends in a bare `\r` (and every undropped trailing empty row leaves `,\r` residue).

Concretely, a sheet `[["Name","Age"], ["Alice","30"], (None,None), (None,None), (None,None)]` renders to `'Name,Age\r\nAlice,30\r\n,\r\n,\r\n,\r'` instead of `'Name,Age\nAlice,30'`. This noisy text then flows through tabular detection → SmartCrusher and on to the model — extra rows and control-character residue for every spreadsheet with a trailing used-range.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/transforms/spreadsheet_ingest.py`: drop the trailing run of fully-empty rows before writing (a row is empty when every cell is `None` or blank-after-strip), and set `csv.writer(..., lineterminator="\n")` so `.strip("\n")` leaves no dangling `\r`. Interior empty rows are preserved (only the trailing run is dropped); a fully empty sheet renders to `""`.
- `tests/test_transforms_tabular.py`: added `test_rows_to_csv_drops_trailing_empty_rows_and_has_no_dangling_cr`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
tests/test_transforms_tabular.py  ->  38 passed, 2 skipped in 1.76s
(the new test FAILS on pre-fix code, verified via git stash)
uvx ruff@0.16.2 check headroom/transforms/spreadsheet_ingest.py tests/test_transforms_tabular.py  ->  All checks passed!
uvx mypy@1.20.2 headroom/transforms/spreadsheet_ingest.py  ->  Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.16.2 and mypy 1.20.2 via uvx.
- Exact command / steps: `_rows_to_csv([["Name","Age"],["Alice","30"],[None,None],["","  "],[None,None]])` returned `'Name,Age\r\nAlice,30\r\n,\r\n,\r...'` before the fix and `'Name,Age\nAlice,30'` after; `[["a","b"],[None,None],["c","d"],[None,None]]` → `'a,b\n,\nc,d'` (interior empty kept, trailing dropped); an all-empty sheet → `''`.
- Observed result: trailing empty rows dropped, no stray `\r`, interior rows and data unchanged.
- Not tested: exercised `_rows_to_csv` directly rather than round-tripping a physical `.xlsx` (the existing `test_load_and_compress_xlsx` covers the openpyxl path; `splitlines()` there is agnostic to the terminator change).

## Runtime Rollout Safety

- Rollout-managed feature(s): none. This is the SDK-side spreadsheet ingestion adapter, not a rollout-channel-gated runtime feature.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: only the incorrect output is corrected — trailing empty rows and the stray `\r` are gone; data rows, interior empty rows, and sheet skipping are unchanged. The line terminator in the intermediate CSV text is now `\n` (it feeds text compression, not a strict CSV consumer).
- Kill switch / disable path: N/A.
- Unsafe override required: no.
- Qualification impact: none.
- Rollback path: revert this PR.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A: internal behavior)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`
