### PR TITLE
fix(proxy): stop the WS->HTTP fallback from ignoring the timeout config

### DIFF
--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -104,6 +104,12 @@ _OPENAI_RESPONSES_UNIT_CACHE_INIT_LOCK = threading.RLock()
 _OPENAI_RESPONSES_UNIT_EXECUTOR_LOCK = threading.RLock()
 _OPENAI_RESPONSES_UNIT_EXECUTOR: ThreadPoolExecutor | None = None
 _CODEX_WS_COMPRESSION_TIMEOUT_SECONDS = 5.0
+# The WS->HTTP fallback streams SSE, so `read` is the gap BETWEEN events, not a
+# cap on the whole response: 120s of silence from a live Codex turn means the
+# upstream is gone, not thinking. That is this path's own bound and is
+# deliberately tighter than the generic request timeout. The other three phases
+# are not this path's business and come from ProxyConfig.
+_WS_HTTP_FALLBACK_READ_TIMEOUT_SECONDS = 120.0
 _CCR_HASH_RE = re.compile(
     r"(?:Retrieve (?:more|original): hash=|<<ccr:)([a-fA-F0-9]{12,24})(?=[^a-fA-F0-9]|$)"
 )
@@ -9206,6 +9212,22 @@ class OpenAIHandlerMixin:
                 metrics=getattr(self, "metrics", None),
             )
 
+    def _ws_http_fallback_timeout(self) -> httpx.Timeout:
+        """Timeout for the WS->HTTP fallback POST.
+
+        This used to be a bare ``timeout=120.0``. httpx expands a float across
+        all four phases, so connecting and pooling silently got 120s instead of
+        the configured 10s, and the send ignored ``write_timeout_seconds``
+        entirely — an operator tightening either knob had no effect on this
+        path. Only ``read`` was ever meant to be 120s here (#3259 follow-up).
+        """
+        return httpx.Timeout(
+            connect=self.config.connect_timeout_seconds,
+            read=_WS_HTTP_FALLBACK_READ_TIMEOUT_SECONDS,
+            write=self.config.write_timeout_seconds,
+            pool=self.config.connect_timeout_seconds,
+        )
+
     async def _ws_http_fallback(
         self,
         websocket: WebSocket,
@@ -9319,7 +9341,7 @@ class OpenAIHandlerMixin:
                         http_url,
                         headers=http_headers,
                         content=outbound_bytes,
-                        timeout=120.0,
+                        timeout=self._ws_http_fallback_timeout(),
                     ) as response:
                         if response.status_code != 200:
                             error_body = b""

--- a/tests/test_ws_http_fallback.py
+++ b/tests/test_ws_http_fallback.py
@@ -72,12 +72,84 @@ def _make_handler():
     obj = object.__new__(OpenAIHandlerMixin)
     obj.OPENAI_API_URL = "https://api.openai.com"
     obj.http_client = None
+    # Deliberately odd values: a test that asserts the real defaults would pass
+    # even if the timeout stopped being read from config at all.
     obj.config = SimpleNamespace(
         retry_max_attempts=3,
         retry_base_delay_ms=0,
         retry_max_delay_ms=0,
+        connect_timeout_seconds=7,
+        write_timeout_seconds=33,
+        request_timeout_seconds=999,
     )
     return obj
+
+
+class TestWsHttpFallbackTimeout:
+    """The fallback POST must honor the configured timeouts.
+
+    It passed a bare ``timeout=120.0``, and httpx expands a float across all
+    four phases -- so connect and pool silently got 120s instead of the
+    configured value, and the send ignored ``write_timeout_seconds``. Only the
+    SSE read bound was ever meant to be 120s here.
+    """
+
+    def test_connect_and_pool_come_from_config(self):
+        handler = _make_handler()
+
+        timeout = handler._ws_http_fallback_timeout()
+
+        assert timeout.connect == 7
+        assert timeout.pool == 7
+
+    def test_write_comes_from_config(self):
+        handler = _make_handler()
+
+        timeout = handler._ws_http_fallback_timeout()
+
+        assert timeout.write == 33
+
+    def test_the_read_bound_is_not_smeared_across_the_other_phases(self):
+        """The regression itself: one float became all four phases."""
+        handler = _make_handler()
+
+        timeout = handler._ws_http_fallback_timeout()
+
+        assert timeout.read == 120.0
+        assert timeout.connect != timeout.read
+        assert timeout.write != timeout.read
+        assert timeout.pool != timeout.read
+
+    def test_read_stays_the_paths_own_sse_stall_bound(self):
+        """`read` is the gap between SSE events, so it is not the generic cap."""
+        handler = _make_handler()
+
+        timeout = handler._ws_http_fallback_timeout()
+
+        assert timeout.read == 120.0
+        assert timeout.read != handler.config.request_timeout_seconds
+
+    def test_the_fallback_request_actually_uses_it(self):
+        """Pin the wiring, not just the helper."""
+        handler = _make_handler()
+        ws = FakeWebSocket()
+        captured_kwargs = {}
+
+        class CapturingClient:
+            def stream(self, method, url, **kwargs):
+                captured_kwargs.update(kwargs)
+                return FakeStreamResponse(200, ["data: [DONE]\n\n"])
+
+        handler.http_client = CapturingClient()
+
+        body = {"model": "gpt-5.4", "input": "test"}
+        asyncio.run(handler._ws_http_fallback(ws, body, json.dumps(body), {}, "req_timeout"))
+
+        timeout = captured_kwargs["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert timeout.connect == 7
+        assert timeout.write == 33
+        assert timeout.read == 120.0
 
 
 class TestWsHttpFallback:


### PR DESCRIPTION
## Description

Follow-up to #3327, from reviewing that PR rather than from a report.

The Codex WS→HTTP fallback POST passed a bare float:

```python
async with self.http_client.stream(
    "POST", http_url, headers=http_headers, content=outbound_bytes,
    timeout=120.0,
) as response:
```

httpx expands a float across **all four phases**, so this one call ran with `connect=120, read=120, write=120, pool=120`. Three of those are wrong:

- `connect=120` and `pool=120` instead of the configured 10s — a dead host takes two minutes to fail here rather than ten seconds.
- `write=120` ignores `write_timeout_seconds` entirely.

After #3327 this was the only upstream call in the proxy that didn't honor the timeout configuration — an operator tightening `HEADROOM_CONNECT_TIMEOUT_SECONDS` or `HEADROOM_WRITE_TIMEOUT_SECONDS` had no effect on this path. I checked every `timeout=` argument passed to an httpx client call across `headroom/proxy/`; the other three sites all pass a proper `httpx.Timeout`, and this was the last bare float.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

`_ws_http_fallback_timeout()` builds the timeout from config, keeping the 120s read bound as this path's own deliberate value:

```python
httpx.Timeout(
    connect=self.config.connect_timeout_seconds,
    read=_WS_HTTP_FALLBACK_READ_TIMEOUT_SECONDS,   # 120.0
    write=self.config.write_timeout_seconds,
    pool=self.config.connect_timeout_seconds,
)
```

**`read` is deliberately left at 120s and not wired to `request_timeout_seconds`.** This path streams SSE, so `read` is the gap *between* events, not a cap on the whole response — 120s of silence from a live Codex turn means the upstream is gone, not that it's thinking. That is a tighter and more useful bound than the generic 300s, and it was the one phase the original float got right. Promoting it to a named constant makes that intent explicit instead of accidental.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (CI-pinned `ruff` 0.16.3)
- [x] Type checking passes (`mypy`)
- [x] New tests added for new functionality

Five new tests in `TestWsHttpFallbackTimeout`, including one that pins the wiring (the timeout the `stream()` call actually receives) rather than just the helper. The fixture config uses deliberately odd values — `connect_timeout_seconds=7`, `write_timeout_seconds=33` — so a test would fail if the timeout stopped being read from config but happened to match the real defaults.

All five fail against the pre-fix handler, verified by reverting only that file:

```text
$ git stash push -- headroom/proxy/handlers/openai.py
$ pytest tests/test_ws_http_fallback.py::TestWsHttpFallbackTimeout -q
5 failed in 0.49s
```

### Test Output

```text
$ pytest tests/test_*openai* tests/test_*codex* tests/test_ws_*
578 passed, 18 skipped in 29.61s

$ pytest tests/test_proxy/ tests/test_proxy_hardening.py tests/test_upstream_write_timeout.py
302 passed in 40.74s
```
