### PR TITLE
fix(proxy): enforce budgets across generation routes

### DIFF
--- a/headroom/proxy/handlers/gemini.py
+++ b/headroom/proxy/handlers/gemini.py
@@ -404,6 +404,17 @@ class GeminiHandlerMixin:
                     detail=f"Rate limited. Retry after {wait_seconds:.1f}s",
                 )
 
+        # Cost tracking is shared across providers; enforce its configured
+        # budget before any Gemini generation request reaches the upstream.
+        cost_tracker = getattr(self, "cost_tracker", None)
+        if cost_tracker:
+            allowed, _ = cost_tracker.check_budget()
+            if not allowed:
+                raise HTTPException(
+                    status_code=429,
+                    detail=cost_tracker.budget_denial_detail(),
+                )
+
         # Convert Gemini format to messages for optimization
         system_instruction = body.get("systemInstruction")
         messages, preserved_indices = self._gemini_contents_to_messages(
@@ -1173,6 +1184,7 @@ class GeminiHandlerMixin:
         model: str,
     ) -> StreamingResponse | JSONResponse:
         """Handle Gemini streaming endpoint /v1beta/models/{model}:streamGenerateContent."""
+        from fastapi import HTTPException
         from fastapi.responses import JSONResponse
 
         from headroom.proxy.helpers import _read_request_json
@@ -1215,6 +1227,15 @@ class GeminiHandlerMixin:
             stripped_count=_pre_strip_count_gem_stream,
             request_id=request_id,
         )
+
+        cost_tracker = getattr(self, "cost_tracker", None)
+        if cost_tracker:
+            allowed, _ = cost_tracker.check_budget()
+            if not allowed:
+                raise HTTPException(
+                    status_code=429,
+                    detail=cost_tracker.budget_denial_detail(),
+                )
 
         # Token counting (offloaded off the event loop — GH #1701). Reuse the
         # shared _dict_parts coercion and keep only str text values: count_text

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -3529,6 +3529,18 @@ class OpenAIHandlerMixin:
                     detail=f"Rate limited. Retry after {wait_seconds:.1f}s",
                 )
 
+        # Enforce the same proxy-wide spend budget as the Anthropic handler.
+        # Cost records are provider-independent, so skipping this preflight
+        # would let OpenAI traffic continue spending after the configured cap.
+        cost_tracker = getattr(self, "cost_tracker", None)
+        if cost_tracker:
+            allowed, _ = cost_tracker.check_budget()
+            if not allowed:
+                raise HTTPException(
+                    status_code=429,
+                    detail=cost_tracker.budget_denial_detail(),
+                )
+
         # Snapshot cache-key fields ONCE here (pre-upstream), reused verbatim
         # at the cache.set site below — re-reading body at set risks a mutated
         # body (e.g. tools reassigned) and a key mismatch (#327). OpenAI's
@@ -5597,6 +5609,17 @@ class OpenAIHandlerMixin:
                     detail=f"Rate limited. Retry after {wait_seconds:.1f}s",
                 )
 
+        # Budget enforcement must run before token counting/compression and,
+        # critically, before dispatching the Responses request upstream.
+        cost_tracker = getattr(self, "cost_tracker", None)
+        if cost_tracker:
+            allowed, _ = cost_tracker.check_budget()
+            if not allowed:
+                raise HTTPException(
+                    status_code=429,
+                    detail=cost_tracker.budget_denial_detail(),
+                )
+
         # Token counting on converted messages (offloaded off the event loop — GH #1701)
         tokenizer, original_tokens = await self._count_tokens_offloaded(model, messages)
 
@@ -6675,6 +6698,13 @@ class OpenAIHandlerMixin:
         session_handle: WSSessionHandle | None = None
         termination_cause: TerminationCause = "unknown"
 
+        def _budget_denial_detail() -> str | None:
+            cost_tracker = getattr(self, "cost_tracker", None)
+            if cost_tracker is None:
+                return None
+            allowed, _ = cost_tracker.check_budget()
+            return None if allowed else cost_tracker.budget_denial_detail()
+
         # Forward client headers to upstream, adding required OpenAI-Beta header
         ws_headers = dict(websocket.headers)
         _ws_url_obj = getattr(websocket, "url", None)
@@ -6691,6 +6721,16 @@ class OpenAIHandlerMixin:
                 _header_get(ws_headers, "origin"),
             )
             await websocket.close(code=1008, reason="origin not allowed")
+            return
+        budget_denial = _budget_denial_detail()
+        if budget_denial is not None:
+            logger.info(
+                "event=websocket_budget_rejected request_id=%s session_id=%s path=%s",
+                request_id,
+                session_id,
+                _ws_path,
+            )
+            await websocket.close(code=1008, reason=budget_denial[:123])
             return
         # WS sessions bypass the HTTP middleware that stamps X-Client: codex on
         # the Responses endpoint, so apply the same path-based stamp here before
@@ -7857,6 +7897,20 @@ class OpenAIHandlerMixin:
                 },
             )
 
+            # Re-check after the first frame wait: another request may have
+            # exhausted the shared budget while this socket was idle or while
+            # its upstream handshake was being established.
+            budget_denial = _budget_denial_detail()
+            if budget_denial is not None:
+                logger.info(
+                    "event=websocket_budget_rejected request_id=%s session_id=%s path=%s frame=1",
+                    request_id,
+                    session_id,
+                    _ws_path,
+                )
+                await websocket.close(code=1008, reason=budget_denial[:123])
+                return
+
             if ws_connected:
                 async with upstream:
                     await upstream.send(_strip_codex_lite_metadata(first_msg_raw))
@@ -8227,6 +8281,21 @@ class OpenAIHandlerMixin:
                                     isinstance(_inbound_frame_body, dict)
                                     and _inbound_frame_body.get("type") == "response.create"
                                 ):
+                                    budget_denial = _budget_denial_detail()
+                                    if budget_denial is not None:
+                                        logger.info(
+                                            "event=websocket_budget_rejected "
+                                            "request_id=%s session_id=%s path=%s frame=%d",
+                                            request_id,
+                                            session_id,
+                                            _ws_path,
+                                            client_frame_index,
+                                        )
+                                        await websocket.close(
+                                            code=1008,
+                                            reason=budget_denial[:123],
+                                        )
+                                        return
                                     ws_response_create_frames += 1
                                     inbound_response = _inbound_frame_body.get(
                                         "response", _inbound_frame_body

--- a/tests/test_proxy_budget_provider_enforcement.py
+++ b/tests/test_proxy_budget_provider_enforcement.py
@@ -1,0 +1,177 @@
+"""Provider-level regression coverage for proxy spend-budget enforcement."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from headroom.proxy.server import ProxyConfig, create_app
+
+
+def _budget_exhausted_app():  # noqa: ANN202
+    return create_app(
+        ProxyConfig(
+            optimize=False,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=True,
+            budget_limit_usd=0.0,
+            log_requests=False,
+            ccr_inject_tool=False,
+            ccr_handle_responses=False,
+            ccr_context_tracking=False,
+            image_optimize=False,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "headers", "body"),
+    [
+        (
+            "/v1/messages",
+            {"x-api-key": "test-key", "anthropic-version": "2023-06-01"},
+            {
+                "model": "claude-3-5-sonnet-20241022",
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        ),
+        (
+            "/v1/chat/completions",
+            {"authorization": "Bearer test-key"},
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": False,
+            },
+        ),
+        (
+            "/v1/responses",
+            {"authorization": "Bearer test-key"},
+            {"model": "gpt-4o-mini", "input": "hello"},
+        ),
+        (
+            "/v1beta/models/gemini-2.0-flash:generateContent?key=test-key",
+            {},
+            {"contents": [{"role": "user", "parts": [{"text": "hello"}]}]},
+        ),
+        (
+            "/v1beta/models/gemini-2.0-flash:streamGenerateContent?key=test-key",
+            {},
+            {"contents": [{"role": "user", "parts": [{"text": "hello"}]}]},
+        ),
+    ],
+)
+def test_exhausted_budget_rejects_every_generation_http_route_before_upstream(
+    path: str,
+    headers: dict[str, str],
+    body: dict[str, object],
+) -> None:
+    upstream_calls: list[str] = []
+
+    with TestClient(_budget_exhausted_app(), client=("127.0.0.1", 50000)) as client:
+        proxy = client.app.state.proxy
+
+        async def _unexpected_retry(method, url, request_headers, request_body, **kwargs):  # noqa: ANN001, ANN202
+            upstream_calls.append(str(url))
+            raise AssertionError("budget-exhausted request reached the upstream")
+
+        async def _unexpected_stream(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            upstream_calls.append("stream")
+            raise AssertionError("budget-exhausted stream reached the upstream")
+
+        proxy._retry_request = _unexpected_retry
+        proxy._stream_response = _unexpected_stream
+
+        response = client.post(path, headers=headers, json=body)
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == "Budget exceeded for daily period"
+    assert upstream_calls == []
+
+
+class _BudgetDeniedWebSocket:
+    def __init__(self) -> None:
+        self.headers = {"authorization": "Bearer test-key"}
+        self.url = SimpleNamespace(path="/v1/responses")
+        self.client = SimpleNamespace(host="127.0.0.1", port=50000)
+        self.closed: tuple[int, str] | None = None
+
+    async def close(self, *, code: int, reason: str) -> None:
+        self.closed = (code, reason)
+
+
+def test_exhausted_budget_rejects_responses_websocket_before_upstream() -> None:
+    app = _budget_exhausted_app()
+    websocket = _BudgetDeniedWebSocket()
+
+    asyncio.run(app.state.proxy.handle_openai_responses_ws(websocket))
+
+    assert websocket.closed == (1008, "Budget exceeded for daily period")
+
+
+@pytest.mark.asyncio
+async def test_responses_websocket_rechecks_budget_between_turns() -> None:
+    from tests.test_openai_codex_ws_lifecycle import (
+        _DummyOpenAIHandler,
+        _FakeUpstream,
+        _FakeWebSocket,
+        _first_frame,
+        _make_fake_websockets_module,
+    )
+
+    class _TurnBudget:
+        def __init__(self) -> None:
+            self.first_turn_recorded = asyncio.Event()
+
+        def check_budget(self) -> tuple[bool, float]:
+            return (not self.first_turn_recorded.is_set(), 1.0)
+
+        def budget_denial_detail(self) -> str:
+            return "Budget exceeded for daily period"
+
+        def record_tokens(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            self.first_turn_recorded.set()
+
+    class _TwoTurnWebSocket(_FakeWebSocket):
+        def __init__(self, budget: _TurnBudget) -> None:
+            super().__init__(frames=[_first_frame(), _first_frame()])
+            self._budget = budget
+            self._received = 0
+
+        async def receive_text(self) -> str:
+            self._received += 1
+            if self._received == 2:
+                await self._budget.first_turn_recorded.wait()
+            return await super().receive_text()
+
+    completed = json.dumps(
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp-1",
+                "model": "gpt-5.4",
+                "usage": {"input_tokens": 10, "output_tokens": 2},
+            },
+        }
+    )
+    budget = _TurnBudget()
+    upstream = _FakeUpstream([completed], hold_after_events=True)
+    handler = _DummyOpenAIHandler()
+    handler.cost_tracker = budget
+    websocket = _TwoTurnWebSocket(budget)
+    fake_websockets = _make_fake_websockets_module(upstream)
+
+    with patch.dict(sys.modules, {"websockets": fake_websockets}):
+        await handler.handle_openai_responses_ws(websocket)
+
+    assert len(upstream.sent) == 1
+    assert websocket.close_code == 1008
+    assert websocket.close_reason == "Budget exceeded for daily period"


### PR DESCRIPTION
## Description

`--budget` / `HEADROOM_BUDGET` was enforced only by the Anthropic Messages handler. The shared cost tracker correctly recorded OpenAI and Gemini spend, but their generation handlers never called `check_budget()`, so requests continued reaching providers after the configured spending ceiling was exhausted.

This adds the missing provider-level preflight to OpenAI Chat Completions, OpenAI Responses HTTP, Gemini GenerateContent, and Gemini StreamGenerateContent. OpenAI Responses WebSocket sessions now check at the handshake, immediately before the first frame, and before every subsequent `response.create` turn so a long-lived connection cannot outlive the budget.

Closes #3374

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Added budget preflights after rate limiting and before token counting, compression, or upstream dispatch in both OpenAI HTTP generation handlers.
- Added the same preflight to buffered and streaming Gemini generation routes, including the non-text early-forward path.
- Reject OpenAI Responses WebSocket handshakes with close code 1008 when already over budget.
- Re-check the WebSocket budget before its first upstream frame and before each later `response.create` turn, covering idle sockets and long-lived multi-turn sessions.
- Added production-app route tests proving all five HTTP generation routes return 429 with zero upstream calls.
- Added WebSocket regression coverage for both initially exhausted budgets and a budget crossed between two turns.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest \
    tests/test_proxy_budget_provider_enforcement.py \
    tests/test_proxy_openai.py \
    tests/test_gemini_nonjson_status.py \
    tests/test_tokenizer_count_offload.py \
    tests/test_openai_codex_ws_lifecycle.py \
    tests/test_anthropic_pre_upstream_backpressure.py -q
117 passed, 1 warning in 8.10s

$ ruff check \
    headroom/proxy/handlers/openai.py \
    headroom/proxy/handlers/gemini.py \
    tests/test_proxy_budget_provider_enforcement.py
All checks passed!

$ ruff format \
    headroom/proxy/handlers/openai.py \
    headroom/proxy/handlers/gemini.py \
    tests/test_proxy_budget_provider_enforcement.py
3 files left unchanged
```

## Real Behavior Proof

- Environment: Linux 7.1.9 x86_64, Python 3.14.7, Headroom v0.37.0/current `main` at `7b3d226598fec88b5766bcf171cdd7f2a5d1cd3b`; `ProxyConfig(budget_limit_usd=0.0)` with production FastAPI routes and a recording upstream stub.
- Exact command / steps: started `create_app()` with cost tracking enabled and an exhausted zero-dollar daily budget; POSTed valid requests to Anthropic Messages, OpenAI Chat Completions, OpenAI Responses, Gemini GenerateContent, and Gemini StreamGenerateContent; recorded whether the proxy invoked `_retry_request` or `_stream_response`. Repeated the same script before and after the patch. Separately drove the production Responses WebSocket mixin through two `response.create` turns with the budget changing to denied after the first completed outcome.
- Observed result: before the fix, OpenAI Chat, OpenAI Responses, and Gemini GenerateContent returned HTTP 200 and made three upstream calls while the Anthropic control returned 429. After the fix, all five HTTP generation routes returned `429 Budget exceeded for daily period` and the recording upstream observed zero calls. An initially exhausted Responses WebSocket closed with code 1008 before connecting upstream; in a two-turn session where the first completed turn exhausted the budget, only the first frame reached OpenAI and the second was rejected with code 1008.
- Not tested: live paid-provider traffic or a deployed multi-worker instance; the production routing and handler code was exercised locally with provider calls replaced by deterministic recording stubs to avoid real spend.

```text
anthropic_status=429 detail=Budget exceeded for daily period
openai_chat_status=429 detail=Budget exceeded for daily period
openai_responses_status=429 detail=Budget exceeded for daily period
gemini_generate_status=429 detail=Budget exceeded for daily period
gemini_stream_status=429 detail=Budget exceeded for daily period
upstream_calls=0
```

## Runtime Rollout Safety

- Rollout-managed feature(s): none.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: only when a configured budget is exhausted; OpenAI and Gemini generation now reject consistently with the existing Anthropic behavior. With no budget or remaining budget, behavior is unchanged.
- Kill switch / disable path: unset `--budget` / `HEADROOM_BUDGET`, or disable cost tracking as before.
- Unsafe override required: no.
- Qualification impact: provider-parity checks for HTTP streaming/buffered generation and Responses WebSocket turns.
- Rollback path: revert this commit to restore the previous provider-specific enforcement gap.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A: this restores the already-documented `--budget` contract; no public option changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A

## Additional Notes

PR #885 made cost recording provider-independent but did not add the missing OpenAI/Gemini handler checks. PR #3368 changes the internal complexity of `check_budget()` and is orthogonal; this PR simply ensures every spend-generating provider path calls it. The check remains fail-open when no budget is configured, preserving current default behavior.
