### PR TITLE
test(agno): drop dead module-level Metrics import

### DIFF
--- a/tests/test_integrations/agno/test_model.py
+++ b/tests/test_integrations/agno/test_model.py
@@ -19,11 +19,6 @@ try:
     AGNO_AVAILABLE = True
 except ImportError:
     AGNO_AVAILABLE = False
-else:
-    try:  # agno < 3: the per-message usage dataclass lived at agno.models.metrics
-        from agno.models.metrics import Metrics
-    except ImportError:  # agno >= 3 moved it to agno.metrics, renamed MessageMetrics
-        from agno.metrics import MessageMetrics as Metrics
 
 from headroom import HeadroomConfig, HeadroomMode
 


### PR DESCRIPTION
Main's lint gate is red: `tests/test_integrations/agno/test_model.py:26` fails ruff F401 (`MessageMetrics as Metrics` imported but unused) after recent changes left the module-level import dead — `_response_usage()` already resolves the metrics dataclass locally for both Agno 2.x and 3.x layouts. This deletes the dead try/except block.

Every open PR inherits this failure through its merge ref (it blocked #3261's lint check), so this unblocks the queue.

- `ruff check` + `ruff format --check`: clean
- Test file behavior unchanged (the block was unused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWKCmcH47hvvoQ35wftXhE