### PR TITLE
test(agno): drop the duplicate metrics compat shim that turned lint red

### DIFF
--- a/tests/test_integrations/agno/test_model.py
+++ b/tests/test_integrations/agno/test_model.py
@@ -19,11 +19,6 @@ try:
     AGNO_AVAILABLE = True
 except ImportError:
     AGNO_AVAILABLE = False
-else:
-    try:  # agno < 3: the per-message usage dataclass lived at agno.models.metrics
-        from agno.models.metrics import Metrics
-    except ImportError:  # agno >= 3 moved it to agno.metrics, renamed MessageMetrics
-        from agno.metrics import MessageMetrics as Metrics
 
 from headroom import HeadroomConfig, HeadroomMode
 


### PR DESCRIPTION
## Description

`lint` is red on main since 36cc8001: #3260 and #3246 each carried a compat fix for the agno 3.0.0 metrics move, and after both merged the file has two - the `_response_usage()` helper from #3246 (which the fixtures actually call) and the module-level `Metrics` alias from #3260, which nothing references any more. ruff flags the alias as F401, so every CI run that includes current main fails the lint job (see main's run for the 36cc8001 push, and the refreshed run on #3209).

This deletes the dead module-level shim and keeps `_response_usage()`, which already handles both agno module layouts.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Remove the now-unused module-level `try: from agno.models.metrics import Metrics / except ImportError: from agno.metrics import MessageMetrics as Metrics` block from `tests/test_integrations/agno/test_model.py` (5 lines). No behavior change: the fixtures build usage objects through `_response_usage()`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run --frozen --extra dev ruff check tests/test_integrations/agno/test_model.py
All checks passed!
$ ruff format --check tests/test_integrations/agno/test_model.py
1 file already formatted

$ uv run --frozen --extra dev --extra agno --with agno==3.0.0 pytest tests/test_integrations/agno/ -q
================== 79 passed, 5 skipped, 1 warning in 10.05s ===================

$ uv run --frozen --extra dev --extra agno --with agno==2.9.0 pytest tests/test_integrations/agno/ -q
================== 79 passed, 5 skipped, 1 warning in 10.13s ===================
```

## Real Behavior Proof

- Environment: macOS 15 (arm64), CPython 3.12, uv-managed venv; branch = upstream/main `36cc8001` + this one commit.
- Exact command / steps: On pristine upstream/main, `ruff check tests/test_integrations/agno/test_model.py` reproduces the CI failure (`F401 agno.metrics.MessageMetrics imported but unused`, the exact error in main's lint job). Applied this commit, re-ran ruff, then the full agno suite under agno 3.0.0 and 2.9.0.
- Observed result: ruff clean; the agno suite passes under both agno majors, so both module layouts still resolve through `_response_usage()`.
- Not tested: agno 1.x (the extra's floor); mypy not re-run (tests-only, no annotations touched).

## Runtime Rollout Safety

- Rollout-managed feature(s): None - tests only.
- Minimum rollout channel: Stable.
- Stable/default behavior changed: No. No shipped code changes.
- Kill switch / disable path: Not applicable (test-only change).
- Unsafe override required: No.
- Qualification impact: None.
- Rollback path: Revert the single commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` - it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

- Deletion-only cleanup of the #3260/#3246 overlap; no new test since the lint gate itself is the regression check.
- Local pinned ruff (0.16.3) does not flag this F401 while the CI lint job's ruff does, which is why it slipped through both PRs' local checks; the fix is version-independent either way.
