### PR TITLE
fix(memory): reload persisted HNSW index at vector-index creation

### DIFF
--- a/headroom/memory/factory.py
+++ b/headroom/memory/factory.py
@@ -7,6 +7,7 @@ and proper wiring between components.
 
 from __future__ import annotations
 
+import logging
 import threading
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -23,6 +24,8 @@ from headroom.memory.config import (
 if TYPE_CHECKING:
     from headroom.memory.ports import Embedder, MemoryCache, MemoryStore, TextIndex, VectorIndex
 
+
+logger = logging.getLogger(__name__)
 
 # Extension groups for memory backends registered via setuptools entry points.
 _MEMORY_STORE_GROUP = "headroom.memory_store"
@@ -307,7 +310,7 @@ def _create_vector_index(config: MemoryConfig) -> VectorIndex:
         if config.db_path:
             hnsw_save_path = config.db_path.parent / f"{config.db_path.stem}_hnsw"
 
-        return HNSWVectorIndex(
+        index = HNSWVectorIndex(
             dimension=config.vector_dimension,
             ef_construction=config.hnsw_ef_construction,
             m=config.hnsw_m,
@@ -316,6 +319,31 @@ def _create_vector_index(config: MemoryConfig) -> VectorIndex:
             save_path=hnsw_save_path,
             auto_save=True,
         )
+
+        # auto_save=True persists this index on every mutation, but nothing
+        # ever loaded it back: every fresh process started empty, vector
+        # search returned nothing until rows were re-indexed, and the first
+        # write from the empty process overwrote the persisted artifacts.
+        # Reload the existing index when the artifacts are present; on
+        # mismatch or corruption, warn and start fresh instead of crashing.
+        if hnsw_save_path is not None:
+            try:
+                index.load_index(hnsw_save_path)
+                logger.info(
+                    "Memory: loaded persisted HNSW index from %s (%d entries)",
+                    hnsw_save_path,
+                    index.size,
+                )
+            except FileNotFoundError:
+                pass  # first run: nothing persisted yet
+            except Exception as exc:
+                logger.warning(
+                    "Memory: could not load persisted HNSW index at %s (%s); "
+                    "starting with an empty index",
+                    hnsw_save_path,
+                    exc,
+                )
+        return index
 
     raise ValueError(f"Unknown vector backend: {config.vector_backend}")
 

--- a/tests/test_memory/test_factory_hnsw_persistence.py
+++ b/tests/test_memory/test_factory_hnsw_persistence.py
@@ -1,0 +1,88 @@
+"""The factory must reload the persisted HNSW index instead of starting empty.
+
+``_create_vector_index`` builds ``HNSWVectorIndex`` with ``auto_save=True`` and
+a ``save_path`` derived from the db path, so every mutation persists the index
+next to the db. But nothing ever loaded those artifacts back: each fresh
+process started with an EMPTY index, so
+
+* vector search returned nothing until every row was re-indexed, and
+* the first write from the fresh process overwrote the persisted artifacts
+  with the near-empty in-memory index, discarding it for every later process.
+
+These tests fail on that behavior and pass once the factory reloads the
+persisted index when it exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from headroom.memory.config import MemoryConfig, VectorBackend
+from headroom.memory.factory import _create_vector_index
+from headroom.memory.models import Memory
+
+try:
+    from headroom.memory.adapters.hnsw import _check_hnswlib_available
+
+    HNSW_AVAILABLE = _check_hnswlib_available()
+except ImportError:
+    HNSW_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not HNSW_AVAILABLE, reason="hnswlib not installed")
+
+
+def _config(db_path: Path) -> MemoryConfig:
+    return MemoryConfig(
+        db_path=db_path,
+        vector_backend=VectorBackend.HNSW,
+        vector_dimension=8,
+    )
+
+
+def _mem(i: int) -> Memory:
+    rng = np.random.default_rng(i)
+    return Memory(
+        content=f"persisted memory {i}",
+        user_id="user",
+        embedding=rng.standard_normal(8).astype(np.float32),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fresh_index_reloads_persisted_entries(tmp_path: Path) -> None:
+    db_path = tmp_path / "memory.db"
+
+    first = _create_vector_index(_config(db_path))
+    await first.index(_mem(1))
+    await first.index(_mem(2))
+
+    # auto_save must have persisted the artifacts next to the db.
+    assert (tmp_path / "memory_hnsw.hnsw").exists()
+    assert (tmp_path / "memory_hnsw.meta").exists()
+
+    # A fresh process must see the persisted entries immediately.
+    second = _create_vector_index(_config(db_path))
+    assert second.size == 2, (
+        "fresh HNSWVectorIndex started empty: the factory did not reload the persisted index"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fresh_save_does_not_clobber_persisted_index(tmp_path: Path) -> None:
+    db_path = tmp_path / "memory.db"
+
+    first = _create_vector_index(_config(db_path))
+    await first.index(_mem(1))
+    await first.index(_mem(2))
+    assert first.size == 2
+
+    # A fresh process adds one entry; with load-on-init the persisted index
+    # keeps all previous entries instead of being rewritten from near-empty.
+    second = _create_vector_index(_config(db_path))
+    await second.index(_mem(3))
+
+    third = _create_vector_index(_config(db_path))
+    assert third.size == 3, "persisted HNSW index was clobbered by a write from a fresh process"


### PR DESCRIPTION
## Description

`_create_vector_index` builds `HNSWVectorIndex` with `auto_save=True` and a `save_path` derived from the db path, so every mutation persists the index next to the db — but **nothing ever loaded those artifacts back**. For any fresh process this means:

1. The in-memory vector index starts **empty**: vector/hybrid search returns nothing until every row is re-indexed (`HNSWVectorIndex.search` short-circuits on an empty index).
2. Worse, the **first write from the empty process overwrites the persisted artifacts** with the near-empty in-memory index (auto_save), discarding them for every later process. The cross-process persistence that the `save_path` derivation promises silently never happened.

This PR reloads the persisted index right after construction when the artifacts exist. Missing artifacts (first run) are a no-op; a dimension mismatch or corrupt artifact logs a warning and starts fresh instead of crashing, so upgrades that change `vector_dimension` cannot brick startup.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/memory/factory.py` (`_create_vector_index`, HNSW branch): construct the index into a local, call `index.load_index(hnsw_save_path)` when a save path is configured, log the restored entry count, and return it. `FileNotFoundError` → first run, pass; any other exception → warn and start empty.
- `tests/test_memory/test_factory_hnsw_persistence.py`: two regression tests (fail on `main`, pass with this change).

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

Reproduction (fails on `main`, passes with this PR):

```
$ uv run --frozen --with pytest --with pytest-asyncio --with hnswlib --with numpy \
    -m pytest tests/test_memory/test_factory_hnsw_persistence.py -q

main:    2 failed   (fresh index starts empty; persisted artifacts get clobbered)
this PR: 2 passed
```

```
FAILED tests/test_memory/test_factory_hnsw_persistence.py::test_fresh_index_reloads_persisted_entries
FAILED tests/test_memory/test_factory_hnsw_persistence.py::test_fresh_save_does_not_clobber_persisted_index
```

No regressions in the surrounding suites (identical results before/after; the 5 remaining failures in `test_factory.py` are pre-existing optional-dependency errors — `ModuleNotFoundError: No module named 'openai'` — unrelated to this change):

```
$ -m pytest tests/test_memory/test_factory.py tests/test_memory/test_hnsw_batch_capacity.py tests/test_memory/test_hierarchical.py -q
before: 5 failed, 78 passed, 4 skipped
after:  5 failed, 78 passed, 4 skipped
```

`ruff check` / `ruff format --check` clean on both changed files.

Manual verification on a long-running deployment (global memory db, headroom proxy + per-call helper processes): fresh processes went from `0` entries in the vector index to the full persisted entry count immediately, restoring vector search after every restart.
