### PR TITLE
test: let the cache-price stub absorb the long_context tier selector

### DIFF
--- a/tests/test_proxy_savings_history.py
+++ b/tests/test_proxy_savings_history.py
@@ -1070,7 +1070,10 @@ def test_stats_history_persists_across_restarts_and_stats_stays_compatible(tmp_p
     monkeypatch.setenv("HEADROOM_SAVINGS_PATH", str(savings_path))
     monkeypatch.setattr(
         "headroom.proxy.server.CostTracker._get_cache_prices",
-        lambda self, model: (0.001, 0.0015, 0.002),
+        # **kwargs so the stub keeps standing in for the real method as its
+        # signature grows: it takes a keyword-only `long_context` tier selector,
+        # which a positional-only stub turns into a TypeError inside /stats.
+        lambda self, model, **kwargs: (0.001, 0.0015, 0.002),
     )
 
     config = ProxyConfig(
@@ -1270,7 +1273,10 @@ def test_stats_history_csv_export_is_frontend_friendly(tmp_path, monkeypatch):
     monkeypatch.setenv("HEADROOM_SAVINGS_PATH", str(savings_path))
     monkeypatch.setattr(
         "headroom.proxy.server.CostTracker._get_cache_prices",
-        lambda self, model: (0.001, 0.0015, 0.002),
+        # **kwargs so the stub keeps standing in for the real method as its
+        # signature grows: it takes a keyword-only `long_context` tier selector,
+        # which a positional-only stub turns into a TypeError inside /stats.
+        lambda self, model, **kwargs: (0.001, 0.0015, 0.002),
     )
 
     config = ProxyConfig(


### PR DESCRIPTION
`main` is currently red: `tests/test_proxy_savings_history.py::test_stats_history_persists_across_restarts_and_stats_stays_compatible` fails on `bfe3c787`.

#3356 widened `_get_cache_prices` to `(self, model, *, long_context=False)` and calls it with that keyword from `stats()`. Two stubs in this file take `(self, model)` positionally, so `/stats` raises:

```
TypeError: <lambda>() got an unexpected keyword argument 'long_context'
  headroom/proxy/cost.py in stats
    prices = self._get_cache_prices(model, long_context=long_context)
```

The irony is that this is the test asserting the `/stats` payload stays backward compatible, so it is exactly the right test to have caught a signature widening.

This fix was pushed to #3356's branch before merge but did not make it into the squash, so it needs to land on its own. `**kwargs` matches the pattern already used by the sibling stub in the same file, and keeps the stub valid as the signature grows.

39 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)