### PR TITLE
fix(ci): restore the repository Ruff gate

### DIFF
--- a/headroom/perf/analyzer.py
+++ b/headroom/perf/analyzer.py
@@ -14,9 +14,11 @@ import logging
 import math
 import os
 import re
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 from headroom import paths as _paths
 from headroom.pricing.litellm_pricing import resolve_litellm_model
@@ -498,8 +500,7 @@ def parse_log_files(last_n_hours: float = 168.0) -> PerfReport:
     return report
 
 
-
-def _as_number(value: object, cast: type) -> "int | float":
+def _as_number(value: object, cast: Callable[[Any], int | float]) -> int | float:
     """Coerce a self-reported savings figure, or 0 if it is not a number.
 
     `savings=` is base64 JSON written by whatever plugin recorded it, and
@@ -806,9 +807,7 @@ def format_report(report: PerfReport) -> str:
         for item in getattr(record, "savings_breakdown", ()) or ():
             source = str(item.get("source") or "other")
             realized = bool(item.get("realized", True))
-            row = by_source.setdefault(
-                (source, realized), {"events": 0, "tokens": 0, "usd": 0.0}
-            )
+            row = by_source.setdefault((source, realized), {"events": 0, "tokens": 0, "usd": 0.0})
             row["events"] += 1
             row["tokens"] += max(0, _as_number(item.get("tokens"), int))
             row["usd"] += _as_number(item.get("usd"), float)

--- a/headroom/proxy/cost.py
+++ b/headroom/proxy/cost.py
@@ -703,8 +703,9 @@ def build_session_summary(
     # artifact, not a measurement, so report no percentage rather than one that
     # is wrong by three orders of magnitude.
     _baseline_is_meaningful = cost_without > max(0.01, 0.05 * cost_with)
-    savings_pct_cost = (round(total_saved_usd / cost_without * 100, 1)
-                        if _baseline_is_meaningful else 0.0)
+    savings_pct_cost = (
+        round(total_saved_usd / cost_without * 100, 1) if _baseline_is_meaningful else 0.0
+    )
 
     # Primary models used
     models = dict(metrics.requests_by_model)

--- a/tests/test_cli_perf_format.py
+++ b/tests/test_cli_perf_format.py
@@ -431,6 +431,7 @@ def test_throughput_empty_and_percentiles():
 # nothing rendered it, so a paid extension's contribution was invisible in the
 # report operators actually read.
 
+
 def _savings_perf_line(encoded: str, req: int = 1) -> str:
     return (
         f"2026-08-31 16:00:0{req},000 - headroom.proxy - INFO - [hr_1_00000{req}] PERF "
@@ -467,9 +468,13 @@ def test_dollar_only_source_is_reported_with_zero_tokens(tmp_path, monkeypatch):
     from headroom.proxy.savings_attribution import encode
 
     out = _report_for(
-        [_savings_perf_line(encode([{"source": "routemegood", "tokens": 0,
-                             "usd": 0.1257, "realized": True}]))],
-        tmp_path, monkeypatch,
+        [
+            _savings_perf_line(
+                encode([{"source": "routemegood", "tokens": 0, "usd": 0.1257, "realized": True}])
+            )
+        ],
+        tmp_path,
+        monkeypatch,
     )
     assert "Savings by Source" in out
     assert "routemegood" in out
@@ -481,11 +486,18 @@ def test_token_source_and_dollar_source_coexist(tmp_path, monkeypatch):
     from headroom.proxy.savings_attribution import encode
 
     out = _report_for(
-        [_savings_perf_line(encode([
-            {"source": "routemegood", "tokens": 0, "usd": 0.0431, "realized": True},
-            {"source": "lossless_guard", "tokens": 2233, "usd": 0.0, "realized": True},
-        ]))],
-        tmp_path, monkeypatch,
+        [
+            _savings_perf_line(
+                encode(
+                    [
+                        {"source": "routemegood", "tokens": 0, "usd": 0.0431, "realized": True},
+                        {"source": "lossless_guard", "tokens": 2233, "usd": 0.0, "realized": True},
+                    ]
+                )
+            )
+        ],
+        tmp_path,
+        monkeypatch,
     )
     assert "routemegood" in out and "lossless_guard" in out
     assert "2,233 tokens" in out

--- a/tests/test_routing_stats_seam.py
+++ b/tests/test_routing_stats_seam.py
@@ -30,9 +30,18 @@ def _matrix(**over):
         "downgrades": 1,
         "upgrades": 0,
         "unchanged": 2,
-        "pairs": [{"requested": "claude-opus-5", "served": "claude-sonnet-5",
-                   "direction": "downgrade", "count": 1, "enforced": 1,
-                   "holdout": 0, "measured": 1, "savings_usd": 0.42}],
+        "pairs": [
+            {
+                "requested": "claude-opus-5",
+                "served": "claude-sonnet-5",
+                "direction": "downgrade",
+                "count": 1,
+                "enforced": 1,
+                "holdout": 0,
+                "measured": 1,
+                "savings_usd": 0.42,
+            }
+        ],
     }
     base.update(over)
     return base
@@ -65,11 +74,18 @@ def test_a_broken_provider_never_breaks_stats():
 
 def test_unknown_keys_survive_so_providers_can_lead_the_dashboard():
     """`window` and `session` reach the template even on an older core."""
-    set_routing_stats_provider(lambda: _matrix(
-        window="lifetime",
-        session={"decisions": 4, "downgrades": 3, "upgrades": 0,
-                 "unchanged": 1, "since": 1788140194.8},
-    ))
+    set_routing_stats_provider(
+        lambda: _matrix(
+            window="lifetime",
+            session={
+                "decisions": 4,
+                "downgrades": 3,
+                "upgrades": 0,
+                "unchanged": 1,
+                "since": 1788140194.8,
+            },
+        )
+    )
     out = get_routing_stats()
     assert out["window"] == "lifetime"
     assert out["session"]["downgrades"] == 3
@@ -83,11 +99,18 @@ def test_live_session_counter_can_be_zero_while_the_panel_still_renders():
     that has only just started. Reporting the SESSION in ``pairs`` instead
     emptied it and took the whole section down.
     """
-    set_routing_stats_provider(lambda: _matrix(
-        window="lifetime",
-        session={"decisions": 0, "downgrades": 0, "upgrades": 0,
-                 "unchanged": 0, "since": 1788140194.8},
-    ))
+    set_routing_stats_provider(
+        lambda: _matrix(
+            window="lifetime",
+            session={
+                "decisions": 0,
+                "downgrades": 0,
+                "upgrades": 0,
+                "unchanged": 0,
+                "since": 1788140194.8,
+            },
+        )
+    )
     out = get_routing_stats()
     assert out is not None, "panel must survive a session with no decisions yet"
     assert out["pairs"], "lifetime pairs keep the section on screen"


### PR DESCRIPTION
## Description

Proposes an isolated repair for the repository-wide Ruff gate currently failing on `main` and therefore on otherwise-clean PR merge refs.

This is intentionally a draft for human review. It does not merge or modify `main` directly.

## Changes

- Give `_as_number` a concrete callable type and unquoted union return annotation.
- Apply the repository's pinned Ruff formatter to the three files currently reported by `ruff format --check .`.
- No runtime behavior or test assertions are changed.

## Evidence

```text
ruff check headroom/perf/analyzer.py headroom/proxy/cost.py tests/test_cli_perf_format.py tests/test_routing_stats_seam.py
All checks passed!

ruff format --check headroom/perf/analyzer.py headroom/proxy/cost.py tests/test_cli_perf_format.py tests/test_routing_stats_seam.py
4 files already formatted

pytest -q tests/test_cli_perf_format.py tests/test_routing_stats_seam.py
28 passed
```

The same inherited formatting failures are visible in refreshed PR CI (for example #3013). This PR keeps the repair separate from those feature branches and leaves merge disposition to a human maintainer.