### PR TITLE
fix(codex): preserve auth.json API keys through Headroom

### DIFF
--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -42,7 +42,7 @@ from headroom.install.state import ManifestError, load_manifest, save_manifest
 from headroom.install.supervisors import start_supervisor
 from headroom.providers.claude import TOOL_SEARCH_DEFAULT, TOOL_SEARCH_ENV
 from headroom.providers.claude.runtime import TOOL_SEARCH_FOUNDRY_DEFAULT
-from headroom.providers.codex.install import codex_uses_chatgpt_auth
+from headroom.providers.codex.install import build_codex_auth_config, codex_uses_chatgpt_auth
 from headroom.providers.codex.threads import retag_to_headroom
 
 from .main import main
@@ -327,6 +327,7 @@ def _ensure_codex_provider(path: Path, port: int) -> None:
         if codex_uses_chatgpt_auth(path.parent / "auth.json")
         else ""
     )
+    auth_config = build_codex_auth_config(path.parent / "auth.json")
     block = (
         f"{_CODEX_PROVIDER_MARKER_START}\n"
         'model_provider = "headroom"\n'
@@ -335,6 +336,7 @@ def _ensure_codex_provider(path: Path, port: int) -> None:
         'name = "Headroom init proxy"\n'
         f'base_url = "http://127.0.0.1:{port}/v1"\n'
         "supports_websockets = true\n"
+        f"{auth_config}"
         f"{requires_openai_auth}"
         f"{_CODEX_PROVIDER_MARKER_END}"
     )

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -94,7 +94,11 @@ from headroom.providers.claude import (
 )
 from headroom.providers.claude.runtime import TOOL_SEARCH_FOUNDRY_DEFAULT
 from headroom.providers.codex import build_launch_env as _build_codex_launch_env
-from headroom.providers.codex.install import build_codex_auth_config, codex_uses_chatgpt_auth
+from headroom.providers.codex.install import (
+    build_codex_auth_config,
+    cleanup_codex_auth_helper,
+    codex_uses_chatgpt_auth,
+)
 from headroom.providers.codex.threads import retag_to_headroom, retag_to_native
 from headroom.providers.copilot import (
     build_launch_env as _build_copilot_launch_env,
@@ -3220,17 +3224,28 @@ def _restore_codex_provider_config() -> tuple[str, Path]:
     * ``"noop"``     — nothing to undo; no Headroom marker and no backup.
     """
     config_file, backup_file = _codex_config_paths()
+    helper_auth_path = config_file.parent / "auth.json"
+    helper_path = helper_auth_path.parent / ".headroom-codex-auth.py"
 
     # Case 1: pre-wrap snapshot exists — restore it exactly.
     if backup_file.exists():
+        try:
+            helper_was_preexisting = str(helper_path.resolve()) in _read_text(backup_file)
+        except OSError:
+            # If the backup cannot be inspected, preserve the helper rather than
+            # risk deleting a file that predates this wrap.
+            helper_was_preexisting = True
         shutil.copy2(backup_file, config_file)
         backup_file.unlink()
+        if not helper_was_preexisting:
+            cleanup_codex_auth_helper(helper_auth_path)
         return "restored", config_file
 
     # Case 2: no backup, but config file exists and has markers — strip them.
     if config_file.exists():
         original = _read_text(config_file)
         if _codex_config_has_headroom_markers(original):
+            helper_was_referenced = str(helper_path.resolve()) in original
             # Without a backup, only remove named MCP blocks when this file
             # also carries wrap-owned provider markers from a full wrap.
             remove_named_mcp = any(
@@ -3251,8 +3266,12 @@ def _restore_codex_provider_config() -> tuple[str, Path]:
                 # Nothing left but Headroom content — remove the file entirely
                 # so Codex falls back to its default config.
                 config_file.unlink()
+                if helper_was_referenced:
+                    cleanup_codex_auth_helper(helper_auth_path)
                 return "removed", config_file
             _write_text(config_file, cleaned)
+            if helper_was_referenced:
+                cleanup_codex_auth_helper(helper_auth_path)
             return "cleaned", config_file
 
     # Nothing to undo.

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -94,7 +94,7 @@ from headroom.providers.claude import (
 )
 from headroom.providers.claude.runtime import TOOL_SEARCH_FOUNDRY_DEFAULT
 from headroom.providers.codex import build_launch_env as _build_codex_launch_env
-from headroom.providers.codex.install import codex_uses_chatgpt_auth
+from headroom.providers.codex.install import build_codex_auth_config, codex_uses_chatgpt_auth
 from headroom.providers.codex.threads import retag_to_headroom, retag_to_native
 from headroom.providers.copilot import (
     build_launch_env as _build_copilot_launch_env,
@@ -3091,6 +3091,7 @@ def _inject_codex_provider_config(port: int) -> str | None:
     requires_openai_auth = (
         "requires_openai_auth = true\n" if codex_uses_chatgpt_auth(config_dir / "auth.json") else ""
     )
+    auth_config = build_codex_auth_config(config_dir / "auth.json")
     # Per-project savings: Codex sends the X-Headroom-Project header only
     # when the mapped env var (HEADROOM_PROJECT, set by `headroom wrap
     # codex`) exists at Codex runtime. When a custom upstream was detected,
@@ -3106,6 +3107,7 @@ def _inject_codex_provider_config(port: int) -> str | None:
         'name = "OpenAI via Headroom proxy"\n'
         f'base_url = "http://127.0.0.1:{port}/v1"\n'
         f"supports_websockets = true\n"
+        f"{auth_config}"
         f"{requires_openai_auth}"
         # Inline table keeps the key inside this section so
         # _strip_codex_headroom_blocks removes it with the rest of the block.

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -97,6 +97,7 @@ from headroom.providers.codex import build_launch_env as _build_codex_launch_env
 from headroom.providers.codex.install import (
     build_codex_auth_config,
     cleanup_codex_auth_helper,
+    codex_auth_helper_is_referenced,
     codex_uses_chatgpt_auth,
 )
 from headroom.providers.codex.threads import retag_to_headroom, retag_to_native
@@ -3230,7 +3231,11 @@ def _restore_codex_provider_config() -> tuple[str, Path]:
     # Case 1: pre-wrap snapshot exists — restore it exactly.
     if backup_file.exists():
         try:
-            helper_was_preexisting = str(helper_path.resolve()) in _read_text(backup_file)
+            helper_was_preexisting = (
+                codex_auth_helper_is_referenced(
+                    _read_text(backup_file), str(helper_path.resolve())
+                ) is not False
+            )
         except OSError:
             # If the backup cannot be inspected, preserve the helper rather than
             # risk deleting a file that predates this wrap.
@@ -3245,7 +3250,9 @@ def _restore_codex_provider_config() -> tuple[str, Path]:
     if config_file.exists():
         original = _read_text(config_file)
         if _codex_config_has_headroom_markers(original):
-            helper_was_referenced = str(helper_path.resolve()) in original
+            helper_was_referenced = codex_auth_helper_is_referenced(
+                original, str(helper_path.resolve())
+            )
             # Without a backup, only remove named MCP blocks when this file
             # also carries wrap-owned provider markers from a full wrap.
             remove_named_mcp = any(
@@ -3266,11 +3273,11 @@ def _restore_codex_provider_config() -> tuple[str, Path]:
                 # Nothing left but Headroom content — remove the file entirely
                 # so Codex falls back to its default config.
                 config_file.unlink()
-                if helper_was_referenced:
+                if helper_was_referenced is True:
                     cleanup_codex_auth_helper(helper_auth_path)
                 return "removed", config_file
             _write_text(config_file, cleaned)
-            if helper_was_referenced:
+            if helper_was_referenced is True:
                 cleanup_codex_auth_helper(helper_auth_path)
             return "cleaned", config_file
 

--- a/headroom/providers/codex/install.py
+++ b/headroom/providers/codex/install.py
@@ -156,13 +156,7 @@ def build_codex_auth_config(auth_path: Path | None) -> str:
         return ""
 
     helper_path = auth_path.parent / _CODEX_API_KEY_HELPER_NAME
-    try:
-        if (
-            not helper_path.exists()
-            or helper_path.read_text(encoding="utf-8") != _CODEX_API_KEY_HELPER
-        ):
-            helper_path.write_text(_CODEX_API_KEY_HELPER, encoding="utf-8")
-    except OSError:
+    if not _ensure_codex_auth_helper(helper_path):
         return ""
 
     return (
@@ -170,6 +164,61 @@ def build_codex_auth_config(auth_path: Path | None) -> str:
         f"{json.dumps(sys.executable)}, args = [{json.dumps(str(helper_path.resolve()))}], "
         "refresh_interval_ms = 300000 }\n"
     )
+
+
+def _ensure_codex_auth_helper(helper_path: Path) -> bool:
+    """Create or validate the private, Headroom-owned auth helper."""
+    created = False
+    try:
+        # Never follow a user-created link or overwrite an unrelated file.
+        if helper_path.is_symlink():
+            return False
+        if helper_path.exists():
+            if not helper_path.is_file():
+                return False
+            if helper_path.read_text(encoding="utf-8") != _CODEX_API_KEY_HELPER:
+                return False
+            helper_path.chmod(0o600)
+            return True
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(helper_path, flags, 0o600)
+        created = True
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
+                fd = -1
+                handle.write(_CODEX_API_KEY_HELPER)
+                handle.flush()
+                os.fsync(handle.fileno())
+        finally:
+            if fd >= 0:
+                os.close(fd)
+        helper_path.chmod(0o600)
+        return True
+    except (OSError, UnicodeError):
+        if created:
+            try:
+                if helper_path.is_file() and not helper_path.is_symlink():
+                    helper_path.unlink()
+            except OSError:
+                pass
+        return False
+
+
+def cleanup_codex_auth_helper(auth_path: Path) -> None:
+    """Remove a private helper only when it still contains Headroom code."""
+    helper_path = auth_path.parent / _CODEX_API_KEY_HELPER_NAME
+    try:
+        if (
+            helper_path.is_symlink()
+            or not helper_path.is_file()
+            or helper_path.read_text(encoding="utf-8") != _CODEX_API_KEY_HELPER
+        ):
+            return
+        helper_path.unlink()
+    except (OSError, UnicodeError):
+        return
 
 
 def _id_token_carries_chatgpt_account(raw: Any) -> bool:
@@ -321,6 +370,8 @@ def revert_provider_scope(mutation: ManagedMutation, manifest: DeploymentManifes
     if not path.exists():
         return
     content = path.read_text(encoding="utf-8")
+    helper_path = path.parent / _CODEX_API_KEY_HELPER_NAME
+    helper_was_referenced = str(helper_path.resolve()) in content
     # Remove the managed marker block.
     if _CODEX_MARKER_START in content:
         content = _CODEX_PATTERN.sub("", content)
@@ -330,6 +381,8 @@ def revert_provider_scope(mutation: ManagedMutation, manifest: DeploymentManifes
     content = _ORPHAN_OPENAI_BASE_URL.sub("", content)
     content = _ORPHAN_HEADROOM_TABLE.sub("", content)
     path.write_text(content.strip() + "\n", encoding="utf-8")
+    if helper_was_referenced:
+        cleanup_codex_auth_helper(path.parent / "auth.json")
     # Hand the threads back to the native-provider menu so the full history stays
     # visible once Codex no longer routes through Headroom. Best-effort.
     retag_to_native(path.parent)

--- a/headroom/providers/codex/install.py
+++ b/headroom/providers/codex/install.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +45,22 @@ _ORPHAN_HEADROOM_TABLE = re.compile(
 _TOML_TABLE_HEADER_RE = re.compile(r"^[ \t]*(?:\[\[[^\]\r\n]+\]\]|\[[^\]\r\n]+\])[ \t]*(?:#.*)?$")
 _ROOT_MODEL_PROVIDER_RE = re.compile(r"^[ \t]*model_provider[ \t]*=")
 _ROOT_OPENAI_BASE_URL_RE = re.compile(r"^[ \t]*openai_base_url[ \t]*=")
+_CODEX_API_KEY_HELPER_NAME = ".headroom-codex-auth.py"
+_CODEX_API_KEY_HELPER = """from pathlib import Path
+import json
+
+
+try:
+    auth = json.loads(Path(__file__).with_name("auth.json").read_text(encoding="utf-8"))
+except (OSError, ValueError):
+    raise SystemExit(2)
+
+key = auth.get("OPENAI_API_KEY") if isinstance(auth, dict) else None
+if not isinstance(key, str) or not key.strip():
+    raise SystemExit(2)
+
+print(key, end="")
+"""
 
 
 def _codex_credential_store(config_dir: Path) -> str | None:
@@ -107,6 +124,54 @@ def codex_uses_chatgpt_auth(auth_path: Path) -> bool:
     return False
 
 
+def codex_uses_api_key_auth(auth_path: Path) -> bool:
+    """Whether Codex has a file-backed OpenAI API key.
+
+    A custom provider does not read Codex's ``auth.json`` when
+    ``requires_openai_auth`` is false.  Detect the API-key shape separately so
+    the generated provider can use Codex's command-backed bearer-token config
+    without forcing API-key users into the OAuth login flow.
+    """
+    try:
+        data = json.loads(auth_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return (
+        isinstance(data, dict)
+        and isinstance(data.get("OPENAI_API_KEY"), str)
+        and bool(data["OPENAI_API_KEY"].strip())
+    )
+
+
+def build_codex_auth_config(auth_path: Path | None) -> str:
+    """Build a Codex provider auth command for a file-backed API key.
+
+    The helper is generated next to ``auth.json`` and emits only the token at
+    runtime.  The token is never copied into Headroom's environment or the
+    generated TOML configuration.
+    """
+    if auth_path is None or codex_uses_chatgpt_auth(auth_path):
+        return ""
+    if not codex_uses_api_key_auth(auth_path):
+        return ""
+
+    helper_path = auth_path.parent / _CODEX_API_KEY_HELPER_NAME
+    try:
+        if (
+            not helper_path.exists()
+            or helper_path.read_text(encoding="utf-8") != _CODEX_API_KEY_HELPER
+        ):
+            helper_path.write_text(_CODEX_API_KEY_HELPER, encoding="utf-8")
+    except OSError:
+        return ""
+
+    return (
+        "auth = { command = "
+        f"{json.dumps(sys.executable)}, args = [{json.dumps(str(helper_path.resolve()))}], "
+        "refresh_interval_ms = 300000 }\n"
+    )
+
+
 def _id_token_carries_chatgpt_account(raw: Any) -> bool:
     """Whether an ``id_token`` carries the ChatGPT account claim (#3206).
 
@@ -150,6 +215,7 @@ def build_provider_section(
     marker_end: str = _CODEX_MARKER_END,
     include_markers: bool = True,
     requires_openai_auth: bool = False,
+    auth_path: Path | None = None,
 ) -> str:
     """Build a managed Codex provider block.
 
@@ -163,6 +229,7 @@ def build_provider_section(
         f'name = "{name}"\n'
         f'base_url = "{proxy_base_url(port)}"\n'
         "supports_websockets = true\n"
+        f"{build_codex_auth_config(auth_path)}"
     )
     if requires_openai_auth:
         body += "requires_openai_auth = true\n"
@@ -228,6 +295,7 @@ def apply_provider_scope(manifest: DeploymentManifest) -> ManagedMutation | None
             name="Headroom persistent proxy",
             include_markers=False,
             requires_openai_auth=codex_uses_chatgpt_auth(path.parent / "auth.json"),
+            auth_path=path.parent / "auth.json",
         )
         + f"{_CODEX_MARKER_END}\n"
     )

--- a/headroom/providers/codex/install.py
+++ b/headroom/providers/codex/install.py
@@ -221,6 +221,24 @@ def cleanup_codex_auth_helper(auth_path: Path) -> None:
         return
 
 
+def codex_auth_helper_is_referenced(content: str, helper_path: str) -> bool | None:
+    """Whether parsed Codex TOML names this exact generated helper.
+
+    ``None`` means the configuration is not parseable, so callers can retain
+    the helper instead of risking deletion of a pre-existing user file.
+    """
+    try:
+        document = tomllib.loads(content)
+    except (tomllib.TOMLDecodeError, TypeError):
+        return None
+
+    providers = document.get("model_providers")
+    headroom = providers.get("headroom") if isinstance(providers, dict) else None
+    auth = headroom.get("auth") if isinstance(headroom, dict) else None
+    args = auth.get("args") if isinstance(auth, dict) else None
+    return isinstance(args, list) and helper_path in args
+
+
 def _id_token_carries_chatgpt_account(raw: Any) -> bool:
     """Whether an ``id_token`` carries the ChatGPT account claim (#3206).
 
@@ -371,7 +389,9 @@ def revert_provider_scope(mutation: ManagedMutation, manifest: DeploymentManifes
         return
     content = path.read_text(encoding="utf-8")
     helper_path = path.parent / _CODEX_API_KEY_HELPER_NAME
-    helper_was_referenced = str(helper_path.resolve()) in content
+    helper_was_referenced = codex_auth_helper_is_referenced(
+        content, str(helper_path.resolve())
+    )
     # Remove the managed marker block.
     if _CODEX_MARKER_START in content:
         content = _CODEX_PATTERN.sub("", content)
@@ -381,7 +401,7 @@ def revert_provider_scope(mutation: ManagedMutation, manifest: DeploymentManifes
     content = _ORPHAN_OPENAI_BASE_URL.sub("", content)
     content = _ORPHAN_HEADROOM_TABLE.sub("", content)
     path.write_text(content.strip() + "\n", encoding="utf-8")
-    if helper_was_referenced:
+    if helper_was_referenced is True:
         cleanup_codex_auth_helper(path.parent / "auth.json")
     # Hand the threads back to the native-provider menu so the full history stays
     # visible once Codex no longer routes through Headroom. Best-effort.

--- a/tests/test_cli/test_init_cli.py
+++ b/tests/test_cli/test_init_cli.py
@@ -629,11 +629,15 @@ def test_ensure_codex_provider_omits_requires_openai_auth_for_api_key(
 ) -> None:
     init_cli, _ = _load_init_module(monkeypatch)
     path = tmp_path / "config.toml"
-    (tmp_path / "auth.json").write_text('{"auth_mode": "apikey"}', encoding="utf-8")
+    (tmp_path / "auth.json").write_text(
+        '{"auth_mode": "apikey", "OPENAI_API_KEY": "sk-test-only"}', encoding="utf-8"
+    )
 
     init_cli._ensure_codex_provider(path, 8787)
 
     assert "requires_openai_auth" not in path.read_text(encoding="utf-8")
+    assert "auth = { command =" in path.read_text(encoding="utf-8")
+    assert "sk-test-only" not in path.read_text(encoding="utf-8")
 
 
 def test_ensure_codex_feature_flag_replaces_existing_marker(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_cli/test_wrap_codex.py
+++ b/tests/test_cli/test_wrap_codex.py
@@ -283,6 +283,25 @@ class TestInjectAndRestoreRoundTrip:
         assert not config_file.exists()
         assert not (tmp_path / ".codex" / "config.toml.headroom-backup").exists()
 
+    def test_wrap_unwrap_removes_generated_auth_helper(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _set_test_home(monkeypatch, tmp_path)
+        config_dir = tmp_path / ".codex"
+        config_dir.mkdir()
+        (config_dir / "auth.json").write_text(
+            '{"OPENAI_API_KEY": "sk-test-only"}', encoding="utf-8"
+        )
+
+        wrap_mod._inject_codex_provider_config(8787)
+        helper = config_dir / ".headroom-codex-auth.py"
+        assert helper.exists()
+
+        status, _ = wrap_mod._restore_codex_provider_config()
+
+        assert status == "removed"
+        assert not helper.exists()
+
     def test_wrap_unwrap_respects_codex_home(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/test_cli/test_wrap_codex.py
+++ b/tests/test_cli/test_wrap_codex.py
@@ -296,11 +296,33 @@ class TestInjectAndRestoreRoundTrip:
         wrap_mod._inject_codex_provider_config(8787)
         helper = config_dir / ".headroom-codex-auth.py"
         assert helper.exists()
+        config = tomllib.loads((config_dir / "config.toml").read_text(encoding="utf-8"))
+        assert config["model_providers"]["headroom"]["auth"]["args"] == [str(helper.resolve())]
 
         status, _ = wrap_mod._restore_codex_provider_config()
 
         assert status == "removed"
         assert not helper.exists()
+
+    def test_wrap_unwrap_preserves_preexisting_unrelated_auth_helper(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _set_test_home(monkeypatch, tmp_path)
+        config_dir = tmp_path / ".codex"
+        config_dir.mkdir()
+        config_file = config_dir / "config.toml"
+        config_file.write_text('model = "gpt-5"\n', encoding="utf-8")
+        (config_dir / "auth.json").write_text(
+            '{"OPENAI_API_KEY": "sk-test-only"}', encoding="utf-8"
+        )
+        helper = config_dir / ".headroom-codex-auth.py"
+        helper.write_text("user content", encoding="utf-8")
+
+        wrap_mod._inject_codex_provider_config(8787)
+        status, _ = wrap_mod._restore_codex_provider_config()
+
+        assert status == "restored"
+        assert helper.read_text(encoding="utf-8") == "user content"
 
     def test_wrap_unwrap_respects_codex_home(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/test_install/test_codex_install.py
+++ b/tests/test_install/test_codex_install.py
@@ -85,6 +85,23 @@ def test_file_backed_auth_preserves_existing_modes(tmp_path: Path) -> None:
     assert codex_uses_chatgpt_auth(auth) is False
 
 
+def test_api_key_auth_is_persisted_as_a_codex_command(tmp_path: Path, monkeypatch) -> None:
+    config = tmp_path / "config.toml"
+    auth = tmp_path / "auth.json"
+    config.write_text('model = "gpt-5"\n', encoding="utf-8")
+    auth.write_text('{"OPENAI_API_KEY": "sk-test-only"}', encoding="utf-8")
+    monkeypatch.setattr("headroom.providers.codex.install.codex_config_path", lambda: config)
+
+    apply_provider_scope(_manifest(tmp_path))
+
+    content = config.read_text(encoding="utf-8")
+    helper = tmp_path / ".headroom-codex-auth.py"
+    assert "auth = { command =" in content
+    assert str(helper) in content
+    assert "sk-test-only" not in content
+    assert helper.exists()
+
+
 def test_legacy_file_backed_account_id_stays_supported(tmp_path: Path) -> None:
     auth = tmp_path / "auth.json"
     auth.write_text('{"tokens": {"account_id": "acct"}}', encoding="utf-8")

--- a/tests/test_install/test_codex_install.py
+++ b/tests/test_install/test_codex_install.py
@@ -9,6 +9,7 @@ from headroom.providers.codex.install import (
     apply_provider_scope,
     build_provider_section,
     codex_uses_chatgpt_auth,
+    revert_provider_scope,
 )
 
 
@@ -92,7 +93,8 @@ def test_api_key_auth_is_persisted_as_a_codex_command(tmp_path: Path, monkeypatc
     auth.write_text('{"OPENAI_API_KEY": "sk-test-only"}', encoding="utf-8")
     monkeypatch.setattr("headroom.providers.codex.install.codex_config_path", lambda: config)
 
-    apply_provider_scope(_manifest(tmp_path))
+    mutation = apply_provider_scope(_manifest(tmp_path))
+    assert mutation is not None
 
     content = config.read_text(encoding="utf-8")
     helper = tmp_path / ".headroom-codex-auth.py"
@@ -100,6 +102,10 @@ def test_api_key_auth_is_persisted_as_a_codex_command(tmp_path: Path, monkeypatc
     assert str(helper) in content
     assert "sk-test-only" not in content
     assert helper.exists()
+
+    revert_provider_scope(mutation, _manifest(tmp_path))
+
+    assert not helper.exists()
 
 
 def test_legacy_file_backed_account_id_stays_supported(tmp_path: Path) -> None:

--- a/tests/test_install/test_codex_install.py
+++ b/tests/test_install/test_codex_install.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from types import SimpleNamespace
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised only on Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
 
 from headroom.install.models import DeploymentManifest
 from headroom.providers.codex.install import (
@@ -99,7 +105,9 @@ def test_api_key_auth_is_persisted_as_a_codex_command(tmp_path: Path, monkeypatc
     content = config.read_text(encoding="utf-8")
     helper = tmp_path / ".headroom-codex-auth.py"
     assert "auth = { command =" in content
-    assert str(helper) in content
+    assert tomllib.loads(content)["model_providers"]["headroom"]["auth"]["args"] == [
+        str(helper.resolve())
+    ]
     assert "sk-test-only" not in content
     assert helper.exists()
 

--- a/tests/test_install/test_providers.py
+++ b/tests/test_install/test_providers.py
@@ -682,6 +682,10 @@ def test_inject_codex_provider_config_writes_openai_base_url(
     home = tmp_path
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("USERPROFILE", str(home))
+    (home / ".codex").mkdir()
+    (home / ".codex" / "auth.json").write_text(
+        '{"OPENAI_API_KEY": "sk-test-only"}', encoding="utf-8"
+    )
 
     wrap_mod._inject_codex_provider_config(8787)
 
@@ -704,6 +708,8 @@ def test_inject_codex_provider_config_writes_openai_base_url(
     assert "requires_openai_auth" not in content, (
         f"requires_openai_auth must be absent from the injected provider block; got:\n{content}"
     )
+    assert "auth = { command =" in content
+    assert "sk-test-only" not in content
     # openai_base_url must be in the top-level block, NOT inside [model_providers.*]
     lines = content.splitlines()
     in_provider_section = False

--- a/tests/test_provider_codex_install.py
+++ b/tests/test_provider_codex_install.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised only on Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
 from headroom.providers.codex.install import (
     build_codex_auth_config,
     build_provider_section,
     cleanup_codex_auth_helper,
+    codex_auth_helper_is_referenced,
     codex_uses_api_key_auth,
     codex_uses_chatgpt_auth,
 )
@@ -84,7 +91,7 @@ def test_build_codex_auth_config_generates_helper_without_copying_key(tmp_path: 
     helper = tmp_path / ".headroom-codex-auth.py"
 
     assert "auth = { command =" in config
-    assert str(helper) in config
+    assert tomllib.loads(config)["auth"]["args"] == [str(helper.resolve())]
     assert "sk-test-only" not in config
     assert helper.read_text(encoding="utf-8").count("OPENAI_API_KEY") == 1
     assert helper.stat().st_mode & 0o777 == 0o600
@@ -92,6 +99,16 @@ def test_build_codex_auth_config_generates_helper_without_copying_key(tmp_path: 
         [sys.executable, str(helper)], capture_output=True, text=True, check=True
     )
     assert result.stdout == "sk-test-only"
+
+
+def test_codex_auth_helper_reference_parses_toml_escaped_windows_path() -> None:
+    helper = r"C:\Users\example\.codex\.headroom-codex-auth.py"
+    config = (
+        "[model_providers.headroom]\n"
+        f"auth = {{ command = \"python\", args = [{json.dumps(helper)}] }}\n"
+    )
+
+    assert codex_auth_helper_is_referenced(config, helper) is True
 
 
 def test_build_codex_auth_config_does_not_overwrite_existing_helper(

--- a/tests/test_provider_codex_install.py
+++ b/tests/test_provider_codex_install.py
@@ -94,7 +94,8 @@ def test_build_codex_auth_config_generates_helper_without_copying_key(tmp_path: 
     assert tomllib.loads(config)["auth"]["args"] == [str(helper.resolve())]
     assert "sk-test-only" not in config
     assert helper.read_text(encoding="utf-8").count("OPENAI_API_KEY") == 1
-    assert helper.stat().st_mode & 0o777 == 0o600
+    if sys.platform != "win32":
+        assert helper.stat().st_mode & 0o777 == 0o600
     result = subprocess.run(
         [sys.executable, str(helper)], capture_output=True, text=True, check=True
     )

--- a/tests/test_provider_codex_install.py
+++ b/tests/test_provider_codex_install.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
-from headroom.providers.codex.install import build_provider_section, codex_uses_chatgpt_auth
+from headroom.providers.codex.install import (
+    build_codex_auth_config,
+    build_provider_section,
+    codex_uses_api_key_auth,
+    codex_uses_chatgpt_auth,
+)
 
 
 def test_codex_provider_section_omits_requires_openai_auth_by_default() -> None:
@@ -50,6 +57,44 @@ def test_codex_uses_chatgpt_auth_false_for_api_key(tmp_path: Path) -> None:
     auth.write_text('{"auth_mode": "apikey", "OPENAI_API_KEY": "sk-x"}', encoding="utf-8")
 
     assert codex_uses_chatgpt_auth(auth) is False
+
+
+def test_codex_uses_api_key_auth_detects_file_backed_key(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    auth.write_text('{"OPENAI_API_KEY": "sk-x"}', encoding="utf-8")
+
+    assert codex_uses_api_key_auth(auth) is True
+
+
+def test_codex_uses_api_key_auth_rejects_missing_or_blank_key(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    for document in ("{}", '{"OPENAI_API_KEY": "  "}', "not json"):
+        auth.write_text(document, encoding="utf-8")
+        assert codex_uses_api_key_auth(auth) is False
+
+
+def test_build_codex_auth_config_generates_helper_without_copying_key(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    auth.write_text('{"OPENAI_API_KEY": "sk-test-only"}', encoding="utf-8")
+
+    config = build_codex_auth_config(auth)
+    helper = tmp_path / ".headroom-codex-auth.py"
+
+    assert "auth = { command =" in config
+    assert str(helper) in config
+    assert "sk-test-only" not in config
+    assert helper.read_text(encoding="utf-8").count("OPENAI_API_KEY") == 1
+    result = subprocess.run(
+        [sys.executable, str(helper)], capture_output=True, text=True, check=True
+    )
+    assert result.stdout == "sk-test-only"
+
+
+def test_build_codex_auth_config_skips_chatgpt_auth(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    auth.write_text('{"auth_mode": "chatgpt"}', encoding="utf-8")
+
+    assert build_codex_auth_config(auth) == ""
 
 
 def test_codex_uses_chatgpt_auth_false_for_missing_or_malformed(tmp_path: Path) -> None:

--- a/tests/test_provider_codex_install.py
+++ b/tests/test_provider_codex_install.py
@@ -4,9 +4,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from headroom.providers.codex.install import (
     build_codex_auth_config,
     build_provider_section,
+    cleanup_codex_auth_helper,
     codex_uses_api_key_auth,
     codex_uses_chatgpt_auth,
 )
@@ -84,10 +87,60 @@ def test_build_codex_auth_config_generates_helper_without_copying_key(tmp_path: 
     assert str(helper) in config
     assert "sk-test-only" not in config
     assert helper.read_text(encoding="utf-8").count("OPENAI_API_KEY") == 1
+    assert helper.stat().st_mode & 0o777 == 0o600
     result = subprocess.run(
         [sys.executable, str(helper)], capture_output=True, text=True, check=True
     )
     assert result.stdout == "sk-test-only"
+
+
+def test_build_codex_auth_config_does_not_overwrite_existing_helper(
+    tmp_path: Path,
+) -> None:
+    auth = tmp_path / "auth.json"
+    auth.write_text('{"OPENAI_API_KEY": "sk-test-only"}', encoding="utf-8")
+    helper = tmp_path / ".headroom-codex-auth.py"
+    helper.write_text("user content", encoding="utf-8")
+
+    assert build_codex_auth_config(auth) == ""
+    assert helper.read_text(encoding="utf-8") == "user content"
+
+
+def test_build_codex_auth_config_rejects_helper_symlink(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    auth.write_text('{"OPENAI_API_KEY": "sk-test-only"}', encoding="utf-8")
+    target = tmp_path / "user-file.txt"
+    target.write_text("user content", encoding="utf-8")
+    helper = tmp_path / ".headroom-codex-auth.py"
+    try:
+        helper.symlink_to(target)
+    except OSError:
+        pytest.skip("symlinks are unavailable")
+
+    assert build_codex_auth_config(auth) == ""
+    assert target.read_text(encoding="utf-8") == "user content"
+    assert helper.is_symlink()
+
+
+def test_build_codex_auth_config_handles_invalid_existing_helper(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    auth.write_text('{"OPENAI_API_KEY": "sk-test-only"}', encoding="utf-8")
+    helper = tmp_path / ".headroom-codex-auth.py"
+    helper.write_bytes(b"\xff\xfe")
+
+    assert build_codex_auth_config(auth) == ""
+    assert helper.read_bytes() == b"\xff\xfe"
+
+
+def test_cleanup_codex_auth_helper_only_removes_headroom_file(tmp_path: Path) -> None:
+    auth = tmp_path / "auth.json"
+    auth.write_text('{"OPENAI_API_KEY": "sk-test-only"}', encoding="utf-8")
+    build_codex_auth_config(auth)
+    helper = tmp_path / ".headroom-codex-auth.py"
+
+    cleanup_codex_auth_helper(auth)
+
+    assert not helper.exists()
 
 
 def test_build_codex_auth_config_skips_chatgpt_auth(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

Closes #3354.

When Codex uses an OpenAI API key stored in auth.json, Headroom's generated provider block did not configure authentication. Codex therefore sent requests to the local Headroom proxy without an Authorization header and received 401 Missing bearer.

This is separate from #3206: that issue covers ChatGPT OAuth authentication, while this change covers file-backed API-key authentication.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- Detect file-backed OPENAI_API_KEY credentials in Codex's auth.json.
- Generate a Headroom-managed helper beside auth.json that emits the token only when Codex invokes it.
- Configure Codex's supported auth.command provider field for persistent install, headroom init codex, and headroom wrap codex.
- Keep requires_openai_auth limited to ChatGPT OAuth mode.
- Do not copy the secret into Headroom's environment or generated TOML.
- Create the helper with 0600 permissions and exclusive creation.
- Refuse to follow symlinks or overwrite an unrelated same-name file.
- Remove the helper on persistent uninstall and wrap cleanup when it was created by Headroom.

## Testing

- [x] Unit tests pass
- [x] Linting passes
- [ ] Type checking
- [x] New tests added
- [x] Manual testing performed

### Test Output

```text
35 passed in 0.36s (Codex auth/install tests)
116 passed in 0.45s (provider/init tests)
93 passed in 219.86s (Codex wrap tests)
ruff check: All checks passed
ruff format --check: 7 files already formatted
```

## Real Behavior Proof

- Environment: macOS Apple Silicon, Headroom 0.37.0, Codex CLI 0.149.0, API key stored in Codex auth.json.
- Exact command / steps: Applied the generated auth.command configuration, restarted the persistent Headroom deployment, then ran codex exec --skip-git-repo-check --json 'Reply with exactly OK.'.
- Observed result: A new Codex session returned OK with no 401 error.
- Not tested: The full native-extension test suite could not be collected locally because Rust 1.87.0 cannot build dependencies requiring Rust 1.88.0; Windows behavior was not tested.

## Runtime Rollout Safety

- Rollout-managed feature(s): None.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: Yes, only when Codex has a file-backed API key and Headroom writes a provider block.
- Kill switch / disable path: Remove the Headroom-managed provider block or run the existing Codex unwrap command.
- Unsafe override required: No.
- Qualification impact: None.
- Rollback path: Revert the generated provider block; auth.json is unchanged.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of the code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did not edit CHANGELOG.md

## Additional Notes

The helper contains no credential value. It only reads the user's existing Codex credential file at runtime, so API-key rotation remains effective without rerunning the installer.