### PR TITLE
fix(proxy/anthropic): authenticate and attribute buffered Copilot turns

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -27,7 +27,7 @@ import httpx
 from headroom.agent_savings import proxy_pipeline_kwargs
 from headroom.ccr.context_tracker import looks_like_claude_code_compact_summary
 from headroom.ccr.marker_resolution import resolve_markers_in_response
-from headroom.copilot_auth import build_copilot_upstream_url
+from headroom.copilot_auth import apply_copilot_api_auth, build_copilot_upstream_url
 from headroom.pipeline import PipelineStage, summarize_routing_markers
 from headroom.proxy.auth_mode import (
     classify_auth_mode,
@@ -3501,10 +3501,20 @@ class AnthropicHandlerMixin:
 
             # Direct Anthropic API, or a provider-compatible Anthropic
             # Messages endpoint such as Vertex AI publisher rawPredict.
+            # Both arms build through `build_copilot_upstream_url` because that
+            # is the only place `mark_request_routed_to_copilot` fires, and the
+            # outcome funnel relabels `provider` to "copilot" off that flag (see
+            # proxy/outcome.py). The resolved target reaches Copilot without any
+            # per-request `upstream_base_url` — `wrap vscode` points the
+            # Anthropic target at the Copilot host — so this else arm carries the
+            # Claude-on-Copilot traffic, and building it by f-string attributed
+            # every one of those turns to "anthropic" on the dashboard.
+            # For a non-Copilot base the builder only joins base + path, so the
+            # URL itself is unchanged.
             url = (
                 build_copilot_upstream_url(upstream_base_url, request.url.path)
                 if upstream_base_url
-                else f"{self.ANTHROPIC_API_URL}/v1/messages"
+                else build_copilot_upstream_url(self.ANTHROPIC_API_URL, "/v1/messages")
             )
             if upstream_base_url and request.url.query:
                 url = f"{url}?{request.url.query}"
@@ -3761,6 +3771,27 @@ class AnthropicHandlerMixin:
                         for _accept_key in [k for k in headers if k.lower() == "accept"]:
                             headers.pop(_accept_key, None)
                         headers["accept"] = "application/json"
+
+                    # Copilot auth is applied per-URL, and until now only the
+                    # streaming forwarder did it (``_stream_response``). This
+                    # buffered arm sends via ``_retry_request``, which forwards
+                    # headers untouched — so a Claude turn routed to Copilot
+                    # arrived with whatever the client happened to send and none
+                    # of Headroom's own credential handling: no minted or
+                    # refreshed token (the one ``wrap vscode`` hands the proxy),
+                    # no ``Copilot-Integration-Id`` default. A client token that
+                    # went stale mid-session therefore 401'd here while the
+                    # streaming path recovered.
+                    #
+                    # A non-Copilot URL returns the headers unchanged, so this is
+                    # a no-op everywhere else.
+                    #
+                    # Mutated in place for the same reason as the accept header
+                    # above: the closures below capture ``headers``, and the CCR
+                    # continuation rebuilds its own header set from it.
+                    _copilot_authed_headers = await apply_copilot_api_auth(dict(headers), url=url)
+                    headers.clear()
+                    headers.update(_copilot_authed_headers)
 
                     # Populated once the upstream answers 200 with parseable
                     # JSON, so the guard below can fall back to it (#3088).

--- a/tests/test_proxy/test_anthropic_copilot_upstream_auth.py
+++ b/tests/test_proxy/test_anthropic_copilot_upstream_auth.py
@@ -113,6 +113,23 @@ def _headers_lower(send: _Send) -> dict[str, str]:
     return {k.lower(): v for k, v in send.headers.items()}
 
 
+def _emitted_providers(anthropic_api_url: str, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Provider labels on the outcomes this request emitted.
+
+    The relabel happens inside ``emit_request_outcome``, which runs in a task
+    created by ``asyncio.shield`` — so this also pins that the flag survives the
+    context copy into that task, which asserting on the flag alone would not.
+    """
+    import headroom.telemetry.session as telemetry_session
+
+    seen: list[str] = []
+    monkeypatch.setattr(
+        telemetry_session, "record_outcome", lambda outcome: seen.append(outcome.provider)
+    )
+    _post(anthropic_api_url, monkeypatch)
+    return seen
+
+
 # --- Copilot target ---------------------------------------------------------
 
 
@@ -144,6 +161,13 @@ def test_buffered_turn_to_copilot_is_flagged_for_attribution(
     assert send.routed_to_copilot is True
 
 
+def test_buffered_turn_to_copilot_is_labeled_copilot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End of the chain: the outcome that reaches the dashboard says "copilot"."""
+    providers = contextvars.Context().run(lambda: _emitted_providers(COPILOT, monkeypatch))
+
+    assert providers == ["copilot"]
+
+
 # --- non-Copilot target (control) -------------------------------------------
 
 
@@ -157,3 +181,9 @@ def test_anthropic_target_is_left_alone(monkeypatch: pytest.MonkeyPatch) -> None
     # No Copilot credential or handshake headers invented for a non-Copilot host.
     assert headers.get("authorization") != f"Bearer {MINTED}"
     assert "copilot-integration-id" not in headers
+
+
+def test_anthropic_target_is_not_relabeled(monkeypatch: pytest.MonkeyPatch) -> None:
+    providers = contextvars.Context().run(lambda: _emitted_providers(ANTHROPIC, monkeypatch))
+
+    assert providers == ["anthropic"]

--- a/tests/test_proxy/test_anthropic_copilot_upstream_auth.py
+++ b/tests/test_proxy/test_anthropic_copilot_upstream_auth.py
@@ -1,0 +1,159 @@
+"""A Claude turn routed to GitHub Copilot must reach it authenticated, and be
+attributed to Copilot — on the buffered (non-streaming) arm, not just streaming.
+
+Copilot serves Claude models from its Anthropic surface (``/v1/messages``) on
+the same host as its OpenAI surface, so the resolved Anthropic target can be a
+Copilot host with no per-request ``x-headroom-base-url`` in play. Two things
+used to be true only on the streaming path:
+
+- **Auth.** ``apply_copilot_api_auth`` is keyed on the upstream URL and was
+  applied only by ``_stream_response``. The buffered arm sends through
+  ``_retry_request``, which forwards headers untouched, so the request carried
+  no minted token and no ``Copilot-Integration-Id``.
+- **Attribution.** ``build_copilot_upstream_url`` is the only place the
+  routed-to-Copilot flag is set, and the buffered arm built its URL by
+  f-string — so ``emit_request_outcome`` never relabeled the provider and the
+  turn showed as "anthropic".
+
+Both are pinned here at the ``_retry_request`` seam: the URL that was built, the
+headers as they went on the wire, and the flag as it stood at send time.
+"""
+
+from __future__ import annotations
+
+import contextvars
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from headroom import copilot_auth  # noqa: E402
+from headroom.proxy.server import ProxyConfig, create_app  # noqa: E402
+
+MESSAGES = "/v1/messages"
+COPILOT = "https://api.githubcopilot.com"
+ANTHROPIC = "https://api.anthropic.com"
+BODY = {
+    "model": "claude-sonnet-5",
+    "max_tokens": 16,
+    "stream": False,
+    "messages": [{"role": "user", "content": "hi"}],
+}
+MINTED = "tid_minted_for_test"
+
+
+def _make_config(**overrides) -> ProxyConfig:
+    base = {
+        "optimize": False,
+        "cache_enabled": False,
+        "rate_limit_enabled": False,
+        "mode": "token",
+    }
+    base.update(overrides)
+    return ProxyConfig(**base)
+
+
+def _stub_token_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mint a deterministic Copilot API token instead of calling GitHub."""
+
+    class _Token:
+        token = MINTED
+
+    class _Provider:
+        async def get_api_token(self, integration_id: str | None = None):
+            return _Token()
+
+    monkeypatch.setattr(copilot_auth, "get_copilot_token_provider", lambda: _Provider())
+
+
+class _Send:
+    """Capture what the buffered arm was about to put on the wire."""
+
+    def __init__(self) -> None:
+        self.url: str | None = None
+        self.headers: dict[str, str] = {}
+        self.routed_to_copilot: bool | None = None
+
+    async def __call__(self, method, url, headers, body, **kwargs):
+        self.url = url
+        self.headers = dict(headers)
+        # Read the flag where it matters: at send time, before the outcome
+        # funnel consumes it.
+        self.routed_to_copilot = copilot_auth.request_routed_to_copilot()
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": BODY["model"],
+                "content": [{"type": "text", "text": "hi"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 5, "output_tokens": 2},
+            },
+            request=httpx.Request(method, url),
+        )
+
+
+def _post(anthropic_api_url: str, monkeypatch: pytest.MonkeyPatch) -> _Send:
+    _stub_token_provider(monkeypatch)
+    send = _Send()
+    app = create_app(_make_config(anthropic_api_url=anthropic_api_url))
+    with TestClient(app) as client:
+        client.app.state.proxy._retry_request = send
+        resp = client.post(MESSAGES, json=BODY)
+    assert resp.status_code == 200
+    return send
+
+
+def _headers_lower(send: _Send) -> dict[str, str]:
+    return {k.lower(): v for k, v in send.headers.items()}
+
+
+# --- Copilot target ---------------------------------------------------------
+
+
+def test_buffered_turn_to_copilot_is_authenticated(monkeypatch: pytest.MonkeyPatch) -> None:
+    send = contextvars.Context().run(lambda: _post(COPILOT, monkeypatch))
+
+    headers = _headers_lower(send)
+    assert headers["authorization"] == f"Bearer {MINTED}"
+    # The credential and the integration id have to leave together, or GitHub
+    # cannot HMAC-validate the pair.
+    assert headers.get("copilot-integration-id")
+    assert headers.get("editor-version")
+
+
+def test_buffered_turn_to_copilot_keeps_the_v1_messages_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Copilot's Anthropic surface keeps ``/v1``; stripping it 404s (#2409)."""
+    send = contextvars.Context().run(lambda: _post(COPILOT, monkeypatch))
+
+    assert send.url == f"{COPILOT}/v1/messages"
+
+
+def test_buffered_turn_to_copilot_is_flagged_for_attribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    send = contextvars.Context().run(lambda: _post(COPILOT, monkeypatch))
+
+    assert send.routed_to_copilot is True
+
+
+# --- non-Copilot target (control) -------------------------------------------
+
+
+def test_anthropic_target_is_left_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Off the Copilot path both changes must be inert."""
+    send = contextvars.Context().run(lambda: _post(ANTHROPIC, monkeypatch))
+
+    headers = _headers_lower(send)
+    assert send.url == f"{ANTHROPIC}/v1/messages"
+    assert send.routed_to_copilot is False
+    # No Copilot credential or handshake headers invented for a non-Copilot host.
+    assert headers.get("authorization") != f"Bearer {MINTED}"
+    assert "copilot-integration-id" not in headers


### PR DESCRIPTION
## Description

Follow-up to #3258. That PR points the Anthropic target at the Copilot host so Claude models stop 401'ing. This PR fixes two things on the Anthropic path that were only ever correct on the **streaming** arm, and which #3258 makes reachable for real Copilot traffic.

Copilot serves Claude models from its Anthropic surface (`/v1/messages`) on the same host as its OpenAI surface, so the resolved Anthropic target can be a Copilot host with no per-request `upstream_base_url` involved. That is the case both arms below get wrong.

**1. The buffered arm sent no Copilot credential.** `apply_copilot_api_auth` is keyed on the upstream URL and was applied only by `_stream_response` (`handlers/streaming.py:1205`). The buffered/non-stream arm sends through `_retry_request` (`proxy/server.py:2132`), which forwards headers untouched — so the request carried whatever the client happened to send and none of Headroom's own credential handling: no minted or refreshed token (the one `wrap vscode` explicitly hands the proxy), no `Copilot-Integration-Id` default. A client token that went stale mid-session 401'd here while the streaming path recovered. That arm is not an edge case — it is the CCR `stream:true → buffered stream:false` flip, and Claude Code's non-stream retry.

**2. Copilot turns were attributed to "anthropic".** `build_copilot_upstream_url` is the only place `mark_request_routed_to_copilot` fires (`copilot_auth.py:1288`), and `emit_request_outcome` relabels the provider off that flag (`proxy/outcome.py:419`). The buffered arm built its URL by f-string, skipping the chokepoint, so those turns showed as `anthropic` on the dashboard. The URL produced is byte-identical either way — this is attribution only, not routing. `proxy/cost.py` has no Copilot-specific branch, so pricing is unaffected.

Both changes are inert off the Copilot path: `apply_copilot_api_auth` returns the headers unchanged for a non-Copilot URL, and `build_copilot_upstream_url` only joins base + path there.

Independent of #3258 and based on `main` — the gaps are reachable today by setting `ANTHROPIC_TARGET_API_URL` to a Copilot host.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `handlers/anthropic.py`: build the default-target URL through `build_copilot_upstream_url` instead of an f-string, so the routed-to-Copilot flag is set for attribution.
- `handlers/anthropic.py`: apply `apply_copilot_api_auth` on the buffered arm before the upstream send. Mutated in place, matching the accept-header handling directly above — the closures below capture `headers`, and the CCR continuation rebuilds its own header set from it, so the continuation inherits the auth too.
- New test pinning both at the `_retry_request` seam: URL built, headers as they go on the wire, and the flag as it stands at send time.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`, CI-pinned 0.16.3)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

Both new assertions fail on `main` with exactly the symptoms described, and pass with the fix:

```text
$ git stash && pytest tests/test_proxy/test_anthropic_copilot_upstream_auth.py
tests/.../test_buffered_turn_to_copilot_is_authenticated
E   KeyError: 'authorization'
tests/.../test_buffered_turn_to_copilot_is_flagged_for_attribution
E   assert False is True
==================== 2 failed, 2 passed, 1 warning in 3.38s ====================

$ git stash pop && pytest tests/test_proxy/test_anthropic_copilot_upstream_auth.py
========================= 4 passed, 1 warning in 2.88s =========================
```

The two that pass on `main` are the invariants this must not break (path `/v1` preserved per #2409, non-Copilot target untouched).

Regression run over the affected surface:

```text
$ pytest tests/ -k "copilot or anthropic or outcome or provider_registry or proxy_routes or upstream"
= 3 failed, 1111 passed, 33 skipped, 11112 deselected in 152.98s =
```

The 3 failures are `tests/test_proxy/test_openai_transport_path_prefix.py` and are **pre-existing on `main`** (verified by running that file on a clean checkout — same 3 fail). Untouched by this PR, which is Anthropic-path only.

```text
$ uvx ruff@0.16.3 check headroom/proxy/handlers/anthropic.py tests/test_proxy/test_anthropic_copilot_upstream_auth.py
All checks passed!
$ mypy headroom/proxy/handlers/anthropic.py
Success: no issues found in 1 source file
```

## Real Behavior Proof

- **Environment:** macOS arm64, Python 3.12.13, `main` @ 0.36.5.
- **Exact command / steps:** drive `POST /v1/messages` through the real app (`create_app` + `TestClient`, non-stream body) with the Anthropic target set to `https://api.githubcopilot.com`, intercepting `_retry_request` to capture what was about to go on the wire. Copilot token minting stubbed to a fixed value.
- **Observed result:** before — no `Authorization` header at all on the buffered arm, and `request_routed_to_copilot()` is `False` at send time. After — `Authorization: Bearer <minted>` plus `Copilot-Integration-Id` and `Editor-Version`, flag `True`, URL unchanged at `https://api.githubcopilot.com/v1/messages`. With a non-Copilot target, no credential is invented and the flag stays `False`.
- **Not tested:** against live `api.githubcopilot.com` — no Copilot subscription in this environment. Token minting is stubbed, so the refresh path itself is exercised only to the provider boundary. Anthropic **batch** endpoints (`/v1/messages/batches`, `handlers/anthropic.py:5066+`) still build against `self.ANTHROPIC_API_URL` and will point at Copilot, which does not serve them — pre-existing and out of scope here — filed as #3278.

## Runtime Rollout Safety

- **Rollout-managed feature(s):** none — no flag or channel involved.
- **Minimum rollout channel:** n/a.
- **Stable/default behavior changed:** no, for every non-Copilot upstream: the URL is byte-identical and `apply_copilot_api_auth` early-returns for non-Copilot URLs. Behavior changes only when the Anthropic target is a Copilot host, which is the broken case.
- **Kill switch / disable path:** set `ANTHROPIC_TARGET_API_URL` to a non-Copilot host; both paths go inert.
- **Unsafe override required:** none.
- **Qualification impact:** none.
- **Rollback path:** revert this commit — it is self-contained to one file plus a new test.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review