### PR TITLE
fix(ccr): hold the Redis max-lifetime ceiling, and cover CCR in CI on Redis and Valkey

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,7 @@ jobs:
     # run, and the suite is executed against each in turn: the backend claims
     # to be RESP-compatible rather than Redis-specific, and a claim about two
     # servers is only proven by testing two servers. They are cheap to run
-    # together — the whole backend surface is PING/SETEX/GET/TTL/EXPIRE/DEL,
+    # together — the whole backend surface is PING/SETEX/GET/EXPIRE/DEL,
     # with no Lua, no module and no cluster command, so neither sidecar needs
     # anything beyond a stock image.
     #
@@ -225,6 +225,14 @@ jobs:
           HEADROOM_TEST_REDIS_URL: redis://127.0.0.1:6379
         run: cargo test -p headroom-core --features redis --test ccr_backends
       - name: cargo test CCR backends against Valkey
+        # `!cancelled()` rather than the default (an implicit `success()`),
+        # because a step with no `if:` is skipped once an earlier step has
+        # failed. Without it a Redis failure aborts the job before this
+        # step runs and there is no Valkey result at all — which defeats
+        # the reason for having two named steps. Both servers must always
+        # report, so that "both red" (a bug in the backend) stays
+        # distinguishable from "one red" (a genuine RESP divergence).
+        if: ${{ !cancelled() }}
         env:
           HEADROOM_TEST_REDIS_URL: redis://127.0.0.1:6380
         run: cargo test -p headroom-core --features redis --test ccr_backends

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,53 @@ jobs:
     if: needs.rust-changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Sidecars for the `redis` feature's CCR backend tests below. BOTH servers
+    # run, and the suite is executed against each in turn: the backend claims
+    # to be RESP-compatible rather than Redis-specific, and a claim about two
+    # servers is only proven by testing two servers. They are cheap to run
+    # together — the whole backend surface is PING/SETEX/GET/TTL/EXPIRE/DEL,
+    # with no Lua, no module and no cluster command, so neither sidecar needs
+    # anything beyond a stock image.
+    #
+    # Distinct host ports because both listen on 6379 inside their own
+    # container; the two test steps below select a server purely by URL.
+    #
+    # Pinned by digest, not just tag, to match the supply-chain posture of
+    # the `audit` job (cargo-audit + cargo-deny) — a mutable tag would let a
+    # server under test change without a commit. Note this is stricter than
+    # the repo's compose files, which pin images by version tag alone
+    # (`qdrant/qdrant:v1.17.1`, `neo4j:5.26`); the extra strictness is here
+    # because these two containers ARE the compatibility evidence.
+    #
+    # Each digest below is the multi-arch INDEX digest, which is the only kind
+    # that works here. `docker image inspect`'s RepoDigests on a developer
+    # machine reports the digest of the single platform manifest that machine
+    # pulled, so copying it from an arm64 laptop pins an arm64 image and the
+    # amd64 runner dies with `exec format error` before any step runs. Get it
+    # with `docker buildx imagetools inspect <image> --format
+    # '{{.Manifest.Digest}}'` and check the MediaType says `image.index`.
+    services:
+      redis:
+        image: redis:8.2-alpine@sha256:30abb90e62f14b737010746def3ba99cc79fe19dcdb3d37b41f21fc62e7da19d
+        ports:
+          - 6379:6379
+        # Without a health gate the first test can connect before the server
+        # is accepting, which surfaces as a flaky `PING` failure in
+        # `RedisCcrStore::open` rather than as an obvious startup race.
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      valkey:
+        image: valkey/valkey:9.1.1-alpine@sha256:de31910896150d5e754a07d57d227cfdde4e258ddd0d1aa4607f2d2f95843715
+        ports:
+          - 6380:6379
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v7
       - name: Install stable toolchain
@@ -144,6 +191,43 @@ jobs:
         run: cargo clippy --workspace -- -D warnings
       - name: cargo test
         run: cargo test --workspace
+
+      # `--workspace` above does NOT imply `--all-features`, so the `redis`
+      # feature — and with it `ccr/backends/redis.rs` — was never compiled,
+      # linted or executed by this workflow. The two steps below close that
+      # gap. They are additive: the default-feature build stays exactly as
+      # it was, which is what keeps the in-memory and SQLite CCR backends
+      # covered by an unchanged code path.
+      #
+      # Deliberately `-p headroom-core` and not `--all-targets`: the
+      # workspace benches fail on unrelated pre-existing lints
+      # (deprecated `criterion::black_box` in `bench "ccr_store"`), so
+      # widening the scope here would drag unrelated cleanup into any PR
+      # that touches Rust.
+      - name: cargo clippy (redis feature)
+        run: cargo clippy -p headroom-core --features redis -- -D warnings
+      # Same suite, twice, once per server. Two steps rather than a job-level
+      # matrix on purpose: a matrix would re-run fmt, clippy and the whole
+      # default-feature `cargo test --workspace` for each server, which is
+      # several minutes of duplicated work to gain nothing. These two steps
+      # add roughly 9s each on top of a build that is already warm.
+      #
+      # Separate steps rather than one step with a loop so that a failure
+      # names the server in the check output — "against Valkey" red with
+      # "against Redis" green is the single most useful signal this job can
+      # produce, because it is the only thing here that isolates a genuine
+      # RESP divergence from a bug in the backend itself.
+      - name: cargo test CCR backends against Redis
+        # The redis-gated tests early-return unless this URL is set, so
+        # supplying it is what actually executes them. Contributors without
+        # a server leave it unset and the suite still passes.
+        env:
+          HEADROOM_TEST_REDIS_URL: redis://127.0.0.1:6379
+        run: cargo test -p headroom-core --features redis --test ccr_backends
+      - name: cargo test CCR backends against Valkey
+        env:
+          HEADROOM_TEST_REDIS_URL: redis://127.0.0.1:6380
+        run: cargo test -p headroom-core --features redis --test ccr_backends
 
   simulator-e2e:
     name: simulator e2e (${{ matrix.os }})

--- a/crates/headroom-core/src/ccr/backends/redis.rs
+++ b/crates/headroom-core/src/ccr/backends/redis.rs
@@ -13,9 +13,11 @@
 //! payload bytes, with a `SETEX` TTL applied on every write. The TTL is
 //! an **idle window** (#2604): every successful `get` re-arms the key's
 //! expiry, bounded by an absolute max lifetime tracked in a companion
-//! `ccr:{hash}:born` key whose own expiry marks the ceiling. Redis
-//! handles purging via key expiry — no application-side sweep needed
-//! (matching the SQLite backend's lazy-purge but at the Redis level).
+//! `ccr:{hash}:born` key. That marker outlives the ceiling it encodes by
+//! a grace period (see `born_grace_seconds`), so its *remaining* TTL —
+//! not its existence — is what carries the ceiling. Redis handles
+//! purging via key expiry — no application-side sweep needed (matching
+//! the SQLite backend's lazy-purge but at the Redis level).
 //!
 //! # Concurrency
 //!
@@ -78,10 +80,38 @@ impl RedisCcrStore {
         format!("{}:{}", self.key_prefix, hash)
     }
 
-    /// Companion key whose expiry marks the entry's absolute max
-    /// lifetime; its remaining TTL caps every idle-window re-arm.
+    /// Companion key carrying the entry's absolute max lifetime; its
+    /// remaining TTL, less `born_grace_seconds`, caps every idle-window
+    /// re-arm.
     fn born_key_for(&self, hash: &str) -> String {
         format!("{}:{}:born", self.key_prefix, hash)
+    }
+
+    /// Seconds the born marker is kept *past* the ceiling it encodes.
+    ///
+    /// The marker cannot expire exactly at the ceiling. `TTL` has
+    /// whole-second resolution, so a born key that expires at the ceiling
+    /// disappears between two `get`s rather than being observed at zero —
+    /// and a missing born key is indistinguishable from a legacy entry
+    /// that never had one, which sends `get` down the backfill path and
+    /// resets the very ceiling it was enforcing. An entry under constant
+    /// access is then pinned indefinitely.
+    ///
+    /// Holding the marker `default_ttl_seconds` longer than the ceiling
+    /// guarantees it outlives the payload key it governs — that key's own
+    /// TTL is never more than `default_ttl_seconds` — so a past-the-
+    /// ceiling entry is always observed as `remaining == 0` while its
+    /// marker still exists, and the purge fires on the next `get`.
+    fn born_grace_seconds(&self) -> u64 {
+        // `max(1)` keeps the guarantee at a zero idle TTL, where the
+        // grace would otherwise collapse to nothing.
+        self.default_ttl_seconds.max(1)
+    }
+
+    /// TTL to write on the born marker: the ceiling plus the grace.
+    fn born_key_ttl_seconds(&self) -> u64 {
+        self.max_lifetime_seconds
+            .saturating_add(self.born_grace_seconds())
     }
 
     /// Default TTL (seconds) applied on every `put`.
@@ -122,7 +152,7 @@ impl CcrStore for RedisCcrStore {
         // idle-window re-arm in `get`, so constant access cannot pin an
         // entry past `max_lifetime_seconds`.
         let born: redis::RedisResult<()> =
-            conn.set_ex(self.born_key_for(hash), 1_u8, self.max_lifetime_seconds);
+            conn.set_ex(self.born_key_for(hash), 1_u8, self.born_key_ttl_seconds());
         if let Err(err) = born {
             tracing::warn!(
                 target = "ccr.redis",
@@ -167,12 +197,16 @@ impl CcrStore for RedisCcrStore {
         let born_key = self.born_key_for(hash);
         let born_remaining: i64 = conn.ttl(&born_key).unwrap_or(-1);
         let remaining = if born_remaining >= 0 {
-            born_remaining as u64
+            // The marker outlives the ceiling by the grace period, so strip
+            // it back off to get the ceiling actually remaining. Saturates
+            // to zero once the ceiling has passed, which is the purge
+            // signal below.
+            (born_remaining as u64).saturating_sub(self.born_grace_seconds())
         } else {
             // Legacy entry written by a pre-sliding build (no born key):
             // backfill the ceiling from now rather than dropping data.
             let backfill: redis::RedisResult<()> =
-                conn.set_ex(&born_key, 1_u8, self.max_lifetime_seconds);
+                conn.set_ex(&born_key, 1_u8, self.born_key_ttl_seconds());
             if let Err(err) = backfill {
                 tracing::warn!(
                     target = "ccr.redis",

--- a/crates/headroom-core/src/ccr/backends/redis.rs
+++ b/crates/headroom-core/src/ccr/backends/redis.rs
@@ -13,11 +13,16 @@
 //! payload bytes, with a `SETEX` TTL applied on every write. The TTL is
 //! an **idle window** (#2604): every successful `get` re-arms the key's
 //! expiry, bounded by an absolute max lifetime tracked in a companion
-//! `ccr:{hash}:born` key. That marker outlives the ceiling it encodes by
-//! a grace period (see `born_grace_seconds`), so its *remaining* TTL —
-//! not its existence — is what carries the ceiling. Redis handles
-//! purging via key expiry — no application-side sweep needed (matching
-//! the SQLite backend's lazy-purge but at the Redis level).
+//! `ccr:{hash}:born` key. That marker's *value* is the entry's birth
+//! instant in unix seconds, and the ceiling is derived by comparing it
+//! to now — the same absolute-birth-instant model the SQLite backend
+//! uses in its `created_at` column and the in-memory backend uses in
+//! its `inserted: Instant`. The marker's own TTL is only a cleanup
+//! bound, so it carries no part of the ceiling arithmetic and a store
+//! reading it needs no knowledge of the TTL the writer was configured
+//! with. Redis handles purging via key expiry — no application-side
+//! sweep needed (matching the SQLite backend's lazy-purge but at the
+//! Redis level).
 //!
 //! # Concurrency
 //!
@@ -29,6 +34,8 @@
 
 #![cfg(feature = "redis")]
 
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use redis::Commands;
 
 use crate::ccr::{max_lifetime_for, CcrStore};
@@ -36,6 +43,14 @@ use crate::ccr::{max_lifetime_for, CcrStore};
 /// Key prefix applied to every CCR entry. Configurable per-deployment
 /// so multiple proxies sharing one Redis don't collide.
 const DEFAULT_KEY_PREFIX: &str = "ccr";
+
+/// Smallest value accepted as a birth instant in a born marker
+/// (2020-09-13). Builds before this one wrote a `1` placeholder there
+/// rather than a timestamp, so anything below the threshold is treated
+/// as a legacy marker and backfilled instead of being read as a birth
+/// instant somewhere in 1970 — which would purge every in-flight entry
+/// on upgrade.
+const MIN_PLAUSIBLE_BORN_AT: u64 = 1_600_000_000;
 
 /// Redis-backed CCR store. Cfg-gated behind `feature = "redis"`.
 pub struct RedisCcrStore {
@@ -54,11 +69,42 @@ impl RedisCcrStore {
         Self::open_with_prefix(url, DEFAULT_KEY_PREFIX.to_string(), default_ttl_seconds)
     }
 
+    /// Open with an explicit key prefix; the max lifetime is derived as
+    /// `8x` the idle TTL (see [`max_lifetime_for`]).
     pub fn open_with_prefix(
         url: &str,
         key_prefix: String,
         default_ttl_seconds: u64,
     ) -> redis::RedisResult<Self> {
+        let max_lifetime_seconds =
+            max_lifetime_for(std::time::Duration::from_secs(default_ttl_seconds)).as_secs();
+        Self::open_with_ttls(url, key_prefix, default_ttl_seconds, max_lifetime_seconds)
+    }
+
+    /// Open with both the idle window and the absolute ceiling set
+    /// explicitly. Mirrors `SqliteCcrStore::open_with_ttls` and
+    /// `InMemoryCcrStore::with_capacity_and_ttls` so all three backends
+    /// expose the same knobs — without it the ceiling can only ever be
+    /// `8x` the idle TTL, which forces any test of the ceiling to wait
+    /// out eight idle windows.
+    pub fn open_with_ttls(
+        url: &str,
+        key_prefix: String,
+        default_ttl_seconds: u64,
+        max_lifetime_seconds: u64,
+    ) -> redis::RedisResult<Self> {
+        // Reject a zero idle TTL loudly instead of accepting a store
+        // whose every write then fails (`feedback_no_silent_fallbacks.md`).
+        // `SETEX` requires a positive expire, so at 0 the payload write
+        // is rejected by the server and `put` becomes a no-op that logs
+        // a warning and stores nothing — a silent data-loss config.
+        if default_ttl_seconds == 0 {
+            return Err(redis::RedisError::from((
+                redis::ErrorKind::InvalidClientConfig,
+                "CCR redis backend requires default_ttl_seconds >= 1",
+                format!("got {default_ttl_seconds}; SETEX rejects a zero expire"),
+            )));
+        }
         let client = redis::Client::open(url)?;
         // Smoke-test the connection at startup so init failures are
         // loud (`feedback_no_silent_fallbacks.md`). The `PING` round-trip
@@ -66,8 +112,6 @@ impl RedisCcrStore {
         // signal.
         let mut conn = client.get_connection()?;
         let _: String = redis::cmd("PING").query(&mut conn)?;
-        let max_lifetime_seconds =
-            max_lifetime_for(std::time::Duration::from_secs(default_ttl_seconds)).as_secs();
         Ok(Self {
             client,
             key_prefix,
@@ -80,43 +124,47 @@ impl RedisCcrStore {
         format!("{}:{}", self.key_prefix, hash)
     }
 
-    /// Companion key carrying the entry's absolute max lifetime; its
-    /// remaining TTL, less `born_grace_seconds`, caps every idle-window
-    /// re-arm.
+    /// Companion key whose *value* is the entry's birth instant in unix
+    /// seconds. Every idle-window re-arm is capped by what remains of
+    /// `max_lifetime_seconds` measured from that instant.
     fn born_key_for(&self, hash: &str) -> String {
         format!("{}:{}:born", self.key_prefix, hash)
     }
 
-    /// Seconds the born marker is kept *past* the ceiling it encodes.
+    /// TTL to write on the born marker.
     ///
-    /// The marker cannot expire exactly at the ceiling. `TTL` has
-    /// whole-second resolution, so a born key that expires at the ceiling
-    /// disappears between two `get`s rather than being observed at zero —
-    /// and a missing born key is indistinguishable from a legacy entry
-    /// that never had one, which sends `get` down the backfill path and
-    /// resets the very ceiling it was enforcing. An entry under constant
-    /// access is then pinned indefinitely.
+    /// This is a cleanup bound only — the ceiling lives in the marker's
+    /// value, not in its expiry — but the marker must still outlive the
+    /// payload key it governs. If it expires first, `get` cannot tell
+    /// "past the ceiling" from "legacy entry with no marker", takes the
+    /// backfill path, and resets the very ceiling it was enforcing;
+    /// under constant access the entry is then pinned indefinitely.
     ///
-    /// Holding the marker `default_ttl_seconds` longer than the ceiling
-    /// guarantees it outlives the payload key it governs — that key's own
-    /// TTL is never more than `default_ttl_seconds` — so a past-the-
-    /// ceiling entry is always observed as `remaining == 0` while its
-    /// marker still exists, and the purge fires on the next `get`.
-    fn born_grace_seconds(&self) -> u64 {
-        // `max(1)` keeps the guarantee at a zero idle TTL, where the
-        // grace would otherwise collapse to nothing.
-        self.default_ttl_seconds.max(1)
-    }
-
-    /// TTL to write on the born marker: the ceiling plus the grace.
+    /// A payload key's TTL is never more than `default_ttl_seconds` and
+    /// is never re-armed beyond the ceiling, so holding the marker one
+    /// idle window past the ceiling is sufficient.
     fn born_key_ttl_seconds(&self) -> u64 {
         self.max_lifetime_seconds
-            .saturating_add(self.born_grace_seconds())
+            .saturating_add(self.default_ttl_seconds)
     }
 
     /// Default TTL (seconds) applied on every `put`.
     pub fn default_ttl_seconds(&self) -> u64 {
         self.default_ttl_seconds
+    }
+
+    /// Absolute max lifetime (seconds) capping the sliding idle window.
+    pub fn max_lifetime_seconds(&self) -> u64 {
+        self.max_lifetime_seconds
+    }
+
+    fn now_unix_seconds() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            // System clock before 1970 is impossible on any sane host;
+            // fall through to 0 rather than panic in the unlikely case.
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
     }
 }
 
@@ -148,11 +196,18 @@ impl CcrStore for RedisCcrStore {
             );
             return;
         }
-        // Companion max-lifetime marker: its remaining TTL caps every
-        // idle-window re-arm in `get`, so constant access cannot pin an
-        // entry past `max_lifetime_seconds`.
-        let born: redis::RedisResult<()> =
-            conn.set_ex(self.born_key_for(hash), 1_u8, self.born_key_ttl_seconds());
+        // Companion max-lifetime marker holding this entry's birth
+        // instant. `get` derives the remaining ceiling from it, so
+        // constant access cannot pin an entry past
+        // `max_lifetime_seconds`. Storing the instant rather than
+        // encoding the ceiling in the marker's TTL is what keeps the
+        // ceiling absolute: a store with a different `default_ttl_seconds`
+        // reads the same birth instant and computes the same ceiling.
+        let born: redis::RedisResult<()> = conn.set_ex(
+            self.born_key_for(hash),
+            Self::now_unix_seconds(),
+            self.born_key_ttl_seconds(),
+        );
         if let Err(err) = born {
             tracing::warn!(
                 target = "ccr.redis",
@@ -193,29 +248,57 @@ impl CcrStore for RedisCcrStore {
         };
 
         // Sliding idle window (#2604): re-arm the key's expiry on every
-        // hit, capped by the companion born-key's remaining lifetime.
+        // hit, capped by what remains of the ceiling measured from the
+        // birth instant in the companion born key.
         let born_key = self.born_key_for(hash);
-        let born_remaining: i64 = conn.ttl(&born_key).unwrap_or(-1);
-        let remaining = if born_remaining >= 0 {
-            // The marker outlives the ceiling by the grace period, so strip
-            // it back off to get the ceiling actually remaining. Saturates
-            // to zero once the ceiling has passed, which is the purge
-            // signal below.
-            (born_remaining as u64).saturating_sub(self.born_grace_seconds())
-        } else {
-            // Legacy entry written by a pre-sliding build (no born key):
-            // backfill the ceiling from now rather than dropping data.
-            let backfill: redis::RedisResult<()> =
-                conn.set_ex(&born_key, 1_u8, self.born_key_ttl_seconds());
-            if let Err(err) = backfill {
+        let born_raw: redis::RedisResult<Option<String>> = conn.get(&born_key);
+        let born_at = match born_raw {
+            // A failed read is not evidence about the ceiling, and it is
+            // not a legacy entry either. Serve the payload and leave the
+            // key's existing TTL alone: backfilling here would reset the
+            // ceiling on every transient error, which is exactly what
+            // lets constant access pin an entry indefinitely.
+            Err(err) => {
                 tracing::warn!(
                     target = "ccr.redis",
                     hash = %hash,
                     error = %err,
-                    "ccr_redis_born_backfill_failed"
+                    "ccr_redis_born_read_failed"
                 );
+                return Some(payload);
             }
-            self.max_lifetime_seconds
+            Ok(raw) => raw
+                .and_then(|raw| raw.parse::<u64>().ok())
+                .filter(|born_at| *born_at >= MIN_PLAUSIBLE_BORN_AT),
+        };
+        let remaining = match born_at {
+            Some(born_at) => {
+                // Absolute ceiling: elapsed since birth, not something
+                // recovered from a TTL, so it survives a re-arm and does
+                // not depend on this store's own TTL configuration.
+                let age = Self::now_unix_seconds().saturating_sub(born_at);
+                self.max_lifetime_seconds.saturating_sub(age)
+            }
+            None => {
+                // No marker (entry written by a pre-sliding build) or a
+                // marker holding the old `1` placeholder rather than a
+                // birth instant: backfill the ceiling from now rather
+                // than dropping data.
+                let backfill: redis::RedisResult<()> = conn.set_ex(
+                    &born_key,
+                    Self::now_unix_seconds(),
+                    self.born_key_ttl_seconds(),
+                );
+                if let Err(err) = backfill {
+                    tracing::warn!(
+                        target = "ccr.redis",
+                        hash = %hash,
+                        error = %err,
+                        "ccr_redis_born_backfill_failed"
+                    );
+                }
+                self.max_lifetime_seconds
+            }
         };
         let new_ttl = self.default_ttl_seconds.min(remaining);
         if new_ttl == 0 {

--- a/crates/headroom-core/tests/ccr_backends.rs
+++ b/crates/headroom-core/tests/ccr_backends.rs
@@ -335,6 +335,18 @@ mod redis_tests {
         std::env::var("HEADROOM_TEST_REDIS_URL").ok()
     }
 
+    /// A key prefix that is genuinely unique per run, so a leftover key
+    /// from an earlier run — or a concurrent run against a shared
+    /// server — cannot influence a result. The pid alone is not enough:
+    /// pids are recycled.
+    fn unique_prefix(tag: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        format!("ccr_test_{tag}_{}_{nanos}", std::process::id())
+    }
+
     #[test]
     fn redis_round_trip() {
         let Some(url) = redis_url() else {
@@ -401,33 +413,152 @@ mod redis_tests {
             );
             return;
         };
-        // Idle TTL 1s → ceiling 8s (the 8x multiplier, same as in-memory).
-        // 1s is the floor here because EXPIRE/TTL have whole-second
-        // resolution, so the shortest ceiling the backend can express is 8s.
-        // A unique prefix per run keeps this independent of the other tests'
-        // keyspaces and of leftovers from a previous run.
-        let store = RedisCcrStore::open_with_prefix(&url, "ccr_test_ceiling".to_string(), 1)
-            .expect("open redis store");
+        // Idle 2s with a 5s ceiling, both set explicitly rather than
+        // riding the 8x default — deriving the ceiling would force an
+        // idle TTL of 1s (the whole-second floor for EXPIRE/TTL) and so
+        // an 8s ceiling, roughly doubling this test's wall clock.
+        let store = RedisCcrStore::open_with_ttls(&url, unique_prefix("ceiling"), 2, 5)
+            .expect("open redis store with ceiling");
         let payload = "capped redis";
         let hash = compute_key(payload.as_bytes());
         store.put(&hash, payload);
-        // Touch every 900ms: inside the 1s idle window, so the entry never
-        // dies of idleness and the assertion below can only pass via the
-        // ceiling — the thing under test. The deadline is 12s, half again the
-        // 8s ceiling, so a correct backend has several touches' worth of
-        // slack to purge in.
-        let deadline = std::time::Instant::now() + Duration::from_millis(12_000);
-        let mut expired = false;
+
+        // Assert a hit before the ceiling first. Without this the test
+        // passes if the very first `get` returns None — i.e. it cannot
+        // tell "purged by the ceiling" from "purged on contact", which
+        // is what a ceiling-arithmetic bug at small TTLs looks like.
+        // Mirrors the positive assertion in the SQLite equivalent.
+        std::thread::sleep(Duration::from_millis(700));
+        assert_eq!(
+            store.get(&hash).as_deref(),
+            Some(payload),
+            "entry inside both the idle window and the ceiling must hit"
+        );
+
+        // Touch every 700ms: inside the 2s idle window, so the entry
+        // never dies of idleness and the purge below can only come from
+        // the ceiling — the thing under test.
+        let start = std::time::Instant::now();
+        let deadline = start + Duration::from_millis(12_000);
+        let mut expired_after = None;
         while std::time::Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(900));
+            std::thread::sleep(Duration::from_millis(700));
             if store.get(&hash).is_none() {
-                expired = true;
+                expired_after = Some(start.elapsed());
                 break;
             }
         }
+        let expired_after =
+            expired_after.expect("constant access must not extend an entry past its max lifetime");
+        // The 5s ceiling runs from the `put` ~0.7s before `start`, and
+        // TTL/EXPIRE truncate to whole seconds, so the earliest
+        // legitimate purge is ~3.3s into this loop. Anything much faster
+        // means the entry died of something other than the ceiling.
         assert!(
-            expired,
-            "constant access must not extend an entry past its max lifetime"
+            expired_after >= Duration::from_millis(1_500),
+            "entry was purged after only {expired_after:?} — too early to be the 5s ceiling"
+        );
+    }
+
+    #[test]
+    fn redis_ceiling_is_independent_of_the_reading_stores_ttl() {
+        let Some(url) = redis_url() else {
+            eprintln!(
+                "skipping redis_ceiling_is_independent_of_the_reading_stores_ttl: \
+                 HEADROOM_TEST_REDIS_URL not set"
+            );
+            return;
+        };
+        // Regression test: the ceiling used to be encoded as the born
+        // marker's TTL plus a grace period equal to the *writing* store's
+        // idle TTL, which `get` then subtracted using the *reading*
+        // store's idle TTL. Any store configured with a larger idle TTL
+        // than the writer therefore computed a negative remainder,
+        // saturated to zero, and purged a live entry on first read. That
+        // is the shared-keyspace case this backend exists for, and it is
+        // also what raising HEADROOM_CCR_TTL_SECONDS would have done to
+        // every in-flight entry.
+        let prefix = unique_prefix("reconfig");
+        let payload = "survives a ttl reconfiguration";
+        let hash = compute_key(payload.as_bytes());
+
+        // Writer: short idle window, generous ceiling.
+        let writer =
+            RedisCcrStore::open_with_ttls(&url, prefix.clone(), 2, 60).expect("open writing store");
+        writer.put(&hash, payload);
+
+        // Reader: same keyspace, much larger idle window — a second
+        // worker configured differently, or the same worker after an
+        // operator raised the TTL. The birth instant is absolute, so the
+        // reader must derive a ceiling that has barely elapsed and hit.
+        let reader =
+            RedisCcrStore::open_with_prefix(&url, prefix, 300).expect("open reading store");
+        assert_eq!(
+            reader.get(&hash).as_deref(),
+            Some(payload),
+            "a store with a larger idle TTL must not purge an entry nowhere near its ceiling"
+        );
+    }
+
+    #[test]
+    fn redis_legacy_born_placeholder_is_backfilled_not_purged() {
+        use redis::Commands as _;
+
+        let Some(url) = redis_url() else {
+            eprintln!(
+                "skipping redis_legacy_born_placeholder_is_backfilled_not_purged: \
+                 HEADROOM_TEST_REDIS_URL not set"
+            );
+            return;
+        };
+        // Builds before the birth-instant change wrote a `1` placeholder
+        // as the born marker's value. Read naively as a unix timestamp
+        // that is 1970, making every such entry look infinitely old and
+        // purging it on the first `get` after an upgrade. It must be
+        // recognised as a legacy marker and backfilled instead.
+        let prefix = unique_prefix("legacy_born");
+        let payload = "legacy born marker";
+        let hash = compute_key(payload.as_bytes());
+        let store = RedisCcrStore::open_with_ttls(&url, prefix.clone(), 300, 2_400)
+            .expect("open redis store");
+        store.put(&hash, payload);
+
+        let client = redis::Client::open(url.as_str()).expect("raw client");
+        let mut conn = client.get_connection().expect("raw connection");
+        let born_key = format!("{prefix}:{hash}:born");
+        let _: () = conn
+            .set_ex(&born_key, 1_u8, 2_400)
+            .expect("overwrite born marker with the legacy placeholder");
+
+        assert_eq!(
+            store.get(&hash).as_deref(),
+            Some(payload),
+            "a legacy `1` placeholder must backfill the ceiling, not purge the entry"
+        );
+        let born: String = conn.get(&born_key).expect("read back born marker");
+        assert!(
+            born.parse::<u64>().expect("born marker must be numeric") >= 1_600_000_000,
+            "backfill must replace the placeholder with a unix-second birth instant, got {born}"
+        );
+    }
+
+    #[test]
+    fn redis_rejects_a_zero_idle_ttl() {
+        // No server needed — the guard runs before the client is opened,
+        // so this covers contributors with no Redis available too.
+        //
+        // A zero idle TTL is accepted by `SqliteCcrStore` but makes every
+        // Redis `SETEX` fail server-side, so without this guard the store
+        // opens fine and then silently stores nothing.
+        //
+        // Matched rather than `expect_err`'d because `RedisCcrStore` holds a
+        // `redis::Client` and so cannot derive `Debug`.
+        let Err(err) = RedisCcrStore::open("redis://127.0.0.1:6379", 0) else {
+            panic!("a zero idle TTL must be rejected at open");
+        };
+        assert!(
+            err.to_string().contains("default_ttl_seconds"),
+            "the error must name the offending setting, got: {err}"
         );
     }
 }

--- a/crates/headroom-core/tests/ccr_backends.rs
+++ b/crates/headroom-core/tests/ccr_backends.rs
@@ -392,4 +392,42 @@ mod redis_tests {
         std::thread::sleep(Duration::from_millis(3_100));
         assert_eq!(store.get(&hash), None);
     }
+
+    #[test]
+    fn redis_max_lifetime_caps_sliding_window() {
+        let Some(url) = redis_url() else {
+            eprintln!(
+                "skipping redis_max_lifetime_caps_sliding_window: HEADROOM_TEST_REDIS_URL not set"
+            );
+            return;
+        };
+        // Idle TTL 1s → ceiling 8s (the 8x multiplier, same as in-memory).
+        // 1s is the floor here because EXPIRE/TTL have whole-second
+        // resolution, so the shortest ceiling the backend can express is 8s.
+        // A unique prefix per run keeps this independent of the other tests'
+        // keyspaces and of leftovers from a previous run.
+        let store = RedisCcrStore::open_with_prefix(&url, "ccr_test_ceiling".to_string(), 1)
+            .expect("open redis store");
+        let payload = "capped redis";
+        let hash = compute_key(payload.as_bytes());
+        store.put(&hash, payload);
+        // Touch every 900ms: inside the 1s idle window, so the entry never
+        // dies of idleness and the assertion below can only pass via the
+        // ceiling — the thing under test. The deadline is 12s, half again the
+        // 8s ceiling, so a correct backend has several touches' worth of
+        // slack to purge in.
+        let deadline = std::time::Instant::now() + Duration::from_millis(12_000);
+        let mut expired = false;
+        while std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(900));
+            if store.get(&hash).is_none() {
+                expired = true;
+                break;
+            }
+        }
+        assert!(
+            expired,
+            "constant access must not extend an entry past its max lifetime"
+        );
+    }
 }

--- a/docs/content/docs/ccr.mdx
+++ b/docs/content/docs/ccr.mdx
@@ -162,11 +162,15 @@ The compression store is pluggable. Which backend you run decides whether a `hea
 call still resolves after a restart, and whether it resolves when it lands on a different worker
 than the one that did the compressing.
 
+The table below describes the **Rust core's** backends (`CcrBackendConfig`). The Python proxy path
+has its own, narrower set — see [Python proxy path](#python-proxy-path) below, and note that it is
+the Python path that serves proxy traffic today.
+
 | Backend | Survives restart | Shared across workers | Use it when |
 |---|---|---|---|
 | In-memory | No | No | Single-process library use, tests |
 | SQLite (default) | Yes | Same host only | The default proxy deployment |
-| Redis-compatible | Yes | Across hosts | Multiple proxy workers, more than one host |
+| Redis-compatible <br/>*(not yet operator-selectable)* | Yes | Across hosts | Multiple proxy workers, more than one host |
 
 The default is SQLite, at `ccr_store.db` under the workspace directory. That is deliberate: the
 30-minute retention window assumes a store that outlives a single request, and a file-backed store
@@ -185,10 +189,10 @@ original; [Valkey](https://valkey.io/) is a BSD-licensed, RESP-compatible fork o
 licensing and operational grounds, not on Headroom compatibility.
 
 The reason that choice is genuinely free is how little of either server the backend uses. Its entire
-server-side surface is six commands — `PING`, `SETEX`, `GET`, `TTL`, `EXPIRE` and `DEL` — plus the
+server-side surface is five commands — `PING`, `SETEX`, `GET`, `EXPIRE` and `DEL` — plus the
 `CLIENT SETINFO` handshake the client library sends when it connects. No Lua scripting, no module
 dependency, no cluster-specific command. That makes compatibility a narrow, checkable question rather
-than an open-ended one: all seven commands were exercised against **Redis 8.2** and **Valkey 9.1**,
+than an open-ended one: all six commands were exercised against **Redis 8.2** and **Valkey 9.1**,
 with identical observed behavior on both.
 
 To run either locally:
@@ -200,6 +204,14 @@ docker run -d --name redis  -p 127.0.0.1:6379:6379 redis:8.2-alpine
 # ...or
 docker run -d --name valkey -p 127.0.0.1:6379:6379 valkey/valkey:9.1.1-alpine
 ```
+
+<Callout type="warning" title="Securing a shared server">
+  That loopback binding is doing real work. The store holds **uncompressed** tool output — file
+  contents, logs, API responses — so anything beyond a local container needs the transport and the
+  server locked down: connect with `rediss://` for TLS, set `requirepass` or an ACL user, and keep
+  the server on a private network rather than a public interface. Note that the `rediss://` path is
+  not yet covered by the test suite; CI exercises `redis://` against both servers.
+</Callout>
 
 Because the dependency is optional, the backend is only compiled when the `redis` Cargo feature is
 enabled. The same flag gates its test suite, which needs a server URL to run against — the URL scheme
@@ -252,8 +264,9 @@ so an entry the agent keeps coming back to stays available through a long run in
 mid-session. To stop constant access from pinning an entry forever, each original also carries an
 absolute ceiling of eight times the idle TTL, measured from when it was first stored; once that
 ceiling passes, the entry is purged on its next access rather than served. This is what the
-`TTL`, `EXPIRE` and `DEL` commands in the Redis-compatible backend's surface are doing — reading the
-remaining ceiling, re-arming the idle window against it, and purging once it runs out.
+`GET`, `EXPIRE` and `DEL` commands in the Redis-compatible backend's surface are doing — reading the
+stored birth instant to work out what is left of the ceiling, re-arming the idle window against it,
+and purging once it runs out.
 
 ## Message-level CCR
 

--- a/docs/content/docs/ccr.mdx
+++ b/docs/content/docs/ccr.mdx
@@ -156,6 +156,85 @@ response = client.chat.completions.create(
 </Tab>
 </Tabs>
 
+## Storage backends
+
+The compression store is pluggable. Which backend you run decides whether a `headroom_retrieve`
+call still resolves after a restart, and whether it resolves when it lands on a different worker
+than the one that did the compressing.
+
+| Backend | Survives restart | Shared across workers | Use it when |
+|---|---|---|---|
+| In-memory | No | No | Single-process library use, tests |
+| SQLite (default) | Yes | Same host only | The default proxy deployment |
+| Redis-compatible | Yes | Across hosts | Multiple proxy workers, more than one host |
+
+The default is SQLite, at `ccr_store.db` under the workspace directory. That is deliberate: the
+30-minute retention window assumes a store that outlives a single request, and a file-backed store
+is shared by every worker on the host for free.
+
+The reason the third row exists is that SQLite stops being enough as soon as the workers are spread
+over more than one machine. Compression happens on whichever worker received the request, but the
+LLM's follow-up `headroom_retrieve` call can arrive at any of them. With a host-local store, that
+either forces sticky sessions at the load balancer or produces retrieval misses. A Redis-compatible
+store removes the constraint — every worker reads and writes the same keyspace.
+
+### Running CCR on Redis or Valkey
+
+Either server works, with no Headroom-side difference between them. [Redis](https://redis.io/) is the
+original; [Valkey](https://valkey.io/) is a BSD-licensed, RESP-compatible fork of it. Pick on
+licensing and operational grounds, not on Headroom compatibility.
+
+The reason that choice is genuinely free is how little of either server the backend uses. Its entire
+server-side surface is six commands — `PING`, `SETEX`, `GET`, `TTL`, `EXPIRE` and `DEL` — plus the
+`CLIENT SETINFO` handshake the client library sends when it connects. No Lua scripting, no module
+dependency, no cluster-specific command. That makes compatibility a narrow, checkable question rather
+than an open-ended one: all seven commands were exercised against **Redis 8.2** and **Valkey 9.1**,
+with identical observed behavior on both.
+
+To run either locally:
+
+```bash
+# Bound to loopback: the store holds uncompressed tool output, and both
+# containers ship with no authentication.
+docker run -d --name redis  -p 127.0.0.1:6379:6379 redis:8.2-alpine
+# ...or
+docker run -d --name valkey -p 127.0.0.1:6379:6379 valkey/valkey:9.1.1-alpine
+```
+
+Because the dependency is optional, the backend is only compiled when the `redis` Cargo feature is
+enabled. The same flag gates its test suite, which needs a server URL to run against — the URL scheme
+is `redis://` for both servers, since Valkey speaks the same protocol:
+
+```bash
+HEADROOM_TEST_REDIS_URL=redis://127.0.0.1:6379 \
+  cargo test -p headroom-core --features redis --test ccr_backends
+```
+
+Without `HEADROOM_TEST_REDIS_URL` those tests report themselves as skipped and the rest of the suite
+still runs, so a contributor with no server available is never blocked. CI runs the suite **twice, once
+against each server**, alongside `cargo clippy --features redis` — so the two-server claim above is
+re-checked on every change rather than being a one-off measurement.
+
+<Callout type="warning" title="Not yet selectable from configuration">
+  The Redis-compatible backend is implemented and tested, but `CcrBackendConfig` is not yet read
+  from operator-facing configuration — so there is currently no environment variable or config key
+  that switches the Rust core onto it. Until that wiring lands, the backend is reachable only by
+  constructing the store directly. Treat this section as a description of the backend's state, not
+  as a deployment recipe.
+</Callout>
+
+### Python proxy path
+
+The Python path resolves its backend from `HEADROOM_CCR_BACKEND`, which accepts `memory`,
+`sqlite` (the default when unset), or the name of a backend registered under the
+`headroom.ccr_backend` setuptools entry point.
+
+No Redis-compatible adapter ships in the box. Setting `HEADROOM_CCR_BACKEND=redis` without having
+installed a package that registers that entry-point name logs a warning and falls back to the
+in-process store, which means retrieval quietly stops surviving restarts. An out-of-tree adapter
+receives its connection URL from `HEADROOM_REDIS_URL` and an optional key namespace from
+`HEADROOM_CCR_TENANT_PREFIX`.
+
 ## Retention
 
 Proxy CCR originals are kept for 1800 seconds (30 minutes) by default. For longer autonomous
@@ -167,6 +246,14 @@ HEADROOM_CCR_TTL_SECONDS=7200 headroom proxy
 
 Check the effective setting at `/v1/retrieve/stats` under
 `store.default_ttl_seconds`.
+
+That figure is an **idle** window, not a wall-clock deadline. Every successful retrieval re-arms it,
+so an entry the agent keeps coming back to stays available through a long run instead of expiring
+mid-session. To stop constant access from pinning an entry forever, each original also carries an
+absolute ceiling of eight times the idle TTL, measured from when it was first stored; once that
+ceiling passes, the entry is purged on its next access rather than served. This is what the
+`TTL`, `EXPIRE` and `DEL` commands in the Redis-compatible backend's surface are doing — reading the
+remaining ceiling, re-arming the idle window against it, and purging once it runs out.
 
 ## Message-level CCR
 


### PR DESCRIPTION
## Description

`ccr/backends/redis.rs` had never been compiled, linted or executed by CI, because
`cargo test --workspace` and `cargo clippy --workspace` do not imply `--all-features` and its tests
are additionally gated on `HEADROOM_TEST_REDIS_URL`. Writing the one ceiling test the backend was
missing surfaced a real defect in it. This PR fixes that defect, adds the test, puts **two** service
containers — Redis and Valkey — in front of the `redis` feature and runs the suite against each, and
documents the compression store's backends, which `docs/` did not mention at all.

Both servers rather than one because what the backend claims is RESP compatibility, not Redis
support, and a claim about two servers is only proven by testing two servers. The repo had no Redis
or Valkey image anywhere before this — not in CI, not in any compose file.

Closes #3184.

One thing to read before the diff: **the fix in here is not the fix #3184 proposed.** That issue
suggested holding the born marker a grace period past the ceiling it encodes; I implemented that,
then self-review found it wrong, and this PR ships a different model. [Where this diverges from
\#3184](#where-this-diverges-from-3184) below is the short version, and *The fix, and the fix to the
fix* has the arithmetic.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- **`crates/headroom-core/src/ccr/backends/redis.rs`** — the max-lifetime ceiling is now derived from
  a birth instant stored as the `:born` marker's *value*, rather than encoded in the marker's expiry.
  Also on the same code path: a failed born-marker read no longer resets the ceiling; `open_with_ttls`
  exposes the idle window and the ceiling separately, matching both sibling backends; a zero
  `default_ttl_seconds` is rejected at `open` instead of silently failing every write.
- **`crates/headroom-core/tests/ccr_backends.rs`** — adds `redis_max_lifetime_caps_sliding_window`
  (the test that found the bug), plus `redis_ceiling_is_independent_of_the_reading_stores_ttl`,
  `redis_legacy_born_placeholder_is_backfilled_not_purged` and `redis_rejects_a_zero_idle_ttl`.
  Key prefixes are now unique per run.
- **`.github/workflows/rust.yml`** — two digest-pinned, health-gated service containers (Redis on
  `6379`, Valkey on `6380`), `cargo clippy` with the `redis` feature on, and the CCR suite run once
  per server. The Valkey step carries `if: ${{ !cancelled() }}` so both servers always report.
- **`docs/content/docs/ccr.mdx`** — documents the storage backends, scopes the backend table to the
  Rust core, and adds hardening guidance for a shared server.

## The bug this PR fixes

The backend caps its sliding idle window with an absolute max lifetime, tracked in a companion
`:born` key whose *expiry* was the ceiling. Reading that with `TTL` cannot distinguish two cases —
both return `-2`:

- the marker expired, so this entry is past its ceiling → should purge
- this entry never had a marker (legacy, pre-sliding-window build) → should backfill

A past-the-ceiling entry took the second branch, got a fresh ceiling written from *now*, and
survived. An entry under constant access was pinned indefinitely, which is the exact failure the
ceiling exists to prevent.

It looked correct because there is one narrow case where it does work: `TTL` rounds to nearest, so it
reports `0` for the last ~500 ms before expiry, and a `get` landing in that window purges properly.
Measured on Valkey 9.1.1 — `PTTL 510 → TTL 1`, `PTTL 302 → TTL 0`. Touch an entry more often than
every 500 ms and the backend passes.

**It is not server-specific.** Reverting just `redis.rs` to `main` and re-running the new test against
**Redis 8.2.9** fails 3/3, matching Valkey's 5/5. So this is a defect in the backend, not a RESP
divergence — which is also the clearest demonstration of why the CI below runs both servers.

## The fix, and the fix to the fix

The first three commits held the marker `default_ttl_seconds` past the ceiling it encoded and
subtracted that grace when reading it. **Self-review found that this was itself wrong**, and the last
three commits replace it. Recording the iteration because the second defect is the more interesting
one:

the marker's TTL encoded `ceiling + writer.default_ttl_seconds`, but `get` subtracted
`reader.default_ttl_seconds`. The grace was never stored alongside the marker, so **the marker's
meaning depended on the config of whoever read it.** A reader with a larger idle TTL than the writer
computed a negative remainder, saturated it to zero, and purged a live entry on first read:

```
writer at ttl=300  -> born TTL = 2400 (8x ceiling) + 300 (grace) = 2700
reader at ttl=7200 -> 2700 - 7200 saturates to 0 -> new_ttl = 0 -> DEL, return None
```

The entry was seconds old and its own 2400 s ceiling was nowhere near passed. That is precisely the
shared-keyspace, differently-configured-workers case this backend exists for, and it is also what
raising `HEADROOM_CCR_TTL_SECONDS` would have done to every in-flight entry. Before this PR the
marker's TTL *was* the ceiling with no subtraction, so a TTL change was harmless — the grace fix
introduced the coupling.

**The replacement:** store the birth instant (unix seconds) as the born key's *value* — it previously
held an unused `1_u8` — and derive the ceiling by comparing it to now. This is the model **both**
sibling backends already use (`sqlite.rs`'s `created_at` column, `in_memory.rs`'s `inserted: Instant`),
so the ceiling becomes absolute and reader-config-independent, and the grace period disappears
entirely. The marker's TTL is now a cleanup bound only, held one idle window past the ceiling so it
cannot expire before the payload key it governs.

A marker value below `MIN_PLAUSIBLE_BORN_AT` (`1_600_000_000`) is recognised as the legacy `1`
placeholder and backfilled, rather than read as a 1970 timestamp — which would otherwise purge every
in-flight entry on upgrade.

Three further defects on the same path, fixed in the same commit:

- **A failed born read reset the ceiling.** `conn.ttl(&born_key).unwrap_or(-1)` mapped a transient
  error onto the same sentinel as "no marker", took the legacy-backfill branch and wrote a fresh
  ceiling. Under intermittent errors plus constant access an entry was pinned indefinitely — the
  original defect, re-entering through the error path. `get` now serves the payload and leaves the
  existing TTL alone, per `feedback_no_silent_fallbacks.md`.
- **No `open_with_ttls`.** The ceiling could only ever be `8x` the idle TTL, so any test of it had to
  wait out eight idle windows. Both sibling backends expose the two knobs separately; this one now
  does too.
- **A zero `default_ttl_seconds` was accepted.** The store opened fine and then failed every `SETEX`
  server-side, leaving something that logged a warning and silently persisted nothing. Now rejected
  at `open`, which is also the one redis test that needs no server.

## Where this diverges from #3184

Everything in the issue's *Proposed Solution* ships as written — two health-gated, digest-pinned
sidecars on the existing ubuntu `test` job, two named steps rather than a job-level matrix, distinct
host ports, `-p headroom-core` rather than `--all-targets`, and the storage-backends section in
`ccr.mdx` including the "not yet operator-selectable" statement — with three exceptions:

- **The fix is different, because the one I proposed was wrong.** #3184 said to "hold the born marker
  a grace period *past* the ceiling it encodes, so its **remaining** TTL rather than its existence is
  what carries the ceiling," and claimed "same stored value format — no migration in either
  direction." I implemented exactly that, and it is broken: the grace is not stored anywhere, so
  `get` subtracts the *reader's* `default_ttl_seconds` from a marker whose TTL encoded the *writer's*.
  A reader configured with a larger idle window purges a seconds-old entry on first read. This PR
  stores the birth instant as the marker's value instead. That **does** change the stored value format
  — the old `1` placeholder is now recognised and backfilled, which is what keeps the upgrade
  non-destructive. Details and the arithmetic are in *The fix, and the fix to the fix*.
- **Five server commands, not six.** #3184 inventoried `PING`, `SETEX`, `GET`, `TTL`, `EXPIRE`, `DEL`.
  `TTL` is gone: the ceiling is now read out of the marker's *value* with `GET`. The argument built on
  that inventory — no Lua, no module, no cluster command, so the server choice is free — is unchanged
  and, if anything, slightly stronger.
- **Four redis tests became seven, and 15/15 became 18/18.** Beyond the ceiling test the issue named,
  the reader-TTL regression test, the legacy-marker upgrade test and the zero-TTL config test are new.
  The counts in the issue were measured before those existed.

Also worth flagging against the issue's own framing: #3184 is filed as `[FEATURE]` because the CI and
docs work is additive, but the `redis.rs` change is a **bug fix** on a code path that is real today,
which is why the PR title and the Type of Change boxes read that way.

## Integration scope

- **Asked for:** enable and CI-prove the existing `RedisCcrStore`; add the missing ceiling test;
  document the storage backends.
- **Beyond that:** the ceiling fix. Not planned — writing the required test found it. Included rather
  than filed separately because the test cannot pass without it, and shipping the test alone would
  have meant shipping a green check over a broken mechanism.
- **Deliberately kept out:** wiring `CcrBackendConfig` into operator-facing config, cluster mode, TLS,
  and the Python-side adapter — the four items #3184 lists as out of scope. They stay out; the
  follow-ups at the bottom restate them.

## Redis and Valkey

The backend's entire server-side surface is `PING`, `SETEX`, `GET`, `EXPIRE`, `DEL`, plus the
`CLIENT SETINFO` handshake `redis-rs` sends per connection. No Lua, no module, no cluster-specific
command. `TTL` is no longer among them: the ceiling is read out of the marker's value with `GET`.
All were replayed against a live Valkey 9.1.1 with the server's own `MONITOR` recording the wire
traffic, so the inventory reflects what the client actually sent rather than what a source reading
predicts — `CLIENT SETINFO` appears nowhere in Headroom's code and was the most frequent command on
the wire.

**Incompatibilities found: none**, in either direction. No key-space, TTL-resolution or return-value
divergence.

| | Redis | Valkey |
|---|---|---|
| Image | `redis:8.2-alpine` | `valkey/valkey:9.1.1-alpine` |
| `INFO server` | `redis_version:8.2.9` | `valkey_version:9.1.1`, `redis_version:7.2.4`, `server_name:valkey` |
| `MODULE LIST` | search, bloom, timeseries, ReJSON, vectorset | `lua` only |
| CCR suite | 18/18 | 18/18 |

That module-list row is the one visible difference between the two images, and it is worth stating
precisely because it changes nothing here: the backend uses none of those modules, which is exactly
why a five-command surface makes the server choice free.

## Test coverage

| Area | Before | After |
|---|---|---|
| `redis` feature compiled in CI | never | `cargo clippy -p headroom-core --features redis -- -D warnings` |
| Redis CCR tests executed | never (double-gated) | 7 tests, run twice — once per server |
| Server coverage | none | Redis 8.2 **and** Valkey 9.1, both as service containers |
| Ceiling / max-lifetime | untested (in-memory and SQLite both had a test; Redis did not) | `redis_max_lifetime_caps_sliding_window` |
| Ceiling independent of the reader's TTL | untested | `redis_ceiling_is_independent_of_the_reading_stores_ttl` |
| Legacy born marker on upgrade | untested | `redis_legacy_born_placeholder_is_backfilled_not_purged` |
| Zero-TTL config | accepted silently | `redis_rejects_a_zero_idle_ttl` |
| `DEL`, born-key backfill | reached by no test | reached by the new tests |

`redis_max_lifetime_caps_sliding_window` touches every 700 ms against a 2 s idle window and a 5 s
ceiling, so idleness cannot be what kills the entry — only the ceiling can. It asserts a hit *before*
the ceiling and pins how long the purge took, so it can no longer pass if the very first `get` returns
`None` — which is what a ceiling-arithmetic bug at small TTLs looks like, and is why the original
version of this test did not catch the grace-period defect.

`redis_ceiling_is_independent_of_the_reading_stores_ttl` is the regression test for that defect, and it
was confirmed against the pre-fix code rather than assumed: restoring the grace arithmetic makes it
fail with `left: None, right: Some("survives a ttl reconfiguration")`.

## CI changes

Two service containers on the ubuntu `test` job (Redis on `6379`, Valkey on `6380`, since both listen
on 6379 inside their own container) plus three steps: clippy with the feature on, then the CCR suite
once per server, selected purely by `HEADROOM_TEST_REDIS_URL`. This is a new pattern for the repo — no
workflow had a service container — so it is scoped to one job, health-gated (`redis-cli` / `valkey-cli
ping`) so a startup race surfaces as a service failure rather than a flaky `PING` inside
`RedisCcrStore::open`.

**Two steps, not a matrix.** A job-level matrix would re-run `fmt`, `clippy` and the whole
default-feature `cargo test --workspace` per server — minutes of duplicated work for no extra signal.
Two steps add ~9 s each on an already-warm build. Keeping them separately *named* also means a failure
identifies the server, which is the only signal in this job that distinguishes a genuine RESP
divergence from a backend bug.

**The Valkey step carries `if: ${{ !cancelled() }}`.** A step with no `if:` has an implicit
`success()` condition, so it is skipped once an earlier step has failed — meaning a Redis failure
would abort the job before Valkey ran, and there would be no Valkey result at all. That defeats the
reason for having two named steps: "both red" (a backend bug) is only distinguishable from "one red"
(a RESP divergence) if both servers always report.

**On digest pinning.** Both images are pinned by digest, which is stricter than this repo's compose
files (`qdrant/qdrant:v1.17.1`, `neo4j:5.26` — version tags only). The asymmetry is deliberate: those
containers are a dev convenience, whereas these two *are* the compatibility evidence, so a mutable tag
would let the servers under test change without a commit. Happy to drop to version tags for
consistency if you'd rather. Both pins are multi-arch **index** digests — a platform-specific digest
(what `docker image inspect` reports on an arm64 machine) fails the amd64 runner with `exec format
error` before any step runs, and the workflow carries a comment saying so.

Deliberately **not** `--all-targets`: the workspace benches fail on unrelated pre-existing lints
(deprecated `criterion::black_box`, 9 errors in bench `ccr_store`, plus two lints under
`transforms/`). Confirmed pre-existing by control runs on an unmodified tree. Widening the scope here
would drag unrelated cleanup into every Rust PR.

## Testing

The three Python boxes below are **N/A** — no Python file changed in this PR — so the Rust
equivalents are listed underneath and were all run.

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed
- [x] `cargo test --workspace` passes (58 test binaries, 0 failures)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo clippy -p headroom-core --features redis -- -D warnings` clean
- [x] `ccr_backends` green against Redis 8.2 and Valkey 9.1, locally and on a GitHub runner
- [x] `ccr_backends` green with the feature on and **no** server URL (the redis tests self-skip)
- [x] `ccr_backends` green with the feature off
- [x] The new regression test verified to fail against the pre-fix code

### Test Output

Local, against `redis:8.2-alpine` on `:6389` — identical run against `valkey/valkey:9.1.1-alpine`
on `:6390`:

```text
running 18 tests
test redis_tests::redis_rejects_a_zero_idle_ttl ... ok
test from_config_in_memory_roundtrip ... ok
test from_config_sqlite_roundtrip ... ok
test redis_tests::redis_round_trip ... ok
test redis_tests::redis_round_trip_via_from_config ... ok
test redis_tests::redis_ceiling_is_independent_of_the_reading_stores_ttl ... ok
test backend_swap_byte_equal_keys ... ok
test redis_tests::redis_legacy_born_placeholder_is_backfilled_not_purged ... ok
test sqlite_migrates_legacy_schema_without_last_accessed ... ok
test sqlite_persists_across_proxy_restart ... ok
test sqlite_round_trip ... ok
test in_memory_max_lifetime_caps_sliding_window ... ok
test in_memory_get_refreshes_idle_ttl ... ok
test sqlite_ttl_purge ... ok
test sqlite_max_lifetime_caps_sliding_window ... ok
test redis_tests::redis_max_lifetime_caps_sliding_window ... ok
test redis_tests::redis_get_refreshes_idle_ttl ... ok
test sqlite_get_refreshes_idle_ttl ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.12s
```

The control run that proves the new regression test is real — grace arithmetic restored, everything
else unchanged:

```text
running 1 test
test redis_tests::redis_ceiling_is_independent_of_the_reading_stores_ttl ... FAILED

thread 'redis_tests::redis_ceiling_is_independent_of_the_reading_stores_ttl' panicked at
crates/headroom-core/tests/ccr_backends.rs:496:9:
assertion `left == right` failed: a store with a larger idle TTL must not purge an entry nowhere
near its ceiling
  left: None
 right: Some("survives a ttl reconfiguration")

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 17 filtered out; finished in 0.01s
```

On GitHub Actions — the same workflow run on my fork before opening this PR, `test (ubuntu)` at
`87b3858`, [job 97501302103](https://github.com/daric93/headroom/actions/runs/32749002630/job/97501302103),
conclusion `success`, both sidecars up and both CCR steps green:

```text
2026-08-24T16:11:18.157Z running 18 tests
2026-08-24T16:11:18.168Z test redis_tests::redis_ceiling_is_independent_of_the_reading_stores_ttl ... ok
2026-08-24T16:11:18.171Z test redis_tests::redis_legacy_born_placeholder_is_backfilled_not_purged ... ok
2026-08-24T16:11:18.480Z test redis_tests::redis_rejects_a_zero_idle_ttl ... ok
2026-08-24T16:11:18.482Z test redis_tests::redis_round_trip ... ok
2026-08-24T16:11:18.484Z test redis_tests::redis_round_trip_via_from_config ... ok
2026-08-24T16:11:23.082Z test redis_tests::redis_max_lifetime_caps_sliding_window ... ok
2026-08-24T16:11:24.271Z test redis_tests::redis_get_refreshes_idle_ttl ... ok
2026-08-24T16:11:26.590Z test result: ok. 18 passed; 0 failed; ... finished in 8.43s
2026-08-24T16:11:26.885Z running 18 tests
   ... (second server, all seven redis tests again) ...
2026-08-24T16:11:35.318Z test result: ok. 18 passed; 0 failed; ... finished in 8.43s
```

Two independent `18 passed` blocks, each preceded by all seven redis tests named and by its own
`HEADROOM_TEST_REDIS_URL` (`:6379` then `:6380`). No `skipping redis` line anywhere, so the URLs
reached the tests and they genuinely executed against two separate servers rather than self-skipping.

## Real Behavior Proof

- Environment: macOS 15.6 (arm64), Rust 1.95.0 (the pinned toolchain), `redis` crate 0.27.6 from the
  existing `Cargo.lock`; Docker `redis:8.2-alpine` on `:6389` and `valkey/valkey:9.1.1-alpine` on
  `:6390`, running side by side. Also GitHub Actions `ubuntu-latest` with both images as service
  containers.
- Exact command / steps: `docker run -d -p 127.0.0.1:6389:6379 redis:8.2-alpine` plus the Valkey
  equivalent on `:6390`, then `HEADROOM_TEST_REDIS_URL=redis://127.0.0.1:6389 cargo test -p
  headroom-core --features redis --test ccr_backends` and the same again against `:6390`. Then
  `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, `cargo clippy -p
  headroom-core --features redis -- -D warnings` and `cargo test --workspace`.
- Observed result: 18 passed / 0 failed against each server locally (8.12 s each) and on a real
  runner (8.43 s each). `cargo test --workspace` green across 58 test binaries with 0 failures — the
  regression check that matters here, since it is the default-feature path the in-memory and SQLite
  backends run on. fmt and both clippy invocations clean. **Cross-worker retrieval in separate OS
  processes:** two independently-constructed `RedisCcrStore` instances against one Valkey, standing in
  for two proxy workers — process `pid=99432` stored a 70-byte tool-output payload and a *different*
  process `pid=99447` retrieved it byte-identical, with a third process (`valkey-cli --scan`) seeing
  both keys in the shared keyspace. That is the claim the backend exists to make, and what a
  host-local store cannot do. **The ceiling arithmetic on the wire:** after a `put` at the 300 s
  default, `TTL` on the payload key reads 291 and `GET` on the born marker returns a unix-second
  timestamp within a second of now, with the marker's own TTL at 2700 (the 8x ceiling plus one idle
  window of cleanup slack).
- Not tested: no end-to-end proxy run — `CcrBackendConfig` has no consumer outside `headroom-core`
  and `headroom-proxy` does not reference `CcrStore`, so there is no operator-facing way to point the
  proxy at this backend, which is why the cross-worker check above uses two store instances directly
  (wiring `from_config` is Phase C's job per `backends/mod.rs:26`). Single node only — cluster mode
  untested, and the backend has no cluster branch. TLS (`rediss://`) untested; verified with a
  `redis://` URL. Python side untouched — no Python file changed and `redis` is off by default, so
  `headroom._core` is byte-identical.

## Runtime Rollout Safety

- Rollout-managed feature(s): None. The `redis` Cargo feature, off by default, is the only gate; no
  runtime rollout channel is involved.
- Minimum rollout channel: N/A — nothing here reaches a rollout channel, because the backend is not
  operator-selectable at all yet (see the docs Callout and the follow-up below).
- Stable/default behavior changed: No. Default features do not compile this backend, and the
  in-memory and SQLite paths are byte-for-byte untouched — `cargo test --workspace` green confirms it.
- Kill switch / disable path: Build without `--features redis`. The backend then cannot be
  constructed and `from_config` returns `CcrBackendInitError::UnsupportedBackend`, which is itself
  covered by `from_config_redis_unsupported_when_feature_off`.
- Unsafe override required: No. No `unsafe`, no new dependency, no env var, no config key.
- Qualification impact: Adds two service containers and two ~9 s steps to the ubuntu `test` job.
  No new required status check, and the default-feature path of that job is unchanged.
- Rollback path: Revert per file — `redis.rs` alone restores the previous ceiling handling, and an
  in-flight born marker written by either version is read correctly by the other (the new code
  backfills a legacy `1`; the old code reads a timestamp as a large TTL remainder and re-arms
  conservatively). `ccr_backends.rs` alone drops the new tests. `rust.yml` is purely additive, so
  removing the `services:` block and the three steps returns CI to exactly today's behavior.
  `ccr.mdx` is documentation only.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — no UI surface. The observable output is the CI logs and the docs page, both quoted above.

## Additional Notes

**N/A checklist items.** The three Python verification boxes under `Testing` (`pytest`,
`ruff check .`, `mypy headroom`) are not applicable: no Python file changed, so `ci-precheck-python`
and `make test-parity` were not re-run either. The Rust equivalents are listed and checked in their
place.

**Heads-up: `test-agno` breaks on an unpinned dependency, independently of this PR.** On my fork's CI
(2026-08-24) three tests in `tests/test_integrations/agno/test_model.py` failed with
`ModuleNotFoundError: No module named 'agno.models.metrics'` — 3 failed / 76 passed.
`pyproject.toml:218` pins `agno>=1.0.0` and the runner resolved **agno 3.0.0**, which moved that
module. The same job was green on an unmodified `main` five hours earlier, and this PR changes no
Python file, so the cause is the new major release rather than this diff. I left it alone as out of
scope — happy to open a separate issue, or fold in a `agno<3` pin here if you'd rather. Everything
else on the branch is green.

**Two pre-existing clippy failures under `--tests`** — `transforms/code_compressor.rs:1900` (manual
`RangeInclusive::contains`) and `transforms/log_compressor.rs:1780` (field-reassign-with-default).
Both are in files this PR does not touch, and CI does not run clippy with `--tests`, so they are left
alone for the same reason the benches are excluded above.

**Follow-ups, out of scope:**

- **Wire `CcrBackendConfig` into the proxy** so the backend is operator-selectable. Until then it is
  reachable only by constructing the store directly, which the docs now say plainly rather than
  describing a deployment recipe that does not exist.
- **The Python proxy path has no Redis-compatible adapter.** `HEADROOM_CCR_BACKEND` resolves unknown
  names through the `headroom.ccr_backend` entry point; setting the value its own docstring advertises
  finds nothing, logs a warning, and **silently falls back to the in-memory store** — contradicting
  the project's own no-silent-fallbacks principle. Documented here; worth its own issue.
- **TLS is undocumented territory.** The docs now tell operators to use `rediss://` plus
  `requirepass`/ACLs for anything beyond loopback, and say plainly that the `rediss://` path is not
  itself covered by the suite. Adding a TLS sidecar to CI would close that gap.
- **`len()` returns 0 by design** — a global count would need an O(N) `KEYS` scan. Fine for the
  documented "informational" contract, but it means telemetry cannot report store size on this
  backend.

