### PR TITLE
fix: keep dashboard route boundaries out of upstream passthrough

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -3841,6 +3841,12 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
 
     # check_dir=False keeps a missing assets directory from aborting proxy
     # startup: the dashboard JS 404s, but proxying itself still works.
+    @app.get("/dashboard/static", include_in_schema=False)
+    @app.get("/dashboard/static/", include_in_schema=False)
+    async def dashboard_static_directory():
+        """Keep the static directory boundary out of upstream passthrough."""
+        return PlainTextResponse("Not Found", status_code=404)
+
     app.mount(
         "/dashboard/static",
         StaticFiles(directory=STATIC_DIR, check_dir=False),
@@ -3848,6 +3854,7 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
     )
 
     @app.get("/dashboard", response_class=HTMLResponse)
+    @app.get("/dashboard/", response_class=HTMLResponse, include_in_schema=False)
     async def dashboard():
         """Serve the Headroom dashboard UI."""
         return get_dashboard_html()

--- a/tests/test_dashboard_static_assets.py
+++ b/tests/test_dashboard_static_assets.py
@@ -7,10 +7,13 @@ Windows machines. Tailwind/htmx/alpine are vendored and served locally instead.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 pytest.importorskip("fastapi")
 
+from fastapi.responses import Response  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 from headroom.dashboard import get_dashboard_html, get_settings_html  # noqa: E402
@@ -20,7 +23,8 @@ ASSETS = ["tailwind.min.js", "htmx.min.js", "alpine.min.js"]
 
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
+    monkeypatch.setenv("HEADROOM_SKIP_UPSTREAM_CHECK", "1")
     app = create_app(
         ProxyConfig(
             optimize=False,
@@ -28,10 +32,21 @@ def client():
             rate_limit_enabled=False,
             cost_tracking_enabled=False,
             log_requests=False,
+            http2=False,
         )
     )
     with TestClient(app) as c:
         yield c
+
+
+@pytest.fixture
+def passthrough(client):
+    with patch.object(
+        client.app.state.proxy,
+        "handle_passthrough",
+        new=AsyncMock(return_value=Response("upstream", status_code=418)),
+    ) as handler:
+        yield handler
 
 
 @pytest.mark.parametrize("html", [get_dashboard_html(), get_settings_html()])
@@ -41,10 +56,35 @@ def test_templates_reference_no_cdn(html: str):
 
 
 @pytest.mark.parametrize("asset", ASSETS)
-def test_asset_is_served(client, asset: str):
+def test_asset_is_served(client, passthrough, asset: str):
     resp = client.get(f"/dashboard/static/{asset}")
     assert resp.status_code == 200, resp.text
     assert len(resp.content) > 10_000
+    passthrough.assert_not_called()
+
+
+def test_dashboard_trailing_slash_is_served_locally(client, passthrough):
+    resp = client.get("/dashboard/")
+
+    assert resp.status_code == 200
+    assert resp.text == get_dashboard_html()
+    passthrough.assert_not_called()
+
+
+@pytest.mark.parametrize("path", ["/dashboard/static", "/dashboard/static/"])
+def test_static_directory_boundaries_are_not_forwarded(client, passthrough, path: str):
+    resp = client.get(path)
+
+    assert resp.status_code == 404
+    assert resp.text == "Not Found"
+    passthrough.assert_not_called()
+
+
+def test_unrelated_unknown_path_still_reaches_passthrough(client, passthrough):
+    resp = client.get("/unrelated-unknown-path")
+
+    assert resp.status_code == 418
+    passthrough.assert_awaited_once()
 
 
 def test_dashboard_only_references_served_assets(client):


### PR DESCRIPTION
## Description

`/dashboard/` and the `/dashboard/static` directory path had no local route, so both fell through to the catch-all and were forwarded upstream instead of being answered locally.

`StaticFiles` is mounted at `/dashboard/static`, which serves files *underneath* that prefix but does not answer the bare directory path, and `/dashboard` was registered without its trailing-slash form. Anything hitting those two boundaries went to passthrough.

Closes #3243

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Register `/dashboard/` alongside `/dashboard` so the trailing-slash form is served locally.
- Answer `/dashboard/static` and `/dashboard/static/` with a local 404, registered ahead of the mount so the directory boundary resolves here rather than being proxied. Files under the prefix are still served by the existing mount.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

`mypy headroom` is unchecked because it does not currently come back clean: 10 pre-existing errors in `headroom/integrations/crewai/agents.py` and `headroom/memory/backends/direct_mem0.py`, both untouched here. `headroom/proxy/server.py` reports no mypy errors, so this change adds none.

Manual testing is unchecked: the behaviour is asserted by the tests below rather than exercised by hand against a live upstream.

### Test Output

```text
# Paste relevant command output or artifact links here
$ uv run pytest tests/test_dashboard_static_assets.py -q
10 passed, 1 warning in 1.25s

$ uv run ruff check .
All checks passed!

$ uv run mypy headroom
Found 10 errors in 2 files (checked 528 source files)
# both files pre-existing and unrelated; no errors in headroom/proxy/server.py
```

## Real Behavior Proof

- Environment: macOS, Python 3.14, project `.venv` via `uv sync --all-extras`, FastAPI TestClient against `create_app()` with passthrough mocked.
- Exact command / steps: `uv run pytest tests/test_dashboard_static_assets.py -q`, then `git stash push -- headroom/proxy/server.py` and re-run to confirm the new cases fail without the fix.
- Observed result: 10 passed with the change. With `server.py` reverted and the tests kept: `3 failed, 7 passed` — `test_dashboard_trailing_slash_is_served_locally` and both `test_static_directory_boundaries_are_not_forwarded[/dashboard/static]` and `[/dashboard/static/]`. `test_unrelated_unknown_path_still_reaches_passthrough` is the control and stays green in both directions, so the new routes do not over-capture.
- Not tested: no run against a real upstream proxy target, and no browser check of the rendered dashboard. The assertions cover routing resolution, not rendering.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. This is unconditional route registration in `create_app()`.
- Minimum rollout channel: N/A, not gated by a rollout channel.
- Stable/default behavior changed: yes, and intentionally. `/dashboard/` now serves the dashboard instead of being proxied, and the two `/dashboard/static` directory paths now return a local 404 instead of being proxied.
- Kill switch / disable path: none added. Reverting this commit restores the previous passthrough behaviour.
- Unsafe override required: no.
- Qualification impact: none expected. Files under `/dashboard/static/...` are still served by the unchanged mount.
- Rollback path: revert this commit; the change is two route registrations in one function.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A. The change is a routing boundary, covered by the tests above rather than by a visual.

## Additional Notes

Documentation is unchecked because this restores intended routing behaviour and adds no new user-facing surface to document.

The local 404 is registered before `app.mount` deliberately: Starlette matches routes in registration order, so declaring it after the mount would leave the bare directory path unmatched again.

AI was used for assistance.
