### PR TITLE
fix(init): slugify non-ASCII directory names in local profile

### DIFF
--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -114,9 +114,9 @@ def _enable_verbose_logging() -> None:
 
 def _local_profile(cwd: Path | None = None) -> str:
     root = (cwd or Path.cwd()).resolve()
-    slug = "".join(ch if ch.isalnum() or ch in "-._" else "-" for ch in root.name.lower()).strip(
-        "-"
-    )
+    slug = "".join(
+        ch if (ch.isascii() and ch.isalnum()) or ch in "-._" else "-" for ch in root.name.lower()
+    ).strip("-")
     digest = sha1(str(root).encode("utf-8")).hexdigest()[:8]
     return validate_profile_name(f"init-{slug or 'repo'}-{digest}")
 

--- a/tests/test_cli/test_init_cli.py
+++ b/tests/test_cli/test_init_cli.py
@@ -6,6 +6,7 @@ import os
 import sys
 import types
 from contextlib import contextmanager
+from hashlib import sha1
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -17,6 +18,10 @@ except ModuleNotFoundError:  # Python < 3.11
 import click
 import pytest
 from click.testing import CliRunner
+
+
+def _digest(path: Path) -> str:
+    return sha1(str(path.resolve()).encode("utf-8")).hexdigest()[:8]
 
 
 def _load_init_module(monkeypatch):
@@ -1554,3 +1559,26 @@ def test_init_codex_strip_removes_openai_base_url(monkeypatch, tmp_path: Path) -
         f"_strip_codex_init_block must remove orphaned openai_base_url:\n{orphan_stripped}"
     )
     assert 'model = "gpt-4o"' in orphan_stripped
+
+
+def test_local_profile_slugifies_non_ascii_directory_names(monkeypatch, tmp_path) -> None:
+    init_cli, _ = _load_init_module(monkeypatch)
+
+    cjk = tmp_path / "海洋腐蚀专项"
+    cjk.mkdir()
+    accented = tmp_path / "café-app"
+    accented.mkdir()
+
+    assert init_cli._local_profile(cjk) == f"init-repo-{_digest(cjk)}"
+    assert init_cli._local_profile(accented) == f"init-caf--app-{_digest(accented)}"
+
+
+def test_local_profile_keeps_non_ascii_directories_distinct(monkeypatch, tmp_path) -> None:
+    init_cli, _ = _load_init_module(monkeypatch)
+
+    first = tmp_path / "海洋"
+    first.mkdir()
+    second = tmp_path / "腐蚀"
+    second.mkdir()
+
+    assert init_cli._local_profile(first) != init_cli._local_profile(second)


### PR DESCRIPTION
## Description

Fix `_local_profile` so project directories containing non-ASCII characters produce valid ASCII-only local profile names. `str.isalnum()` is Unicode-aware, while `validate_profile_name()` accepts only `[A-Za-z0-9._-]`; the mismatch caused `headroom init hook ensure` to fail repeatedly for affected Claude Code sessions.

Fixes #3264.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring only

## Changes Made

- Restrict preserved directory-name characters to ASCII alphanumerics plus `-._`.
- Replace other characters with `-`, retaining the existing `repo` fallback for fully non-ASCII names.
- Retain the SHA-1 digest of the resolved absolute path so distinct non-ASCII directories remain distinct.
- Add focused CJK, accented-name, and collision-resistance regression coverage.

## Testing

- [x] Focused tests pass on the submitted implementation
- [x] Ruff checks pass on the changed files
- [x] Ruff formatting passes on the changed files
- [x] New regression tests added

Author-reported validation:

```text
python -m pytest tests/test_cli/test_init_cli.py tests/test_install/test_paths.py -q
78 passed, 1 warning

ruff check headroom/cli/init.py tests/test_cli/test_init_cli.py
All checks passed!

ruff format --check headroom/cli/init.py tests/test_cli/test_init_cli.py
2 files already formatted
```

Exact-head CI is rerunning after the branch was updated from current `main`.

## Real Behavior Proof

- Environment: macOS 15 arm64, headroom-ai 0.36.5 installed with `uv tool install`, Python 3.13, invoked through Claude Code SessionStart/PreToolUse hooks.
- Exact command / steps: run `headroom init hook ensure` from a project directory named `海洋腐蚀专项` before and after the patch.
- Observed result: before the patch, profile validation rejected `init-海洋腐蚀专项-<digest>`; after the patch, `_local_profile` returns `init-repo-<digest>` and the hook exits successfully. An accented directory such as `café-app` becomes `init-caf--app-<digest>`.
- Not tested: Windows and Linux filesystem integration. Parent-only non-ASCII path components are unaffected because the slug uses `root.name`; the digest already covers the full resolved path.

## Runtime Rollout Safety

- Rollout-managed feature(s): local init profile-name derivation.
- Minimum rollout channel: normal CI-qualified release.
- Stable/default behavior changed: only directory names containing non-ASCII characters produce a different, now-valid slug; existing ASCII names are unchanged.
- Kill switch / disable path: none required; reverting this one-line predicate restores the old behavior.
- Unsafe override required: no.
- Qualification impact: focused init/path tests and exact-head repository CI must pass.
- Rollback path: revert the predicate change; profile state uses the existing path digest and requires no migration.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
- [x] Branch updated from current `main`
- [ ] Exact-head CI complete and green

## Checklist

- [x] The change preserves existing ASCII profile names.
- [x] Fully non-ASCII names retain collision resistance through the path digest.
- [x] Regression tests cover CJK and accented directory names.
- [x] `CHANGELOG.md` was not edited.
