### PR TITLE
fix(proxy): reject Anthropic batch operations on Copilot

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -27,7 +27,11 @@ import httpx
 from headroom.agent_savings import proxy_pipeline_kwargs
 from headroom.ccr.context_tracker import looks_like_claude_code_compact_summary
 from headroom.ccr.marker_resolution import resolve_markers_in_response
-from headroom.copilot_auth import apply_copilot_api_auth, build_copilot_upstream_url
+from headroom.copilot_auth import (
+    apply_copilot_api_auth,
+    build_copilot_upstream_url,
+    is_copilot_upstream_url,
+)
 from headroom.pipeline import PipelineStage, summarize_routing_markers
 from headroom.proxy.auth_mode import (
     classify_auth_mode,
@@ -4850,6 +4854,26 @@ class AnthropicHandlerMixin:
             # permanently. The emit function is idempotent.
             await _finalize_pre_upstream()
 
+    def _anthropic_batch_capability_error(self) -> Response | None:
+        """Return the stable client error for a Copilot batch target."""
+        if not is_copilot_upstream_url(self.ANTHROPIC_API_URL):
+            return None
+
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            status_code=501,
+            content={
+                "type": "error",
+                "error": {
+                    "type": "api_error",
+                    "message": (
+                        "Anthropic batch operations are not supported for Copilot targets."
+                    ),
+                },
+            },
+        )
+
     async def handle_anthropic_batch_create(
         self,
         request: Request,
@@ -4874,6 +4898,9 @@ class AnthropicHandlerMixin:
         This method applies compression to each request's messages before forwarding.
         """
         from fastapi.responses import JSONResponse, Response
+
+        if (capability_error := self._anthropic_batch_capability_error()) is not None:
+            return capability_error
 
         from headroom.ccr import CCRToolInjector
         from headroom.proxy.helpers import MAX_REQUEST_BODY_SIZE, _read_request_json
@@ -5214,6 +5241,9 @@ class AnthropicHandlerMixin:
         """
         from fastapi.responses import Response
 
+        if (capability_error := self._anthropic_batch_capability_error()) is not None:
+            return capability_error
+
         request_id = await self._next_request_id()
         start_time = time.time()
         path = request.url.path
@@ -5353,6 +5383,9 @@ class AnthropicHandlerMixin:
         4. Returns processed results with complete responses
         """
         from fastapi.responses import Response
+
+        if (capability_error := self._anthropic_batch_capability_error()) is not None:
+            return capability_error
 
         from headroom.ccr import BatchResultProcessor, get_batch_context_store
 

--- a/tests/test_copilot_auth.py
+++ b/tests/test_copilot_auth.py
@@ -901,6 +901,14 @@ def test_is_copilot_api_url_matches_ghe_copilot_hosts() -> None:
     assert not copilot_auth.is_copilot_api_url("https://not-copilot-api.acme.ghe.com/v1/responses")
 
 
+def test_is_copilot_upstream_url_matches_public_and_enterprise_hosts() -> None:
+    assert copilot_auth.is_copilot_upstream_url("https://api.githubcopilot.com/v1/messages/batches")
+    assert copilot_auth.is_copilot_upstream_url(
+        "https://copilot-api.acme.ghe.com/v1/messages/batches"
+    )
+    assert not copilot_auth.is_copilot_upstream_url("https://api.anthropic.com/v1/messages/batches")
+
+
 def test_is_copilot_api_url_trusts_configured_enterprise_api_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_proxy_batch_integration.py
+++ b/tests/test_proxy_batch_integration.py
@@ -16,15 +16,16 @@ Run with:
 
 import json
 import os
+from unittest.mock import AsyncMock
 
 import pytest
 
+httpx = pytest.importorskip("httpx")
 pytest.importorskip("fastapi")
-pytest.importorskip("httpx")
 
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: E402
 
-from headroom.proxy.server import ProxyConfig, create_app
+from headroom.proxy.server import ProxyConfig, create_app  # noqa: E402
 
 # =============================================================================
 # Fixtures
@@ -520,3 +521,134 @@ class TestBatchErrorHandling:
             content=b"not valid json",
         )
         assert response.status_code == 400
+
+
+@pytest.fixture
+def copilot_anthropic_batch_client():
+    """Create a client whose resolved Anthropic target is public Copilot."""
+    from headroom.proxy.server import HeadroomProxy
+
+    original_anthropic_api_url = HeadroomProxy.ANTHROPIC_API_URL
+    original_openai_api_url = HeadroomProxy.OPENAI_API_URL
+    config = ProxyConfig(
+        optimize=True,
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+        openai_api_url="https://api.githubcopilot.com",
+    )
+    app = create_app(config)
+    with TestClient(app) as client:
+        proxy = app.state.proxy
+        proxy.http_client = AsyncMock()
+        proxy.http_client.request.return_value = httpx.Response(
+            404,
+            json={
+                "type": "error",
+                "error": {
+                    "type": "not_found_error",
+                    "message": "Batch endpoint not found",
+                },
+            },
+        )
+        try:
+            yield client, proxy.http_client
+        finally:
+            HeadroomProxy.ANTHROPIC_API_URL = original_anthropic_api_url
+            HeadroomProxy.OPENAI_API_URL = original_openai_api_url
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs"),
+    [
+        (
+            "post",
+            "/v1/messages/batches",
+            {
+                "json": {
+                    "requests": [
+                        {
+                            "custom_id": "req-1",
+                            "params": {
+                                "model": "claude-3-5-sonnet-20241022",
+                                "max_tokens": 1024,
+                                "messages": [{"role": "user", "content": "Hello"}],
+                            },
+                        }
+                    ]
+                }
+            },
+        ),
+        ("get", "/v1/messages/batches", {}),
+        ("get", "/v1/messages/batches/batch_123", {}),
+        ("post", "/v1/messages/batches/batch_123/cancel", {}),
+        ("get", "/v1/messages/batches/batch_123/results", {}),
+    ],
+)
+def test_copilot_anthropic_batch_routes_are_rejected_before_upstream(
+    copilot_anthropic_batch_client, method, path, kwargs
+):
+    """Every registered batch route returns one stable capability response."""
+    client, http_client = copilot_anthropic_batch_client
+
+    response = getattr(client, method)(path, **kwargs)
+
+    assert response.status_code == 501
+    assert response.json() == {
+        "type": "error",
+        "error": {
+            "type": "api_error",
+            "message": "Anthropic batch operations are not supported for Copilot targets.",
+        },
+    }
+    http_client.request.assert_not_called()
+    http_client.get.assert_not_called()
+    if method == "post":
+        http_client.post.assert_not_called()
+
+
+def test_copilot_anthropic_batch_rejection_precedes_body_parsing(copilot_anthropic_batch_client):
+    """Capability rejection wins even when the batch body is invalid."""
+    client, http_client = copilot_anthropic_batch_client
+
+    response = client.post("/v1/messages/batches", content=b"not json")
+
+    assert response.status_code == 501
+    assert response.json()["error"]["type"] == "api_error"
+    http_client.request.assert_not_called()
+    http_client.post.assert_not_called()
+
+
+def test_explicit_non_copilot_anthropic_target_forwards():
+    """An explicit Anthropic target remains outside the Copilot guard."""
+    from headroom.proxy.server import HeadroomProxy
+
+    original_anthropic_api_url = HeadroomProxy.ANTHROPIC_API_URL
+    original_openai_api_url = HeadroomProxy.OPENAI_API_URL
+    config = ProxyConfig(
+        optimize=False,
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+        openai_api_url="https://api.githubcopilot.com",
+        anthropic_api_url="https://api.anthropic.com",
+    )
+    app = create_app(config)
+    try:
+        with TestClient(app) as client:
+            proxy = app.state.proxy
+            proxy.http_client = AsyncMock()
+            proxy.http_client.request.return_value = httpx.Response(200, json={"data": []})
+            http_client = proxy.http_client
+
+            response = client.get("/v1/messages/batches")
+    finally:
+        HeadroomProxy.ANTHROPIC_API_URL = original_anthropic_api_url
+        HeadroomProxy.OPENAI_API_URL = original_openai_api_url
+
+    assert response.status_code == 200
+    http_client.request.assert_called_once()
+    assert http_client.request.call_args.kwargs["url"] == (
+        "https://api.anthropic.com/v1/messages/batches"
+    )
+    http_client.post.assert_not_called()


### PR DESCRIPTION
## Description

Anthropic batch routes followed the resolved Anthropic target to GitHub Copilot, where the batch surface isn't available, and returned an opaque upstream failure. This change returns a stable unsupported response before batch parsing or mutation while preserving normal Copilot-hosted messages and explicit non-Copilot Anthropic overrides.

Closes #3278

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Added one handler-level capability check for Copilot-resolved Anthropic batch routes.
- Applied the response consistently to batch create, list, get, cancel, and results routes.
- Added regressions for Copilot batch routes and explicit Anthropic overrides. Existing provider-registry coverage continues to verify normal message target resolution.

## Testing

- [x] Unit tests pass (`uv run pytest tests/test_proxy_batch_integration.py tests/test_copilot_auth.py tests/test_provider_registry.py -q`)
- [x] Linting passes (`uv run ruff check headroom/proxy/handlers/anthropic.py tests/test_proxy_batch_integration.py tests/test_copilot_auth.py`)
- [ ] Type checking passes (`uv run mypy headroom`)
- [x] New tests added for new functionality when applicable
- [ ] Manual testing performed

### Test Output

```text
uv run python -m pytest tests/test_proxy_batch_integration.py tests/test_copilot_auth.py tests/test_provider_registry.py -q
139 passed, 14 skipped, 1 warning in 7.78s

uv run ruff check headroom/proxy/handlers/anthropic.py tests/test_proxy_batch_integration.py tests/test_copilot_auth.py
All checks passed!

git diff --check
completed without whitespace errors
```

## Real Behavior Proof

- Environment: Windows, focused Headroom test client, no live provider credential
- Exact command / steps: send Anthropic batch create and the remaining batch routes with the resolved target set to a Copilot host, then repeat with an explicit non-Copilot Anthropic target
- Observed result: the five registered Anthropic batch routes return HTTP 501 with `{"type":"error","error":{"type":"api_error","message":"Anthropic batch operations are not supported for Copilot targets."}}` before body parsing or upstream access; with OpenAI forced to `https://api.githubcopilot.com`, the explicit `https://api.anthropic.com` override forwards to `https://api.anthropic.com/v1/messages/batches`. The focused run reported `139 passed, 14 skipped, 1 warning` and the route test reported `6 passed, 17 deselected, 1 warning`.
- Not tested: live Copilot tenant

## Runtime Rollout Safety

- Rollout-managed feature(s): none
- Unsafe override required: no
- Minimum rollout channel: standard release after focused CI checks pass
- Stable/default behavior changed: Copilot-resolved Anthropic batch routes now return a deterministic unsupported response before upstream access
- Kill switch / disable path: revert the handler guard or disable the surrounding batch route configuration
- Qualification impact: ordinary Copilot messages and explicit Anthropic targets keep their existing routing paths
- Rollback path: revert the handler guard and its focused regressions; no persisted-state migration is required

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md if applicable

## Additional Notes

This follows the Anthropic message-target routing introduced in [PR #3258](https://github.com/headroomlabs-ai/headroom/pull/3258). Headroom generates changelog entries from conventional commits. The provider's hosted batch capability remains an external contract; local proof covers Headroom's deterministic guard and route behavior.
