### PR TITLE
fix(proxy): install SOCKS support for websocket proxies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ proxy = [
     "magika>=0.6.0",              # ML content detection for ContentRouter
     "zstandard>=0.20.0",          # Decompress zstd request bodies (Codex, etc.)
     "websockets>=13.0",           # WebSocket proxy for /v1/responses (Codex gpt-5.4+)
+    "python-socks[asyncio]>=2.7.1",  # SOCKS support when websockets discovers a system proxy
     # Rust fastembed enables ORT C API 24. ORT <1.24 deadlocks instead of
     # returning an initialization error; 1.24+ no longer ships Python 3.10
     # wheels, so 3.10 keeps Python-only ORT and bypasses native detection.

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -23,6 +23,7 @@ PLATFORM_MACHINE_MARKER = "platform_machine"
 TORCH_PACKAGE_NAME = "torch"
 TORCH_TRANSITIVE_PACKAGE_NAMES = frozenset({"sentence-transformers"})
 ORJSON_PACKAGE_NAME = "orjson"
+PYTHON_SOCKS_PACKAGE_NAME = "python-socks"
 PROXY_EXTRA = "proxy"
 UV_LOCK_FILE = "uv.lock"
 
@@ -127,3 +128,19 @@ def test_proxy_extra_includes_orjson_for_litellm_backends() -> None:
 
     assert ORJSON_PACKAGE_NAME in selected_proxy_dependency_names
     assert ORJSON_PACKAGE_NAME in selected_all_dependency_names
+
+
+def test_proxy_extra_includes_socks_support_for_websocket_proxy_discovery() -> None:
+    """A system SOCKS proxy must not disable Codex Responses WebSockets."""
+
+    pyproject = tomllib.loads((ROOT / PYPROJECT_FILE).read_text(encoding="utf-8"))
+    optional_deps = pyproject["project"]["optional-dependencies"]
+    environment = default_environment()
+
+    selected_proxy_dependency_names = _selected_dependency_names_for_extra(
+        optional_deps,
+        PROXY_EXTRA,
+        environment,
+    )
+
+    assert PYTHON_SOCKS_PACKAGE_NAME in selected_proxy_dependency_names

--- a/uv.lock
+++ b/uv.lock
@@ -1668,7 +1668,7 @@ wheels = [
 
 [[package]]
 name = "headroom-ai"
-version = "0.36.0"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "ast-grep-cli" },
@@ -1707,6 +1707,7 @@ all = [
     { name = "opentelemetry-sdk" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "pillow" },
+    { name = "python-socks", extra = ["asyncio"] },
     { name = "rapidocr", marker = "python_full_version >= '3.13'" },
     { name = "rapidocr-onnxruntime", marker = "python_full_version < '3.13'" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11'" },
@@ -1826,6 +1827,7 @@ proxy = [
     { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "python-socks", extra = ["asyncio"] },
     { name = "sqlite-vec" },
     { name = "transformers" },
     { name = "uvicorn" },
@@ -1843,6 +1845,7 @@ proxy-prod = [
     { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "python-socks", extra = ["asyncio"] },
     { name = "sqlite-vec" },
     { name = "transformers" },
     { name = "uvicorn" },
@@ -1878,6 +1881,7 @@ sandbox = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "python-socks", extra = ["asyncio"] },
     { name = "sqlite-vec" },
     { name = "starlette" },
     { name = "trafilatura" },
@@ -1982,6 +1986,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "python-socks", extras = ["asyncio"], marker = "extra == 'proxy'", specifier = ">=2.7.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qdrant-client", marker = "extra == 'memory-stack'", specifier = ">=1.9.0,<2.0" },
     { name = "rapidocr", marker = "python_full_version >= '3.13' and extra == 'image'", specifier = ">=3.0,<4" },
@@ -5272,6 +5277,20 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/64/7e/9b35ad8f3d9ca680f7c87a88f19612fdd8da9796c4d3b46e560ac79dcc4a/python_multipart-0.0.31.tar.gz", hash = "sha256:fc631183bb13e56db3158a4909908dfb2e23565286744e798241e63750e5d680", size = 46689, upload-time = "2026-06-04T08:27:49.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/1e/7f7f299527a5a8ad90acd5f2f78dfa6c8495c6301a3205106ea68a84de96/python_multipart-0.0.31-py3-none-any.whl", hash = "sha256:8408153d68a9773291fc1da39a8b85a50044bddbabd2dd72e9229776b7b15e28", size = 29996, upload-time = "2026-06-04T08:27:47.804Z" },
+]
+
+[[package]]
+name = "python-socks"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/6b/bd9e15e67cf42b318970028a572750924adbe28776e8420fcdfe60838c61/python_socks-3.0.0.tar.gz", hash = "sha256:c20ddf978b5c90467bf242757a11dcd00d7c8bd339901de1839b492d5571ab7f", size = 232731, upload-time = "2026-08-11T11:17:09.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/e7/af080d0d2d5bbc3dbdf58a805812ee45175c5c32c6673f23a5480f9785c2/python_socks-3.0.0-py3-none-any.whl", hash = "sha256:e06a421d4d7f3fc17ef2740ab6c291640364f6a362b94a1ae87a136c29bd0067", size = 49519, upload-time = "2026-08-11T11:17:07.118Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "async-timeout", marker = "python_full_version < '3.11'" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Install the SOCKS transport dependency required when `websockets` discovers a system SOCKS proxy. Without it, Codex Responses WebSocket relay logs `connecting through a SOCKS proxy requires python-socks` and cannot establish the upstream WebSocket.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add `python-socks[asyncio]>=2.7.1` to the `proxy` extra.
- Regenerate `uv.lock`, resolving `python-socks` 3.0.0.
- Add a package-contract regression test that asserts `headroom-ai[proxy]` includes the SOCKS transport dependency.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run --extra proxy pytest tests/test_optional_dependencies.py -q
collected 3 items

tests/test_optional_dependencies.py ...                                  [100%]

3 passed, 1 warning in 0.27s

$ uv lock --check
Resolved 270 packages in 3ms
```

The pytest warning is the existing `asyncio_mode` unknown-config warning from this test environment. Full test, lint, and type-check suites were not run for this packaging-only change.

## Real Behavior Proof

- Environment: macOS persistent Headroom service, with a system SOCKS proxy at `127.0.0.1:7897`.
- Exact command / steps: Run Codex Responses WebSocket relay with the `proxy` extra before and after `uv pip install --python <headroom-venv>/bin/python "python-socks[asyncio]"`.
- Observed result: Before installation, the relay logs `connecting through a SOCKS proxy requires python-socks` and falls back to HTTP. After installation, that SOCKS dependency error no longer occurs and WebSocket negotiation proceeds.
- Not tested: clean install of a built distribution and the full test suite on Linux/Windows. The observed upstream HTTP 426 from a custom Sub2API endpoint is outside this dependency fix.

## Runtime Rollout Safety

- Rollout-managed feature(s): none.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: `headroom-ai[proxy]` and extras that include it install one pure-Python SOCKS transport dependency; no request routing or compression behavior changes without a SOCKS proxy.
- Kill switch / disable path: remove SOCKS proxy configuration from the process/system environment.
- Unsafe override required: no.
- Qualification impact: package extras and lockfile only.
- Rollback path: revert this commit or deploy the prior package release.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A.

## Additional Notes

The upstream `websockets` library requires `python-socks` to use an automatically discovered SOCKS proxy. The new test intentionally verifies the install contract rather than attempting an external proxy connection.