### PR TITLE
feat(bob): add IBM Bob CLI wrap support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,7 @@ pyrightconfig.json
 
 # Local development configuration
 CLAUDE.md
+.claude/
 
 # Vitals provenance data
 .vitals/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Headroom compresses everything your AI agent reads — tool outputs, logs, RAG c
 
 - **Library** — `compress(messages)` in Python or TypeScript, inline in any app
 - **Proxy** — `headroom proxy --port 8787`, zero code changes, any language
-- **Agent wrap** — `headroom wrap claude|codex|grok|copilot|cursor|aider|opencode|cline|continue|goose|openhands|openclaw|vibe|omp|zcode` in one command; undo with `headroom unwrap <tool>`
+- **Agent wrap** — `headroom wrap claude|codex|grok|bob|copilot|cursor|aider|opencode|cline|continue|goose|openhands|openclaw|vibe|omp|zcode` in one command; undo with `headroom unwrap <tool>`
 - **MCP server** — `headroom_compress`, `headroom_retrieve`, `headroom_stats` for any MCP client
 - **Cross-agent memory** — shared store across Claude, Codex, Gemini, Grok, auto-dedup
 - **`headroom learn`** — mines failed sessions, writes corrections to `CLAUDE.local.md` (default, gitignored) or `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / `GROK.md`
@@ -230,6 +230,7 @@ shows an **Output Tokens Saved** card next to input compression, labelled
 | Claude Code  | ✅              | `--memory` · `--code-graph` · `--1m` · `--tool-search` |
 | Codex        | ✅              | shares memory with Claude        |
 | Grok CLI     | ✅              | routes via `GROK_MODELS_BASE_URL` |
+| IBM Bob      | ✅              | routes via `BOB_GATEWAY_URL`; CLI only (not the VS Code GUI); use `HEADROOM_MODE=token` |
 | Cursor       | Manual setup    | starts proxy and prints base URLs for Cursor settings |
 | Aider        | ✅              | starts proxy + launches          |
 | Copilot CLI  | ✅              | starts proxy + launches          |

--- a/benchmarks/bob_session_mode_benchmark.py
+++ b/benchmarks/bob_session_mode_benchmark.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Replay real IBM Bob sessions through baseline/token/cache simulations.
+
+The Bob counterpart to claude_session_mode_benchmark.py, deliberately much
+smaller. That harness models Anthropic's cache-prefix economics — TTL expiry,
+cache-bust turns, separate cache-read/cache-write pricing. Bob bills every
+token class at one flat rate with no cache discount, so none of that applies
+and including it would only mislead: under flat pricing the only thing that
+matters is how many tokens go over the wire.
+
+Reads ~/.bob/db/bob.db directly, reconstructs the OpenAI-shaped chat payload
+Bob would have sent on each turn, and runs it through Headroom's real
+openai_pipeline in each mode. No network, no coins, no run-to-run variance —
+so it can be re-run on every change, unlike a live A/B.
+
+    python benchmarks/bob_session_mode_benchmark.py
+    python benchmarks/bob_session_mode_benchmark.py --since 2026-08-27 --json out.json
+    python benchmarks/bob_session_mode_benchmark.py --task c38d643f
+
+What it does NOT measure: whether compression changes Bob's behaviour. A
+replay reproduces the payload, not the decisions the model makes about it, so
+turn inflation from degraded context is invisible here and needs live runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sqlite3
+import statistics
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DB = Path.home() / ".bob" / "db" / "bob.db"
+
+# Bob's flat rate: input, cacheRead, cacheWrite and output all bill the same.
+# Verified against ~/.bob/db/bob.db spend records with zero residual over 41
+# turns, which is why this harness reports one number instead of four.
+BOB_RATE_USD_PER_MTOK = 2.0
+
+MODES = ("baseline", "token", "cache")
+
+
+@dataclass
+class BobTurn:
+    """One reconstructed request: everything Bob would have posted upstream."""
+
+    task_id: str
+    seq: int
+    model: str
+    messages: list[dict[str, Any]]
+    observed_context_tokens: int = 0
+
+
+@dataclass
+class TurnResult:
+    task_id: str
+    seq: int
+    raw_tokens: int
+    forwarded_tokens: int
+
+    @property
+    def saved(self) -> int:
+        return self.raw_tokens - self.forwarded_tokens
+
+    @property
+    def saved_pct(self) -> float:
+        return 100.0 * self.saved / self.raw_tokens if self.raw_tokens else 0.0
+
+
+@dataclass
+class ModeSummary:
+    mode: str
+    turns: list[TurnResult] = field(default_factory=list)
+
+    @property
+    def raw(self) -> int:
+        return sum(t.raw_tokens for t in self.turns)
+
+    @property
+    def forwarded(self) -> int:
+        return sum(t.forwarded_tokens for t in self.turns)
+
+    @property
+    def saved(self) -> int:
+        return self.raw - self.forwarded
+
+    @property
+    def saved_pct(self) -> float:
+        return 100.0 * self.saved / self.raw if self.raw else 0.0
+
+    @property
+    def cost_usd(self) -> float:
+        return self.forwarded * BOB_RATE_USD_PER_MTOK / 1e6
+
+
+def load_turns(
+    db_path: Path,
+    since: str | None = None,
+    task_prefix: str | None = None,
+    max_tasks: int | None = None,
+) -> list[BobTurn]:
+    """Reconstruct per-turn request payloads from Bob's message log.
+
+    Bob stores one row per message rather than per request, so a turn's payload
+    is the conversation *up to and including* that point — which is exactly the
+    residency effect that makes long sessions expensive, and what compression
+    has to act on.
+    """
+    if not db_path.exists():
+        raise SystemExit(f"bob db not found: {db_path}")
+
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    con.row_factory = sqlite3.Row
+
+    q = "select id, costs, created_at from tasks"
+    where: list[str] = []
+    params: list[str | int] = []
+    if task_prefix:
+        where.append("id like ?")
+        params.append(task_prefix + "%")
+    if since:
+        try:
+            cutoff = datetime.fromisoformat(since).replace(tzinfo=timezone.utc)
+        except ValueError as exc:
+            raise SystemExit(f"--since must be ISO date (YYYY-MM-DD), got {since!r}") from exc
+        where.append("created_at > ?")
+        params.append(int(cutoff.timestamp() * 1000))
+    if where:
+        q += " where " + " and ".join(where)
+    q += " order by created_at"
+
+    tasks = con.execute(q, params).fetchall()
+    if max_tasks:
+        tasks = tasks[-max_tasks:]
+
+    turns: list[BobTurn] = []
+    for t in tasks:
+        try:
+            costs = json.loads(t["costs"] or "{}")
+        except (TypeError, ValueError):
+            costs = {}
+        rows = con.execute(
+            "select role, data from messages where task_id=? order by created_at",
+            (t["id"],),
+        ).fetchall()
+
+        convo: list[dict[str, Any]] = []
+        seq = 0
+        for r in rows:
+            try:
+                d = json.loads(r["data"])
+            except (TypeError, ValueError):
+                continue
+            msg = {"role": r["role"], "content": d.get("content") or ""}
+            # Tool calls and results carry the bulk of the payload; keep them
+            # in the shape the OpenAI pipeline expects to see.
+            if d.get("toolCalls"):
+                msg["tool_calls"] = d["toolCalls"]
+            convo.append(msg)
+            # A request is sent whenever the assistant is about to speak, so
+            # the payload is everything before that assistant message.
+            if r["role"] == "assistant" and len(convo) > 1:
+                seq += 1
+                turns.append(
+                    BobTurn(
+                        task_id=t["id"],
+                        seq=seq,
+                        model=costs.get("model") or "gpt-4o",
+                        messages=copy.deepcopy(convo[:-1]),
+                        observed_context_tokens=costs.get("contextTokens", 0),
+                    )
+                )
+    con.close()
+    return turns
+
+
+def build_proxy(mode: str) -> Any:
+    """A proxy instance configured for one mode, with no network listener."""
+    from headroom.proxy.models import ProxyConfig
+    from headroom.proxy.server import HeadroomProxy
+
+    cfg_kwargs: dict[str, Any] = {}
+    try:
+        cfg = ProxyConfig(mode=mode, **cfg_kwargs)
+    except TypeError:
+        # Older/newer ProxyConfig signatures: fall back to the default and set
+        # the attribute directly rather than guessing at keyword names.
+        cfg = ProxyConfig()
+        cfg.mode = mode
+    return HeadroomProxy(cfg)
+
+
+def count_tokens(tokenizer: Any, messages: list[dict[str, Any]]) -> int:
+    text = json.dumps(messages, separators=(",", ":"))
+    try:
+        return len(tokenizer.encode(text))
+    except Exception:
+        # The estimate only has to be consistent between arms; a tokenizer
+        # that refuses one payload must not abort the whole run.
+        return len(text) // 4
+
+
+def replay(turns: list[BobTurn], mode: str, verbose: bool = False) -> ModeSummary:
+    from headroom.tokenizers import get_tokenizer
+    from headroom.utils import extract_user_query
+
+    summary = ModeSummary(mode=mode)
+    tokenizer = get_tokenizer("gpt-4o")
+
+    if mode == "baseline":
+        for t in turns:
+            n = count_tokens(tokenizer, t.messages)
+            summary.turns.append(TurnResult(t.task_id, t.seq, n, n))
+        return summary
+
+    proxy = build_proxy(mode)
+    pipeline = proxy.openai_pipeline
+    provider = proxy.openai_provider
+
+    # Verify the treatment actually took. ProxyConfig silently accepts an
+    # unknown mode, and a benchmark that reports a mode it did not run is
+    # worse than no benchmark — this is the failure that invalidated a live
+    # session earlier: nothing asserted the mode before the work started.
+    effective = getattr(proxy.config, "mode", None)
+    if effective != mode:
+        raise SystemExit(f"mode not applied: asked for {mode!r}, proxy reports {effective!r}")
+
+    for t in turns:
+        raw = count_tokens(tokenizer, t.messages)
+        try:
+            limit = provider.get_context_limit(t.model)
+        except Exception:
+            limit = 128_000
+        # Cache mode freezes every prior turn and mutates only the latest one
+        # ("Prefix freeze: strict / Mutations: latest turn only"). Replaying it
+        # with frozen_message_count=0 lets it rewrite the whole conversation and
+        # over-credits it badly — it scored above token mode here while live
+        # measurement had it at 0.30% against token's 11.32%. Token mode
+        # re-freezes after compression, so 0 is the right floor there.
+        frozen = max(len(t.messages) - 1, 0) if mode == "cache" else 0
+        try:
+            result = pipeline.apply(
+                messages=copy.deepcopy(t.messages),
+                model=t.model,
+                model_limit=limit,
+                context=extract_user_query(t.messages),
+                frozen_message_count=frozen,
+            )
+            forwarded = count_tokens(tokenizer, result.messages)
+        except Exception as exc:  # noqa: BLE001 - one bad turn must not kill the run
+            if verbose:
+                print(f"  ! {t.task_id[:8]}#{t.seq} {mode}: {exc}", file=sys.stderr)
+            forwarded = raw
+        summary.turns.append(TurnResult(t.task_id, t.seq, raw, forwarded))
+    return summary
+
+
+def scaling_curve(s: ModeSummary) -> list[tuple[str, int, int, float]]:
+    """Savings bucketed by payload size.
+
+    This is the load-bearing view. A live measurement showed cache mode saving
+    a near-constant ~74 tokens whether the payload was 16K or 115K — so its
+    percentage collapsed exactly as sessions got expensive — while token mode's
+    savings grew with the payload. An aggregate percentage hides that.
+    """
+    buckets = [
+        ("<10K", 0, 10_000),
+        ("10-25K", 10_000, 25_000),
+        ("25-50K", 25_000, 50_000),
+        ("50K+", 50_000, 10**9),
+    ]
+    out = []
+    for label, lo, hi in buckets:
+        group = [t for t in s.turns if lo <= t.raw_tokens < hi]
+        if not group:
+            continue
+        raw = sum(t.raw_tokens for t in group)
+        saved = sum(t.saved for t in group)
+        out.append((label, len(group), saved // len(group), 100.0 * saved / raw if raw else 0.0))
+    return out
+
+
+def report(summaries: dict[str, ModeSummary], turns: list[BobTurn]) -> None:
+    tasks = len({t.task_id for t in turns})
+    print(
+        f"\nreplayed {len(turns)} turns from {tasks} Bob tasks "
+        f"(flat ${BOB_RATE_USD_PER_MTOK}/Mtok, no cache discount)\n"
+    )
+
+    base = summaries["baseline"]
+    print(
+        f"{'mode':<10}{'forwarded tok':>15}{'saved':>12}{'saved %':>10}{'cost':>10}{'vs base':>10}"
+    )
+    for mode in MODES:
+        s = summaries.get(mode)
+        if not s:
+            continue
+        delta = base.cost_usd - s.cost_usd
+        vs_base = f"-${delta:.2f}" if delta > 0 else "—"
+        print(
+            f"{mode:<10}{s.forwarded:>15,}{s.saved:>12,}{s.saved_pct:>9.2f}%"
+            f"{s.cost_usd:>10.2f}{vs_base:>10}"
+        )
+
+    for mode in MODES:
+        s = summaries.get(mode)
+        if not s or mode == "baseline":
+            continue
+        curve = scaling_curve(s)
+        if not curve:
+            continue
+        print(f"\n{mode} mode — does saving scale with payload?")
+        print(f"  {'payload':<10}{'turns':>7}{'avg saved':>12}{'saved %':>10}")
+        for label, n, avg, pct in curve:
+            print(f"  {label:<10}{n:>7}{avg:>12,}{pct:>9.2f}%")
+
+    for mode in MODES:
+        s = summaries.get(mode)
+        if not s or mode == "baseline" or not s.turns:
+            continue
+        pcts = sorted(t.saved_pct for t in s.turns)
+        print(
+            f"\n{mode} per-turn spread: median {statistics.median(pcts):.2f}%  "
+            f"p10 {pcts[len(pcts) // 10]:.2f}%  p90 {pcts[9 * len(pcts) // 10]:.2f}%"
+        )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--db", type=Path, default=DEFAULT_DB)
+    ap.add_argument("--since", help="ISO date; only tasks created after it")
+    ap.add_argument("--task", help="task id prefix, e.g. c38d643f")
+    ap.add_argument("--max-tasks", type=int, help="keep only the N most recent")
+    ap.add_argument("--modes", default=",".join(MODES))
+    ap.add_argument("--json", type=Path, help="write full per-turn results here")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    turns = load_turns(args.db, since=args.since, task_prefix=args.task, max_tasks=args.max_tasks)
+    if not turns:
+        print("no turns matched", file=sys.stderr)
+        return 1
+
+    modes = [m.strip() for m in args.modes.split(",") if m.strip()]
+    if "baseline" not in modes:
+        modes.insert(0, "baseline")
+
+    summaries: dict[str, ModeSummary] = {}
+    for mode in modes:
+        if args.verbose:
+            print(f"replaying {len(turns)} turns in {mode} mode…", file=sys.stderr)
+        summaries[mode] = replay(turns, mode, verbose=args.verbose)
+
+    report(summaries, turns)
+
+    if args.json:
+        args.json.write_text(
+            json.dumps(
+                {
+                    "rate_usd_per_mtok": BOB_RATE_USD_PER_MTOK,
+                    "turns": len(turns),
+                    "tasks": len({t.task_id for t in turns}),
+                    "modes": {
+                        m: {
+                            "raw_tokens": s.raw,
+                            "forwarded_tokens": s.forwarded,
+                            "saved_tokens": s.saved,
+                            "saved_pct": s.saved_pct,
+                            "cost_usd": s.cost_usd,
+                            "turns": [
+                                {
+                                    "task": t.task_id,
+                                    "seq": t.seq,
+                                    "raw": t.raw_tokens,
+                                    "forwarded": t.forwarded_tokens,
+                                    "saved_pct": t.saved_pct,
+                                }
+                                for t in s.turns
+                            ],
+                        }
+                        for m, s in summaries.items()
+                    },
+                },
+                indent=2,
+            )
+        )
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/bob_session_mode_benchmark.py
+++ b/benchmarks/bob_session_mode_benchmark.py
@@ -53,7 +53,10 @@ class BobTurn:
     seq: int
     model: str
     messages: list[dict[str, Any]]
-    observed_context_tokens: int = 0
+    # Memoized raw token count. The payload is identical in every mode, so
+    # counting it once instead of once per mode removes two full tokenizer
+    # passes over every turn.
+    raw_token_cache: int | None = None
 
 
 @dataclass
@@ -114,9 +117,6 @@ def load_turns(
     if not db_path.exists():
         raise SystemExit(f"bob db not found: {db_path}")
 
-    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    con.row_factory = sqlite3.Row
-
     q = "select id, costs, created_at from tasks"
     where: list[str] = []
     params: list[str | int] = []
@@ -124,12 +124,25 @@ def load_turns(
         where.append("id like ?")
         params.append(task_prefix + "%")
     if since:
+        # Parse before opening the database so a bad --since fails fast without
+        # leaving a connection behind.
         try:
-            cutoff = datetime.fromisoformat(since).replace(tzinfo=timezone.utc)
+            cutoff = datetime.fromisoformat(since)
         except ValueError as exc:
             raise SystemExit(f"--since must be ISO date (YYYY-MM-DD), got {since!r}") from exc
+        # A bare date is naive and means UTC; an explicit offset is the caller's
+        # deliberate choice, so convert rather than overwrite it.
+        cutoff = (
+            cutoff.replace(tzinfo=timezone.utc)
+            if cutoff.tzinfo is None
+            else cutoff.astimezone(timezone.utc)
+        )
         where.append("created_at > ?")
         params.append(int(cutoff.timestamp() * 1000))
+
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    con.row_factory = sqlite3.Row
+
     if where:
         q += " where " + " and ".join(where)
     q += " order by created_at"
@@ -171,8 +184,12 @@ def load_turns(
                         task_id=t["id"],
                         seq=seq,
                         model=costs.get("model") or "gpt-4o",
-                        messages=copy.deepcopy(convo[:-1]),
-                        observed_context_tokens=costs.get("contextTokens", 0),
+                        # A shallow copy of the prefix, not a deep one: `replay`
+                        # deep-copies again before handing the payload to the
+                        # pipeline, and nothing here mutates a message in place.
+                        # Deep-copying per turn made the whole load quadratic in
+                        # conversation length.
+                        messages=list(convo[:-1]),
                     )
                 )
     con.close()
@@ -191,16 +208,7 @@ def build_proxy(mode: str, disable_kompress: bool = False) -> Any:
     from headroom.proxy.models import ProxyConfig
     from headroom.proxy.server import HeadroomProxy
 
-    cfg_kwargs: dict[str, Any] = {"disable_kompress": disable_kompress}
-    try:
-        cfg = ProxyConfig(mode=mode, **cfg_kwargs)
-    except TypeError:
-        # Older/newer ProxyConfig signatures: fall back to the default and set
-        # the attributes directly rather than guessing at keyword names.
-        cfg = ProxyConfig()
-        cfg.mode = mode
-        cfg.disable_kompress = disable_kompress
-    return HeadroomProxy(cfg)
+    return HeadroomProxy(ProxyConfig(mode=mode, disable_kompress=disable_kompress))
 
 
 def count_tokens(tokenizer: Any, messages: list[dict[str, Any]]) -> int:
@@ -211,6 +219,13 @@ def count_tokens(tokenizer: Any, messages: list[dict[str, Any]]) -> int:
         # The estimate only has to be consistent between arms; a tokenizer
         # that refuses one payload must not abort the whole run.
         return len(text) // 4
+
+
+def raw_tokens(tokenizer: Any, turn: BobTurn) -> int:
+    """Token count of a turn's untouched payload, computed once per turn."""
+    if turn.raw_token_cache is None:
+        turn.raw_token_cache = count_tokens(tokenizer, turn.messages)
+    return turn.raw_token_cache
 
 
 def replay(
@@ -224,7 +239,7 @@ def replay(
 
     if mode == "baseline":
         for t in turns:
-            n = count_tokens(tokenizer, t.messages)
+            n = raw_tokens(tokenizer, t)
             summary.turns.append(TurnResult(t.task_id, t.seq, n, n))
         return summary
 
@@ -240,8 +255,9 @@ def replay(
     if effective != mode:
         raise SystemExit(f"mode not applied: asked for {mode!r}, proxy reports {effective!r}")
 
+    failures = 0
     for t in turns:
-        raw = count_tokens(tokenizer, t.messages)
+        raw = raw_tokens(tokenizer, t)
         try:
             limit = provider.get_context_limit(t.model)
         except Exception:
@@ -263,10 +279,22 @@ def replay(
             )
             forwarded = count_tokens(tokenizer, result.messages)
         except Exception as exc:  # noqa: BLE001 - one bad turn must not kill the run
+            # Counting a failed turn as "forwarded everything" is the honest
+            # floor, but it is indistinguishable from a turn that genuinely
+            # compressed to nothing. A payload shape the pipeline rejects would
+            # otherwise report 0% savings for the whole mode with no signal, so
+            # the count is always surfaced, not just under -v.
+            failures += 1
             if verbose:
                 print(f"  ! {t.task_id[:8]}#{t.seq} {mode}: {exc}", file=sys.stderr)
             forwarded = raw
         summary.turns.append(TurnResult(t.task_id, t.seq, raw, forwarded))
+    if failures:
+        print(
+            f"  ! {mode}: {failures}/{len(turns)} turns failed to compress and were "
+            "counted as fully forwarded (rerun with -v for the errors)",
+            file=sys.stderr,
+        )
     return summary
 
 
@@ -311,7 +339,17 @@ def report(summaries: dict[str, ModeSummary], turns: list[BobTurn]) -> None:
         if not s:
             continue
         delta = base.cost_usd - s.cost_usd
-        vs_base = f"-${delta:.2f}" if delta > 0 else "—"
+        # A mode that costs MORE than baseline is the result most worth seeing,
+        # so show the sign rather than collapsing it into the same dash used
+        # for "no difference".
+        if mode == "baseline":
+            vs_base = "—"
+        elif delta > 0:
+            vs_base = f"-${delta:.2f}"
+        elif delta < 0:
+            vs_base = f"+${-delta:.2f}"
+        else:
+            vs_base = "$0.00"
         print(
             f"{mode:<10}{s.forwarded:>15,}{s.saved:>12,}{s.saved_pct:>9.2f}%"
             f"{s.cost_usd:>10.2f}{vs_base:>10}"

--- a/benchmarks/bob_session_mode_benchmark.py
+++ b/benchmarks/bob_session_mode_benchmark.py
@@ -179,19 +179,27 @@ def load_turns(
     return turns
 
 
-def build_proxy(mode: str) -> Any:
-    """A proxy instance configured for one mode, with no network listener."""
+def build_proxy(mode: str, disable_kompress: bool = False) -> Any:
+    """A proxy instance configured for one mode, with no network listener.
+
+    HEADROOM_* env vars are parsed by the proxy's CLI factory, not by
+    ProxyConfig itself, so constructing the config directly ignores them. A
+    first attempt to measure Kompress by exporting HEADROOM_DISABLE_KOMPRESS=1
+    produced byte-identical results in both arms for exactly this reason —
+    every toggle this harness varies has to be passed as a keyword.
+    """
     from headroom.proxy.models import ProxyConfig
     from headroom.proxy.server import HeadroomProxy
 
-    cfg_kwargs: dict[str, Any] = {}
+    cfg_kwargs: dict[str, Any] = {"disable_kompress": disable_kompress}
     try:
         cfg = ProxyConfig(mode=mode, **cfg_kwargs)
     except TypeError:
         # Older/newer ProxyConfig signatures: fall back to the default and set
-        # the attribute directly rather than guessing at keyword names.
+        # the attributes directly rather than guessing at keyword names.
         cfg = ProxyConfig()
         cfg.mode = mode
+        cfg.disable_kompress = disable_kompress
     return HeadroomProxy(cfg)
 
 
@@ -205,7 +213,9 @@ def count_tokens(tokenizer: Any, messages: list[dict[str, Any]]) -> int:
         return len(text) // 4
 
 
-def replay(turns: list[BobTurn], mode: str, verbose: bool = False) -> ModeSummary:
+def replay(
+    turns: list[BobTurn], mode: str, verbose: bool = False, disable_kompress: bool = False
+) -> ModeSummary:
     from headroom.tokenizers import get_tokenizer
     from headroom.utils import extract_user_query
 
@@ -218,7 +228,7 @@ def replay(turns: list[BobTurn], mode: str, verbose: bool = False) -> ModeSummar
             summary.turns.append(TurnResult(t.task_id, t.seq, n, n))
         return summary
 
-    proxy = build_proxy(mode)
+    proxy = build_proxy(mode, disable_kompress=disable_kompress)
     pipeline = proxy.openai_pipeline
     provider = proxy.openai_provider
 
@@ -340,6 +350,11 @@ def main() -> int:
     ap.add_argument("--max-tasks", type=int, help="keep only the N most recent")
     ap.add_argument("--modes", default=",".join(MODES))
     ap.add_argument("--json", type=Path, help="write full per-turn results here")
+    ap.add_argument(
+        "--disable-kompress",
+        action="store_true",
+        help="turn off the ModernBERT token compressor to isolate its contribution",
+    )
     ap.add_argument("-v", "--verbose", action="store_true")
     args = ap.parse_args()
 
@@ -356,7 +371,9 @@ def main() -> int:
     for mode in modes:
         if args.verbose:
             print(f"replaying {len(turns)} turns in {mode} mode…", file=sys.stderr)
-        summaries[mode] = replay(turns, mode, verbose=args.verbose)
+        summaries[mode] = replay(
+            turns, mode, verbose=args.verbose, disable_kompress=args.disable_kompress
+        )
 
     report(summaries, turns)
 

--- a/headroom/cli/install.py
+++ b/headroom/cli/install.py
@@ -23,7 +23,7 @@ from headroom.install.models import (
     RuntimeKind,
     SupervisorKind,
 )
-from headroom.install.planner import build_manifest
+from headroom.install.planner import SUPPORTED_TARGETS, build_manifest
 from headroom.install.providers import apply_mutations, revert_mutations
 from headroom.install.runtime import (
     acquire_runtime_start_lock,
@@ -60,6 +60,13 @@ class TurnkeyPlan:
     supervisor_kind: str | None
     reason: str
     base_env: dict[str, str] | None = None
+
+
+# Derived, not restated: two hand-maintained copies of this list had already
+# drifted from the planner (one missing `grok`, the other `grok` and
+# `grok_build`), and a target the planner supports but the CLI rejects is
+# simply unreachable.
+_TARGET_CHOICES = [target.value for target in SUPPORTED_TARGETS]
 
 
 @main.group()
@@ -495,9 +502,7 @@ def _echo_installed(manifest: DeploymentManifest, *, prefix: str = "Installed pe
     "--target",
     "targets",
     multiple=True,
-    type=click.Choice(
-        ["claude", "copilot", "codex", "aider", "cursor", "grok_build", "openclaw", "opencode"]
-    ),
+    type=click.Choice(_TARGET_CHOICES),
     help="Tool target to configure when --providers manual is used.",
 )
 @click.option("--profile", default="default", show_default=True, help="Deployment profile name.")
@@ -729,7 +734,7 @@ def install_apply(
     "--target",
     "targets",
     multiple=True,
-    type=click.Choice(["claude", "copilot", "codex", "aider", "cursor", "openclaw", "opencode"]),
+    type=click.Choice(_TARGET_CHOICES),
     help="Tool target to configure when --providers manual is used.",
 )
 @click.option("--memory", is_flag=True, help="Enable persistent memory in the proxy runtime.")

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -3956,6 +3956,46 @@ def _restart_persistent_proxy(manifest: Any, port: int) -> bool:
     return False
 
 
+def _verify_persistent_openai_upstream(
+    manifest: Any,
+    port: int,
+    requested_openai_api_url: str,
+    *,
+    agent_type: str = "unknown",
+) -> None:
+    """Raise when a restarted persistent deployment still has the wrong upstream.
+
+    ``_restart_persistent_proxy`` replays ``manifest.proxy_args`` verbatim, so it
+    can resolve a stale *version* but never a missing ``--openai-api-url``. The
+    callers below used to treat its ``True`` as "mismatch resolved" and return
+    the port as success, which handed the agent a proxy pointed at the wrong
+    provider: a ``headroom wrap bob`` session against a dashboard deployment
+    installed without ``--target bob`` sent Bob's IBM ``Authorization: apikey …``
+    to api.openai.com and 401'd every request.
+
+    Verifying after the restart keeps the legitimate case working — a manifest
+    that already carries the right flag comes back matching — while turning the
+    unfixable case into an actionable error instead of silent misrouting.
+    """
+    running_config = _proxy_health_config(_query_proxy_health(port)) or _query_proxy_config(port)
+    running_raw = running_config.get("openai_api_url") if running_config else None
+    if _normalize_proxy_api_url(running_raw) == _normalize_proxy_api_url(requested_openai_api_url):
+        return
+
+    running_display = running_raw or "the default OpenAI upstream (https://api.openai.com)"
+    target_hint = agent_type if agent_type and agent_type != "unknown" else "<tool>"
+    raise click.ClickException(
+        f"Persistent deployment '{manifest.profile}' on port {port} forwards "
+        f"OpenAI-compatible traffic to {running_display}, but this session needs "
+        f"{requested_openai_api_url}. Restarting the deployment replays its stored "
+        "proxy args, so it cannot pick up a different upstream. Either reinstall it "
+        f"with this tool as a target:\n"
+        f"    headroom install apply --profile {manifest.profile} --target {target_hint}\n"
+        "or give this session its own port:\n"
+        f"    headroom wrap {target_hint} --port {port + 1}"
+    )
+
+
 def _copilot_model_configured(copilot_args: tuple[str, ...], env: dict[str, str]) -> bool:
     """Return True when Copilot BYOK model selection is configured."""
     return _copilot_model_configured_impl(copilot_args, env)
@@ -4084,6 +4124,27 @@ def _ensure_proxy_unlocked(
             "  Warning: --backend/--region/--anyllm-provider have no effect with --no-proxy "
             "(reusing the existing proxy)."
         )
+    if no_proxy and openai_api_url and helpers._check_proxy(port):
+        # Every config check below lives under `if not no_proxy:`, so this flag
+        # used to reuse whatever was listening with no validation at all. For a
+        # provider with its own gateway that means the agent's credential is
+        # forwarded to the wrong host and every request fails upstream.
+        # `--no-proxy` is an explicit "use what is already there", so warn
+        # rather than fail — but do not stay silent about it.
+        running_config = helpers._proxy_health_config(
+            helpers._query_proxy_health(port)
+        ) or helpers._query_proxy_config(port)
+        running_raw = running_config.get("openai_api_url") if running_config else None
+        if _normalize_proxy_api_url(running_raw) != _normalize_proxy_api_url(openai_api_url):
+            running_display = running_raw or "the default OpenAI upstream (https://api.openai.com)"
+            click.echo(
+                f"  Warning: the proxy on port {port} forwards OpenAI-compatible traffic to "
+                f"{running_display}, but this session expects {openai_api_url}."
+            )
+            click.echo(
+                "  --no-proxy reuses it as-is; requests will likely fail upstream. "
+                "Drop --no-proxy to let Headroom start a correctly configured proxy."
+            )
     if not no_proxy:
         manifest = helpers._find_persistent_manifest(port)
         isolated_copilot_subscription_proxy = copilot_subscription_seed_requested and (
@@ -4190,6 +4251,10 @@ def _ensure_proxy_unlocked(
                             "did not expose config; restarting with requested features..."
                         )
                         if helpers._restart_persistent_proxy(manifest, port):
+                            if openai_api_url:
+                                helpers._verify_persistent_openai_upstream(
+                                    manifest, port, openai_api_url, agent_type=agent_type
+                                )
                             return None, port
                         raise click.ClickException(
                             f"Persistent deployment '{manifest.profile}' on port {port} "
@@ -4220,6 +4285,10 @@ def _ensure_proxy_unlocked(
                             f"{flags_str}; restarting..."
                         )
                         if helpers._restart_persistent_proxy(manifest, port):
+                            if openai_api_url:
+                                helpers._verify_persistent_openai_upstream(
+                                    manifest, port, openai_api_url, agent_type=agent_type
+                                )
                             return None, port
                         raise click.ClickException(
                             f"Persistent deployment '{manifest.profile}' on port {port} "
@@ -6952,8 +7021,15 @@ def bob(
     Sets ``BOB_GATEWAY_URL`` so Bob routes inference traffic through Headroom
     while keeping its own ``Authorization: apikey …`` credential and its
     ~/.bob/settings files untouched. Bob speaks OpenAI-shaped chat completions
-    under an ``/inference/v1`` gateway prefix; its non-inference routes
-    (profile, metrics) pass through uncompressed.
+    under an ``/inference/v1`` gateway prefix, which is the traffic Headroom
+    compresses.
+
+    \b
+    Known limitation: only ``/inference/v1/chat/completions`` is routed
+    correctly. Bob's other gateway routes (``/admin/v1/profile``,
+    ``/metrics-forwarder/…``) reach the catch-all passthrough, which resolves
+    its upstream from the same ``…/inference`` base and so forwards them to
+    ``…/inference/admin/v1/profile`` rather than the path IBM serves.
 
     \b
     Mode matters more for Bob than for most agents. Its traffic is ~46% system
@@ -8476,7 +8552,7 @@ def unwrap_bob(port: int, no_stop_proxy: bool) -> None:
     """
     click.echo()
     click.echo("  ╔═══════════════════════════════════════════════╗")
-    click.echo("  ║            HEADROOM UNWRAP: BOB              ║")
+    click.echo("  ║            HEADROOM UNWRAP: BOB               ║")
     click.echo("  ╚═══════════════════════════════════════════════╝")
     click.echo()
 

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -10,6 +10,7 @@ Usage:
     headroom wrap openclaude                # Start proxy + OpenClaude
     headroom wrap vibe                      # Start proxy + Mistral Vibe
     headroom wrap grok                      # Start proxy + Grok CLI
+    headroom wrap bob                       # Start proxy + IBM Bob CLI
     headroom wrap cursor                    # Start proxy + print Cursor config instructions
     headroom wrap grok-build                # Start proxy + configure Grok Build
     headroom wrap openclaw                  # Install + configure OpenClaw plugin
@@ -73,6 +74,12 @@ from headroom.copilot_auth import (
     resolve_subscription_bearer_token_details,
 )
 from headroom.providers.aider import build_launch_env as _build_aider_launch_env
+from headroom.providers.bob import (
+    DEFAULT_API_URL as _BOB_DEFAULT_API_URL,
+)
+from headroom.providers.bob import (
+    build_launch_env as _build_bob_launch_env,
+)
 from headroom.providers.claude import (
     REMOTE_CONTROL_BASE_URL_ENV,
     TOOL_SEARCH_DEFAULT,
@@ -4982,6 +4989,7 @@ def wrap(ctx: click.Context) -> None:
         headroom wrap openclaude          # OpenClaude
         headroom wrap vibe                # Mistral Vibe
         headroom wrap grok                # Grok CLI (xAI)
+        headroom wrap bob                 # IBM Bob CLI
         headroom wrap cursor              # Cursor (prints config instructions)
         headroom wrap grok-build          # Grok Build (updates ~/.grok/config.toml)
         headroom wrap cline               # Cline (VS Code; prints config instructions)
@@ -6904,6 +6912,94 @@ def grok(
 
 
 # =============================================================================
+# IBM Bob
+# =============================================================================
+
+
+@wrap.command(context_settings={"ignore_unknown_options": True})
+@_retired_context_tool_option
+@click.option(
+    "--port", "-p", default=8787, type=click.IntRange(1, 65535), help="Proxy port (default: 8787)"
+)
+@click.option("--no-proxy", is_flag=True, help="Skip proxy startup (use existing proxy)")
+@click.option("--learn", is_flag=True, help="Enable live traffic learning")
+@click.option("--memory", is_flag=True, help="Enable persistent cross-session memory")
+@click.option(
+    "--backend",
+    default=None,
+    help="API backend for the proxy: 'anthropic' (default), 'litellm-openai', etc.",
+)
+@click.option("--anyllm-provider", default=None, help="Provider for any-llm backend")
+@click.option("--region", default=None, help="Cloud region for Vertex/Bedrock backends")
+@click.option("--verbose", "-v", is_flag=True, help="Verbose output")
+@click.option("--prepare-only", is_flag=True, hidden=True)
+@click.argument("bob_args", nargs=-1, type=click.UNPROCESSED)
+def bob(
+    port: int,
+    no_proxy: bool,
+    learn: bool,
+    memory: bool,
+    backend: str | None,
+    anyllm_provider: str | None,
+    region: str | None,
+    verbose: bool,
+    prepare_only: bool,
+    bob_args: tuple,
+) -> None:
+    """Launch IBM Bob CLI through Headroom proxy.
+
+    \b
+    Sets ``BOB_GATEWAY_URL`` so Bob routes inference traffic through Headroom
+    while keeping its own ``Authorization: apikey …`` credential and its
+    ~/.bob/settings files untouched. Bob speaks OpenAI-shaped chat completions
+    under an ``/inference/v1`` gateway prefix; its non-inference routes
+    (profile, metrics) pass through uncompressed.
+
+    \b
+    Mode matters more for Bob than for most agents. Its traffic is ~46% system
+    prompt and ~44% tool output, and the default cache mode protects every tool
+    result from compression. Replaying 285 requests of real Bob history measured
+    0.8% saved in cache mode versus 8.0% in token mode:
+        HEADROOM_MODE=token headroom wrap bob
+
+    \b
+    Examples:
+        headroom wrap bob                          # Start proxy + bob
+        headroom wrap bob -- run "fix the bug"     # Pass args to bob
+        headroom wrap bob --port 9999              # Custom proxy port
+    """
+    if prepare_only:
+        return
+
+    bob_bin = shutil.which("bob")
+    if not bob_bin:
+        click.echo("Error: 'bob' not found in PATH.")
+        click.echo("Install IBM Bob CLI: npm install -g bobshell")
+        raise SystemExit(1)
+
+    env, env_vars_display = _build_bob_launch_env(
+        port, os.environ, project=_project_name_from_cwd()
+    )
+
+    _launch_tool(
+        binary=bob_bin,
+        args=bob_args,
+        env=env,
+        port=port,
+        no_proxy=no_proxy,
+        tool_label="BOB",
+        env_vars_display=env_vars_display,
+        learn=learn,
+        memory=memory,
+        agent_type="bob",
+        backend=backend,
+        anyllm_provider=anyllm_provider,
+        region=region,
+        openai_api_url=_BOB_DEFAULT_API_URL,
+    )
+
+
+# =============================================================================
 # Cursor
 # =============================================================================
 
@@ -8356,6 +8452,40 @@ def unwrap_grok(port: int, no_stop_proxy: bool) -> None:
     click.echo("✓ Grok is no longer configured for Headroom MCP retrieval.")
     click.echo("  Start Grok without `headroom wrap grok` so API traffic skips the proxy.")
     if not no_stop_proxy and removed_any:
+        _echo_unwrap_proxy_stop_status(_stop_local_proxy_for_unwrap(port), port)
+    click.echo()
+
+
+# =============================================================================
+# IBM Bob (unwrap)
+# =============================================================================
+
+
+@unwrap.command("bob")
+@click.option(
+    "--port", "-p", default=8787, type=click.IntRange(1, 65535), help="Proxy port (default: 8787)"
+)
+@click.option("--no-stop-proxy", is_flag=True, help="Do not stop the local Headroom proxy")
+def unwrap_bob(port: int, no_stop_proxy: bool) -> None:
+    """Stop routing IBM Bob through Headroom.
+
+    Bob's inference routing is session-scoped via ``BOB_GATEWAY_URL`` and
+    ``wrap bob`` writes no Bob config, so there is nothing to restore --
+    this stops the local proxy. Start Bob without ``headroom wrap bob`` and
+    it returns to its default gateway.
+    """
+    click.echo()
+    click.echo("  ╔═══════════════════════════════════════════════╗")
+    click.echo("  ║            HEADROOM UNWRAP: BOB              ║")
+    click.echo("  ╚═══════════════════════════════════════════════╝")
+    click.echo()
+
+    click.echo("  Nothing to undo: `wrap bob` only sets BOB_GATEWAY_URL for the")
+    click.echo("  session it launches; ~/.bob/settings was never modified.")
+    click.echo()
+    click.echo("✓ IBM Bob is no longer routed through the Headroom proxy.")
+    click.echo("  Start Bob without `headroom wrap bob` so API traffic skips the proxy.")
+    if not no_stop_proxy:
         _echo_unwrap_proxy_stop_status(_stop_local_proxy_for_unwrap(port), port)
     click.echo()
 

--- a/headroom/install/models.py
+++ b/headroom/install/models.py
@@ -59,6 +59,7 @@ class ToolTarget(str, Enum):
     GROK = "grok"
     OPENCLAW = "openclaw"
     OPENCODE = "opencode"
+    BOB = "bob"
 
 
 def iso_utc_now() -> str:

--- a/headroom/install/planner.py
+++ b/headroom/install/planner.py
@@ -9,6 +9,7 @@ from collections.abc import Iterable
 import click
 
 from headroom import paths as _paths
+from headroom.providers.bob.runtime import DEFAULT_API_URL as _BOB_DEFAULT_API_URL
 from headroom.providers.grok.runtime import DEFAULT_API_URL as _GROK_DEFAULT_API_URL
 from headroom.providers.install_registry import build_install_target_envs
 from headroom.rollout import RolloutChannel
@@ -34,6 +35,7 @@ SUPPORTED_TARGETS = [
     ToolTarget.GROK,
     ToolTarget.OPENCLAW,
     ToolTarget.OPENCODE,
+    ToolTarget.BOB,
 ]
 PROVIDER_SCOPE_TARGETS = [
     ToolTarget.CLAUDE,
@@ -178,19 +180,44 @@ def build_manifest(
     base_env["HEADROOM_TELEMETRY"] = "on" if telemetry_enabled else "off"
     if memory_enabled:
         base_env["HEADROOM_MEMORY_ENABLED"] = "1"
-    # Grok / Grok Build need proxy upstream = xAI. Only auto-set when no other
-    # OpenAI-compatible tools share this proxy (those may need api.openai.com /
-    # Copilot). Explicit OPENAI_TARGET_API_URL in extra_env still wins below.
+    # Some tools speak the OpenAI wire format but against their own gateway:
+    # Grok/Grok Build need xAI, Bob needs the IBM gateway. A proxy has a single
+    # `--openai-api-url` slot, so a default is only derived when exactly one
+    # such family is installed and no OpenAI-native tool shares this proxy
+    # (those may need api.openai.com / Copilot). With two competing families
+    # neither may silently win — leaving it unset keeps the default rather than
+    # pointing one tool's credential at the other's host. Explicit
+    # OPENAI_TARGET_API_URL in extra_env still wins below.
     _openai_native = {
         ToolTarget.CODEX.value,
         ToolTarget.COPILOT.value,
         ToolTarget.AIDER.value,
         ToolTarget.OPENCODE.value,
     }
-    _grok_targets = {ToolTarget.GROK.value, ToolTarget.GROK_BUILD.value}
+    _exclusive_openai_gateways = (
+        ("grok", {ToolTarget.GROK.value, ToolTarget.GROK_BUILD.value}, _GROK_DEFAULT_API_URL),
+        ("bob", {ToolTarget.BOB.value}, _BOB_DEFAULT_API_URL),
+    )
     target_set = set(resolved_targets)
-    if target_set & _grok_targets and not (target_set & _openai_native):
-        base_env.setdefault("OPENAI_TARGET_API_URL", _GROK_DEFAULT_API_URL)
+    explicit_upstream = (extra_env or {}).get("OPENAI_TARGET_API_URL")
+    if not (target_set & _openai_native) and not explicit_upstream:
+        claimed = [
+            (name, url) for name, family, url in _exclusive_openai_gateways if target_set & family
+        ]
+        if len(claimed) == 1:
+            base_env.setdefault("OPENAI_TARGET_API_URL", claimed[0][1])
+        elif len(claimed) > 1:
+            # Refusing beats both alternatives. Leaving it unset sends every
+            # one of these tools to api.openai.com, and picking a winner
+            # breaks the loser — either way the user learns about it as an
+            # upstream 401 with nothing pointing at this decision.
+            names = ", ".join(sorted(name for name, _ in claimed))
+            raise click.ClickException(
+                f"Targets {names} each need a different OpenAI-compatible upstream, "
+                "and a proxy has only one. Install them on separate ports/profiles, "
+                "or choose the upstream explicitly with "
+                "`--env OPENAI_TARGET_API_URL=<url>`."
+            )
     # Applied last so explicit --env overrides win over the auto-derived
     # defaults above (e.g. a custom HEADROOM_WORKSPACE_DIR).
     if extra_env:

--- a/headroom/providers/bob/__init__.py
+++ b/headroom/providers/bob/__init__.py
@@ -1,0 +1,17 @@
+"""IBM Bob CLI provider helpers."""
+
+from .runtime import (
+    DEFAULT_API_URL,
+    GATEWAY_CHAT_COMPLETIONS_PATH,
+    PROXY_ENV_KEY,
+    build_launch_env,
+    proxy_base_url,
+)
+
+__all__ = [
+    "DEFAULT_API_URL",
+    "GATEWAY_CHAT_COMPLETIONS_PATH",
+    "PROXY_ENV_KEY",
+    "build_launch_env",
+    "proxy_base_url",
+]

--- a/headroom/providers/bob/install.py
+++ b/headroom/providers/bob/install.py
@@ -1,0 +1,11 @@
+"""IBM Bob install-time helpers."""
+
+from __future__ import annotations
+
+from .runtime import PROXY_ENV_KEY, proxy_base_url
+
+
+def build_install_env(*, port: int, backend: str) -> dict[str, str]:
+    """Build the persistent install environment for IBM Bob CLI."""
+    del backend
+    return {PROXY_ENV_KEY: proxy_base_url(port)}

--- a/headroom/providers/bob/runtime.py
+++ b/headroom/providers/bob/runtime.py
@@ -47,9 +47,16 @@ def build_launch_env(
 
     Bob routes inference traffic through ``BOB_GATEWAY_URL`` when set. The
     proxy forwards OpenAI-compatible chat requests upstream to IBM while Bob
-    keeps its own ``Authorization: apikey …`` credential and its non-inference
-    routes (``/admin/v1/profile``, ``/metrics-forwarder/…``) pass through
-    untouched.
+    keeps its own ``Authorization: apikey …`` credential.
+
+    Caveat: setting this env var reroutes *every* Bob gateway call, not just
+    inference. Only ``/inference/v1/chat/completions`` has a matching proxy
+    route; Bob's other gateway routes (``/admin/v1/profile``,
+    ``/metrics-forwarder/…``) land on the catch-all passthrough, whose upstream
+    base is the same ``…/inference`` target, so they are forwarded to
+    ``…/inference/admin/v1/profile`` instead of the path IBM serves. Fixing
+    that needs a per-provider upstream-path mapping the proxy does not have
+    yet.
 
     ``project`` (the wrap launch directory) is encoded as a ``/p/<name>``
     base-URL prefix because Bob sends no custom attribution headers; the proxy

--- a/headroom/providers/bob/runtime.py
+++ b/headroom/providers/bob/runtime.py
@@ -1,0 +1,61 @@
+"""Runtime helpers for IBM Bob CLI integrations."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+from headroom.proxy.project_context import with_project_prefix
+
+# IBM Bob's default gateway. Bob appends its own ``/inference/v1`` prefix to
+# whatever gateway URL it is given, so this is a bare origin -- unlike most
+# providers here, where the configured value already ends in ``/v1``.
+DEFAULT_GATEWAY_URL = "https://api.us-east.bob.ibm.com"
+
+# The upstream target handed to the proxy. ``_normalize_api_url`` strips the
+# trailing ``/v1``, and ``handle_openai_chat`` re-appends ``/v1/chat/completions``,
+# so the request lands on ``…/inference/v1/chat/completions`` -- the path Bob
+# itself calls.
+DEFAULT_API_URL = f"{DEFAULT_GATEWAY_URL}/inference/v1"
+
+# Bob resolves its gateway as ``config.gatewayUrl ?? BOB_GATEWAY_URL ?? default``,
+# so setting this env var reroutes inference without touching ~/.bob/settings.
+PROXY_ENV_KEY = "BOB_GATEWAY_URL"
+
+# Bob posts OpenAI-shaped chat completions under its own ``/inference/v1``
+# prefix rather than the conventional ``/v1``. The proxy routes this path to
+# ``handle_openai_chat`` so the traffic is compressed instead of falling
+# through to the uncompressed catch-all passthrough.
+GATEWAY_CHAT_COMPLETIONS_PATH = "/inference/v1/chat/completions"
+
+
+def proxy_base_url(port: int) -> str:
+    """Return the local proxy gateway URL used by IBM Bob integrations.
+
+    No ``/v1`` suffix: Bob builds ``{gateway}/inference/v1/chat/completions``
+    itself, so handing it a ``/v1`` base would produce a doubled prefix.
+    """
+    return f"http://127.0.0.1:{port}"
+
+
+def build_launch_env(
+    port: int,
+    environ: Mapping[str, str] | None = None,
+    project: str | None = None,
+) -> tuple[dict[str, str], list[str]]:
+    """Build environment variables for IBM Bob CLI through the local proxy.
+
+    Bob routes inference traffic through ``BOB_GATEWAY_URL`` when set. The
+    proxy forwards OpenAI-compatible chat requests upstream to IBM while Bob
+    keeps its own ``Authorization: apikey …`` credential and its non-inference
+    routes (``/admin/v1/profile``, ``/metrics-forwarder/…``) pass through
+    untouched.
+
+    ``project`` (the wrap launch directory) is encoded as a ``/p/<name>``
+    base-URL prefix because Bob sends no custom attribution headers; the proxy
+    strips it and attributes savings per project.
+    """
+    env = dict(environ or os.environ)
+    gateway_url = with_project_prefix(proxy_base_url(port), project)
+    env[PROXY_ENV_KEY] = gateway_url
+    return env, [f"{PROXY_ENV_KEY}={gateway_url}"]

--- a/headroom/providers/install_registry.py
+++ b/headroom/providers/install_registry.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 from headroom.install.models import DeploymentManifest, ManagedMutation
 from headroom.providers.aider.install import build_install_env as _build_aider_install_env
+from headroom.providers.bob.install import build_install_env as _build_bob_install_env
 from headroom.providers.claude.install import (
     apply_provider_scope as _apply_claude_provider_scope,
 )
@@ -54,6 +55,7 @@ _ENV_BUILDERS: dict[str, _InstallEnvBuilder] = {
     "copilot": _build_copilot_install_env,
     "codex": _build_codex_install_env,
     "aider": _build_aider_install_env,
+    "bob": _build_bob_install_env,
     "cortex-code": _build_cortex_code_install_env,
     "cursor": _build_cursor_install_env,
     "grok_build": _build_grok_build_install_env,

--- a/headroom/providers/route_specs.py
+++ b/headroom/providers/route_specs.py
@@ -108,6 +108,11 @@ OPENAI_HANDLER_ROUTES: tuple[ProviderHandlerRoute, ...] = (
     # Copilot Chat derives this unprefixed path from overrideCapiUrl. Route it
     # through the real handler; the generic catch-all would bypass compression.
     ProviderHandlerRoute("POST", "/chat/completions", "handle_openai_chat"),
+    # IBM Bob posts OpenAI-shaped chat completions under its own `/inference/v1`
+    # gateway prefix, which it appends to BOB_GATEWAY_URL. Same reason as the
+    # Copilot entry above: without this the request matches only the catch-all
+    # and is forwarded uncompressed.
+    ProviderHandlerRoute("POST", "/inference/v1/chat/completions", "handle_openai_chat"),
 )
 
 

--- a/tests/e2e_bob_live.py
+++ b/tests/e2e_bob_live.py
@@ -1,0 +1,260 @@
+"""Live end-to-end check: the real `bob` binary through a real Headroom proxy.
+
+Mocked tests pin routing; only this pins that IBM *accepts* what we forward.
+The failure it exists for was invisible to unit tests: a proxy whose OpenAI
+target was left at the default forwarded Bob's ``Authorization: apikey …`` to
+api.openai.com, which answered 401 to every ``/inference/v1/chat/completions``.
+Every layer looked healthy — the proxy was up, the route matched, compression
+ran — and only the upstream status told the truth.
+
+Bob's stored access token expires and is refreshed by Bob itself, so this
+drives the real binary rather than replaying a captured credential.
+
+Run::
+
+    python tests/e2e_bob_live.py                     # token + cache
+    python tests/e2e_bob_live.py --modes token
+    python tests/e2e_bob_live.py --prompt "say hi"
+
+Requires a logged-in `bob` on PATH. Exits non-zero on the first failing mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from headroom.paths import proxy_log_path  # noqa: E402
+from headroom.providers.bob import (  # noqa: E402
+    DEFAULT_API_URL,
+    GATEWAY_CHAT_COMPLETIONS_PATH,
+    PROXY_ENV_KEY,
+)
+
+PROJECT = "bob-live-e2e"
+# Statuses that mean the upstream rejected us. 401 is the exact symptom of the
+# misrouted-upstream bug; the rest would equally invalidate a savings number.
+FATAL_STATUSES = {401, 403, 404, 407, 500, 502, 503}
+
+
+@dataclass
+class ModeResult:
+    mode: str
+    ok: bool
+    bob_returncode: int | None = None
+    chat_requests: int = 0
+    bad_statuses: dict[int, int] = field(default_factory=dict)
+    requests_delta: int = 0
+    tokens_saved_delta: int = 0
+    failure: str = ""
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _get_json(url: str, timeout: float = 5.0) -> dict | None:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+            return json.loads(response.read().decode())
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, TimeoutError):
+        return None
+
+
+def _wait_ready(port: int, timeout: float = 60.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _get_json(f"http://127.0.0.1:{port}/readyz") is not None:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def _project_stats(port: int) -> tuple[int, int]:
+    """(requests, tokens_saved) recorded for this script's project so far.
+
+    ``savings.per_project`` is persisted across proxy restarts, so callers must
+    compare a delta rather than an absolute.
+    """
+    stats = _get_json(f"http://127.0.0.1:{port}/stats") or {}
+    row = (stats.get("savings", {}).get("per_project", {}) or {}).get(PROJECT, {})
+    return int(row.get("requests", 0)), int(row.get("tokens_saved", 0))
+
+
+def _scan_log(from_offset: int) -> tuple[int, dict[int, int]]:
+    """Count chat-completion responses and upstream rejections since an offset.
+
+    The proxy's structured request log is the only place the *upstream* status
+    is visible; Bob can exit 0 while every one of its calls was rejected.
+    """
+    log_path = proxy_log_path()
+    if not log_path.exists():
+        return 0, {}
+    with log_path.open("r", errors="replace") as handle:
+        handle.seek(from_offset)
+        tail = handle.read()
+
+    chat_requests = 0
+    bad: dict[int, int] = {}
+    for line in tail.splitlines():
+        if "event=proxy_inbound_response" not in line:
+            continue
+        if GATEWAY_CHAT_COMPLETIONS_PATH not in line:
+            continue
+        chat_requests += 1
+        for field_ in line.split():
+            if field_.startswith("status="):
+                try:
+                    status = int(field_.split("=", 1)[1])
+                except ValueError:
+                    break
+                if status in FATAL_STATUSES:
+                    bad[status] = bad.get(status, 0) + 1
+                break
+    return chat_requests, bad
+
+
+def _log_offset() -> int:
+    log_path = proxy_log_path()
+    return log_path.stat().st_size if log_path.exists() else 0
+
+
+def run_mode(mode: str, prompt: str, bob_timeout: float) -> ModeResult:
+    result = ModeResult(mode=mode, ok=False)
+    port = _free_port()
+
+    proxy = subprocess.Popen(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "headroom.cli",
+            "proxy",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--mode",
+            mode,
+            "--openai-api-url",
+            DEFAULT_API_URL,
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        if not _wait_ready(port):
+            result.failure = f"proxy on port {port} never became ready"
+            return result
+
+        # Confirm the treatment took before spending a real API call on it: a
+        # proxy that quietly kept the default upstream is the whole bug.
+        health = _get_json(f"http://127.0.0.1:{port}/health") or {}
+        running_url = (health.get("config") or {}).get("openai_api_url")
+        if running_url != DEFAULT_API_URL:
+            result.failure = f"proxy upstream is {running_url!r}, expected {DEFAULT_API_URL!r}"
+            return result
+
+        before_requests, before_saved = _project_stats(port)
+        offset = _log_offset()
+
+        env = dict(os.environ)
+        env[PROXY_ENV_KEY] = f"http://127.0.0.1:{port}/p/{PROJECT}"
+        try:
+            completed = subprocess.run(  # noqa: S603
+                ["bob", "run", prompt],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=bob_timeout,
+            )
+            result.bob_returncode = completed.returncode
+            bob_output = (completed.stdout or "") + (completed.stderr or "")
+        except subprocess.TimeoutExpired:
+            result.failure = f"bob did not finish within {bob_timeout:.0f}s"
+            return result
+
+        # Give the proxy a moment to flush its response log line.
+        time.sleep(1.0)
+        result.chat_requests, result.bad_statuses = _scan_log(offset)
+        after_requests, after_saved = _project_stats(port)
+        result.requests_delta = after_requests - before_requests
+        result.tokens_saved_delta = after_saved - before_saved
+
+        if result.bob_returncode != 0:
+            result.failure = f"bob exited {result.bob_returncode}: {bob_output.strip()[:300]}"
+            return result
+        if result.chat_requests == 0:
+            result.failure = "bob made no chat-completion calls through the proxy"
+            return result
+        if result.bad_statuses:
+            rendered = ", ".join(
+                f"{status}x{count}" for status, count in result.bad_statuses.items()
+            )
+            result.failure = f"upstream rejected Bob traffic: {rendered}"
+            return result
+        if result.requests_delta < 1:
+            result.failure = "proxy recorded no requests for this project (observability broken)"
+            return result
+
+        result.ok = True
+        return result
+    finally:
+        proxy.terminate()
+        try:
+            proxy.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proxy.kill()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--modes", default="token,cache", help="comma-separated proxy modes")
+    parser.add_argument("--prompt", default="Reply with the single word: ready.")
+    parser.add_argument("--timeout", type=float, default=300.0, help="per-mode bob timeout")
+    args = parser.parse_args()
+
+    if not shutil.which("bob"):
+        print("SKIP: 'bob' not found on PATH (npm install -g bobshell)")
+        return 0
+
+    modes = [mode.strip() for mode in args.modes.split(",") if mode.strip()]
+    results: list[ModeResult] = []
+    for mode in modes:
+        print(f"\n=== mode={mode} ===")
+        result = run_mode(mode, args.prompt, args.timeout)
+        results.append(result)
+        if result.ok:
+            print(
+                f"  PASS  chat_requests={result.chat_requests} "
+                f"recorded_requests=+{result.requests_delta} "
+                f"tokens_saved=+{result.tokens_saved_delta}"
+            )
+        else:
+            print(f"  FAIL  {result.failure}")
+
+    print("\n--- summary ---")
+    for result in results:
+        status = "PASS" if result.ok else "FAIL"
+        print(f"  {result.mode:<8} {status:<5} {result.failure}")
+
+    return 0 if all(result.ok for result in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli/test_install_cli.py
+++ b/tests/test_cli/test_install_cli.py
@@ -1344,3 +1344,27 @@ def test_install_agent_ensure_propagates_start_deployment_failure(monkeypatch) -
     result = runner.invoke(main, ["install", "agent", "ensure"])
     assert result.exit_code != 0, f"expected non-zero exit, got {result.exit_code}: {result.output}"
     assert "simulated start failure" in result.output
+
+
+def test_install_target_choices_track_supported_targets() -> None:
+    """`--target` must offer exactly the targets the planner accepts.
+
+    Both choice lists were maintained by hand and had already drifted: `apply`
+    was missing `grok`, `deploy` was missing `grok` and `grok_build`. A target
+    the planner supports but the CLI rejects is unreachable, which is how
+    `bob` stayed unusable even after its env builder was registered.
+    """
+    import click
+
+    from headroom.cli.install import deploy as deploy_cmd
+    from headroom.cli.install import install_apply
+    from headroom.install.planner import SUPPORTED_TARGETS
+
+    expected = {target.value for target in SUPPORTED_TARGETS}
+
+    for command in (install_apply, deploy_cmd):
+        param = next(p for p in command.params if p.name == "targets")
+        assert isinstance(param.type, click.Choice)
+        assert set(param.type.choices) == expected, (
+            f"{command.name} --target choices drifted from SUPPORTED_TARGETS"
+        )

--- a/tests/test_cli/test_wrap_persistent.py
+++ b/tests/test_cli/test_wrap_persistent.py
@@ -834,24 +834,33 @@ def test_ensure_proxy_restarts_persistent_deployment_for_memory_mismatch(monkeyp
 def test_ensure_proxy_restarts_recovered_persistent_for_openai_api_url_mismatch(
     monkeypatch,
 ) -> None:
+    """A manifest that already carries the right upstream is fixed by a restart.
+
+    The stale proxy predates the manifest's ``--openai-api-url``, so restarting
+    it picks the flag up and the post-restart verification passes.
+    """
     calls: list[object] = []
-    health = {
-        "version": wrap_cli._HEADROOM_VERSION,
-        "runtime": {"websocket_sessions": {"active_sessions": 0, "active_relay_tasks": 0}},
-        "config": {
-            "pid": 12345,
-            "memory": False,
-            "learn": False,
-            "code_graph": False,
-            "openai_api_url": None,
-        },
-    }
+    requested = "https://api.business.githubcopilot.com"
+
+    def _health(port: int) -> dict:
+        restarted = bool(calls)
+        return {
+            "version": wrap_cli._HEADROOM_VERSION,
+            "runtime": {"websocket_sessions": {"active_sessions": 0, "active_relay_tasks": 0}},
+            "config": {
+                "pid": 12345,
+                "memory": False,
+                "learn": False,
+                "code_graph": False,
+                "openai_api_url": requested if restarted else None,
+            },
+        }
 
     monkeypatch.setattr(wrap_cli, "_find_persistent_manifest", lambda port: _Manifest())
     monkeypatch.setattr("headroom.install.health.probe_ready", lambda url: False)
     monkeypatch.setattr(wrap_cli, "_recover_persistent_proxy", lambda port: True)
     monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: True)
-    monkeypatch.setattr(wrap_cli, "_query_proxy_health", lambda port: health)
+    monkeypatch.setattr(wrap_cli, "_query_proxy_health", _health)
     monkeypatch.setattr(
         wrap_cli,
         "_restart_persistent_proxy",
@@ -865,11 +874,7 @@ def test_ensure_proxy_restarts_recovered_persistent_for_openai_api_url_mismatch(
         ),
     )
 
-    proc, actual_port = wrap_cli._ensure_proxy(
-        8787,
-        False,
-        openai_api_url="https://api.business.githubcopilot.com",
-    )
+    proc, actual_port = wrap_cli._ensure_proxy(8787, False, openai_api_url=requested)
 
     assert proc is None
     assert actual_port == 8787
@@ -877,14 +882,24 @@ def test_ensure_proxy_restarts_recovered_persistent_for_openai_api_url_mismatch(
 
 
 def test_ensure_proxy_restarts_recovered_persistent_when_config_unavailable(monkeypatch) -> None:
+    """A recovered deployment that exposes no config is restarted, then verified.
+
+    The restart makes the config readable; because the manifest carries the
+    requested upstream, verification passes and the port is reused.
+    """
     calls: list[object] = []
+    requested = "https://api.business.githubcopilot.com"
 
     monkeypatch.setattr(wrap_cli, "_find_persistent_manifest", lambda port: _Manifest())
     monkeypatch.setattr("headroom.install.health.probe_ready", lambda url: False)
     monkeypatch.setattr(wrap_cli, "_recover_persistent_proxy", lambda port: True)
     monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: True)
     monkeypatch.setattr(wrap_cli, "_query_proxy_health", lambda port: {"version": "x"})
-    monkeypatch.setattr(wrap_cli, "_query_proxy_config", lambda port: None)
+    monkeypatch.setattr(
+        wrap_cli,
+        "_query_proxy_config",
+        lambda port: {"openai_api_url": requested} if calls else None,
+    )
     monkeypatch.setattr(
         wrap_cli,
         "_restart_persistent_proxy",
@@ -898,11 +913,7 @@ def test_ensure_proxy_restarts_recovered_persistent_when_config_unavailable(monk
         ),
     )
 
-    proc, actual_port = wrap_cli._ensure_proxy(
-        8787,
-        False,
-        openai_api_url="https://api.business.githubcopilot.com",
-    )
+    proc, actual_port = wrap_cli._ensure_proxy(8787, False, openai_api_url=requested)
 
     assert proc is None
     assert actual_port == 8787
@@ -962,14 +973,70 @@ def test_ensure_proxy_recovered_persistent_deployment_checks_feature_mismatch(mo
     """
 
     calls: list[object] = []
+    requested = "https://api.githubcopilot.com"
+
+    def _health(port: int) -> dict:
+        restarted = bool(calls)
+        return {
+            "version": wrap_cli._HEADROOM_VERSION,
+            "runtime": {"websocket_sessions": {"active_sessions": 0, "active_relay_tasks": 0}},
+            "config": {
+                "pid": "12345",
+                "memory": False,
+                "learn": False,
+                "code_graph": False,
+                "openai_api_url": requested if restarted else None,
+            },
+        }
+
+    monkeypatch.setattr(wrap_cli, "_find_persistent_manifest", lambda port: _Manifest())
+    monkeypatch.setattr("headroom.install.health.probe_ready", lambda url: False)
+    monkeypatch.setattr(wrap_cli, "_recover_persistent_proxy", lambda port: True)
+    monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: True)
+    monkeypatch.setattr(wrap_cli, "_query_proxy_health", _health)
+    monkeypatch.setattr(
+        wrap_cli,
+        "_restart_persistent_proxy",
+        lambda manifest, port: calls.append(("restart", manifest.profile, port)) or True,
+    )
+    monkeypatch.setattr(
+        wrap_cli,
+        "_start_proxy",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("ephemeral proxy should not start")
+        ),
+    )
+
+    proc, actual_port = wrap_cli._ensure_proxy(8787, False, openai_api_url=requested)
+
+    assert proc is None
+    assert actual_port == 8787
+    assert calls == [("restart", "default", 8787)]
+
+
+def test_ensure_proxy_raises_when_persistent_restart_cannot_apply_openai_api_url(
+    monkeypatch,
+) -> None:
+    """A manifest restart that leaves the upstream wrong must not report success.
+
+    ``_restart_persistent_proxy`` replays ``manifest.proxy_args`` verbatim, so it
+    can fix a stale *version* but never a missing ``--openai-api-url``. The old
+    code called it for an upstream mismatch and returned the port as success,
+    handing the agent a proxy pointed at the wrong provider: Bob's IBM
+    ``Authorization: apikey ...`` reached api.openai.com and every
+    ``/inference/v1/chat/completions`` 401'd.
+    """
+    calls: list[object] = []
     health = {
         "version": wrap_cli._HEADROOM_VERSION,
         "runtime": {"websocket_sessions": {"active_sessions": 0, "active_relay_tasks": 0}},
         "config": {
-            "pid": "12345",
+            "pid": 12345,
             "memory": False,
             "learn": False,
             "code_graph": False,
+            # The manifest has no --openai-api-url, so this stays None across
+            # the restart.
             "openai_api_url": None,
         },
     }
@@ -992,12 +1059,76 @@ def test_ensure_proxy_recovered_persistent_deployment_checks_feature_mismatch(mo
         ),
     )
 
+    with pytest.raises(click.ClickException) as excinfo:
+        wrap_cli._ensure_proxy(
+            8787,
+            False,
+            agent_type="bob",
+            openai_api_url="https://api.us-east.bob.ibm.com/inference/v1",
+        )
+
+    message = str(excinfo.value)
+    assert "default" in message
+    assert "api.us-east.bob.ibm.com" in message
+    # The remedy must name the actual tool, not a placeholder.
+    assert "headroom install apply --profile default --target bob" in message
+    assert "headroom wrap bob --port 8788" in message
+    # The restart was attempted before giving up — this is a verification
+    # failure, not a refusal to try.
+    assert calls == [("restart", "default", 8787)]
+
+
+def test_ensure_proxy_warns_when_no_proxy_reuses_mismatched_upstream(monkeypatch, capsys) -> None:
+    """``--no-proxy`` must not silently hand an agent the wrong upstream.
+
+    The whole config-validation block lives under ``if not no_proxy:``, so
+    ``headroom wrap bob --no-proxy`` against a proxy installed for another
+    provider reused it with no check at all and every request 401'd upstream.
+    ``--no-proxy`` means "use what is already there", so this warns rather than
+    failing, but it must not stay silent.
+    """
+    health = {
+        "version": wrap_cli._HEADROOM_VERSION,
+        "runtime": {"websocket_sessions": {"active_sessions": 0, "active_relay_tasks": 0}},
+        "config": {"pid": 12345, "openai_api_url": None},
+    }
+
+    monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: True)
+    monkeypatch.setattr(wrap_cli, "_query_proxy_health", lambda port: health)
+    monkeypatch.setattr(
+        wrap_cli,
+        "_start_proxy",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("--no-proxy must not start a proxy")
+        ),
+    )
+
     proc, actual_port = wrap_cli._ensure_proxy(
         8787,
-        False,
-        openai_api_url="https://api.githubcopilot.com",
+        True,
+        agent_type="bob",
+        openai_api_url="https://api.us-east.bob.ibm.com/inference/v1",
     )
 
     assert proc is None
     assert actual_port == 8787
-    assert calls == [("restart", "default", 8787)]
+    out = capsys.readouterr().out
+    assert "api.us-east.bob.ibm.com" in out
+    assert "--no-proxy" in out
+
+
+def test_ensure_proxy_no_proxy_is_quiet_when_upstream_matches(monkeypatch, capsys) -> None:
+    """Control: a matching upstream under --no-proxy produces no warning."""
+    requested = "https://api.us-east.bob.ibm.com/inference/v1"
+    health = {
+        "version": wrap_cli._HEADROOM_VERSION,
+        "runtime": {"websocket_sessions": {"active_sessions": 0, "active_relay_tasks": 0}},
+        "config": {"pid": 12345, "openai_api_url": requested},
+    }
+
+    monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: True)
+    monkeypatch.setattr(wrap_cli, "_query_proxy_health", lambda port: health)
+
+    wrap_cli._ensure_proxy(8787, True, agent_type="bob", openai_api_url=requested)
+
+    assert "api.us-east.bob.ibm.com" not in capsys.readouterr().out

--- a/tests/test_install/test_planner.py
+++ b/tests/test_install/test_planner.py
@@ -365,3 +365,105 @@ def test_build_manifest_extra_env_wins_over_grok_xai_default() -> None:
     assert manifest.base_env["OPENAI_TARGET_API_URL"] == "https://gateway.example/v1"
     idx = manifest.proxy_args.index("--openai-api-url")
     assert manifest.proxy_args[idx + 1] == "https://gateway.example/v1"
+
+
+def test_resolve_targets_manual_accepts_bob() -> None:
+    """`--target bob` must survive resolution.
+
+    Without ToolTarget.BOB the value was filtered out of `normalized` here, so
+    the Bob env builder registered in install_registry was never reached and the
+    generated manifest carried no IBM gateway upstream.
+    """
+    targets = resolve_targets(ProviderSelectionMode.MANUAL.value, ["bob"])
+
+    assert targets == [ToolTarget.BOB.value]
+
+
+def test_build_manifest_bob_only_sets_ibm_gateway_upstream() -> None:
+    """A persistent install for Bob alone must point the OpenAI upstream at IBM.
+
+    This is the flag whose absence sent Bob's `Authorization: apikey ...` to
+    api.openai.com and 401'd every request.
+    """
+    from headroom.providers.bob import DEFAULT_API_URL
+
+    manifest = build_manifest(**_base_manifest_kwargs(targets=["bob"], backend="openai"))
+
+    assert manifest.base_env.get("OPENAI_TARGET_API_URL") == DEFAULT_API_URL
+    idx = manifest.proxy_args.index("--openai-api-url")
+    assert manifest.proxy_args[idx + 1] == DEFAULT_API_URL
+
+
+def test_build_manifest_bob_with_codex_does_not_force_ibm_gateway() -> None:
+    """Do not hijack the OpenAI upstream when OpenAI-native tools share the proxy."""
+    manifest = build_manifest(**_base_manifest_kwargs(targets=["bob", "codex"], backend="openai"))
+
+    assert "OPENAI_TARGET_API_URL" not in manifest.base_env
+    assert "--openai-api-url" not in manifest.proxy_args
+
+
+def test_build_manifest_rejects_two_competing_openai_gateways() -> None:
+    """Bob and Grok cannot share one proxy, and the conflict must be loud.
+
+    A proxy has a single `--openai-api-url`. Silently leaving it unset sends
+    *both* tools to api.openai.com, where neither credential is valid — the
+    same silent-misroute failure as an upstream pointed at the wrong provider.
+    Picking a winner is no better: it breaks the loser just as quietly.
+    """
+    with pytest.raises(click.ClickException) as excinfo:
+        build_manifest(**_base_manifest_kwargs(targets=["bob", "grok"], backend="openai"))
+
+    message = str(excinfo.value)
+    assert "bob" in message and "grok" in message
+    assert "OPENAI_TARGET_API_URL" in message
+
+
+def test_build_manifest_explicit_upstream_resolves_gateway_conflict() -> None:
+    """An explicit override is the documented escape hatch, so it must not raise."""
+    manifest = build_manifest(
+        **_base_manifest_kwargs(
+            targets=["bob", "grok"],
+            backend="openai",
+            extra_env={"OPENAI_TARGET_API_URL": "https://gateway.example/v1"},
+        )
+    )
+
+    assert manifest.base_env["OPENAI_TARGET_API_URL"] == "https://gateway.example/v1"
+
+
+def test_build_manifest_openai_native_target_defuses_gateway_conflict() -> None:
+    """With an OpenAI-native tool present nothing is auto-derived, so no conflict.
+
+    This is the common `--providers auto` shape on a developer machine (codex
+    or copilot installed alongside everything else) and must keep working
+    exactly as it did before Bob became a valid target.
+    """
+    manifest = build_manifest(
+        **_base_manifest_kwargs(targets=["bob", "grok", "codex"], backend="openai")
+    )
+
+    assert "OPENAI_TARGET_API_URL" not in manifest.base_env
+    assert "--openai-api-url" not in manifest.proxy_args
+
+
+def test_build_manifest_extra_env_wins_over_bob_gateway_default() -> None:
+    manifest = build_manifest(
+        **_base_manifest_kwargs(
+            targets=["bob"],
+            backend="openai",
+            extra_env={"OPENAI_TARGET_API_URL": "https://gateway.example/v1"},
+        )
+    )
+
+    assert manifest.base_env["OPENAI_TARGET_API_URL"] == "https://gateway.example/v1"
+    idx = manifest.proxy_args.index("--openai-api-url")
+    assert manifest.proxy_args[idx + 1] == "https://gateway.example/v1"
+
+
+def test_build_manifest_bob_tool_env_wires_gateway_url() -> None:
+    """The manifest must hand Bob its BOB_GATEWAY_URL, not just configure upstream."""
+    from headroom.providers.bob import PROXY_ENV_KEY
+
+    manifest = build_manifest(**_base_manifest_kwargs(targets=["bob"], backend="openai"))
+
+    assert manifest.tool_envs["bob"][PROXY_ENV_KEY] == "http://127.0.0.1:8787"

--- a/tests/test_provider_bob.py
+++ b/tests/test_provider_bob.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+from headroom.providers.bob import (
+    DEFAULT_API_URL,
+    GATEWAY_CHAT_COMPLETIONS_PATH,
+    PROXY_ENV_KEY,
+    build_launch_env,
+    proxy_base_url,
+)
+from headroom.providers.bob.install import build_install_env
+from headroom.providers.registry import _normalize_api_url
+from headroom.providers.route_specs import OPENAI_HANDLER_ROUTES
+
+
+def test_bob_proxy_base_url_has_no_version_suffix() -> None:
+    # Bob appends `/inference/v1/...` itself; a `/v1` base would double it.
+    assert proxy_base_url(8787) == "http://127.0.0.1:8787"
+
+
+def test_bob_build_launch_env_sets_gateway_url() -> None:
+    env, display = build_launch_env(9999, environ={})
+
+    assert env[PROXY_ENV_KEY] == "http://127.0.0.1:9999"
+    assert display == [f"{PROXY_ENV_KEY}=http://127.0.0.1:9999"]
+
+
+def test_bob_build_launch_env_preserves_existing_environment() -> None:
+    env, _display = build_launch_env(8787, environ={"HOME": "/home/dev"})
+
+    assert env["HOME"] == "/home/dev"
+
+
+def test_bob_build_launch_env_applies_project_prefix() -> None:
+    env, _display = build_launch_env(8787, environ={}, project="frontend")
+
+    assert env[PROXY_ENV_KEY] == "http://127.0.0.1:8787/p/frontend"
+
+
+def test_bob_install_env_returns_gateway_url() -> None:
+    assert build_install_env(port=7654, backend="ignored") == {
+        PROXY_ENV_KEY: "http://127.0.0.1:7654",
+    }
+
+
+def test_bob_inference_path_routes_to_openai_chat_handler() -> None:
+    """Bob's `/inference/v1` prefix must reach the compressing handler.
+
+    Without this route the request matches only the generic catch-all and is
+    forwarded upstream uncompressed -- the wrap would silently save nothing.
+    """
+    routes = {(route.method, route.path): route.handler_name for route in OPENAI_HANDLER_ROUTES}
+
+    assert routes[("POST", GATEWAY_CHAT_COMPLETIONS_PATH)] == "handle_openai_chat"
+
+
+def test_bob_upstream_target_round_trips_to_bob_inference_path() -> None:
+    """`DEFAULT_API_URL` must survive normalization back to Bob's real path.
+
+    `_normalize_api_url` strips a trailing `/v1` and `handle_openai_chat`
+    re-appends `/v1/chat/completions`, so the two must compose back into the
+    `/inference/v1/chat/completions` endpoint Bob's gateway actually serves.
+    """
+    normalized = _normalize_api_url(DEFAULT_API_URL, default="https://unused.invalid")
+
+    assert normalized == "https://api.us-east.bob.ibm.com/inference"
+    assert normalized + "/v1/chat/completions" == (
+        f"https://api.us-east.bob.ibm.com{GATEWAY_CHAT_COMPLETIONS_PATH}"
+    )
+
+
+def test_wrap_bob_prepare_only_skips_host_binary_lookup(monkeypatch) -> None:
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    runner = CliRunner()
+
+    with patch("headroom.cli.wrap.shutil.which") as which_mock:
+        result = runner.invoke(main, ["wrap", "bob", "--prepare-only"])
+
+    assert result.exit_code == 0, result.output
+    which_mock.assert_not_called()
+
+
+def test_wrap_bob_missing_binary_gives_install_hint(monkeypatch) -> None:
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    runner = CliRunner()
+
+    with patch("headroom.cli.wrap.shutil.which", return_value=None):
+        result = runner.invoke(main, ["wrap", "bob"])
+
+    assert result.exit_code == 1
+    assert "'bob' not found" in result.output
+
+
+def test_unwrap_bob_reports_nothing_to_restore(monkeypatch) -> None:
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["unwrap", "bob", "--no-stop-proxy"])
+
+    assert result.exit_code == 0, result.output
+    assert "BOB_GATEWAY_URL" in result.output
+    assert "no longer routed" in result.output

--- a/tests/test_provider_bob.py
+++ b/tests/test_provider_bob.py
@@ -104,3 +104,66 @@ def test_unwrap_bob_reports_nothing_to_restore(monkeypatch) -> None:
     assert result.exit_code == 0, result.output
     assert "BOB_GATEWAY_URL" in result.output
     assert "no longer routed" in result.output
+
+
+def test_wrap_bob_hands_ibm_gateway_upstream_to_the_proxy(monkeypatch) -> None:
+    """`wrap bob` must tell the proxy which upstream Bob needs.
+
+    This is the contract the proxy-reuse checks depend on: without
+    ``openai_api_url`` the mismatch detection has nothing to compare, and a
+    proxy configured for another provider is reused silently. In production
+    that sent Bob's IBM ``Authorization: apikey ...`` to api.openai.com and
+    401'd every ``/inference/v1/chat/completions``.
+    """
+    import headroom.cli.wrap as wrap_mod
+
+    captured: dict[str, object] = {}
+
+    class _Completed:
+        returncode = 0
+
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    monkeypatch.setattr(wrap_mod.shutil, "which", lambda binary: f"/usr/local/bin/{binary}")
+    monkeypatch.setattr(
+        wrap_mod,
+        "_ensure_proxy",
+        lambda port, no_proxy, **kwargs: captured.update(kwargs) or (None, port),
+    )
+    monkeypatch.setattr(wrap_mod.subprocess, "run", lambda *a, **kw: _Completed())
+
+    result = CliRunner().invoke(main, ["wrap", "bob"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["openai_api_url"] == DEFAULT_API_URL
+    # agent_type drives the remedy text in the upstream-mismatch error.
+    assert captured["agent_type"] == "bob"
+
+
+def test_wrap_bob_points_bob_at_the_actual_proxy_port(monkeypatch) -> None:
+    """When the requested port is taken, BOB_GATEWAY_URL must follow the fallback.
+
+    ``_launch_tool`` rewrites ``127.0.0.1:<requested>`` in the launch env after
+    ``_ensure_proxy`` reports the port it really bound. If that rewrite missed
+    Bob's variable, Bob would keep talking to whatever else owns the original
+    port.
+    """
+    import headroom.cli.wrap as wrap_mod
+
+    launched_env: dict[str, str] = {}
+
+    class _Completed:
+        returncode = 0
+
+    def _run(cmd, env=None, **kwargs):
+        launched_env.update(env or {})
+        return _Completed()
+
+    monkeypatch.delenv("HEADROOM_CONTEXT_TOOL", raising=False)
+    monkeypatch.setattr(wrap_mod.shutil, "which", lambda binary: f"/usr/local/bin/{binary}")
+    monkeypatch.setattr(wrap_mod, "_ensure_proxy", lambda port, no_proxy, **kwargs: (None, 8788))
+    monkeypatch.setattr(wrap_mod.subprocess, "run", _run)
+
+    result = CliRunner().invoke(main, ["wrap", "bob", "--port", "8787"])
+
+    assert result.exit_code == 0, result.output
+    assert launched_env[PROXY_ENV_KEY].startswith("http://127.0.0.1:8788")

--- a/tests/test_provider_bob_proxy_modes.py
+++ b/tests/test_provider_bob_proxy_modes.py
@@ -53,6 +53,19 @@ def _conversation() -> list[dict[str, Any]]:
     ]
 
 
+# Deliberately not "headroom": that is a real project in this repo's own
+# savings history, so a test using it would read another session's counters.
+STATS_PROJECT = "bob-stats-attribution-test"
+
+
+def _recorded_requests(client: TestClient, project: str) -> int:
+    """Requests /stats attributes to ``project`` right now."""
+    stats = client.get("/stats")
+    assert stats.status_code == 200, stats.text[:300]
+    row = (stats.json().get("savings", {}).get("per_project", {}) or {}).get(project, {})
+    return int(row.get("requests", 0))
+
+
 def _make_app(**overrides: Any):
     config = ProxyConfig(
         optimize=overrides.pop("optimize", True),
@@ -68,8 +81,37 @@ def _make_app(**overrides: Any):
     return app
 
 
+def _assert_reached_ibm(captured: dict[str, Any]) -> None:
+    """Assert the request reached IBM and nothing reached OpenAI.
+
+    Checked by recording rather than by raising inside the mock: the proxy
+    catches upstream exceptions and forwards them as an error response
+    ("Forwarding upstream streaming error" in the real logs), so an
+    ``AssertionError`` raised from a side_effect is swallowed on the streaming
+    path and never reaches the test.
+    """
+    assert not captured["openai_hits"], (
+        f"Bob traffic was forwarded to OpenAI instead of IBM: {captured['openai_hits']}. "
+        "This is the 401 loop from the persistent-deployment upstream mismatch."
+    )
+    assert captured.get("url") == BOB_UPSTREAM_URL, (
+        f"expected upstream {BOB_UPSTREAM_URL}, got {captured.get('url')!r}"
+    )
+
+
+def _record_openai_hits(router: respx.MockRouter, captured: dict[str, Any]) -> None:
+    """Record any api.openai.com call so `_assert_reached_ibm` can report it."""
+    captured["openai_hits"] = []
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        captured["openai_hits"].append(str(request.url))
+        return httpx.Response(401, json={"error": {"message": "no api key"}})
+
+    router.route(url__startswith="https://api.openai.com").mock(side_effect=_record)
+
+
 def _mock_bob_upstream(router: respx.MockRouter) -> dict[str, Any]:
-    """Mock IBM's gateway and make any api.openai.com call an explicit failure."""
+    """Mock IBM's gateway and record any api.openai.com call as a failure."""
     captured: dict[str, Any] = {}
 
     def _capture(request: httpx.Request) -> httpx.Response:
@@ -96,14 +138,7 @@ def _mock_bob_upstream(router: respx.MockRouter) -> dict[str, Any]:
         )
 
     router.route(url__startswith=BOB_UPSTREAM_ORIGIN).mock(side_effect=_capture)
-
-    def _reject(request: httpx.Request) -> httpx.Response:
-        raise AssertionError(
-            f"Bob traffic was forwarded to OpenAI instead of IBM: {request.url}. "
-            "This is the 401 loop from the persistent-deployment upstream mismatch."
-        )
-
-    router.route(url__startswith="https://api.openai.com").mock(side_effect=_reject)
+    _record_openai_hits(router, captured)
     return captured
 
 
@@ -121,7 +156,7 @@ def test_bob_chat_routes_to_ibm_gateway_in_every_mode(mode: str) -> None:
         )
 
     assert response.status_code == 200, response.text[:300]
-    assert captured["url"] == BOB_UPSTREAM_URL
+    _assert_reached_ibm(captured)
     # Bob's IBM credential must reach IBM unchanged — the proxy relays it, it
     # does not mint or rewrite one.
     assert captured["authorization"] == "apikey test-ibm-key"
@@ -144,7 +179,7 @@ def test_bob_chat_routes_to_ibm_gateway_without_compression() -> None:
         )
 
     assert response.status_code == 200, response.text[:300]
-    assert captured["url"] == BOB_UPSTREAM_URL
+    _assert_reached_ibm(captured)
     # Untouched payload: same message count, same roles.
     assert len(captured["body"]["messages"]) == len(_conversation())
 
@@ -167,7 +202,7 @@ def test_bob_project_prefix_is_stripped_before_routing() -> None:
         )
 
     assert response.status_code == 200, response.text[:300]
-    assert captured["url"] == BOB_UPSTREAM_URL
+    _assert_reached_ibm(captured)
     assert "/p/headroom" not in captured["url"]
 
 
@@ -183,18 +218,143 @@ def test_bob_requests_are_observable_in_stats() -> None:
     app = _make_app(mode="token")
     with TestClient(app) as client:
         _mock_bob_upstream(respx)
+        before = _recorded_requests(client, STATS_PROJECT)
         for _ in range(3):
             response = client.post(
-                f"/p/headroom{GATEWAY_CHAT_COMPLETIONS_PATH}",
+                f"/p/{STATS_PROJECT}{GATEWAY_CHAT_COMPLETIONS_PATH}",
                 headers=BOB_HEADERS,
                 json={"model": "premium-ide", "messages": _conversation()},
             )
             assert response.status_code == 200, response.text[:300]
 
-        stats = client.get("/stats")
+        # Assert a *delta on the project key*, not a substring of the whole
+        # blob. `savings.per_project` is persisted to
+        # ~/.headroom/proxy_savings.json and survives across runs, so an
+        # absolute count can pass on stale data from an earlier run. And a
+        # substring check is vacuous: "headroom" appears in service_name,
+        # without_headroom_usd, and the savings file path whether or not
+        # attribution works.
+        after = _recorded_requests(client, STATS_PROJECT)
 
-    assert stats.status_code == 200, stats.text[:300]
-    payload = stats.json()
-    blob = json.dumps(payload)
-    assert "headroom" in blob, "project attribution missing from /stats"
-    assert payload, "stats payload was empty after three Bob requests"
+    assert after - before == 3, f"expected 3 attributed requests, got {after - before}"
+
+
+# ── Streaming ────────────────────────────────────────────────────────────────
+#
+# Bob streams in production: the 401s that motivated these tests were logged as
+# "Forwarding upstream streaming error status=401". Every test above uses a
+# non-streaming upstream, so the path Bob actually takes was untested.
+
+SSE_CHUNKS = (
+    'data: {"id":"c1","object":"chat.completion.chunk",'
+    '"choices":[{"index":0,"delta":{"role":"assistant","content":"re"}}]}\n\n',
+    'data: {"id":"c1","object":"chat.completion.chunk",'
+    '"choices":[{"index":0,"delta":{"content":"ady"},"finish_reason":"stop"}]}\n\n',
+    'data: {"id":"c1","object":"chat.completion.chunk","choices":[],'
+    '"usage":{"prompt_tokens":900,"completion_tokens":2,"total_tokens":902}}\n\n',
+    "data: [DONE]\n\n",
+)
+
+
+def _mock_bob_sse_upstream(router: respx.MockRouter) -> dict[str, Any]:
+    """Mock IBM's gateway with an SSE response; any OpenAI call fails the test."""
+    captured: dict[str, Any] = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["authorization"] = request.headers.get("authorization")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content="".join(SSE_CHUNKS).encode(),
+        )
+
+    router.route(url__startswith=BOB_UPSTREAM_ORIGIN).mock(side_effect=_capture)
+    _record_openai_hits(router, captured)
+    return captured
+
+
+@pytest.mark.parametrize("mode", ["token", "cache"])
+@respx.mock
+def test_bob_streaming_routes_to_ibm_gateway(mode: str) -> None:
+    """A streamed Bob request must reach IBM, in every mode.
+
+    Routing is decided per request, so a proxy correct for non-streaming is not
+    automatically correct here — and this is the shape Bob actually sends.
+    """
+    app = _make_app(mode=mode)
+    with TestClient(app) as client:
+        captured = _mock_bob_sse_upstream(respx)
+        response = client.post(
+            GATEWAY_CHAT_COMPLETIONS_PATH,
+            headers=BOB_HEADERS,
+            json={"model": "premium-ide", "stream": True, "messages": _conversation()},
+        )
+
+    assert response.status_code == 200, response.text[:300]
+    _assert_reached_ibm(captured)
+    assert captured["authorization"] == "apikey test-ibm-key"
+    # The proxy must not quietly downgrade the request to non-streaming: Bob
+    # renders incrementally and would hang waiting for chunks that never come.
+    assert captured["body"]["stream"] is True
+
+
+@respx.mock
+def test_bob_streaming_relays_sse_response_intact() -> None:
+    """Every upstream SSE chunk must reach Bob unaltered, terminator included.
+
+    A dropped or reordered chunk shows up as truncated output rather than an
+    error, and a missing `[DONE]` leaves the client waiting on a finished
+    stream.
+    """
+    app = _make_app(mode="token")
+    with TestClient(app) as client:
+        _mock_bob_sse_upstream(respx)
+        response = client.post(
+            GATEWAY_CHAT_COMPLETIONS_PATH,
+            headers=BOB_HEADERS,
+            json={"model": "premium-ide", "stream": True, "messages": _conversation()},
+        )
+
+    assert response.status_code == 200, response.text[:300]
+    assert response.headers["content-type"].startswith("text/event-stream")
+
+    body = response.text
+    for chunk in SSE_CHUNKS:
+        assert chunk in body, f"missing SSE chunk: {chunk[:60]}"
+    assert body.rstrip().endswith("data: [DONE]"), body[-80:]
+
+    # Reassembled deltas must spell the upstream content, in order.
+    deltas = [
+        json.loads(line.removeprefix("data: "))
+        for line in body.splitlines()
+        if line.startswith("data: ") and not line.endswith("[DONE]")
+    ]
+    text = "".join(
+        choice["delta"].get("content", "")
+        for chunk in deltas
+        for choice in chunk.get("choices", [])
+    )
+    assert text == "ready", text
+
+
+@respx.mock
+def test_bob_streaming_strips_project_prefix() -> None:
+    """`/p/<name>` must be stripped on the streaming path too.
+
+    The prefix is removed in ASGI scope before routing, which is shared with
+    the non-streaming path — this pins that streaming does not bypass it.
+    """
+    app = _make_app(mode="token")
+    with TestClient(app) as client:
+        captured = _mock_bob_sse_upstream(respx)
+        response = client.post(
+            f"/p/{STATS_PROJECT}{GATEWAY_CHAT_COMPLETIONS_PATH}",
+            headers=BOB_HEADERS,
+            json={"model": "premium-ide", "stream": True, "messages": _conversation()},
+        )
+
+    assert response.status_code == 200, response.text[:300]
+    _assert_reached_ibm(captured)
+    assert "/p/" not in captured["url"]

--- a/tests/test_provider_bob_proxy_modes.py
+++ b/tests/test_provider_bob_proxy_modes.py
@@ -1,0 +1,200 @@
+"""Bob gateway routing and attribution across the proxy's operating modes.
+
+The failure these guard against is not a compression bug: it is Bob's request
+reaching the *wrong host*. A proxy configured for another provider still routes
+``/inference/v1/chat/completions`` happily — it just forwards it to
+api.openai.com, where Bob's IBM ``Authorization: apikey ...`` is not a
+credential and every request comes back 401.
+
+``baseline`` is deliberately not in the mode list. ``normalize_proxy_mode``
+knows only ``token`` and ``cache``; anything else logs "Unknown HEADROOM_MODE"
+and silently becomes ``token``. The no-compression arm is ``optimize=False``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from headroom.providers.bob import DEFAULT_API_URL, GATEWAY_CHAT_COMPLETIONS_PATH  # noqa: E402
+from headroom.proxy.loopback_guard import require_loopback  # noqa: E402
+from headroom.proxy.server import ProxyConfig, create_app  # noqa: E402
+
+# The origin Bob's DEFAULT_API_URL resolves to once `_normalize_api_url` strips
+# the trailing `/v1` and the handler re-appends `/v1/chat/completions`.
+BOB_UPSTREAM_ORIGIN = "https://api.us-east.bob.ibm.com"
+BOB_UPSTREAM_URL = f"{BOB_UPSTREAM_ORIGIN}{GATEWAY_CHAT_COMPLETIONS_PATH}"
+
+# Bob's own headers, as captured from bob-shell/2.0.1 in ~/.headroom/logs.
+BOB_HEADERS = {
+    "authorization": "apikey test-ibm-key",
+    "user-agent": "ai-sdk/openrouter/3.0.0 bob-shell/2.0.1",
+    "x-platform-name": "bob-shell",
+    "x-mode": "agent",
+}
+
+
+def _conversation() -> list[dict[str, Any]]:
+    """A payload with enough repeated bulk that compression has something to do."""
+    filler = "def handler(request):\n    return process(request)\n" * 40
+    return [
+        {"role": "system", "content": "You are Bob, an IBM coding assistant. " + filler},
+        {"role": "user", "content": "Summarize the handler module."},
+        {"role": "assistant", "content": "It defines a request handler. " + filler},
+        {"role": "user", "content": "Now add error handling."},
+    ]
+
+
+def _make_app(**overrides: Any):
+    config = ProxyConfig(
+        optimize=overrides.pop("optimize", True),
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+        log_requests=False,
+        openai_api_url=DEFAULT_API_URL,
+        **overrides,
+    )
+    app = create_app(config)
+    app.dependency_overrides[require_loopback] = lambda: None
+    return app
+
+
+def _mock_bob_upstream(router: respx.MockRouter) -> dict[str, Any]:
+    """Mock IBM's gateway and make any api.openai.com call an explicit failure."""
+    captured: dict[str, Any] = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["authorization"] = request.headers.get("authorization")
+        try:
+            captured["body"] = json.loads(request.content)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            captured["body"] = None
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-bob-1",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 100, "completion_tokens": 2, "total_tokens": 102},
+            },
+        )
+
+    router.route(url__startswith=BOB_UPSTREAM_ORIGIN).mock(side_effect=_capture)
+
+    def _reject(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(
+            f"Bob traffic was forwarded to OpenAI instead of IBM: {request.url}. "
+            "This is the 401 loop from the persistent-deployment upstream mismatch."
+        )
+
+    router.route(url__startswith="https://api.openai.com").mock(side_effect=_reject)
+    return captured
+
+
+@pytest.mark.parametrize("mode", ["token", "cache"])
+@respx.mock
+def test_bob_chat_routes_to_ibm_gateway_in_every_mode(mode: str) -> None:
+    """Every real proxy mode must forward Bob's chat calls to IBM, not OpenAI."""
+    app = _make_app(mode=mode)
+    with TestClient(app) as client:
+        captured = _mock_bob_upstream(respx)
+        response = client.post(
+            GATEWAY_CHAT_COMPLETIONS_PATH,
+            headers=BOB_HEADERS,
+            json={"model": "premium-ide", "messages": _conversation()},
+        )
+
+    assert response.status_code == 200, response.text[:300]
+    assert captured["url"] == BOB_UPSTREAM_URL
+    # Bob's IBM credential must reach IBM unchanged — the proxy relays it, it
+    # does not mint or rewrite one.
+    assert captured["authorization"] == "apikey test-ibm-key"
+
+
+@respx.mock
+def test_bob_chat_routes_to_ibm_gateway_without_compression() -> None:
+    """The no-compression arm must route identically.
+
+    Routing is decided before the pipeline runs, so `optimize=False` must not
+    change the destination — only what is sent to it.
+    """
+    app = _make_app(optimize=False)
+    with TestClient(app) as client:
+        captured = _mock_bob_upstream(respx)
+        response = client.post(
+            GATEWAY_CHAT_COMPLETIONS_PATH,
+            headers=BOB_HEADERS,
+            json={"model": "premium-ide", "messages": _conversation()},
+        )
+
+    assert response.status_code == 200, response.text[:300]
+    assert captured["url"] == BOB_UPSTREAM_URL
+    # Untouched payload: same message count, same roles.
+    assert len(captured["body"]["messages"]) == len(_conversation())
+
+
+@respx.mock
+def test_bob_project_prefix_is_stripped_before_routing() -> None:
+    """`/p/<name>` attribution must not leak into the upstream path.
+
+    Bob sends no attribution headers, so `wrap bob` encodes the project in the
+    base URL instead. If the prefix survived routing, IBM would receive
+    `/p/headroom/inference/v1/chat/completions` and 404.
+    """
+    app = _make_app(mode="token")
+    with TestClient(app) as client:
+        captured = _mock_bob_upstream(respx)
+        response = client.post(
+            f"/p/headroom{GATEWAY_CHAT_COMPLETIONS_PATH}",
+            headers=BOB_HEADERS,
+            json={"model": "premium-ide", "messages": _conversation()},
+        )
+
+    assert response.status_code == 200, response.text[:300]
+    assert captured["url"] == BOB_UPSTREAM_URL
+    assert "/p/headroom" not in captured["url"]
+
+
+@respx.mock
+def test_bob_requests_are_observable_in_stats() -> None:
+    """A wrapped Bob session must show up on the dashboard's data source.
+
+    `headroom dashboard` renders /stats from the proxy the agent is pointed at,
+    so observability only works when the same proxy both serves Bob and records
+    the request. This pins that the request is counted, which is what made the
+    split-port workaround unsatisfying.
+    """
+    app = _make_app(mode="token")
+    with TestClient(app) as client:
+        _mock_bob_upstream(respx)
+        for _ in range(3):
+            response = client.post(
+                f"/p/headroom{GATEWAY_CHAT_COMPLETIONS_PATH}",
+                headers=BOB_HEADERS,
+                json={"model": "premium-ide", "messages": _conversation()},
+            )
+            assert response.status_code == 200, response.text[:300]
+
+        stats = client.get("/stats")
+
+    assert stats.status_code == 200, stats.text[:300]
+    payload = stats.json()
+    blob = json.dumps(payload)
+    assert "headroom" in blob, "project attribution missing from /stats"
+    assert payload, "stats payload was empty after three Bob requests"

--- a/tests/test_provider_route_specs.py
+++ b/tests/test_provider_route_specs.py
@@ -83,6 +83,7 @@ def test_direct_handler_routes_model_endpoint_intent() -> None:
     assert OPENAI_HANDLER_ROUTES == (
         ProviderHandlerRoute("POST", "/v1/chat/completions", "handle_openai_chat"),
         ProviderHandlerRoute("POST", "/chat/completions", "handle_openai_chat"),
+        ProviderHandlerRoute("POST", "/inference/v1/chat/completions", "handle_openai_chat"),
     )
     assert GEMINI_HANDLER_ROUTES == (
         ProviderHandlerRoute(

--- a/tests/test_proxy_dashboard_stats_cache.py
+++ b/tests/test_proxy_dashboard_stats_cache.py
@@ -218,27 +218,21 @@ def test_proxy_throughput_in_stats_endpoint(monkeypatch: pytest.MonkeyPatch) -> 
     `from headroom.perf.analyzer import ...` on every call, so we patch the
     names directly on the `headroom.perf.analyzer` module so the local import
     inside the closure picks up our fakes.
-
-    Skipped locally when headroom._core (Rust extension) is not compiled.
     """
     pytest.importorskip("fastapi")
     from fastapi.testclient import TestClient
 
     import headroom.perf.analyzer as _analyzer_mod
+    from headroom.proxy.loopback_guard import require_loopback
+    from headroom.proxy.server import ProxyConfig, create_app
 
-    try:
-        from headroom.proxy.server import (
-            _throughput_cache,
-            create_app,
-            require_loopback,
-        )
-    except (ImportError, ModuleNotFoundError) as exc:
-        pytest.skip(f"headroom._core not available (Rust extension not compiled): {exc}")
-
-    from headroom.config import ProxyConfig
-
-    # Reset the module-level cache so CI doesn't reuse a stale value
-    _throughput_cache.update({"expires_at": 0.0, "value": None})
+    # No cache reset needed: `_throughput_cache` is a local of `create_app`
+    # captured by the route closures, so each app built below starts with its
+    # own empty cache. It was previously imported here and reset as a
+    # "module-level cache" — an import that cannot succeed, whose ImportError
+    # was caught and reported as a missing Rust extension. That skipped this
+    # test unconditionally, on every machine, including ones where the
+    # extension is compiled.
 
     # Patch at the module level so the local import inside _compute_throughput
     # picks up our stubs instead of the real implementations.


### PR DESCRIPTION
## Description

Adds a `headroom wrap` target for the IBM Bob CLI (npm `bobshell`).

Bob speaks OpenAI-shaped chat completions but posts them under its own gateway
prefix — `POST {gateway}/inference/v1/chat/completions`. That path matches none
of the existing OpenAI handler routes, so even a user who manually points Bob
at a Headroom proxy gets the uncompressed catch-all passthrough with no error
to notice. This PR adds the route (same rationale as the unprefixed
`/chat/completions` entry for Copilot Chat directly above it), a provider
slice on the grok template, and `wrap bob` / `unwrap bob` commands.

Routing is session-scoped via `BOB_GATEWAY_URL` (Bob resolves
`config.gatewayUrl ?? BOB_GATEWAY_URL ?? default`). `wrap bob` writes no Bob
config; `unwrap bob` has nothing to restore because nothing was changed.
Launching Bob without the wrap removes every trace. Bob keeps its own
`Authorization: apikey …` credential — Headroom never touches it. Project
attribution uses the `/p/<name>` path prefix since Bob sends no custom
headers.

No new dependencies.

Closes #3322

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/providers/route_specs.py` — one additive route:
  `POST /inference/v1/chat/completions → handle_openai_chat`. Only Bob-shaped
  paths can match it; no existing agent's traffic changes.
- `headroom/providers/bob/` — new provider slice (`runtime.py`, `install.py`).
  `DEFAULT_API_URL` deliberately carries the `/inference/v1` suffix so that
  `_normalize_api_url` (strips trailing `/v1`) and `handle_openai_chat`
  (re-appends `/v1/chat/completions`) compose back into the path Bob's gateway
  serves; a test pins that round-trip since it spans two modules.
- `headroom/cli/wrap.py` — `wrap bob` and `unwrap bob` commands, help-text
  listings.
- `headroom/providers/install_registry.py` — env builder registration.
- `tests/test_provider_bob.py` — 10 tests: URL construction, project prefix,
  route registration, the normalize/re-append round-trip, and CLI behavior
  (prepare-only, missing-binary hint, unwrap output).
- `benchmarks/bob_session_mode_benchmark.py` — offline replay of real Bob
  sessions (from the local `~/.bob/db/bob.db`) through the real
  `openai_pipeline` in baseline/token/cache modes. Exits cleanly when no Bob
  DB exists — CI and maintainers without Bob are unaffected. Prints aggregate
  numbers only, never message content.
- `README.md` — compatibility-matrix row + wrap list entry.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_provider_bob.py tests/test_provider_route_specs.py -q
17 passed

$ python -m pytest -q tests/test_transforms/test_smart_crusher_bugs.py \
    tests/test_transforms/test_smart_crusher_rust_parity.py \
    tests/test_transforms/test_diff_compressor.py \
    tests/test_transforms/test_diff_compressor_rust_parity.py \
    tests/test_relevance.py tests/test_relevance_extra.py tests/test_ccr.py \
    tests/test_acceptance.py tests/test_critical_fixes.py \
    tests/test_quality_retention.py tests/test_toin_integration.py
192 passed, 4 skipped

$ ruff check headroom/providers/bob/ headroom/cli/wrap.py benchmarks/bob_session_mode_benchmark.py tests/test_provider_bob.py
All checks passed!

$ mypy headroom --ignore-missing-imports
Success: no issues found in 531 source files
```

## Real Behavior Proof

- Environment: macOS (Darwin 25.6.0, arm64), Python 3.13.11, IBM Bob CLI 2.0.1 (`bobshell`, authenticated subscription), upstream gateway `https://api.us-east.bob.ibm.com`, models `premium-ide` + `openai/gpt-oss-20b`
- Exact command / steps: `HEADROOM_MODE=token headroom proxy --port 8790 --openai-api-url https://api.us-east.bob.ibm.com/inference/v1` then `BOB_GATEWAY_URL=http://127.0.0.1:8790 bob run -f json --trust --max-turns 1 "Reply with exactly: PONG"`; then a live multi-turn task; then `python benchmarks/bob_session_mode_benchmark.py` — full detail below
- Observed result: live requests route through `handle_openai_chat`, forward to `/inference/v1/chat/completions` with the `apikey` auth scheme intact, 0 failed requests; live task saved 12.0% (109,170 tokens in, 13,082 saved) with output quality matching an unproxied control; benchmark over 578 recorded turns: token mode 6.39% saved, cache mode 0.36%
- Not tested: Windows/Linux (macOS only); the VS Code-based Bob GUI (out of scope, CLI only); long-session (50+ turn) output quality under compression; all savings data is one user's history and subscription (n=1); Bob's real context-window sizes are unpublished so its models fall back to the 128K default limit

### Detail

  1. Live smoke test against the real IBM gateway through the proxy:

     ```text
     $ HEADROOM_MODE=token headroom proxy --port 8790 \
         --openai-api-url https://api.us-east.bob.ibm.com/inference/v1 &
     $ BOB_GATEWAY_URL=http://127.0.0.1:8790 bob run -f json --trust \
         --max-turns 1 "Reply with exactly: PONG"
     status: success | cost: 0.025246 | reply: 'PONG'
     ```

  2. Live multi-turn task (read 4 Python files, write SUMMARY.md), same
     proxy: `/stats` delta showed **109,170 tokens in, 13,082 saved (12.0%)**,
     7 requests, 0 failed. The produced SUMMARY.md contained correct
     `file:line` references (e.g. `base.py:18` for `TokenCounter`), matching
     a direct (unproxied) control run symbol-for-symbol — compression did not
     degrade output quality on this task.

  3. Reproducible offline benchmark over real recorded Bob sessions:

     ```text
     $ python benchmarks/bob_session_mode_benchmark.py
     replayed 578 turns from 178 Bob tasks (flat $2.0/Mtok, no cache discount)

     mode        forwarded tok       saved   saved %      cost   vs base
     baseline       13,588,045           0     0.00%     27.18         —
     token          12,719,436     868,609     6.39%     25.44    -$1.74
     cache          13,539,052      48,993     0.36%     27.08    -$0.10

     token mode — does saving scale with payload?
       payload     turns   avg saved   saved %
       <10K          188          40     0.64%
       10-25K        227         410     2.95%
       25-50K        103       2,771     7.62%
       50K+           60       8,039     8.78%
     ```

     Bob bills every token class at one flat rate with no cache discount
     (verified against Bob's own spend records with zero residual), so token
     savings translate directly to cost savings.

Additional observed detail: content-part arrays pass through intact, and
IBM's gateway accepts the `max_completion_tokens` rename applied by
`_normalize_openai_max_tokens`.

On the long-session gap in `Not tested`: it matters because Bob streams, and
the OpenAI streaming path cannot inject the CCR retrieve tool ("this path
cannot intercept tool calls"), so lossy-compressed history is unrecoverable
by the agent. That is a pre-existing property of the streaming path that Bob
inherits, not something this PR introduces; the recent-messages protection
window and content-aware compression mitigate it, and the live task above
showed no quality loss — but a long-session A/B has not been run.

## Runtime Rollout Safety

- Rollout-managed feature(s): none.
- Minimum rollout channel: n/a.
- Stable/default behavior changed: no — the route is additive and only
  matches a path no current agent sends; all other changes are new commands.
- Kill switch / disable path: don't run `wrap bob`; launching Bob without the
  wrap fully restores stock behavior (no config was ever written).
- Unsafe override required: no.
- Qualification impact: none.
- Rollback path: revert the commit; no persisted state, no migrations.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
