### PR TITLE
fix(proxy/memory): fail open when backend init errors instead of 500ing the request

### DIFF
--- a/headroom/proxy/memory_handler.py
+++ b/headroom/proxy/memory_handler.py
@@ -316,6 +316,27 @@ class MemoryHandler:
             self._initialized = False
             logger.info(f"Memory: backend initialization cancelled (backend={self.config.backend})")
             raise
+        except Exception as exc:
+            # Fail-open for ANY init failure, not just timeout. Memory is an
+            # optional subsystem: a backend that cannot open (e.g. a SQLite
+            # ``unable to open database file`` on a Docker Desktop macOS
+            # bind-mount, issue #3251) must NOT propagate and 500 the whole
+            # request — the docstring's fail-open contract has to hold here too.
+            # Null the possibly-half-assigned backend (same reasoning as the
+            # timeout branch) and leave ``_initialized=False`` so a later
+            # request can retry once the environment recovers.
+            existing_backend = self._backend
+            if existing_backend is not None:
+                await self._close_backend_instance(existing_backend, reason="init_error")
+            self._backend = None
+            self._initialized = False
+            logger.error(
+                "Memory: backend initialization failed (backend=%s); "
+                "serving requests without memory context. Subsequent requests will retry: %s",
+                self.config.backend,
+                exc,
+            )
+            return
 
     async def _init_backend_locked(self) -> None:
         """Actual backend-init body. Must be called with ``_init_lock`` held."""

--- a/tests/test_memory_handler_concurrent_init.py
+++ b/tests/test_memory_handler_concurrent_init.py
@@ -100,6 +100,53 @@ async def test_ensure_initialized_noop_when_disabled(tmp_path):
     assert handler._backend is None
 
 
+@pytest.mark.asyncio
+async def test_ensure_initialized_fails_open_on_backend_init_error(tmp_path, monkeypatch):
+    """A backend that cannot open must NOT propagate — memory is optional.
+
+    Regression (#3251): a SQLite ``unable to open database file`` on a Docker
+    Desktop macOS bind-mount escaped ``_ensure_initialized`` (which only caught
+    TimeoutError/CancelledError) and 500'd every request. It must fail open: log,
+    leave ``_initialized=False`` and ``_backend=None``, and let the request
+    proceed without memory.
+    """
+    import sqlite3
+
+    closed = {"n": 0}
+
+    class BrokenLocalBackend:
+        def __init__(self, config):
+            self.config = config
+
+        async def _ensure_initialized(self) -> None:
+            # Mirrors the real failure: sqlite3.connect raising mid-init after
+            # the backend object has already been assigned to self._backend.
+            raise sqlite3.OperationalError("unable to open database file")
+
+        async def close(self) -> None:
+            closed["n"] += 1
+
+    import headroom.memory.backends.local as local_mod
+
+    monkeypatch.setattr(local_mod, "LocalBackend", BrokenLocalBackend)
+
+    handler = MemoryHandler(
+        MemoryConfig(enabled=True, backend="local", db_path=str(tmp_path / "mem.db"))
+    )
+
+    # Must not raise — the whole point.
+    await handler._ensure_initialized()
+
+    assert handler._initialized is False
+    assert handler._backend is None
+    # The half-assigned backend was cleaned up.
+    assert closed["n"] == 1
+
+    # A later call retries (and fails open again) rather than short-circuiting.
+    await handler._ensure_initialized()
+    assert handler._initialized is False
+
+
 # -------------------------------------------------------------------
 # Timeout fail-open
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Description

`MemoryHandler._ensure_initialized` documents a "fail-open contract — no exception propagates to request handlers", but only `asyncio.TimeoutError` and `asyncio.CancelledError` are caught:

```python
try:
    await asyncio.wait_for(_do_init(), timeout=STARTUP_INIT_TIMEOUT_SECONDS)
except asyncio.TimeoutError:
    ... # fail open
except asyncio.CancelledError:
    ... # reset + re-raise
```

Any *other* exception raised synchronously during backend init — e.g. `sqlite3.OperationalError: unable to open database file` — escapes both handlers, propagates up through `handle_anthropic_messages` → `memory_handler` → `LocalBackend._init_locked` → `SQLiteMemoryStore._init_db`, and **500s the whole request**.

This is exactly the failure in issue #3251: on the documented macOS Docker Desktop `persistent-docker --memory` deploy, the per-project SQLite memory store cannot be opened in WAL mode over the bind-mount (a known Docker Desktop/VirtioFS + SQLite interaction), and **every** request returns `500 Internal Server Error` — even though compression, caching, and tool-search savings don't need memory at all. An optional subsystem should never take down core proxy traffic; that is Ask #3 of the issue ("a memory-store open failure on the request path should degrade gracefully instead of 500ing").

The environmental root cause (bind-mount + WAL) is out of scope here; this fixes the graceful-degradation gap so `--memory` being unavailable disables memory context for the request rather than killing it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/proxy/memory_handler.py`: added an `except Exception` branch to `_ensure_initialized` that mirrors the timeout branch — best-effort close the possibly-half-assigned backend, null it, leave `_initialized=False` so a later request retries, log an error, and **return** (fail open) instead of propagating. Ordering is preserved: `TimeoutError` (an `Exception`) is still caught first, and `CancelledError` (a `BaseException`, not an `Exception`) still falls through to its own re-raising branch.
- `tests/test_memory_handler_concurrent_init.py`: added `test_ensure_initialized_fails_open_on_backend_init_error` — a `LocalBackend` whose init raises `sqlite3.OperationalError`; asserts `_ensure_initialized` does not raise, cleans up the backend, stays uninitialized, and retries on the next call.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
tests/test_memory_handler_concurrent_init.py  ->  9 passed in 1.80s
(the new test FAILS on pre-fix code — the OperationalError propagates — verified via git stash)
uvx ruff@0.16.2 check headroom/proxy/memory_handler.py tests/test_memory_handler_concurrent_init.py  ->  All checks passed!
uvx mypy@1.20.2 headroom/proxy/memory_handler.py  ->  Success: no issues found in 1 source file
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.12.11, project venv, pytest 9.1.1, ruff 0.16.2 and mypy 1.20.2 via uvx.
- Exact command / steps: monkeypatched `LocalBackend` so its `_ensure_initialized` raises `sqlite3.OperationalError("unable to open database file")` (the #3251 failure). Before the fix, `await handler._ensure_initialized()` re-raised the error (which on the real path becomes a request 500). After the fix, it returns cleanly with `_initialized=False`, `_backend=None`, the half-init backend `close()`d once, and a later call retries.
- Observed result: a backend init failure no longer propagates; memory is skipped for the request and retried later; timeout and cancellation behavior are unchanged.
- Not tested: no live macOS Docker Desktop repro of the bind-mount/WAL open failure (environment-specific); the fail-open path is exercised by injecting the same exception the deploy hits.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. This is the memory-subsystem lazy-init on the proxy request path, not a rollout-channel-gated runtime feature.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: only the failure path — a backend that cannot initialize now disables memory for the request instead of 500ing it. Successful init, the timeout branch, and the cancellation branch are unchanged.
- Kill switch / disable path: memory is already opt-in (`MemoryConfig.enabled`); this makes a broken backend behave like memory-off for affected requests.
- Unsafe override required: no.
- Qualification impact: none for healthy deployments; broken-memory deployments go from all-requests-500 to requests-served-without-memory.
- Rollback path: revert this PR.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A: internal behavior)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

Addresses Ask #3 of #3251 (graceful degradation). The environmental root cause (Docker Desktop macOS bind-mount + SQLite WAL) and Asks #1/#2 (repro / named-volume preset) are deployment concerns left out of this code fix.
