### PR TITLE
feat(opencode): add bound tool policy enforcement

### DIFF
--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -5,6 +5,9 @@ OpenCode integration helpers for Headroom. The package supports two integration 
 1. Provider config helpers used by `headroom wrap opencode` and persistent installs.
 2. A native OpenCode plugin that installs Headroom transport interception and exposes the retrieve tool.
 
+The policy adapter implements the external-plugin direction discussed in
+[headroom#3279](https://github.com/headroomlabs-ai/headroom/issues/3279).
+
 ## Install
 
 ```bash
@@ -52,7 +55,168 @@ export default async function plugin(input) {
 - installs Headroom transport interception for OpenCode provider traffic.
 - exposes the `headroom_retrieve` tool.
 - publishes `HEADROOM_PROXY_URL` in the plugin output env.
+- enforces optional native tool policies, with shell/HTTP transport checks as defense in depth.
 - defaults to `http://127.0.0.1:8787` when no proxy URL is supplied.
+
+### Tool policy enforcement
+
+Pass `toolPolicy` to `HeadroomPlugin` (or set `HEADROOM_TOOL_POLICY_JSON`) to preflight outbound HTTP requests and child-process shell launches before they execute.
+
+```ts
+import { HeadroomPlugin } from "headroom-opencode";
+
+export default async function plugin(input) {
+  return HeadroomPlugin(input, {
+    proxyUrl: "http://127.0.0.1:8787",
+    toolPolicy: {
+      version: 1,
+      mode: "enforce",
+      rules: [
+        {
+          id: "deny-direct-openai",
+          scope: "http",
+          action: "deny",
+          domain: "api.openai.com",
+          reason: "force egress through approved gateways",
+        },
+        {
+          id: "approve-curl",
+          scope: "shell",
+          action: "require_approval",
+          command: "curl",
+        },
+      ],
+    },
+  });
+}
+```
+
+You can also keep the policy outside the plugin code:
+
+```bash
+export HEADROOM_TOOL_POLICY_PATH=~/.headroom/config/tool_policy.json
+```
+
+Or load it from an authenticated policy service:
+
+```bash
+export HEADROOM_TOOL_POLICY_URL=https://policy.example.com/v1/headroom
+export HEADROOM_TOOL_POLICY_TOKEN="$POLICY_READ_TOKEN"
+export HEADROOM_TOOL_POLICY_REFRESH_SECONDS=900
+```
+
+Or commit a repo-local policy file:
+
+```text
+<repo>/.headroom/tool_policy.json
+```
+
+```json
+{
+  "version": 1,
+  "mode": "enforce",
+  "defaultAction": "allow",
+  "rules": [
+    {
+      "id": "deny-direct-openai",
+      "scope": "http",
+      "action": "deny",
+      "domain": "api.openai.com",
+      "reason": "force egress through approved gateways"
+    },
+    {
+      "id": "ask-before-curl-post",
+      "scope": "shell",
+      "action": "require_approval",
+      "command": "curl",
+      "argsPattern": "(^|\\s)-X\\s+POST\\b"
+    }
+  ]
+}
+```
+
+Behavior:
+
+- scopes: `shell`, `http`, and cross-cutting `tool_call`
+- actions: `allow`, `deny`, `require_approval`
+- control precedence: explicit plugin policy → `HEADROOM_TOOL_POLICY_JSON` → `HEADROOM_TOOL_POLICY_PATH` → `HEADROOM_TOOL_POLICY_URL` → `~/.headroom/config/tool_policy.json` → nearest repo `.headroom/tool_policy.json`
+- deterministic precedence: first matching rule wins
+- matchers: `tool`, `command`, `argsPattern`, `cwdPattern`, `envKeys`, `domain`, `urlPattern`
+- `report_only` mode logs the decision but allows the operation
+- decisions are appended to `~/.headroom/tool_policy_audit.jsonl` and emitted as structured JSON lines on stderr
+- native `tool.execute.before` enforcement covers shell and non-shell OpenCode tools; transport interception remains advisory defense in depth
+- remote policies use ETag revalidation and a credential-bound five-minute atomic cache; refresh can be extended to one hour
+- an unavailable or invalid remote policy fails closed after the cache expires
+
+`require_approval` currently fails closed in the OpenCode transport because there is no interactive approval callback yet.
+
+### Enforcement authority and acknowledgements
+
+This plugin treats OpenCode's native tool lifecycle as the execution authority. The
+`tool.execute.before` hook issues a preflight decision bound to the OpenCode caller,
+session, call/task, tool name, effective tool working directory, and a hash of canonical
+arguments. Before returning an allowed preflight, the adapter deeply freezes the
+authorized argument graph and hook output so later hooks cannot replace the bound
+request. A blocked decision receives an immediate
+`headroom_tool_policy_enforcement_acknowledgement` because the adapter commits to
+throwing. An allowed preflight receives no acknowledgement until OpenCode invokes
+`tool.execute.after` with matching final arguments. Argument or working-directory
+mutation between the hooks produces an integrity error and no acknowledgement.
+
+A blocked acknowledgement proves only that the adapter prevented that specific bound
+invocation. An allowed acknowledgement proves that OpenCode completed the matching
+native tool lifecycle; neither is a claim about similar work attempted elsewhere.
+
+Transport interception (`fetch`, `http`, and `child_process`) is labeled
+`authority: "advisory"`. It is defense in depth for operations originating inside the
+plugin process, but it cannot prove that an external executor prevented an effect and
+therefore never emits an enforcement acknowledgement.
+
+Native decisions use this envelope:
+
+```json
+{
+  "version": 1,
+  "decisionId": "<sha256>",
+  "authority": "authoritative",
+  "requestHash": "<request-hash>",
+  "binding": {
+    "caller": "opencode",
+    "adapter": "tool.execute.before",
+    "sessionID": "<session>",
+    "taskID": "<call>",
+    "callID": "<call>",
+    "toolName": "bash",
+    "cwd": "/workspace",
+    "canonicalArgsHash": "<arguments-hash>"
+  }
+}
+```
+
+Only an acknowledgement with the same `decisionId`, `requestHash`, and complete binding
+belongs to that decision. Missing or mismatched acknowledgements must not be interpreted
+as enforcement.
+
+Shell commands that use executable-name escaping, Bash/PowerShell/cmd expansion,
+computed invocation, process substitution, control structures, `eval`, `exec`,
+`source`, or command substitution cannot be statically authorized when a
+restrictive shell policy is present. They fail closed unless a matching rule already
+blocks the statically identified command. Because the process transport is global, a
+second OpenCode workspace with a different policy context is rejected rather than
+replacing the active workspace's policy.
+
+Example audit line:
+
+```json
+{
+  "event": "headroom_tool_policy_decision",
+  "scope": "http",
+  "action": "deny",
+  "effective_action": "deny",
+  "matched_rule": "deny-direct-openai",
+  "resource": "https://api.openai.com/v1/responses"
+}
+```
 
 ## Retrieve Tool
 
@@ -101,6 +265,11 @@ The provider config exposes these as `headroom/<model>` and defaults to `headroo
 |---|---|---|
 | `HEADROOM_PROXY_URL` | Native plugin | Proxy URL used by `HeadroomPlugin` |
 | `OPENCODE_CONFIG_CONTENT` | OpenCode wrapper | Generated OpenCode provider, model, and MCP config |
+| `HEADROOM_TOOL_POLICY_JSON` | Native plugin / child Node processes | Optional JSON policy document for native tool and transport checks |
+| `HEADROOM_TOOL_POLICY_PATH` | Native plugin / child Node processes | Optional path to a shared JSON policy file; falls back to repo-local `.headroom/tool_policy.json` or `~/.headroom/config/tool_policy.json` when unset |
+| `HEADROOM_TOOL_POLICY_URL` | Native plugin | HTTPS endpoint returning a versioned policy JSON document |
+| `HEADROOM_TOOL_POLICY_TOKEN` | Native plugin | Optional bearer token for the remote policy service |
+| `HEADROOM_TOOL_POLICY_REFRESH_SECONDS` | Native plugin | Cache refresh interval from 300 through 3600 seconds; invalid values use 300 |
 
 ## License
 

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -1,22 +1,505 @@
-# headroom-opencode
+# Headroom for OpenCode
 
-OpenCode integration helpers for Headroom. The package supports two integration paths:
+Route OpenCode model traffic through Headroom, expose Headroom retrieval, and apply
+policy to native tool calls before they execute.
 
-1. Provider config helpers used by `headroom wrap opencode` and persistent installs.
-2. A native OpenCode plugin that installs Headroom transport interception and exposes the retrieve tool.
+This package supports:
 
-The policy adapter implements the external-plugin direction discussed in
+- **Individuals:** keep a policy in one repository or in a personal config directory.
+- **Teams:** commit a reviewed policy with the repository.
+- **Enterprises:** retrieve policy from an authenticated HTTPS service with local,
+  credential-bound caching and fail-closed outage behavior.
+
+The policy adapter follows the external-plugin design discussed in
 [headroom#3279](https://github.com/headroomlabs-ai/headroom/issues/3279).
 
-## Install
+## What the plugin does
 
-```bash
-npm install headroom-opencode
+| Capability | Behavior |
+|---|---|
+| Provider routing | Routes supported model traffic through a Headroom proxy. |
+| Retrieval | Adds the `headroom_retrieve` OpenCode tool. |
+| Native policy | Evaluates `tool.execute.before` for shell and non-shell tools. |
+| Defense in depth | Evaluates in-process HTTP and child-process activity as advisory checks. |
+| Audit | Writes structured, secret-safe JSON lines to stderr and disk. |
+
+Policy enforcement is optional. With no policy configured, existing OpenCode tool
+behavior is unchanged.
+
+## Getting started
+
+### Prerequisites
+
+- OpenCode with plugin support
+- Node.js 18 or newer
+- A running Headroom proxy, normally at `http://127.0.0.1:8787`
+
+### 1. Install the plugin dependency
+
+Create `.opencode/package.json` in your project:
+
+```json
+{
+  "dependencies": {
+    "headroom-opencode": "^0.37.0"
+  }
+}
 ```
 
-## Provider Config Helpers
+OpenCode installs dependencies declared in `.opencode/package.json` when it starts.
 
-Use these helpers when you need to generate OpenCode config that routes a `headroom` provider through a running Headroom proxy.
+### 2. Register the plugin
+
+Create `.opencode/plugins/headroom.ts`:
+
+```ts
+import { HeadroomPlugin } from "headroom-opencode";
+
+export default async function headroom(input) {
+  return HeadroomPlugin(input, {
+    proxyUrl: process.env.HEADROOM_PROXY_URL ?? "http://127.0.0.1:8787",
+  });
+}
+```
+
+Local plugins in `.opencode/plugins/` are loaded automatically. The wrapper above
+exports only the plugin factory, which is required by OpenCode's plugin loader.
+
+### 3. Add a starter policy
+
+Create `.headroom/tool_policy.json`:
+
+```json
+{
+  "version": 1,
+  "mode": "enforce",
+  "defaultAction": "allow",
+  "rules": [
+    {
+      "id": "deny-direct-provider-egress",
+      "scope": "http",
+      "action": "deny",
+      "domain": [
+        "api.openai.com",
+        "api.anthropic.com"
+      ],
+      "reason": "use the approved Headroom gateway"
+    },
+    {
+      "id": "deny-curl-post",
+      "scope": "shell",
+      "action": "deny",
+      "command": "curl",
+      "argsPattern": "(^|\\s)(-X|--request)\\s+POST\\b",
+      "reason": "direct HTTP writes are not allowed"
+    }
+  ]
+}
+```
+
+### 4. Verify the setup
+
+Restart OpenCode from the project directory, then ask it to:
+
+1. Run `echo headroom-policy-ok`. The command should be allowed.
+2. Run `curl -X POST https://example.com`. The command should be denied before execution.
+3. Inspect `~/.headroom/tool_policy_audit.jsonl`. It should contain a bound native
+   decision and a terminal acknowledgement.
+
+Do not test a deny rule against a production endpoint. Use a non-sensitive hostname
+such as `example.com`.
+
+## Individual setup
+
+### Repository-specific policy
+
+Use `<repo>/.headroom/tool_policy.json` when a policy belongs to one project. This is
+the simplest setup and can be reviewed like other project configuration.
+
+### Personal policy across repositories
+
+Store a policy at:
+
+```text
+~/.headroom/config/tool_policy.json
+```
+
+The global policy takes precedence over repository policy. Use it for non-negotiable
+personal defaults, such as blocking credential-management commands in every project.
+
+Example:
+
+```json
+{
+  "version": 1,
+  "mode": "enforce",
+  "defaultAction": "allow",
+  "rules": [
+    {
+      "id": "protect-ssh-directory",
+      "scope": "tool_call",
+      "action": "deny",
+      "tool": [
+        "write",
+        "edit"
+      ],
+      "argsPattern": "[\\\\/]\\.ssh[\\\\/]",
+      "reason": "SSH configuration requires manual changes"
+    }
+  ]
+}
+```
+
+To use a different file without changing the plugin wrapper:
+
+```bash
+export HEADROOM_TOOL_POLICY_PATH="$HOME/policies/opencode.json"
+opencode
+```
+
+PowerShell:
+
+```powershell
+$env:HEADROOM_TOOL_POLICY_PATH = "$HOME\policies\opencode.json"
+opencode
+```
+
+### Test a policy before enforcing it
+
+Set `"mode": "report_only"` while developing rules. Matching deny and approval rules
+are audited but operations continue. Review the audit log, then change the mode to
+`"enforce"`.
+
+`report_only` is an observation mode, not a security boundary.
+
+## Team setup
+
+For a shared repository:
+
+1. Commit `.opencode/plugins/headroom.ts`.
+2. Commit `.opencode/package.json`.
+3. Commit `.headroom/tool_policy.json`.
+4. Require code-owner review for `.headroom/**` and `.opencode/**`.
+5. Start with `report_only`, review representative audit output, then switch to
+   `enforce`.
+
+Prefer stable rule IDs because audit consumers use them to group decisions over time.
+Put narrow exceptions before broad rules because the first matching rule wins.
+
+Example default-deny policy:
+
+```json
+{
+  "version": 1,
+  "mode": "enforce",
+  "defaultAction": "deny",
+  "rules": [
+    {
+      "id": "allow-read-tools",
+      "scope": "tool_call",
+      "action": "allow",
+      "tool": [
+        "read",
+        "glob",
+        "grep"
+      ]
+    },
+    {
+      "id": "allow-safe-shell",
+      "scope": "shell",
+      "action": "allow",
+      "command": [
+        "git",
+        "npm"
+      ],
+      "argsPattern": "^(git (status|diff|log)|npm (test|run (build|typecheck)))\\b"
+    }
+  ]
+}
+```
+
+For compound shell commands, an allow rule must cover every executable candidate.
+Unsupported dynamic shell grammar fails closed under a restrictive policy. Prefer
+direct OpenCode tool calls over complex shell programs.
+
+## Enterprise setup
+
+### Recommended architecture
+
+```text
+OpenCode
+  -> Headroom OpenCode plugin
+      -> authenticated policy service
+      -> credential-bound local cache
+      -> native tool lifecycle enforcement
+      -> JSONL audit collector
+```
+
+Run the policy service separately from the Headroom model proxy. Give agents a
+read-only policy credential scoped to the tenant, environment, and policy set.
+
+### Configure a remote policy
+
+Set these variables in the environment that launches OpenCode:
+
+```bash
+export HEADROOM_TOOL_POLICY_URL="https://policy.example.com/v1/opencode"
+export HEADROOM_TOOL_POLICY_TOKEN="$POLICY_READ_TOKEN"
+export HEADROOM_TOOL_POLICY_REFRESH_SECONDS=900
+opencode
+```
+
+PowerShell:
+
+```powershell
+$env:HEADROOM_TOOL_POLICY_URL = "https://policy.example.com/v1/opencode"
+$env:HEADROOM_TOOL_POLICY_TOKEN = $env:POLICY_READ_TOKEN
+$env:HEADROOM_TOOL_POLICY_REFRESH_SECONDS = "900"
+opencode
+```
+
+The URL and bearer token remain in the plugin process. They are removed from OpenCode
+shell environments and wrapped child-process environments. Do not place credentials in
+the policy document.
+
+### Policy service contract
+
+The endpoint must:
+
+- accept `GET`;
+- return a version 1 policy JSON document;
+- return a valid JSON body; `Content-Type: application/json` is strongly recommended;
+- use HTTPS, except loopback HTTP for local development;
+- return an `ETag` when revalidation is supported;
+- honor `If-None-Match` with `304 Not Modified`;
+- keep the response body at or below 1 MiB;
+- avoid redirects, which the client rejects.
+
+Example response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+ETag: "policy-42"
+
+{
+  "version": 1,
+  "mode": "enforce",
+  "defaultAction": "deny",
+  "rules": [
+    {
+      "id": "allow-approved-ci",
+      "scope": "shell",
+      "action": "allow",
+      "command": "npm",
+      "argsPattern": "^npm (test|run build)\\b"
+    }
+  ]
+}
+```
+
+### Cache and outage behavior
+
+- Refresh defaults to 300 seconds and can be configured from 300 through 3600 seconds.
+- Missing, non-integer, or out-of-range refresh values use 300 seconds rather than
+  being clamped.
+- Cache identity includes both the policy URL and bearer token, preventing reuse across
+  credentials or tenants.
+- Cache writes are atomic and stored under `~/.headroom/policy-cache/`.
+- A fresh cache avoids a network request until its refresh interval elapses.
+- After cache expiry, an unavailable, invalid, oversized, or redirected policy fails
+  closed.
+- A second workspace with a different policy or credential context in the same process
+  is rejected rather than replacing the active policy.
+
+When `HEADROOM_STATELESS` is `1`, `true`, `yes`, or `on`, disk audit and cache reads
+and writes are disabled. Remote policy remains fail-closed, but there is no persisted
+cache fallback across requests or restarts; the policy service must remain available
+when a refresh is required.
+
+For recovery, restore the service before the cache expires, correct the local policy
+source, or remove policy configuration to return deliberately to the plugin's
+unconfigured behavior. Do not delete an expired cache as an outage workaround; that
+does not create an allow fallback.
+
+### Rollout checklist
+
+1. Define stable rule IDs and owners.
+2. Deploy the endpoint behind authenticated HTTPS.
+3. Use a short-lived, read-only credential.
+4. Roll out in `report_only`.
+5. Collect audit records across representative repositories and operating systems.
+6. Resolve false positives, especially dynamic shell usage.
+7. Switch a pilot group to `enforce`.
+8. Test endpoint outage and expired-cache behavior.
+9. Expand rollout and monitor `unknown` terminal outcomes.
+10. Document the disable and credential-rotation procedures.
+
+### Audit collection
+
+By default, records are appended to:
+
+```text
+~/.headroom/tool_policy_audit.jsonl
+```
+
+Set `HEADROOM_WORKSPACE_DIR` to move audit and cache storage to a managed directory.
+Unless `HEADROOM_CONFIG_DIR` is set separately, this also moves the global policy to
+`<HEADROOM_WORKSPACE_DIR>/config/tool_policy.json`. Records are also emitted as JSON
+lines on stderr for collection by a supervisor.
+
+Audit output intentionally contains safe resource summaries, such as a command name or
+hostname, plus a hash of the full resource. Signed URLs, bearer tokens, and full command
+arguments are not written.
+
+## Policy reference
+
+### Source precedence
+
+The first configured source wins:
+
+1. `toolPolicy` passed directly to `HeadroomPlugin`
+2. `HEADROOM_TOOL_POLICY_JSON`
+3. `HEADROOM_TOOL_POLICY_PATH`
+4. `HEADROOM_TOOL_POLICY_URL`
+5. global policy file (by default `~/.headroom/config/tool_policy.json`)
+6. nearest `.headroom/tool_policy.json`
+
+An invalid selected source is an error. The plugin does not silently fall through to a
+lower-precedence source.
+
+`HEADROOM_CONFIG_DIR` changes only the global policy directory. For example,
+`HEADROOM_CONFIG_DIR=/etc/headroom` reads `/etc/headroom/tool_policy.json`.
+`HEADROOM_WORKSPACE_DIR` changes the audit/cache root and, when
+`HEADROOM_CONFIG_DIR` is unset, changes global policy lookup to
+`<HEADROOM_WORKSPACE_DIR>/config/tool_policy.json`.
+
+### Document fields
+
+| Field | Required | Description |
+|---|---:|---|
+| `version` | No | Must be `1` when present. |
+| `mode` | No | `enforce` (default) or `report_only`. |
+| `defaultAction` | No | `allow` (default) or `deny`. |
+| `rules` | Yes | Ordered list; first matching rule wins. |
+
+### Rule fields
+
+| Field | Applies to | Description |
+|---|---|---|
+| `id` | all | Stable audit identifier. Generated when omitted. |
+| `scope` | all | `tool_call`, `shell`, or `http`. |
+| `action` | all | `allow`, `deny`, or `require_approval`. |
+| `reason` | all | Operator-facing explanation. |
+| `tool` | tool/shell | Tool name or list of names. |
+| `command` | shell | Executable basename, path, or list. |
+| `argsPattern` | tool/shell | JavaScript regular expression over canonical arguments or command text. |
+| `cwdPattern` | tool/shell | JavaScript regular expression over normalized effective cwd. |
+| `envKeys` | tool/shell | Required environment key names; values are never matched or audited. |
+| `domain` | HTTP | Exact hostname or `*.example.com`. |
+| `urlPattern` | HTTP | JavaScript regular expression over the full URL. |
+
+`require_approval` currently fails closed because OpenCode does not expose an
+interactive approval callback to this plugin.
+
+### Shell safety model
+
+The shell evaluator supports direct, statically identifiable executable invocations,
+including common wrappers such as `sudo` and `env`. Under a restrictive policy, it
+fails closed on grammar that can construct or hide an executable at runtime:
+
+- executable-name escaping;
+- Bash, PowerShell, or cmd variable expansion;
+- command and process substitution;
+- computed invocation;
+- shell control structures;
+- `eval`, `exec`, `source`, and equivalent commands.
+
+This deliberately favors a false denial over authorizing an executable that the policy
+could not identify.
+
+## Authority and terminal outcomes
+
+OpenCode's native tool lifecycle is the authoritative path:
+
+1. `tool.execute.before` evaluates policy.
+2. The decision is bound to caller, session, call/task, tool, normalized cwd, and a
+   hash of canonical arguments.
+3. A denied call emits `effect: "blocked"` and the plugin throws.
+4. An allowed call has its argument graph frozen before execution.
+5. A matching `tool.execute.after` emits `effect: "allowed"`.
+
+OpenCode currently invokes `tool.execute.after` only after successful tool execution;
+it has no error hook. The plugin therefore retains allowed preflights in a bounded,
+expiring store:
+
+- default capacity: 1,024 preflights;
+- default lifetime: 5 minutes;
+- capacity eviction: `effect: "unknown", reason: "capacity_evicted"`;
+- timeout: `effect: "unknown", reason: "postflight_timeout"`;
+- mismatched final binding: `effect: "unknown", reason: "postflight_mismatch"`;
+- ambiguous reuse of a retired argument graph:
+  `effect: "unknown", reason: "ambiguous_reused_call"`;
+- plugin shutdown: `effect: "unknown", reason: "plugin_disposed"`;
+- reused session/call identity: `effect: "unknown", reason: "call_replaced"`.
+
+`unknown` is a terminal audit outcome, not proof that execution succeeded or failed.
+It distinguishes an unobserved postflight from a bypassed or missing record without
+claiming an effect the host did not expose.
+
+The bounds can be tuned in the wrapper:
+
+```ts
+return HeadroomPlugin(input, {
+  pendingPreflightTtlMs: 5 * 60 * 1000,
+  maxPendingPreflights: 1024,
+});
+```
+
+Only an acknowledgement with the same `decisionId`, `requestHash`, and complete
+binding belongs to a decision.
+
+HTTP and child-process interception is labeled `authority: "advisory"`. It provides
+defense in depth for activity originating inside the plugin process, but it cannot
+prove that an external executor prevented an effect and never emits an enforcement
+acknowledgement.
+
+## Troubleshooting
+
+### Policy is not loading
+
+Check sources in precedence order. A machine-global policy shadows repository policy.
+Validate the selected file as JSON and restart OpenCode after changing launch
+environment variables.
+
+### Commands fail with "dynamic or escaped shell execution"
+
+The command uses grammar that cannot be statically authorized. Replace it with direct
+OpenCode tool calls or split it into simple executable invocations. Do not add a broad
+allow rule to bypass the parser.
+
+### Remote policy fails closed
+
+Check HTTPS certificate validity, endpoint reachability, response size, JSON schema,
+and credential scope. Confirm the endpoint does not redirect. Restore service or
+correct configuration; an expired cache is never treated as permission to continue.
+
+### Many terminal outcomes are `unknown`
+
+`postflight_timeout` usually indicates tool failure, cancellation, host shutdown, or a
+missing OpenCode postflight. `capacity_evicted` indicates sustained outstanding calls;
+investigate host behavior before increasing the limit. Correlate by `sessionID`,
+`callID`, and `decisionId`.
+
+### Another workspace is rejected
+
+One Node process cannot safely host incompatible global transport policies. Run the
+workspaces in separate OpenCode processes or give them the same policy context.
+
+## Provider config helpers
+
+Use these helpers to generate OpenCode provider configuration that routes a `headroom`
+provider through a local proxy:
 
 ```ts
 import {
@@ -34,242 +517,45 @@ console.log(provider.provider.headroom.npm);
 console.log(config.model);
 ```
 
-The generated provider uses `@ai-sdk/openai-compatible` and points model requests at `http://127.0.0.1:<port>/v1`.
-
-## Native OpenCode Plugin
-
-Use `HeadroomPlugin` when OpenCode should intercept provider traffic in-process and expose Headroom tooling from a plugin.
+## Retrieve and compression helpers
 
 ```ts
-import { HeadroomPlugin } from "headroom-opencode";
-
-export default async function plugin(input) {
-  return HeadroomPlugin(input, {
-    proxyUrl: process.env.HEADROOM_PROXY_URL ?? "http://127.0.0.1:8787",
-  });
-}
-```
-
-`HeadroomPlugin`:
-
-- installs Headroom transport interception for OpenCode provider traffic.
-- exposes the `headroom_retrieve` tool.
-- publishes `HEADROOM_PROXY_URL` in the plugin output env.
-- enforces optional native tool policies, with shell/HTTP transport checks as defense in depth.
-- defaults to `http://127.0.0.1:8787` when no proxy URL is supplied.
-
-### Tool policy enforcement
-
-Pass `toolPolicy` to `HeadroomPlugin` (or set `HEADROOM_TOOL_POLICY_JSON`) to preflight outbound HTTP requests and child-process shell launches before they execute.
-
-```ts
-import { HeadroomPlugin } from "headroom-opencode";
-
-export default async function plugin(input) {
-  return HeadroomPlugin(input, {
-    proxyUrl: "http://127.0.0.1:8787",
-    toolPolicy: {
-      version: 1,
-      mode: "enforce",
-      rules: [
-        {
-          id: "deny-direct-openai",
-          scope: "http",
-          action: "deny",
-          domain: "api.openai.com",
-          reason: "force egress through approved gateways",
-        },
-        {
-          id: "approve-curl",
-          scope: "shell",
-          action: "require_approval",
-          command: "curl",
-        },
-      ],
-    },
-  });
-}
-```
-
-You can also keep the policy outside the plugin code:
-
-```bash
-export HEADROOM_TOOL_POLICY_PATH=~/.headroom/config/tool_policy.json
-```
-
-Or load it from an authenticated policy service:
-
-```bash
-export HEADROOM_TOOL_POLICY_URL=https://policy.example.com/v1/headroom
-export HEADROOM_TOOL_POLICY_TOKEN="$POLICY_READ_TOKEN"
-export HEADROOM_TOOL_POLICY_REFRESH_SECONDS=900
-```
-
-Or commit a repo-local policy file:
-
-```text
-<repo>/.headroom/tool_policy.json
-```
-
-```json
-{
-  "version": 1,
-  "mode": "enforce",
-  "defaultAction": "allow",
-  "rules": [
-    {
-      "id": "deny-direct-openai",
-      "scope": "http",
-      "action": "deny",
-      "domain": "api.openai.com",
-      "reason": "force egress through approved gateways"
-    },
-    {
-      "id": "ask-before-curl-post",
-      "scope": "shell",
-      "action": "require_approval",
-      "command": "curl",
-      "argsPattern": "(^|\\s)-X\\s+POST\\b"
-    }
-  ]
-}
-```
-
-Behavior:
-
-- scopes: `shell`, `http`, and cross-cutting `tool_call`
-- actions: `allow`, `deny`, `require_approval`
-- control precedence: explicit plugin policy → `HEADROOM_TOOL_POLICY_JSON` → `HEADROOM_TOOL_POLICY_PATH` → `HEADROOM_TOOL_POLICY_URL` → `~/.headroom/config/tool_policy.json` → nearest repo `.headroom/tool_policy.json`
-- deterministic precedence: first matching rule wins
-- matchers: `tool`, `command`, `argsPattern`, `cwdPattern`, `envKeys`, `domain`, `urlPattern`
-- `report_only` mode logs the decision but allows the operation
-- decisions are appended to `~/.headroom/tool_policy_audit.jsonl` and emitted as structured JSON lines on stderr
-- native `tool.execute.before` enforcement covers shell and non-shell OpenCode tools; transport interception remains advisory defense in depth
-- remote policies use ETag revalidation and a credential-bound five-minute atomic cache; refresh can be extended to one hour
-- an unavailable or invalid remote policy fails closed after the cache expires
-
-`require_approval` currently fails closed in the OpenCode transport because there is no interactive approval callback yet.
-
-### Enforcement authority and acknowledgements
-
-This plugin treats OpenCode's native tool lifecycle as the execution authority. The
-`tool.execute.before` hook issues a preflight decision bound to the OpenCode caller,
-session, call/task, tool name, effective tool working directory, and a hash of canonical
-arguments. Before returning an allowed preflight, the adapter deeply freezes the
-authorized argument graph and hook output so later hooks cannot replace the bound
-request. A blocked decision receives an immediate
-`headroom_tool_policy_enforcement_acknowledgement` because the adapter commits to
-throwing. An allowed preflight receives no acknowledgement until OpenCode invokes
-`tool.execute.after` with matching final arguments. Argument or working-directory
-mutation between the hooks produces an integrity error and no acknowledgement.
-
-A blocked acknowledgement proves only that the adapter prevented that specific bound
-invocation. An allowed acknowledgement proves that OpenCode completed the matching
-native tool lifecycle; neither is a claim about similar work attempted elsewhere.
-
-Transport interception (`fetch`, `http`, and `child_process`) is labeled
-`authority: "advisory"`. It is defense in depth for operations originating inside the
-plugin process, but it cannot prove that an external executor prevented an effect and
-therefore never emits an enforcement acknowledgement.
-
-Native decisions use this envelope:
-
-```json
-{
-  "version": 1,
-  "decisionId": "<sha256>",
-  "authority": "authoritative",
-  "requestHash": "<request-hash>",
-  "binding": {
-    "caller": "opencode",
-    "adapter": "tool.execute.before",
-    "sessionID": "<session>",
-    "taskID": "<call>",
-    "callID": "<call>",
-    "toolName": "bash",
-    "cwd": "/workspace",
-    "canonicalArgsHash": "<arguments-hash>"
-  }
-}
-```
-
-Only an acknowledgement with the same `decisionId`, `requestHash`, and complete binding
-belongs to that decision. Missing or mismatched acknowledgements must not be interpreted
-as enforcement.
-
-Shell commands that use executable-name escaping, Bash/PowerShell/cmd expansion,
-computed invocation, process substitution, control structures, `eval`, `exec`,
-`source`, or command substitution cannot be statically authorized when a
-restrictive shell policy is present. They fail closed unless a matching rule already
-blocks the statically identified command. Because the process transport is global, a
-second OpenCode workspace with a different policy context is rejected rather than
-replacing the active workspace's policy.
-
-Example audit line:
-
-```json
-{
-  "event": "headroom_tool_policy_decision",
-  "scope": "http",
-  "action": "deny",
-  "effective_action": "deny",
-  "matched_rule": "deny-direct-openai",
-  "resource": "https://api.openai.com/v1/responses"
-}
-```
-
-## Retrieve Tool
-
-```ts
-import { createHeadroomRetrieveTool } from "headroom-opencode";
+import {
+  compressWithHeadroom,
+  createHeadroomRetrieveTool,
+} from "headroom-opencode";
 
 const retrieve = createHeadroomRetrieveTool({
   proxyBaseUrl: "http://127.0.0.1:8787",
 });
-
-const result = await retrieve.execute({
+const original = await retrieve.execute({
   hash: "0123456789abcdef01234567",
 });
-```
 
-The tool calls `/v1/retrieve/<hash>` on the Headroom proxy.
-
-## Compression Helper
-
-```ts
-import { compressWithHeadroom } from "headroom-opencode";
-
-const result = await compressWithHeadroom(
+const compressed = await compressWithHeadroom(
   [{ role: "user", content: "Summarize this file" }],
   { model: "gpt-4o", proxyUrl: "http://127.0.0.1:8787" },
 );
 
-console.log(`Saved ${result.tokensSaved} tokens`);
+console.log(original);
+console.log(`Saved ${compressed.tokensSaved} tokens`);
 ```
 
-## Models
+## Environment variables
 
-| Model | Context | Output |
-|---|---:|---:|
-| `claude-sonnet-4-6` | 200K | 16K |
-| `claude-opus-4-6` | 200K | 16K |
-| `claude-haiku-4-5-20251001` | 200K | 8K |
-| `gpt-4o` | 128K | 16K |
-| `gpt-4.1` | 1M | 32K |
-
-The provider config exposes these as `headroom/<model>` and defaults to `headroom/claude-sonnet-4-6`.
-
-## Environment
-
-| Variable | Used by | Description |
-|---|---|---|
-| `HEADROOM_PROXY_URL` | Native plugin | Proxy URL used by `HeadroomPlugin` |
-| `OPENCODE_CONFIG_CONTENT` | OpenCode wrapper | Generated OpenCode provider, model, and MCP config |
-| `HEADROOM_TOOL_POLICY_JSON` | Native plugin / child Node processes | Optional JSON policy document for native tool and transport checks |
-| `HEADROOM_TOOL_POLICY_PATH` | Native plugin / child Node processes | Optional path to a shared JSON policy file; falls back to repo-local `.headroom/tool_policy.json` or `~/.headroom/config/tool_policy.json` when unset |
-| `HEADROOM_TOOL_POLICY_URL` | Native plugin | HTTPS endpoint returning a versioned policy JSON document |
-| `HEADROOM_TOOL_POLICY_TOKEN` | Native plugin | Optional bearer token for the remote policy service |
-| `HEADROOM_TOOL_POLICY_REFRESH_SECONDS` | Native plugin | Cache refresh interval from 300 through 3600 seconds; invalid values use 300 |
+| Variable | Description |
+|---|---|
+| `HEADROOM_PROXY_URL` | Proxy URL used by `HeadroomPlugin`. |
+| `HEADROOM_BASE_URL` | Backward-compatible proxy URL fallback when `HEADROOM_PROXY_URL` is unset. |
+| `HEADROOM_TOOL_POLICY_JSON` | Inline JSON policy document. |
+| `HEADROOM_TOOL_POLICY_PATH` | Path to a policy JSON file. |
+| `HEADROOM_TOOL_POLICY_URL` | HTTPS endpoint returning policy JSON. |
+| `HEADROOM_TOOL_POLICY_TOKEN` | Optional bearer token for the policy endpoint. |
+| `HEADROOM_TOOL_POLICY_REFRESH_SECONDS` | Remote refresh interval, 300-3600 seconds. |
+| `HEADROOM_CONFIG_DIR` | Global policy directory; reads `<dir>/tool_policy.json`. |
+| `HEADROOM_WORKSPACE_DIR` | Audit/cache root and fallback global policy root. |
+| `HEADROOM_STATELESS` | Disables disk audit and cache writes when truthy. |
+| `OPENCODE_CONFIG_CONTENT` | Generated OpenCode provider/model/MCP configuration. |
 
 ## License
 

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -20,4 +20,33 @@ export type { RetrieveToolConfig } from "./retrieve.js";
 export { HeadroomPlugin, default } from "./plugin.js";
 export type { HeadroomOpenCodePluginOptions } from "./plugin.js";
 
-export { installHeadroomTransport } from "./transport.js";
+export {
+  defaultGlobalToolPolicyPath,
+  acknowledgeNativeToolExecution,
+  enforceNativeToolExecution,
+  evaluateNativeToolPolicy,
+  findLocalToolPolicyPath,
+  installHeadroomTransport,
+  isAllowedToolPolicyUrl,
+  refreshHeadroomToolPolicy,
+  remoteToolPolicyCachePath,
+  shellCommandBinaries,
+  toolPolicyRefreshSeconds,
+  TOOL_POLICY_ENV,
+  TOOL_POLICY_PATH_ENV,
+  TOOL_POLICY_REFRESH_SECONDS_ENV,
+  TOOL_POLICY_TOKEN_ENV,
+  TOOL_POLICY_URL_ENV,
+} from "./transport.js";
+export type {
+  HeadroomToolPolicyConfig,
+  HeadroomToolPolicyAcknowledgement,
+  HeadroomToolPolicyBinding,
+  HeadroomToolPolicyDecision,
+  HeadroomToolPolicyPreflight,
+  HeadroomToolPolicyRule,
+  ToolPolicyAction,
+  ToolPolicyMode,
+  ToolPolicyScope,
+} from "./transport.js";
+export { ToolPolicyEnforcementError } from "./transport.js";

--- a/plugins/opencode/src/index.ts
+++ b/plugins/opencode/src/index.ts
@@ -23,6 +23,7 @@ export type { HeadroomOpenCodePluginOptions } from "./plugin.js";
 export {
   defaultGlobalToolPolicyPath,
   acknowledgeNativeToolExecution,
+  acknowledgeUnknownNativeToolExecution,
   enforceNativeToolExecution,
   evaluateNativeToolPolicy,
   findLocalToolPolicyPath,

--- a/plugins/opencode/src/plugin.test.ts
+++ b/plugins/opencode/src/plugin.test.ts
@@ -150,6 +150,82 @@ describe("HeadroomPlugin", () => {
     await plugin.dispose?.();
   });
 
+  it("bounds missing postflights and records terminal unknown outcomes", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: { rules: [] },
+      maxPendingPreflights: 2,
+    });
+
+    for (let index = 0; index < 5; index += 1) {
+      await plugin["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "session-bounded", callID: `call-${index}` },
+        { args: { command: `echo ${index}` } },
+      );
+    }
+
+    const recordsBeforeDispose = stderr.mock.calls
+      .map(([value]) => String(value).trim())
+      .filter((value) => value.startsWith("{"))
+      .map((value) => JSON.parse(value) as Record<string, unknown>);
+    expect(
+      recordsBeforeDispose.filter(
+        (record) =>
+          record.event === "headroom_tool_policy_enforcement_acknowledgement" &&
+          record.effect === "unknown" &&
+          record.reason === "capacity_evicted",
+      ),
+    ).toHaveLength(3);
+
+    await plugin.dispose?.();
+    const recordsAfterDispose = stderr.mock.calls
+      .map(([value]) => String(value).trim())
+      .filter((value) => value.startsWith("{"))
+      .map((value) => JSON.parse(value) as Record<string, unknown>);
+    expect(
+      recordsAfterDispose.filter(
+        (record) =>
+          record.event === "headroom_tool_policy_enforcement_acknowledgement" &&
+          record.effect === "unknown",
+      ),
+    ).toHaveLength(5);
+    expect(
+      recordsAfterDispose.filter(
+        (record) => record.effect === "unknown" && record.reason === "plugin_disposed",
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("expires a missing postflight with an unknown outcome", async () => {
+    vi.useFakeTimers();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const plugin = await HeadroomPlugin(pluginInput(), {
+        proxyUrl: "http://127.0.0.1:8787",
+        toolPolicy: { rules: [] },
+        pendingPreflightTtlMs: 25,
+      });
+      await plugin["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "session-timeout", callID: "call-timeout" },
+        { args: { command: "echo waiting" } },
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      expect(
+        stderr.mock.calls.some(([value]) => {
+          const output = String(value);
+          return output.includes('"effect":"unknown"') &&
+            output.includes('"reason":"postflight_timeout"');
+        }),
+      ).toBe(true);
+      await plugin.dispose?.();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects an acknowledgement when final arguments differ from preflight", async () => {
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const plugin = await HeadroomPlugin(pluginInput(), {
@@ -168,12 +244,105 @@ describe("HeadroomPlugin", () => {
           metadata: {},
         },
       ),
-    ).rejects.toThrow(/did not match the bound preflight decision/);
+    ).rejects.toThrow(/did not match the bound preflight/);
     expect(
-      stderr.mock.calls.some(([value]) =>
-        String(value).includes("headroom_tool_policy_enforcement_acknowledgement"),
+      stderr.mock.calls.some(([value]) => {
+        const output = String(value);
+        return output.includes('"effect":"unknown"') &&
+          output.includes('"reason":"postflight_mismatch"');
+      }),
+    ).toBe(true);
+    await plugin.dispose?.();
+  });
+
+  it("uses a unique decision ID when a call identity is reused", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: { rules: [] },
+    });
+    const input = { tool: "bash", sessionID: "session-reused", callID: "call-reused" };
+
+    await plugin["tool.execute.before"]?.(input, { args: { command: "echo same" } });
+    await plugin["tool.execute.before"]?.(input, { args: { command: "echo same" } });
+
+    const decisions = stderr.mock.calls
+      .map(([value]) => String(value).trim())
+      .filter((value) => value.startsWith("{"))
+      .map((value) => JSON.parse(value) as Record<string, unknown>)
+      .filter((record) => record.event === "headroom_tool_policy_decision");
+    expect(decisions).toHaveLength(2);
+    expect(decisions[0].decision_id).not.toBe(decisions[1].decision_id);
+    expect(
+      stderr.mock.calls.some(([value]) => {
+        const output = String(value);
+        return output.includes('"effect":"unknown"') &&
+          output.includes('"reason":"call_replaced"');
+      }),
+    ).toBe(true);
+    await plugin.dispose?.();
+  });
+
+  it("never acknowledges a late postflight as a newer reused call", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: { rules: [] },
+    });
+    const input = { tool: "bash", sessionID: "session-late", callID: "call-late" };
+    const firstArgs = { command: "echo same" };
+    const secondArgs = { command: "echo same" };
+
+    await plugin["tool.execute.before"]?.(input, { args: firstArgs });
+    await plugin["tool.execute.before"]?.(input, { args: secondArgs });
+    await expect(
+      plugin["tool.execute.after"]?.(
+        { ...input, args: firstArgs },
+        { title: "shell", output: "late", metadata: {} },
       ),
-    ).toBe(false);
+    ).rejects.toThrow(/did not match the bound preflight object/);
+
+    const acknowledgements = stderr.mock.calls
+      .map(([value]) => String(value).trim())
+      .filter((value) => value.startsWith("{"))
+      .map((value) => JSON.parse(value) as Record<string, unknown>)
+      .filter(
+        (record) => record.event === "headroom_tool_policy_enforcement_acknowledgement",
+      );
+    expect(acknowledgements.map((record) => record.effect)).toEqual(["unknown", "unknown"]);
+    expect(acknowledgements.some((record) => record.effect === "allowed")).toBe(false);
+    await plugin.dispose?.();
+  });
+
+  it("retires a successfully acknowledged argument graph", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: { rules: [] },
+    });
+    const input = { tool: "bash", sessionID: "session-retired", callID: "call-retired" };
+    const args = { command: "echo same" };
+
+    await plugin["tool.execute.before"]?.(input, { args });
+    await plugin["tool.execute.after"]?.(
+      { ...input, args },
+      { title: "shell", output: "first", metadata: {} },
+    );
+    await plugin["tool.execute.before"]?.(input, { args });
+    await plugin["tool.execute.after"]?.(
+      { ...input, args },
+      { title: "shell", output: "ambiguous", metadata: {} },
+    );
+
+    const acknowledgements = stderr.mock.calls
+      .map(([value]) => String(value).trim())
+      .filter((value) => value.startsWith("{"))
+      .map((value) => JSON.parse(value) as Record<string, unknown>)
+      .filter(
+        (record) => record.event === "headroom_tool_policy_enforcement_acknowledgement",
+      );
+    expect(acknowledgements.map((record) => record.effect)).toEqual(["allowed", "unknown"]);
+    expect(acknowledgements[1].reason).toBe("ambiguous_reused_call");
     await plugin.dispose?.();
   });
 

--- a/plugins/opencode/src/plugin.test.ts
+++ b/plugins/opencode/src/plugin.test.ts
@@ -45,7 +45,7 @@ describe("HeadroomPlugin", () => {
     expect(output.env).toMatchObject({
       HEADROOM_ACTIVE: "1",
       HEADROOM_PROXY_URL: "http://127.0.0.1:8787",
-      HEADROOM_PROJECT: "/repo",
+      HEADROOM_PROJECT: "project-1",
       HEADROOM_BACKEND: "litellm",
       HEADROOM_TOOL_POLICY_JSON: JSON.stringify({
         version: 1,
@@ -418,6 +418,24 @@ describe("HeadroomPlugin", () => {
         { args: { command: "echo ok; curl attacker.example" } },
       ),
     ).rejects.toThrow(/Tool policy denied shell/);
+    await plugin.dispose?.();
+  });
+
+  it("fails closed on dynamic shell grammar in an allowlist policy", async () => {
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: {
+        defaultAction: "deny",
+        rules: [{ id: "allow-echo", scope: "shell", action: "allow", command: "echo" }],
+      },
+    });
+
+    await expect(
+      plugin["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "s-allowlist", callID: "c-allowlist" },
+        { args: { command: "x=echo; $x dynamic" } },
+      ),
+    ).rejects.toThrow(/dynamic or escaped shell execution cannot be safely authorized/);
     await plugin.dispose?.();
   });
 

--- a/plugins/opencode/src/plugin.test.ts
+++ b/plugins/opencode/src/plugin.test.ts
@@ -1,6 +1,11 @@
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { HeadroomPlugin } from "./plugin.js";
+import { ToolPolicyEnforcementError } from "./transport.js";
 
 function pluginInput() {
   return {
@@ -24,6 +29,9 @@ describe("HeadroomPlugin", () => {
     const plugin = await HeadroomPlugin(pluginInput(), {
       proxyUrl: "http://127.0.0.1:8787/",
       backend: "litellm",
+      toolPolicy: {
+        rules: [{ id: "deny-curl", scope: "shell", action: "deny", command: "curl" }],
+      },
     });
     const output = {
       env: {
@@ -37,11 +45,358 @@ describe("HeadroomPlugin", () => {
     expect(output.env).toMatchObject({
       HEADROOM_ACTIVE: "1",
       HEADROOM_PROXY_URL: "http://127.0.0.1:8787",
-      HEADROOM_PROJECT: "project-1",
+      HEADROOM_PROJECT: "/repo",
       HEADROOM_BACKEND: "litellm",
+      HEADROOM_TOOL_POLICY_JSON: JSON.stringify({
+        version: 1,
+        mode: "enforce",
+        defaultAction: "allow",
+        rules: [{ id: "deny-curl", scope: "shell", action: "deny", command: "curl" }],
+      }),
       OPENAI_BASE_URL: "https://deepseek.example/v1",
       ANTHROPIC_BASE_URL: "https://anthropic.example",
     });
+    expect(output.env).not.toHaveProperty("HEADROOM_OPENCODE_TOOL_POLICY_JSON");
+    await plugin.dispose?.();
+  });
+
+  it("locks allowed arguments before later hooks can mutate them", async () => {
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: { rules: [] },
+    });
+    const output = {
+      args: { command: "echo ok", nested: { value: "bound" } },
+    };
+
+    await plugin["tool.execute.before"]?.(
+      { tool: "bash", sessionID: "session-lock", callID: "call-lock" },
+      output,
+    );
+
+    expect(() => {
+      output.args.command = "curl example.test";
+    }).toThrow();
+    expect(() => {
+      output.args.nested.value = "mutated";
+    }).toThrow();
+    expect(() => {
+      output.args = { command: "curl example.test", nested: { value: "mutated" } };
+    }).toThrow();
+    await plugin.dispose?.();
+  });
+
+  it("never exposes remote policy credentials or URLs to shell commands", async () => {
+    const previousToken = process.env.HEADROOM_TOOL_POLICY_TOKEN;
+    const previousUrl = process.env.HEADROOM_TOOL_POLICY_URL;
+    process.env.HEADROOM_TOOL_POLICY_TOKEN = "private-policy-token";
+    process.env.HEADROOM_TOOL_POLICY_URL =
+      "https://policy.example.test/v1?signature=private-signature";
+    try {
+      const plugin = await HeadroomPlugin(pluginInput(), {
+        proxyUrl: "http://127.0.0.1:8787",
+        toolPolicy: { rules: [] },
+      });
+      const output = {
+        env: {
+          HEADROOM_TOOL_POLICY_TOKEN: "inherited-token",
+          HEADROOM_TOOL_POLICY_URL: "https://inherited.example.test/?token=secret",
+        } as Record<string, string>,
+      };
+
+      await plugin["shell.env"]?.({ cwd: "/repo" }, output);
+
+      expect(output.env).not.toHaveProperty("HEADROOM_TOOL_POLICY_TOKEN");
+      expect(output.env).not.toHaveProperty("HEADROOM_TOOL_POLICY_URL");
+      await plugin.dispose?.();
+    } finally {
+      if (previousToken === undefined) delete process.env.HEADROOM_TOOL_POLICY_TOKEN;
+      else process.env.HEADROOM_TOOL_POLICY_TOKEN = previousToken;
+      if (previousUrl === undefined) delete process.env.HEADROOM_TOOL_POLICY_URL;
+      else process.env.HEADROOM_TOOL_POLICY_URL = previousUrl;
+    }
+  });
+
+  it("acknowledges allowed execution only after matching final arguments", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: { rules: [] },
+    });
+    const input = { tool: "bash", sessionID: "session-allow", callID: "call-allow" };
+    const args = { command: "echo ok" };
+
+    await plugin["tool.execute.before"]?.(input, { args });
+    expect(
+      stderr.mock.calls.some(([value]) =>
+        String(value).includes("headroom_tool_policy_enforcement_acknowledgement"),
+      ),
+    ).toBe(false);
+
+    await plugin["tool.execute.after"]?.(
+      { ...input, args },
+      {
+        title: "shell",
+        output: "ok",
+        metadata: {},
+      },
+    );
+    expect(
+      stderr.mock.calls
+        .map(([value]) => String(value))
+        .join("")
+        .match(/headroom_tool_policy_enforcement_acknowledgement/g),
+    ).toHaveLength(1);
+    await plugin.dispose?.();
+  });
+
+  it("rejects an acknowledgement when final arguments differ from preflight", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: { rules: [] },
+    });
+    const input = { tool: "bash", sessionID: "session-mutate", callID: "call-mutate" };
+
+    await plugin["tool.execute.before"]?.(input, { args: { command: "echo ok" } });
+    await expect(
+      plugin["tool.execute.after"]?.(
+        { ...input, args: { command: "curl example.test" } },
+        {
+          title: "shell",
+          output: "",
+          metadata: {},
+        },
+      ),
+    ).rejects.toThrow(/did not match the bound preflight decision/);
+    expect(
+      stderr.mock.calls.some(([value]) =>
+        String(value).includes("headroom_tool_policy_enforcement_acknowledgement"),
+      ),
+    ).toBe(false);
+    await plugin.dispose?.();
+  });
+
+  it("blocks native shell tools using the filesystem project directory", async () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), "headroom-native-policy-"));
+    const previousConfigDir = process.env.HEADROOM_CONFIG_DIR;
+    process.env.HEADROOM_CONFIG_DIR = path.join(repo, "empty-global-config");
+    fs.mkdirSync(path.join(repo, ".headroom"));
+    fs.writeFileSync(
+      path.join(repo, ".headroom", "tool_policy.json"),
+      JSON.stringify({
+        rules: [{ id: "deny-wrapped", scope: "shell", action: "deny", command: "curl" }],
+      }),
+    );
+    const input = pluginInput() as unknown as { directory: string; worktree: string };
+    input.directory = repo;
+    input.worktree = "";
+    try {
+      const plugin = await HeadroomPlugin(input as never, {
+        proxyUrl: "http://127.0.0.1:8787",
+      });
+      await expect(
+        plugin["tool.execute.before"]?.(
+          { tool: "bash", sessionID: "s", callID: "c" },
+          { args: { command: "echo ok && sudo env X=1 curl example.test" } },
+        ),
+      ).rejects.toThrow(/deny-wrapped/);
+      await plugin.dispose?.();
+    } finally {
+      if (previousConfigDir === undefined) delete process.env.HEADROOM_CONFIG_DIR;
+      else process.env.HEADROOM_CONFIG_DIR = previousConfigDir;
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks a non-shell native tool by tool name", async () => {
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: {
+        rules: [
+          {
+            id: "deny-write",
+            scope: "tool_call",
+            action: "deny",
+            tool: "write",
+            argsPattern: '"path":"secret\\.txt"',
+          },
+        ],
+      },
+    });
+
+    await expect(
+      plugin["tool.execute.before"]?.(
+        { tool: "write", sessionID: "s", callID: "c" },
+        { args: { value: "data", path: "secret.txt" } },
+      ),
+    ).rejects.toThrow(/deny-write/);
+    await plugin.dispose?.();
+  });
+
+  it("does not let one allowed binary authorize a compound shell command", async () => {
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: {
+        defaultAction: "deny",
+        rules: [{ id: "allow-echo", scope: "shell", action: "allow", command: "echo" }],
+      },
+    });
+
+    await expect(
+      plugin["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "s-compound", callID: "c-compound" },
+        { args: { command: "echo ok; curl attacker.example" } },
+      ),
+    ).rejects.toThrow(/Tool policy denied shell/);
+    await plugin.dispose?.();
+  });
+
+  it("matches and binds the shell tool's effective workdir", async () => {
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: {
+        rules: [
+          {
+            id: "deny-app-curl",
+            scope: "shell",
+            action: "deny",
+            command: "curl",
+            cwdPattern: "packages[\\\\/]app$",
+          },
+        ],
+      },
+    });
+    let error: unknown;
+    try {
+      await plugin["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "s-workdir", callID: "c-workdir" },
+        { args: { command: "curl example.test", workdir: "packages/app" } },
+      );
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(ToolPolicyEnforcementError);
+    expect((error as ToolPolicyEnforcementError).decision.binding?.cwd).toBe(
+      path.resolve("/repo", "packages/app"),
+    );
+    await plugin.dispose?.();
+  });
+
+  it.each([
+    "cu\\rl example.test",
+    "x=curl; $x example.test",
+    'x=curl; "$x" example.test',
+    "x=rl; cu${x} example.test",
+    "x=curl; /usr/bin/${x} example.test",
+    "$'curl' example.test",
+    "set CMD=curl && %CMD% example.test",
+    "cmd=curl; & ($cmd) example.test",
+    "echo harmless > >(curl attacker.example)",
+    "if true; then curl attacker.example; fi",
+    "eval curl example.test",
+  ])(
+    "fails closed for dynamic shell command %s",
+    async (command) => {
+      const plugin = await HeadroomPlugin(pluginInput(), {
+        proxyUrl: "http://127.0.0.1:8787",
+        toolPolicy: {
+          rules: [{ id: "deny-curl", scope: "shell", action: "deny", command: "curl" }],
+        },
+      });
+      await expect(
+        plugin["tool.execute.before"]?.(
+          { tool: "bash", sessionID: `s-${command}`, callID: `c-${command}` },
+          { args: { command } },
+        ),
+      ).rejects.toThrow(/Tool policy denied shell/);
+      await plugin.dispose?.();
+    },
+  );
+
+  it("refuses to replace another workspace's active policy", async () => {
+    const restrictive = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: {
+        rules: [{ id: "deny-curl", scope: "shell", action: "deny", command: "curl" }],
+      },
+    });
+    await expect(
+      HeadroomPlugin(pluginInput(), {
+        proxyUrl: "http://127.0.0.1:8787",
+        toolPolicy: { rules: [] },
+      }),
+    ).rejects.toThrow(/refusing to replace the active policy/);
+    await expect(
+      restrictive["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "s-isolation", callID: "c-isolation" },
+        { args: { command: "curl example.test" } },
+      ),
+    ).rejects.toThrow(/deny-curl/);
+    await restrictive.dispose?.();
+  });
+
+  it("denies the same action through native and alternate execution paths", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const plugin = await HeadroomPlugin(pluginInput(), {
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: {
+        rules: [{ id: "deny-node", scope: "shell", action: "deny", command: "node" }],
+      },
+    });
+
+    let nativeError: unknown;
+    try {
+      await plugin["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "session-7", callID: "call-9" },
+        { args: { command: "node -e \"console.log('not executed')\"" } },
+      );
+    } catch (error) {
+      nativeError = error;
+    }
+    expect(nativeError).toBeInstanceOf(ToolPolicyEnforcementError);
+    const enforcementError = nativeError as ToolPolicyEnforcementError;
+    expect(enforcementError.decision).toMatchObject({
+      version: 1,
+      authority: "authoritative",
+      binding: {
+        caller: "opencode",
+        adapter: "tool.execute.before",
+        sessionID: "session-7",
+        taskID: "call-9",
+        callID: "call-9",
+        toolName: "bash",
+        cwd: path.resolve("/repo"),
+      },
+    });
+    expect(enforcementError.decision.decisionId).toMatch(/^[a-f0-9]{64}$/);
+    expect(enforcementError.decision.binding?.canonicalArgsHash).toMatch(/^[a-f0-9]{16}$/);
+    expect(enforcementError.acknowledgement).toMatchObject({
+      decisionId: enforcementError.decision.decisionId,
+      authority: "authoritative",
+      effect: "blocked",
+      binding: { sessionID: "session-7", callID: "call-9" },
+    });
+
+    expect(() =>
+      childProcess.exec("node -e \"console.log('alternate path not executed')\""),
+    ).toThrow(/deny-node/);
+
+    const records = stderr.mock.calls
+      .map(([value]) => String(value).trim())
+      .filter((value) => value.startsWith("{"))
+      .map((value) => JSON.parse(value) as Record<string, unknown>);
+    expect(
+      records.filter(
+        (record) => record.event === "headroom_tool_policy_enforcement_acknowledgement",
+      ),
+    ).toHaveLength(1);
+    expect(
+      records
+        .filter((record) => record.event === "headroom_tool_policy_decision")
+        .map((record) => record.authority),
+    ).toEqual(["authoritative", "advisory"]);
+    await plugin.dispose?.();
   });
 
   it("exposes a headroom_retrieve tool backed by the proxy", async () => {

--- a/plugins/opencode/src/plugin.ts
+++ b/plugins/opencode/src/plugin.ts
@@ -59,7 +59,7 @@ export const HeadroomPlugin: Plugin = async (input, options = {}) => {
   const pluginOptions = options as HeadroomOpenCodePluginOptions;
   const proxyUrl = resolveProxyUrl(pluginOptions);
   const projectPath = input.worktree || input.directory;
-  const project = pluginOptions.project ?? projectPath;
+  const project = pluginOptions.project ?? input.project.id;
   const retrieveTool = createHeadroomRetrieveTool({ proxyBaseUrl: proxyUrl });
   const uninstallTransport = installHeadroomTransport({
     proxyUrl,

--- a/plugins/opencode/src/plugin.ts
+++ b/plugins/opencode/src/plugin.ts
@@ -1,15 +1,28 @@
 import type { Plugin } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin";
+import path from "node:path";
 import { z } from "zod";
 
 import { createHeadroomRetrieveTool, getDefaultProxyUrl } from "./retrieve.js";
-import { installHeadroomTransport } from "./transport.js";
+import type { HeadroomToolPolicyConfig } from "./transport.js";
+import {
+  acknowledgeNativeToolExecution,
+  enforceNativeToolExecution,
+  installHeadroomTransport,
+  refreshHeadroomToolPolicy,
+  TOOL_POLICY_ENV,
+  TOOL_POLICY_PATH_ENV,
+  TOOL_POLICY_REFRESH_SECONDS_ENV,
+  TOOL_POLICY_TOKEN_ENV,
+  TOOL_POLICY_URL_ENV,
+} from "./transport.js";
 
 export interface HeadroomOpenCodePluginOptions {
   proxyUrl?: string;
   project?: string;
   backend?: string;
   debug?: boolean;
+  toolPolicy?: HeadroomToolPolicyConfig | string;
 }
 
 function normalizeProxyUrl(url: string): string {
@@ -28,19 +41,39 @@ function resolveProxyUrl(options?: HeadroomOpenCodePluginOptions): string {
 export const HeadroomPlugin: Plugin = async (input, options = {}) => {
   const pluginOptions = options as HeadroomOpenCodePluginOptions;
   const proxyUrl = resolveProxyUrl(pluginOptions);
-  const project =
-    pluginOptions.project ??
-    (input.project as { id?: string } | undefined)?.id ??
-    input.directory;
+  const projectPath = input.worktree || input.directory;
+  const project = pluginOptions.project ?? projectPath;
   const retrieveTool = createHeadroomRetrieveTool({ proxyBaseUrl: proxyUrl });
   const uninstallTransport = installHeadroomTransport({
     proxyUrl,
     project,
+    policyProject: projectPath,
     debug: pluginOptions.debug,
+    toolPolicy: pluginOptions.toolPolicy,
   });
+  await refreshHeadroomToolPolicy();
+  const pendingPreflights = new Map<
+    string,
+    Awaited<ReturnType<typeof enforceNativeToolExecution>>
+  >();
+
+  const effectiveCwd = (args: Record<string, unknown>): string => {
+    const configured = typeof args.workdir === "string" ? args.workdir : projectPath;
+    return path.resolve(projectPath, configured);
+  };
+
+  const freezeArguments = (value: unknown, seen = new Set<object>()): void => {
+    if (!value || typeof value !== "object" || seen.has(value)) return;
+    seen.add(value);
+    for (const child of Object.values(value as Record<string, unknown>)) {
+      freezeArguments(child, seen);
+    }
+    Object.freeze(value);
+  };
 
   return {
     dispose: async () => {
+      pendingPreflights.clear();
       uninstallTransport();
     },
     tool: {
@@ -57,12 +90,57 @@ export const HeadroomPlugin: Plugin = async (input, options = {}) => {
       }),
     },
     "shell.env": async (_input, output) => {
+      delete output.env[TOOL_POLICY_TOKEN_ENV];
+      delete output.env[TOOL_POLICY_URL_ENV];
       output.env.HEADROOM_ACTIVE = "1";
       output.env.HEADROOM_PROXY_URL = proxyUrl;
       output.env.HEADROOM_PROJECT = project;
       if (pluginOptions.backend) {
         output.env.HEADROOM_BACKEND = pluginOptions.backend;
       }
+      if (process.env[TOOL_POLICY_ENV]) {
+        output.env[TOOL_POLICY_ENV] = process.env[TOOL_POLICY_ENV];
+      }
+      if (process.env[TOOL_POLICY_PATH_ENV]) {
+        output.env[TOOL_POLICY_PATH_ENV] = process.env[TOOL_POLICY_PATH_ENV];
+      }
+      for (const name of [TOOL_POLICY_REFRESH_SECONDS_ENV]) {
+        if (process.env[name]) {
+          output.env[name] = process.env[name];
+        }
+      }
+    },
+    "tool.execute.before": async (hookInput, output) => {
+      const preflight = await enforceNativeToolExecution(
+        hookInput.tool,
+        output.args,
+        effectiveCwd(output.args),
+        {
+          sessionID: hookInput.sessionID,
+          callID: hookInput.callID,
+        },
+      );
+      if (preflight) {
+        freezeArguments(output.args);
+        Object.freeze(output);
+        pendingPreflights.set(`${hookInput.sessionID}\0${hookInput.callID}`, preflight);
+      }
+    },
+    "tool.execute.after": async (hookInput) => {
+      const key = `${hookInput.sessionID}\0${hookInput.callID}`;
+      const preflight = pendingPreflights.get(key);
+      pendingPreflights.delete(key);
+      if (!preflight) return;
+      acknowledgeNativeToolExecution(
+        preflight,
+        hookInput.tool,
+        hookInput.args,
+        effectiveCwd(hookInput.args),
+        {
+          sessionID: hookInput.sessionID,
+          callID: hookInput.callID,
+        },
+      );
     },
   };
 };

--- a/plugins/opencode/src/plugin.ts
+++ b/plugins/opencode/src/plugin.ts
@@ -7,6 +7,7 @@ import { createHeadroomRetrieveTool, getDefaultProxyUrl } from "./retrieve.js";
 import type { HeadroomToolPolicyConfig } from "./transport.js";
 import {
   acknowledgeNativeToolExecution,
+  acknowledgeUnknownNativeToolExecution,
   enforceNativeToolExecution,
   installHeadroomTransport,
   refreshHeadroomToolPolicy,
@@ -23,6 +24,22 @@ export interface HeadroomOpenCodePluginOptions {
   backend?: string;
   debug?: boolean;
   toolPolicy?: HeadroomToolPolicyConfig | string;
+  pendingPreflightTtlMs?: number;
+  maxPendingPreflights?: number;
+}
+
+const DEFAULT_PENDING_PREFLIGHT_TTL_MS = 5 * 60 * 1_000;
+const DEFAULT_MAX_PENDING_PREFLIGHTS = 1_024;
+
+interface PendingPreflight {
+  preflight: NonNullable<Awaited<ReturnType<typeof enforceNativeToolExecution>>>;
+  args: Record<string, unknown>;
+  ambiguous: boolean;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  return Number.isSafeInteger(value) && value! > 0 ? value! : fallback;
 }
 
 function normalizeProxyUrl(url: string): string {
@@ -52,10 +69,48 @@ export const HeadroomPlugin: Plugin = async (input, options = {}) => {
     toolPolicy: pluginOptions.toolPolicy,
   });
   await refreshHeadroomToolPolicy();
-  const pendingPreflights = new Map<
-    string,
-    Awaited<ReturnType<typeof enforceNativeToolExecution>>
-  >();
+  const pendingPreflights = new Map<string, PendingPreflight>();
+  const retiredArgumentGraphs = new WeakSet<object>();
+  const pendingPreflightTtlMs = positiveInteger(
+    pluginOptions.pendingPreflightTtlMs,
+    DEFAULT_PENDING_PREFLIGHT_TTL_MS,
+  );
+  const maxPendingPreflights = positiveInteger(
+    pluginOptions.maxPendingPreflights,
+    DEFAULT_MAX_PENDING_PREFLIGHTS,
+  );
+
+  const finishUnknown = (
+    key: string,
+    reason: NonNullable<Parameters<typeof acknowledgeUnknownNativeToolExecution>[1]>,
+  ): void => {
+    const pending = pendingPreflights.get(key);
+    if (!pending) return;
+    pendingPreflights.delete(key);
+    clearTimeout(pending.timer);
+    retiredArgumentGraphs.add(pending.args);
+    acknowledgeUnknownNativeToolExecution(pending.preflight, reason);
+  };
+
+  const rememberPreflight = (
+    key: string,
+    preflight: NonNullable<Awaited<ReturnType<typeof enforceNativeToolExecution>>>,
+    args: Record<string, unknown>,
+  ): void => {
+    finishUnknown(key, "call_replaced");
+    const ambiguous = retiredArgumentGraphs.has(args);
+    while (pendingPreflights.size >= maxPendingPreflights) {
+      const oldestKey = pendingPreflights.keys().next().value as string | undefined;
+      if (oldestKey === undefined) break;
+      finishUnknown(oldestKey, "capacity_evicted");
+    }
+    const timer = setTimeout(
+      () => finishUnknown(key, "postflight_timeout"),
+      pendingPreflightTtlMs,
+    );
+    timer.unref?.();
+    pendingPreflights.set(key, { preflight, args, ambiguous, timer });
+  };
 
   const effectiveCwd = (args: Record<string, unknown>): string => {
     const configured = typeof args.workdir === "string" ? args.workdir : projectPath;
@@ -73,7 +128,9 @@ export const HeadroomPlugin: Plugin = async (input, options = {}) => {
 
   return {
     dispose: async () => {
-      pendingPreflights.clear();
+      for (const key of [...pendingPreflights.keys()]) {
+        finishUnknown(key, "plugin_disposed");
+      }
       uninstallTransport();
     },
     tool: {
@@ -123,24 +180,45 @@ export const HeadroomPlugin: Plugin = async (input, options = {}) => {
       if (preflight) {
         freezeArguments(output.args);
         Object.freeze(output);
-        pendingPreflights.set(`${hookInput.sessionID}\0${hookInput.callID}`, preflight);
+        rememberPreflight(
+          `${hookInput.sessionID}\0${hookInput.callID}`,
+          preflight,
+          output.args,
+        );
       }
     },
     "tool.execute.after": async (hookInput) => {
       const key = `${hookInput.sessionID}\0${hookInput.callID}`;
-      const preflight = pendingPreflights.get(key);
-      pendingPreflights.delete(key);
-      if (!preflight) return;
-      acknowledgeNativeToolExecution(
-        preflight,
-        hookInput.tool,
-        hookInput.args,
-        effectiveCwd(hookInput.args),
-        {
-          sessionID: hookInput.sessionID,
-          callID: hookInput.callID,
-        },
-      );
+      const pending = pendingPreflights.get(key);
+      if (!pending) return;
+      if (pending.ambiguous) {
+        finishUnknown(key, "ambiguous_reused_call");
+        return;
+      }
+      if (pending.args !== hookInput.args) {
+        finishUnknown(key, "postflight_mismatch");
+        throw new Error(
+          "[headroom] OpenCode postflight arguments did not match the bound preflight object",
+        );
+      }
+      try {
+        acknowledgeNativeToolExecution(
+          pending.preflight,
+          hookInput.tool,
+          hookInput.args,
+          effectiveCwd(hookInput.args),
+          {
+            sessionID: hookInput.sessionID,
+            callID: hookInput.callID,
+          },
+        );
+        retiredArgumentGraphs.add(pending.args);
+        pendingPreflights.delete(key);
+        clearTimeout(pending.timer);
+      } catch (error) {
+        finishUnknown(key, "postflight_mismatch");
+        throw error;
+      }
     },
   };
 };

--- a/plugins/opencode/src/transport.test.ts
+++ b/plugins/opencode/src/transport.test.ts
@@ -9,6 +9,8 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  acknowledgeNativeToolExecution,
+  enforceNativeToolExecution,
   evaluateNativeToolPolicy,
   installHeadroomTransport,
   isAllowedToolPolicyUrl,
@@ -94,6 +96,49 @@ function proxyServer(pathPrefix: string = "/v1"): Promise<{
 }
 
 describe("Headroom OpenCode transport", () => {
+  it("binds an independent task ID when the host provides one", async () => {
+    installHeadroomTransport({
+      proxyUrl: "http://127.0.0.1:8787",
+      toolPolicy: { rules: [] },
+    });
+    const args = { command: "echo safe" };
+    const execution = {
+      sessionID: "session-task",
+      taskID: "task-42",
+      callID: "call-7",
+    };
+
+    const preflight = await enforceNativeToolExecution(
+      "bash",
+      args,
+      process.cwd(),
+      execution,
+    );
+
+    expect(preflight?.decision.binding).toMatchObject({
+      taskID: "task-42",
+      callID: "call-7",
+    });
+    expect(() =>
+      acknowledgeNativeToolExecution(
+        preflight!,
+        "bash",
+        args,
+        process.cwd(),
+        execution,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      acknowledgeNativeToolExecution(
+        preflight!,
+        "bash",
+        args,
+        process.cwd(),
+        { ...execution, taskID: "different-task" },
+      ),
+    ).toThrow(/did not match the bound preflight decision/);
+  });
+
   it.each(conformanceCases)("matches shared policy conformance: $name", ({ policy, request, expected }) => {
     const decision = evaluateNativeToolPolicy(
       policy,

--- a/plugins/opencode/src/transport.test.ts
+++ b/plugins/opencode/src/transport.test.ts
@@ -3,9 +3,45 @@ import fs from "node:fs";
 import http from "node:http";
 import http2 from "node:http2";
 import https from "node:https";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { installHeadroomTransport, uninstallHeadroomTransport } from "./transport.js";
+import {
+  evaluateNativeToolPolicy,
+  installHeadroomTransport,
+  isAllowedToolPolicyUrl,
+  refreshHeadroomToolPolicy,
+  remoteToolPolicyCachePath,
+  shellCommandBinaries,
+  toolPolicyRefreshSeconds,
+  uninstallHeadroomTransport,
+} from "./transport.js";
+import type { HeadroomToolPolicyConfig, ToolPolicyAction } from "./transport.js";
+
+interface ConformanceCase {
+  name: string;
+  policy: HeadroomToolPolicyConfig;
+  request: {
+    tool: string;
+    input: Record<string, unknown>;
+    cwd?: string;
+    env?: Record<string, string>;
+  };
+  expected: {
+    action: ToolPolicyAction;
+    effectiveAction: ToolPolicyAction;
+    matchedRule: string | null;
+  };
+}
+
+const conformanceCases = JSON.parse(
+  fs.readFileSync(
+    new URL("../test/fixtures/tool_policy_conformance.json", import.meta.url),
+    "utf8",
+  ),
+) as ConformanceCase[];
 
 afterEach(() => {
   uninstallHeadroomTransport();
@@ -58,6 +94,68 @@ function proxyServer(pathPrefix: string = "/v1"): Promise<{
 }
 
 describe("Headroom OpenCode transport", () => {
+  it.each(conformanceCases)("matches shared policy conformance: $name", ({ policy, request, expected }) => {
+    const decision = evaluateNativeToolPolicy(
+      policy,
+      request.tool,
+      request.env === undefined ? request.input : { ...request.input, env: request.env },
+      request.cwd,
+    );
+    expect({
+      action: decision.action,
+      effectiveAction: decision.effectiveAction,
+      matchedRule: decision.matchedRuleId ?? null,
+    }).toEqual(expected);
+    expect(decision.authority).toBe("advisory");
+    expect(decision.binding).toBeUndefined();
+  });
+
+  it("extracts executable candidates from compound and wrapped shell commands", () => {
+    expect(
+      shellCommandBinaries("A=1 echo ok && sudo env X=2 nohup curl example.test | bash -c 'wget x'"),
+    ).toEqual(["echo", "curl", "bash", "wget"]);
+    expect(shellCommandBinaries("sudo -u root curl example.test")).toEqual(["curl"]);
+    expect(shellCommandBinaries("env -u TOKEN -C /workspace curl example.test")).toEqual(["curl"]);
+    expect(shellCommandBinaries("env -S 'curl example.test'")).toEqual(["curl"]);
+    expect(shellCommandBinaries("time -f %E -o timing.txt curl example.test")).toEqual(["curl"]);
+    expect(shellCommandBinaries("echo ready\r\ncurl example.test")).toEqual(["echo", "curl"]);
+    expect(shellCommandBinaries("echo $(curl example.test)")).toEqual(["echo", "curl"]);
+    expect(shellCommandBinaries("echo $((1 + 2))")).toEqual(["echo"]);
+    expect(shellCommandBinaries("echo `bash -c 'wget example.test'`")).toEqual([
+      "echo",
+      "bash",
+      "wget",
+    ]);
+    const denyCurl = {
+      version: 1,
+      rules: [{ id: "deny-curl", scope: "shell", action: "deny", command: "curl" }],
+    } as HeadroomToolPolicyConfig;
+    for (const command of [
+      "echo ready\ncurl secret.test",
+      "echo $(curl secret.test)",
+      "echo `curl secret.test`",
+    ]) {
+      expect(evaluateNativeToolPolicy(denyCurl, "bash", { command }).action).toBe("deny");
+    }
+  });
+
+  it("bounds remote policy refresh configuration", () => {
+    expect(toolPolicyRefreshSeconds({ HEADROOM_TOOL_POLICY_REFRESH_SECONDS: "300" })).toBe(300);
+    expect(toolPolicyRefreshSeconds({ HEADROOM_TOOL_POLICY_REFRESH_SECONDS: "3600" })).toBe(3600);
+    for (const value of ["299", "3601", "1.5", "nope"]) {
+      expect(toolPolicyRefreshSeconds({ HEADROOM_TOOL_POLICY_REFRESH_SECONDS: value })).toBe(300);
+    }
+  });
+
+  it("requires HTTPS for remote policy except on loopback hosts", () => {
+    expect(isAllowedToolPolicyUrl("https://policy.example/tool-policy")).toBe(true);
+    expect(isAllowedToolPolicyUrl("http://localhost/policy")).toBe(true);
+    expect(isAllowedToolPolicyUrl("http://127.42.0.9/policy")).toBe(true);
+    expect(isAllowedToolPolicyUrl("http://127.attacker.example/policy")).toBe(false);
+    expect(isAllowedToolPolicyUrl("http://[::1]/policy")).toBe(true);
+    expect(isAllowedToolPolicyUrl("http://policy.example/tool-policy")).toBe(false);
+    expect(isAllowedToolPolicyUrl("ftp://localhost/policy")).toBe(false);
+  });
   it("routes fetch chat paths through /v1/chat/completions with proxy base and normalized-path header", async () => {
     const proxyTargets = ["http://127.0.0.1:8787", "http://127.0.0.1:8787/v1"];
     const upstreamPath = "/api/coding/paas/v4/chat/completions";
@@ -293,7 +391,7 @@ describe("Headroom OpenCode transport", () => {
     installHeadroomTransport({ proxyUrl: "http://127.0.0.1:8787/v1" });
 
     expect(() => http2.connect("https://api.openai.com")).toThrow(
-      /blocked direct HTTP\/2 connection to https:\/\/api\.openai\.com/,
+      /blocked direct HTTP\/2 connection to api\.openai\.com/,
     );
   });
 
@@ -386,6 +484,53 @@ describe("Headroom OpenCode transport", () => {
     }
   });
 
+  it("strips remote policy credentials and URLs from wrapped child environments", () => {
+    const originalSpawn = childProcess.spawn;
+    const previousToken = process.env.HEADROOM_TOOL_POLICY_TOKEN;
+    const previousUrl = process.env.HEADROOM_TOOL_POLICY_URL;
+    const spawnMock = vi.fn(() => ({
+      on: vi.fn(),
+      once: vi.fn(),
+      emit: vi.fn(),
+      kill: vi.fn(),
+      killed: false,
+      pid: 123,
+    }));
+    childProcess.spawn = spawnMock as unknown as typeof childProcess.spawn;
+    process.env.HEADROOM_TOOL_POLICY_TOKEN = "private-policy-token";
+    process.env.HEADROOM_TOOL_POLICY_URL =
+      "https://policy.example.test/v1?signature=private-signature";
+
+    try {
+      installHeadroomTransport({
+        proxyUrl: "http://127.0.0.1:8787/v1",
+        toolPolicy: { rules: [] },
+      });
+
+      childProcess.spawn("node", ["agent.js"]);
+      childProcess.spawn("node", ["agent.js"], {
+        env: {
+          PATH: "/bin",
+          HEADROOM_TOOL_POLICY_TOKEN: "custom-private-token",
+          HEADROOM_TOOL_POLICY_URL: "https://custom.example.test/?token=secret",
+        },
+      });
+
+      for (const call of spawnMock.mock.calls) {
+        const options = (call as unknown[])[2] as { env: NodeJS.ProcessEnv };
+        expect(options.env).not.toHaveProperty("HEADROOM_TOOL_POLICY_TOKEN");
+        expect(options.env).not.toHaveProperty("HEADROOM_TOOL_POLICY_URL");
+      }
+    } finally {
+      uninstallHeadroomTransport();
+      childProcess.spawn = originalSpawn;
+      if (previousToken === undefined) delete process.env.HEADROOM_TOOL_POLICY_TOKEN;
+      else process.env.HEADROOM_TOOL_POLICY_TOKEN = previousToken;
+      if (previousUrl === undefined) delete process.env.HEADROOM_TOOL_POLICY_URL;
+      else process.env.HEADROOM_TOOL_POLICY_URL = previousUrl;
+    }
+  });
+
   it("sends x-headroom-project header on routed fetch calls when project is set", async () => {
     const originalFetch = globalThis.fetch;
     const fetchMock = vi.fn(async (..._args: FetchCall) => new Response("ok"));
@@ -414,6 +559,414 @@ describe("Headroom OpenCode transport", () => {
     expect(headers.get("x-headroom-project")).toBeNull();
 
     globalThis.fetch = originalFetch;
+  });
+
+  it("denies fetch calls that match an http policy rule before routing", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(async (..._args: FetchCall) => new Response("ok"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      installHeadroomTransport({
+        proxyUrl: "http://127.0.0.1:8787/v1",
+        toolPolicy: {
+          rules: [
+            {
+              id: "deny-openai",
+              scope: "http",
+              action: "deny",
+              domain: "api.openai.com",
+              reason: "direct egress not approved",
+            },
+          ],
+        },
+      });
+
+      await expect(fetch("https://api.openai.com/v1/responses", { method: "POST" })).rejects.toThrow(
+        /rule=deny-openai/,
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      uninstallHeadroomTransport();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("surfaces require_approval shell decisions as a hard block", () => {
+    const originalSpawn = childProcess.spawn;
+    const spawnMock = vi.fn(() => ({ on: vi.fn(), kill: vi.fn(), pid: 123 }));
+    childProcess.spawn = spawnMock as unknown as typeof childProcess.spawn;
+
+    try {
+      installHeadroomTransport({
+        proxyUrl: "http://127.0.0.1:8787/v1",
+        toolPolicy: {
+          rules: [
+            {
+              id: "approve-curl",
+              scope: "shell",
+              action: "require_approval",
+              command: "curl",
+            },
+          ],
+        },
+      });
+
+      expect(() => childProcess.spawn("curl", ["https://example.com"])).toThrow(
+        /requires approval/,
+      );
+      expect(spawnMock).not.toHaveBeenCalled();
+    } finally {
+      uninstallHeadroomTransport();
+      childProcess.spawn = originalSpawn;
+    }
+  });
+
+  it("matches child-process rules against Node's effective cwd", () => {
+    const nested = path.resolve("nested");
+    const cwdPattern = `^${nested.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`;
+    try {
+      installHeadroomTransport({
+        proxyUrl: "http://127.0.0.1:8787/v1",
+        toolPolicy: {
+          rules: [
+            {
+              id: "deny-relative",
+              scope: "shell",
+              action: "deny",
+              command: "node",
+              cwdPattern,
+            },
+            {
+              id: "deny-default",
+              scope: "shell",
+              action: "deny",
+              command: "python",
+              cwdPattern: `^${process.cwd().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`,
+            },
+            {
+              id: "deny-file-url",
+              scope: "shell",
+              action: "deny",
+              command: "deno",
+              cwdPattern,
+            },
+          ],
+        },
+      });
+
+      expect(() => childProcess.spawn("node", ["agent.js"], { cwd: "nested" })).toThrow(
+        /deny-relative/,
+      );
+      expect(() => childProcess.exec("python agent.py")).toThrow(/deny-default/);
+      expect(() =>
+        childProcess.execFile("deno", ["run", "agent.ts"], { cwd: pathToFileURL(nested) }),
+      ).toThrow(/deny-file-url/);
+    } finally {
+      uninstallHeadroomTransport();
+    }
+  });
+
+  it("logs report-only policy decisions but still allows the request", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(async (..._args: FetchCall) => new Response("ok"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      installHeadroomTransport({
+        proxyUrl: "http://127.0.0.1:8787/v1",
+        toolPolicy: {
+          mode: "report_only",
+          rules: [
+            {
+              id: "report-http",
+              scope: "http",
+              action: "deny",
+              domain: "*.example.com",
+              reason: "dry run",
+            },
+          ],
+        },
+      });
+
+      await fetch("https://api.example.com/v1/messages", { method: "POST" });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"effective_action":"allow"'),
+      );
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('"matched_rule":"report-http"'));
+    } finally {
+      uninstallHeadroomTransport();
+      stderrSpy.mockRestore();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("logs only safe resource summaries while hashing the full resource", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "headroom-policy-safe-audit-"));
+    const previousWorkspace = process.env.HEADROOM_WORKSPACE_DIR;
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    process.env.HEADROOM_WORKSPACE_DIR = root;
+    try {
+      installHeadroomTransport({
+        proxyUrl: "http://127.0.0.1:8787",
+        toolPolicy: {
+          rules: [{ id: "deny-curl", scope: "shell", action: "deny", command: "curl" }],
+        },
+      });
+
+      expect(() =>
+        childProcess.spawn("curl", ["https://example.test/?token=super-secret"]),
+      ).toThrow(/target curl/);
+
+      const stderr = stderrSpy.mock.calls.map(([value]) => String(value)).join("");
+      const audit = fs.readFileSync(path.join(root, "tool_policy_audit.jsonl"), "utf8");
+      for (const output of [stderr, audit]) {
+        expect(output).toContain('"resource":"curl"');
+        expect(output).not.toContain("super-secret");
+        expect(output).not.toContain("https://example.test");
+        expect(output).toMatch(/"request_hash":"[a-f0-9]{16}"/);
+      }
+    } finally {
+      uninstallHeadroomTransport();
+      stderrSpy.mockRestore();
+      if (previousWorkspace === undefined) delete process.env.HEADROOM_WORKSPACE_DIR;
+      else process.env.HEADROOM_WORKSPACE_DIR = previousWorkspace;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("loads policy from the nearest repo-local .headroom/tool_policy.json", () => {
+    const originalSpawn = childProcess.spawn;
+    const spawnMock = vi.fn(() => ({ on: vi.fn(), kill: vi.fn(), pid: 123 }));
+    childProcess.spawn = spawnMock as unknown as typeof childProcess.spawn;
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "headroom-policy-local-"));
+    const previousConfigDir = process.env.HEADROOM_CONFIG_DIR;
+    process.env.HEADROOM_CONFIG_DIR = path.join(tmpRoot, "empty-global-config");
+    const repoRoot = path.join(tmpRoot, "repo");
+    const nested = path.join(repoRoot, "src", "app");
+    fs.mkdirSync(path.join(repoRoot, ".headroom"), { recursive: true });
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(
+      path.join(repoRoot, ".headroom", "tool_policy.json"),
+      JSON.stringify({
+        rules: [{ id: "deny-curl", scope: "shell", action: "deny", command: "curl" }],
+      }),
+    );
+    try {
+      installHeadroomTransport({ proxyUrl: "http://127.0.0.1:8787/v1", project: nested });
+      expect(() => childProcess.spawn("curl", ["https://example.com"])).toThrow(/deny-curl/);
+      expect(spawnMock).not.toHaveBeenCalled();
+    } finally {
+      if (previousConfigDir === undefined) delete process.env.HEADROOM_CONFIG_DIR;
+      else process.env.HEADROOM_CONFIG_DIR = previousConfigDir;
+      uninstallHeadroomTransport();
+      childProcess.spawn = originalSpawn;
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("loads policy from HEADROOM_TOOL_POLICY_PATH", () => {
+    const originalSpawn = childProcess.spawn;
+    const spawnMock = vi.fn(() => ({ on: vi.fn(), kill: vi.fn(), pid: 123 }));
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "headroom-policy-env-"));
+    const policyPath = path.join(tmpRoot, "tool-policy.json");
+    fs.writeFileSync(
+      policyPath,
+      JSON.stringify({
+        rules: [{ id: "deny-node", scope: "shell", action: "deny", command: "node" }],
+      }),
+    );
+    childProcess.spawn = spawnMock as unknown as typeof childProcess.spawn;
+    process.env.HEADROOM_TOOL_POLICY_PATH = policyPath;
+    try {
+      installHeadroomTransport({ proxyUrl: "http://127.0.0.1:8787/v1" });
+      expect(() => childProcess.spawn("node", ["script.js"])).toThrow(/deny-node/);
+      expect(spawnMock).not.toHaveBeenCalled();
+    } finally {
+      uninstallHeadroomTransport();
+      delete process.env.HEADROOM_TOOL_POLICY_PATH;
+      childProcess.spawn = originalSpawn;
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("gives the machine-global policy precedence and persists audit decisions", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "headroom-policy-precedence-"));
+    const repo = path.join(root, "repo");
+    fs.mkdirSync(path.join(root, "config"), { recursive: true });
+    fs.mkdirSync(path.join(repo, ".headroom"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "config", "tool_policy.json"),
+      JSON.stringify({
+        rules: [{ id: "global-deny", scope: "shell", action: "deny", command: "curl" }],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(repo, ".headroom", "tool_policy.json"),
+      JSON.stringify({ rules: [] }),
+    );
+    const originalWorkspace = process.env.HEADROOM_WORKSPACE_DIR;
+    process.env.HEADROOM_WORKSPACE_DIR = root;
+    try {
+      installHeadroomTransport({ proxyUrl: "http://127.0.0.1:8787", project: repo });
+      expect(() => childProcess.spawn("curl", ["example.test"])).toThrow(/global-deny/);
+      const audit = fs.readFileSync(path.join(root, "tool_policy_audit.jsonl"), "utf8");
+      expect(audit).toContain('"matched_rule":"global-deny"');
+    } finally {
+      uninstallHeadroomTransport();
+      if (originalWorkspace === undefined) delete process.env.HEADROOM_WORKSPACE_DIR;
+      else process.env.HEADROOM_WORKSPACE_DIR = originalWorkspace;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses remote auth, cache, ETag revalidation, and fails closed after an expired outage", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "headroom-policy-remote-"));
+    const url = "https://policy.example/tool-policy";
+    const originalFetch = globalThis.fetch;
+    const originalEnv = {
+      workspace: process.env.HEADROOM_WORKSPACE_DIR,
+      url: process.env.HEADROOM_TOOL_POLICY_URL,
+      token: process.env.HEADROOM_TOOL_POLICY_TOKEN,
+      refresh: process.env.HEADROOM_TOOL_POLICY_REFRESH_SECONDS,
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            version: 1,
+            rules: [{ id: "remote-deny", scope: "shell", action: "deny", command: "curl" }],
+          }),
+          { status: 200, headers: { etag: '"v1"' } },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 304 }))
+      .mockRejectedValueOnce(new Error("offline"));
+    globalThis.fetch = fetchMock;
+    process.env.HEADROOM_WORKSPACE_DIR = root;
+    process.env.HEADROOM_TOOL_POLICY_URL = url;
+    process.env.HEADROOM_TOOL_POLICY_TOKEN = "secret-token";
+    process.env.HEADROOM_TOOL_POLICY_REFRESH_SECONDS = "300";
+    try {
+      const initialCachePath = remoteToolPolicyCachePath(url, "secret-token");
+      fs.mkdirSync(path.dirname(initialCachePath), { recursive: true });
+      fs.writeFileSync(initialCachePath, "{corrupt");
+      installHeadroomTransport({ proxyUrl: "http://127.0.0.1:8787" });
+      await refreshHeadroomToolPolicy(1_000);
+      expect(fetchMock.mock.calls[0][1]?.redirect).toBe("manual");
+      expect(new Headers(fetchMock.mock.calls[0][1]?.headers).get("authorization")).toBe(
+        "Bearer secret-token",
+      );
+      expect(fs.existsSync(initialCachePath)).toBe(true);
+      expect(JSON.parse(fs.readFileSync(initialCachePath, "utf8")).cache_version).toBe(2);
+      expect(fs.readdirSync(path.dirname(initialCachePath)).some((name) => name.endsWith(".tmp"))).toBe(
+        false,
+      );
+      await refreshHeadroomToolPolicy(1_100);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const cachePath = remoteToolPolicyCachePath(url, "secret-token");
+      const futureCache = JSON.parse(fs.readFileSync(cachePath, "utf8")) as {
+        fetched_at: number;
+      };
+      futureCache.fetched_at = 9_999;
+      fs.writeFileSync(cachePath, JSON.stringify(futureCache));
+      await refreshHeadroomToolPolicy(1_200);
+      expect(new Headers(fetchMock.mock.calls[1][1]?.headers).get("if-none-match")).toBe('"v1"');
+      await refreshHeadroomToolPolicy(1_501);
+      await expect(
+        import("./transport.js").then(({ enforceNativeToolExecution }) =>
+          enforceNativeToolExecution("bash", { command: "echo allowed" }),
+        ),
+      ).rejects.toThrow(/failing closed/);
+    } finally {
+      uninstallHeadroomTransport();
+      globalThis.fetch = originalFetch;
+      const restore = (name: string, value: string | undefined) => {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      };
+      restore("HEADROOM_WORKSPACE_DIR", originalEnv.workspace);
+      restore("HEADROOM_TOOL_POLICY_URL", originalEnv.url);
+      restore("HEADROOM_TOOL_POLICY_TOKEN", originalEnv.token);
+      restore("HEADROOM_TOOL_POLICY_REFRESH_SECONDS", originalEnv.refresh);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects remote policy responses larger than 1 MiB", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "headroom-policy-oversize-"));
+    const originalFetch = globalThis.fetch;
+    const previousWorkspace = process.env.HEADROOM_WORKSPACE_DIR;
+    const previousUrl = process.env.HEADROOM_TOOL_POLICY_URL;
+    globalThis.fetch = vi.fn(async () => new Response("x".repeat(1024 * 1024 + 1)));
+    process.env.HEADROOM_WORKSPACE_DIR = root;
+    process.env.HEADROOM_TOOL_POLICY_URL = "http://127.0.0.1/policy";
+    try {
+      installHeadroomTransport({ proxyUrl: "http://127.0.0.1:8787" });
+      await refreshHeadroomToolPolicy();
+      await expect(
+        import("./transport.js").then(({ enforceNativeToolExecution }) =>
+          enforceNativeToolExecution("read_file", { path: "secret.txt" }),
+        ),
+      ).rejects.toThrow(/exceeds 1 MiB/);
+    } finally {
+      uninstallHeadroomTransport();
+      globalThis.fetch = originalFetch;
+      if (previousWorkspace === undefined) delete process.env.HEADROOM_WORKSPACE_DIR;
+      else process.env.HEADROOM_WORKSPACE_DIR = previousWorkspace;
+      if (previousUrl === undefined) delete process.env.HEADROOM_TOOL_POLICY_URL;
+      else process.env.HEADROOM_TOOL_POLICY_URL = previousUrl;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("isolates remote policy caches by bearer token", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "headroom-policy-token-cache-"));
+    const url = "https://policy.example/tool-policy";
+    const originalFetch = globalThis.fetch;
+    const previousWorkspace = process.env.HEADROOM_WORKSPACE_DIR;
+    const previousUrl = process.env.HEADROOM_TOOL_POLICY_URL;
+    const previousToken = process.env.HEADROOM_TOOL_POLICY_TOKEN;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ version: 1, rules: [] })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ version: 1, rules: [] })));
+    globalThis.fetch = fetchMock;
+    process.env.HEADROOM_WORKSPACE_DIR = root;
+    process.env.HEADROOM_TOOL_POLICY_URL = url;
+    process.env.HEADROOM_TOOL_POLICY_TOKEN = "tenant-alpha";
+    let dispose: (() => void) | undefined;
+    try {
+      dispose = installHeadroomTransport({ proxyUrl: "http://127.0.0.1:8787" });
+      await refreshHeadroomToolPolicy(1_000);
+      dispose();
+      dispose = undefined;
+      process.env.HEADROOM_TOOL_POLICY_TOKEN = "tenant-bravo";
+      dispose = installHeadroomTransport({ proxyUrl: "http://127.0.0.1:8787" });
+      await refreshHeadroomToolPolicy(1_001);
+
+      const alphaCache = remoteToolPolicyCachePath(url, "tenant-alpha");
+      const bravoCache = remoteToolPolicyCachePath(url, "tenant-bravo");
+      expect(alphaCache).not.toBe(bravoCache);
+      expect(fs.existsSync(alphaCache)).toBe(true);
+      expect(fs.existsSync(bravoCache)).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(new Headers(fetchMock.mock.calls[1][1]?.headers).has("if-none-match")).toBe(false);
+      expect(fs.readFileSync(alphaCache, "utf8")).not.toContain("tenant-alpha");
+      expect(fs.readFileSync(bravoCache, "utf8")).not.toContain("tenant-bravo");
+    } finally {
+      dispose?.();
+      globalThis.fetch = originalFetch;
+      if (previousWorkspace === undefined) delete process.env.HEADROOM_WORKSPACE_DIR;
+      else process.env.HEADROOM_WORKSPACE_DIR = previousWorkspace;
+      if (previousUrl === undefined) delete process.env.HEADROOM_TOOL_POLICY_URL;
+      else process.env.HEADROOM_TOOL_POLICY_URL = previousUrl;
+      if (previousToken === undefined) delete process.env.HEADROOM_TOOL_POLICY_TOKEN;
+      else process.env.HEADROOM_TOOL_POLICY_TOKEN = previousToken;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("sends x-headroom-project header on routed Node https.request calls when project is set", async () => {

--- a/plugins/opencode/src/transport.ts
+++ b/plugins/opencode/src/transport.ts
@@ -1068,10 +1068,12 @@ function evaluatePolicy(
   }
   const hasDynamicShellExecution =
     input.scope === "shell" &&
-    policy.rules.some(
-      (rule) =>
-        rule.action !== "allow" && (rule.scope === "shell" || rule.scope === "tool_call"),
-    ) &&
+    (policy.defaultAction === "deny" ||
+      policy.rules.some(
+        (rule) =>
+          rule.action !== "allow" &&
+          (rule.scope === "shell" || rule.scope === "tool_call"),
+      )) &&
     /(?:\\[A-Za-z0-9]|\$(?:\{|[A-Za-z_('" ])|`|%[^%\r\n]+%|(?:^|[\s;&|])%[A-Za-z]|![A-Za-z_][A-Za-z0-9_]*!|\b(?:eval|exec|source|invoke-expression|iex|get-command|call|if|then|else|elif|fi|for|while|until|do|done|case|esac|select|function|coproc)\b|[<>]\s*\(|(?:^|[;&|]\s*)&\s*\(|[{}])/i.test(
       input.resource,
     );
@@ -1246,7 +1248,7 @@ export async function enforceNativeToolExecution(
   toolName: string,
   args: Record<string, unknown>,
   cwd?: string,
-  execution?: { sessionID: string; callID: string },
+  execution?: { sessionID: string; callID: string; taskID?: string },
 ): Promise<HeadroomToolPolicyPreflight | undefined> {
   await refreshHeadroomToolPolicy();
   const state = getState();
@@ -1256,7 +1258,7 @@ export async function enforceNativeToolExecution(
         caller: "opencode" as const,
         adapter: "tool.execute.before" as const,
         sessionID: execution.sessionID,
-        taskID: execution.callID,
+        taskID: execution.taskID ?? execution.callID,
         callID: execution.callID,
         toolName,
         cwd,
@@ -1276,7 +1278,7 @@ export function acknowledgeNativeToolExecution(
   toolName: string,
   args: Record<string, unknown>,
   cwd: string | undefined,
-  execution: { sessionID: string; callID: string },
+  execution: { sessionID: string; callID: string; taskID?: string },
 ): HeadroomToolPolicyAcknowledgement {
   const binding = preflight.decision.binding;
   const canonicalArgsHash = hashPolicyResource(stableJson(args));
@@ -1287,7 +1289,7 @@ export function acknowledgeNativeToolExecution(
     binding.adapter !== "tool.execute.before" ||
     binding.sessionID !== execution.sessionID ||
     binding.callID !== execution.callID ||
-    binding.taskID !== execution.callID ||
+    binding.taskID !== (execution.taskID ?? execution.callID) ||
     binding.toolName !== toolName ||
     binding.cwd !== cwd ||
     binding.canonicalArgsHash !== canonicalArgsHash

--- a/plugins/opencode/src/transport.ts
+++ b/plugins/opencode/src/transport.ts
@@ -1,4 +1,8 @@
 import { createRequire, syncBuiltinESMExports } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
 
 const nodeRequire = createRequire(import.meta.url);
 const http = nodeRequire("node:http") as typeof import("node:http");
@@ -11,6 +15,17 @@ const BASE_URL_HEADER = "x-headroom-base-url";
 const ORIGINAL_PATH_HEADER = "x-headroom-original-path";
 const PROJECT_HEADER = "x-headroom-project";
 const PROXY_ENV = "HEADROOM_OPENCODE_TRANSPORT_PROXY_URL";
+export const TOOL_POLICY_ENV = "HEADROOM_TOOL_POLICY_JSON";
+export const TOOL_POLICY_PATH_ENV = "HEADROOM_TOOL_POLICY_PATH";
+export const TOOL_POLICY_URL_ENV = "HEADROOM_TOOL_POLICY_URL";
+export const TOOL_POLICY_TOKEN_ENV = "HEADROOM_TOOL_POLICY_TOKEN";
+export const TOOL_POLICY_REFRESH_SECONDS_ENV = "HEADROOM_TOOL_POLICY_REFRESH_SECONDS";
+const TOOL_POLICY_FILE_NAME = "tool_policy.json";
+const POLICY_VERSION = 1;
+const DEFAULT_REFRESH_SECONDS = 300;
+const MAX_REFRESH_SECONDS = 3600;
+const REMOTE_TIMEOUT_MS = 5_000;
+const MAX_REMOTE_POLICY_BYTES = 1024 * 1024;
 const STATE_KEY = Symbol.for("headroom.opencode.transport");
 
 type FetchArgs = Parameters<typeof fetch>;
@@ -23,18 +38,79 @@ type ChildSpawn = typeof childProcess.spawn;
 type ChildExec = typeof childProcess.exec;
 type ChildExecFile = typeof childProcess.execFile;
 type ChildFork = typeof childProcess.fork;
+export type ToolPolicyAction = "allow" | "deny" | "require_approval";
+export type ToolPolicyMode = "enforce" | "report_only";
+export type ToolPolicyScope = "tool_call" | "shell" | "http";
+
+export interface HeadroomToolPolicyRule {
+  id?: string;
+  scope: ToolPolicyScope;
+  action: ToolPolicyAction;
+  reason?: string;
+  tool?: string | string[];
+  command?: string | string[];
+  argsPattern?: string;
+  cwdPattern?: string;
+  envKeys?: string[];
+  domain?: string | string[];
+  urlPattern?: string;
+}
+
+export interface HeadroomToolPolicyConfig {
+  version?: 1;
+  mode?: ToolPolicyMode;
+  defaultAction?: Extract<ToolPolicyAction, "allow" | "deny">;
+  rules: HeadroomToolPolicyRule[];
+}
+
+type HeadroomToolPolicyInput = HeadroomToolPolicyConfig | string;
 
 interface InstallOptions {
   proxyUrl: string;
   project?: string;
+  policyProject?: string;
   debug?: boolean;
+  toolPolicy?: HeadroomToolPolicyInput;
+}
+
+interface CompiledToolPolicyRule {
+  id: string;
+  scope: ToolPolicyScope;
+  action: ToolPolicyAction;
+  reason?: string;
+  tools?: string[];
+  commands?: string[];
+  argsPattern?: RegExp;
+  cwdPattern?: RegExp;
+  envKeys?: string[];
+  domains?: string[];
+  urlPattern?: RegExp;
+}
+
+interface CompiledToolPolicy {
+  version: 1;
+  mode: ToolPolicyMode;
+  defaultAction: "allow" | "deny";
+  rules: CompiledToolPolicyRule[];
+  serialized: string;
+  source: string;
+  validUntil?: number;
 }
 
 interface TransportState {
   refs: number;
+  policyContextKey: string;
   proxyUrl: string;
   project: string | undefined;
   debug: boolean;
+  toolPolicy?: CompiledToolPolicy;
+  toolPolicyInput?: HeadroomToolPolicyInput;
+  remotePolicyUrl?: string;
+  remotePolicyToken: string;
+  policyUnavailable?: string;
+  previousNodeOptions?: string;
+  previousProxyUrlEnv?: string;
+  previousToolPolicyEnv?: string;
   originalFetch: typeof fetch;
   originalHttpRequest: HttpRequest;
   originalHttpGet: HttpGet;
@@ -55,6 +131,89 @@ interface NodeRequestParts {
   url?: URL;
   options: Record<string, unknown>;
   callback?: (...args: unknown[]) => unknown;
+}
+
+export interface HeadroomToolPolicyDecision {
+  version: 1;
+  decisionId: string;
+  authority: "authoritative" | "advisory";
+  scope: ToolPolicyScope;
+  action: ToolPolicyAction;
+  effectiveAction: ToolPolicyAction;
+  mode: ToolPolicyMode;
+  matchedRuleId?: string;
+  reason?: string;
+  resource: string;
+  requestHash: string;
+  source: string;
+  binding?: HeadroomToolPolicyBinding;
+}
+
+export interface HeadroomToolPolicyBinding {
+  caller: "opencode";
+  adapter: "tool.execute.before";
+  sessionID: string;
+  taskID: string;
+  callID: string;
+  toolName: string;
+  cwd?: string;
+  canonicalArgsHash: string;
+}
+
+export interface HeadroomToolPolicyAcknowledgement {
+  version: 1;
+  event: "headroom_tool_policy_enforcement_acknowledgement";
+  decisionId: string;
+  authority: "authoritative";
+  effect: "allowed" | "blocked";
+  requestHash: string;
+  binding: HeadroomToolPolicyBinding;
+  timestamp: string;
+}
+
+export interface HeadroomToolPolicyPreflight {
+  decision: HeadroomToolPolicyDecision;
+}
+
+export class ToolPolicyEnforcementError extends Error {
+  readonly decision: HeadroomToolPolicyDecision;
+  readonly acknowledgement: HeadroomToolPolicyAcknowledgement;
+
+  constructor(
+    message: string,
+    decision: HeadroomToolPolicyDecision,
+    acknowledgement: HeadroomToolPolicyAcknowledgement,
+  ) {
+    super(message);
+    this.name = "ToolPolicyEnforcementError";
+    this.decision = decision;
+    this.acknowledgement = acknowledgement;
+  }
+}
+
+interface ShellPolicyInput {
+  scope: "shell";
+  resource: string;
+  command: string;
+  argsText: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv | Record<string, unknown>;
+  toolName?: string;
+}
+
+interface HttpPolicyInput {
+  scope: "http";
+  resource: string;
+  url: URL;
+}
+
+interface ToolCallPolicyInput {
+  scope: "tool_call";
+  resource: string;
+  toolName: string;
+  argsText: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv | Record<string, unknown>;
 }
 
 function getState(): TransportState | undefined {
@@ -87,9 +246,438 @@ function withNodeImportOption(existing: string | undefined, shim: string): strin
   return parts.join(" ");
 }
 
-function withShimEnv(env: NodeJS.ProcessEnv | Record<string, unknown> | undefined, proxyUrl: string): NodeJS.ProcessEnv {
+function parseToolPolicyJson(raw: string, source: string): HeadroomToolPolicyConfig {
+  try {
+    const parsed = JSON.parse(raw) as HeadroomToolPolicyConfig;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("expected a JSON object");
+    }
+    if (parsed.version !== undefined && parsed.version !== POLICY_VERSION) {
+      throw new Error(`unsupported version ${String(parsed.version)}; expected ${POLICY_VERSION}`);
+    }
+    return parsed;
+  } catch {
+    throw new Error(`Invalid Headroom tool policy JSON in ${source}`);
+  }
+}
+
+function readToolPolicyFile(filePath: string, source: string): HeadroomToolPolicyConfig {
+  try {
+    return parseToolPolicyJson(fs.readFileSync(filePath, "utf8"), source);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Invalid Headroom tool policy JSON")) {
+      throw error;
+    }
+    throw new Error(`Invalid Headroom tool policy file ${filePath} (${source}): ${String(error)}`);
+  }
+}
+
+export function defaultGlobalToolPolicyPath(): string {
+  const explicitConfigDir = process.env.HEADROOM_CONFIG_DIR?.trim();
+  if (explicitConfigDir) {
+    return path.join(explicitConfigDir, TOOL_POLICY_FILE_NAME);
+  }
+  const explicitWorkspaceDir = process.env.HEADROOM_WORKSPACE_DIR?.trim();
+  if (explicitWorkspaceDir) {
+    return path.join(explicitWorkspaceDir, "config", TOOL_POLICY_FILE_NAME);
+  }
+  return path.join(os.homedir(), ".headroom", "config", TOOL_POLICY_FILE_NAME);
+}
+
+export function findLocalToolPolicyPath(project: string | undefined): string | undefined {
+  let start = path.resolve(project || process.cwd());
+  try {
+    if (fs.statSync(start).isFile()) {
+      start = path.dirname(start);
+    }
+  } catch {
+    // Nonexistent project paths are still useful as discovery starting points.
+  }
+  let current = start;
+  while (true) {
+    const candidate = path.join(current, ".headroom", TOOL_POLICY_FILE_NAME);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+function loadToolPolicyConfig(
+  policy: HeadroomToolPolicyInput | undefined,
+  project: string | undefined,
+): HeadroomToolPolicyConfig | undefined {
+  if (policy === undefined) {
+    const raw = process.env[TOOL_POLICY_ENV]?.trim();
+    if (raw) {
+      return parseToolPolicyJson(raw, TOOL_POLICY_ENV);
+    }
+    const rawPath = process.env[TOOL_POLICY_PATH_ENV]?.trim();
+    if (rawPath) {
+      return readToolPolicyFile(rawPath, TOOL_POLICY_PATH_ENV);
+    }
+    if (process.env[TOOL_POLICY_URL_ENV]?.trim()) {
+      return undefined;
+    }
+    const globalPath = defaultGlobalToolPolicyPath();
+    if (fs.existsSync(globalPath)) {
+      return readToolPolicyFile(globalPath, globalPath);
+    }
+    const localPath = findLocalToolPolicyPath(project);
+    if (localPath) {
+      return readToolPolicyFile(localPath, localPath);
+    }
+    return undefined;
+  }
+  if (typeof policy !== "string") {
+    return policy;
+  }
+  const trimmed = policy.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.startsWith("{")) {
+    return parseToolPolicyJson(trimmed, "inline string");
+  }
+  return readToolPolicyFile(trimmed, trimmed);
+}
+
+function compileRegex(source: string | undefined, field: string, ruleId: string): RegExp | undefined {
+  if (!source) {
+    return undefined;
+  }
+  try {
+    return new RegExp(source);
+  } catch {
+    throw new Error(
+      `Invalid Headroom tool policy regex for ${field} in rule ${ruleId}`,
+    );
+  }
+}
+
+function asArray(value: string | string[] | undefined): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function compileToolPolicy(
+  policy: HeadroomToolPolicyInput | undefined,
+  project: string | undefined,
+  source = "configured",
+): CompiledToolPolicy | undefined {
+  const loaded = loadToolPolicyConfig(policy, project);
+  if (!loaded) {
+    return undefined;
+  }
+  if (!Array.isArray(loaded.rules)) {
+    throw new Error("Headroom tool policy requires a rules array");
+  }
+  if (loaded.version !== undefined && loaded.version !== POLICY_VERSION) {
+    throw new Error(`Unsupported Headroom tool policy version: ${String(loaded.version)}`);
+  }
+  const compiledRules = loaded.rules.map((rule, index): CompiledToolPolicyRule => {
+    const id = rule.id?.trim() || `rule_${index + 1}`;
+    if (rule.scope !== "tool_call" && rule.scope !== "shell" && rule.scope !== "http") {
+      throw new Error(`Invalid Headroom tool policy scope in rule ${id}: ${String(rule.scope)}`);
+    }
+    if (rule.action !== "allow" && rule.action !== "deny" && rule.action !== "require_approval") {
+      throw new Error(`Invalid Headroom tool policy action in rule ${id}: ${String(rule.action)}`);
+    }
+    return {
+      id,
+      scope: rule.scope,
+      action: rule.action,
+      reason: rule.reason,
+      tools: asArray(rule.tool)?.map((entry) => entry.toLowerCase()),
+      commands: asArray(rule.command)?.map((entry) => entry.toLowerCase()),
+      argsPattern: compileRegex(rule.argsPattern, "argsPattern", id),
+      cwdPattern: compileRegex(rule.cwdPattern, "cwdPattern", id),
+      envKeys: rule.envKeys?.map((entry) => entry.toLowerCase()),
+      domains: asArray(rule.domain)?.map((entry) => entry.toLowerCase()),
+      urlPattern: compileRegex(rule.urlPattern, "urlPattern", id),
+    };
+  });
+  const defaultAction = loaded.defaultAction ?? "allow";
+  if (defaultAction !== "allow" && defaultAction !== "deny") {
+    throw new Error(`Invalid Headroom tool policy defaultAction: ${String(defaultAction)}`);
+  }
+  const mode = loaded.mode ?? "enforce";
+  if (mode !== "enforce" && mode !== "report_only") {
+    throw new Error(`Invalid Headroom tool policy mode: ${String(mode)}`);
+  }
+  return {
+    version: POLICY_VERSION,
+    mode,
+    defaultAction,
+    rules: compiledRules,
+    serialized: JSON.stringify({
+      version: POLICY_VERSION,
+      mode,
+      defaultAction,
+      rules: loaded.rules.map((rule, index) => ({
+        ...rule,
+        id: rule.id?.trim() || `rule_${index + 1}`,
+      })),
+    }),
+    source,
+  };
+}
+
+function workspaceDir(): string {
+  return process.env.HEADROOM_WORKSPACE_DIR?.trim() || path.join(os.homedir(), ".headroom");
+}
+
+function processIsStateless(): boolean {
+  return ["1", "true", "yes", "on"].includes(
+    process.env.HEADROOM_STATELESS?.trim().toLowerCase() ?? "",
+  );
+}
+
+export function toolPolicyRefreshSeconds(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[TOOL_POLICY_REFRESH_SECONDS_ENV]?.trim();
+  if (!raw || !/^\d+$/.test(raw)) {
+    return DEFAULT_REFRESH_SECONDS;
+  }
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value >= DEFAULT_REFRESH_SECONDS && value <= MAX_REFRESH_SECONDS
+    ? value
+    : DEFAULT_REFRESH_SECONDS;
+}
+
+export function remoteToolPolicyCachePath(url: string, token = ""): string {
+  const digest = createHash("sha256").update(`${url}\0${token}`).digest("hex");
+  return path.join(workspaceDir(), "policy-cache", `${digest}.json`);
+}
+
+export function isAllowedToolPolicyUrl(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.protocol === "https:") {
+    return true;
+  }
+  if (url.protocol !== "http:") {
+    return false;
+  }
+  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  return (
+    hostname === "localhost" ||
+    hostname === "::1" ||
+    /^127(?:\.\d{1,3}){3}$/.test(hostname)
+  );
+}
+
+interface RemotePolicyCache {
+  cache_version: 2;
+  url_hash: string;
+  etag: string;
+  fetched_at: number;
+  policy: HeadroomToolPolicyConfig;
+}
+
+function readRemotePolicyCache(url: string, token: string): RemotePolicyCache | undefined {
+  const cachePath = remoteToolPolicyCachePath(url, token);
+  if (!fs.existsSync(cachePath)) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8")) as Partial<RemotePolicyCache>;
+    if (
+      parsed.cache_version !== 2 ||
+      parsed.url_hash !== createHash("sha256").update(url).digest("hex") ||
+      typeof parsed.fetched_at !== "number" ||
+      !parsed.policy ||
+      typeof parsed.policy !== "object" ||
+      Array.isArray(parsed.policy)
+    ) {
+      return undefined;
+    }
+    return parsed as RemotePolicyCache;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeRemotePolicyCache(url: string, cache: RemotePolicyCache, token: string): void {
+  if (processIsStateless()) {
+    return;
+  }
+  const cachePath = remoteToolPolicyCachePath(url, token);
+  const directory = path.dirname(cachePath);
+  const temporaryPath = path.join(
+    directory,
+    `.${path.basename(cachePath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  fs.mkdirSync(directory, { recursive: true });
+  try {
+    fs.writeFileSync(temporaryPath, `${JSON.stringify(cache)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+    });
+    fs.renameSync(temporaryPath, cachePath);
+  } finally {
+    try {
+      fs.rmSync(temporaryPath, { force: true });
+    } catch {
+      // Cache persistence is best effort; never mask the original failure.
+    }
+  }
+}
+
+async function readLimitedResponseText(response: Response): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_REMOTE_POLICY_BYTES) {
+    throw new Error("remote Headroom tool policy exceeds 1 MiB");
+  }
+  if (!response.body) {
+    return "";
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let size = 0;
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_REMOTE_POLICY_BYTES) {
+        await reader.cancel();
+        throw new Error("remote Headroom tool policy exceeds 1 MiB");
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function loadRemoteToolPolicy(
+  url: string,
+  token: string,
+  originalFetch: typeof fetch,
+  now = Date.now() / 1000,
+): Promise<CompiledToolPolicy> {
+  const remoteLabel = new URL(url).hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const cache = readRemotePolicyCache(url, token);
+  const cacheAge = cache ? now - cache.fetched_at : undefined;
+  if (
+    cache &&
+    cacheAge !== undefined &&
+    cacheAge >= 0 &&
+    cacheAge < toolPolicyRefreshSeconds()
+  ) {
+    const compiled = compileToolPolicy(cache.policy, undefined, `remote-cache:${remoteLabel}`)!;
+    compiled.validUntil = cache.fetched_at + toolPolicyRefreshSeconds();
+    return compiled;
+  }
+
+  const headers = new Headers({ accept: "application/json" });
+  if (token) {
+    headers.set("authorization", `Bearer ${token}`);
+  }
+  if (cache?.etag) {
+    headers.set("if-none-match", cache.etag);
+  }
+
+  let response: Response;
+  try {
+    response = await originalFetch(url, {
+      method: "GET",
+      headers,
+      redirect: "manual",
+      signal: AbortSignal.timeout(REMOTE_TIMEOUT_MS),
+    });
+  } catch {
+    throw new Error(`Headroom tool policy service ${remoteLabel} is unavailable`);
+  }
+  if (response.status === 304 && cache) {
+    const refreshed = { ...cache, fetched_at: now };
+    writeRemotePolicyCache(url, refreshed, token);
+    const compiled = compileToolPolicy(
+      refreshed.policy,
+      undefined,
+      `remote-cache:${remoteLabel}`,
+    )!;
+    compiled.validUntil = now + toolPolicyRefreshSeconds();
+    return compiled;
+  }
+  if (!response.ok) {
+    throw new Error(`Headroom tool policy service ${remoteLabel} returned HTTP ${response.status}`);
+  }
+
+  const text = await readLimitedResponseText(response);
+  const payload = parseToolPolicyJson(text, remoteLabel);
+  const compiled = compileToolPolicy(payload, undefined, `remote:${remoteLabel}`)!;
+  compiled.validUntil = now + toolPolicyRefreshSeconds();
+  writeRemotePolicyCache(
+    url,
+    {
+      cache_version: 2,
+      url_hash: createHash("sha256").update(url).digest("hex"),
+      etag: response.headers.get("etag") ?? "",
+      fetched_at: now,
+      policy: JSON.parse(compiled.serialized) as HeadroomToolPolicyConfig,
+    },
+    token,
+  );
+  return compiled;
+}
+
+export async function refreshHeadroomToolPolicy(now = Date.now() / 1000): Promise<void> {
+  const state = getState();
+  if (!state || state.toolPolicyInput !== undefined) {
+    return;
+  }
+  const url = state.remotePolicyUrl;
+  if (!url) {
+    return;
+  }
+  if (!isAllowedToolPolicyUrl(url)) {
+    state.toolPolicy = undefined;
+    state.policyUnavailable =
+      `${TOOL_POLICY_URL_ENV} must use HTTPS; HTTP is allowed only for loopback hosts`;
+    return;
+  }
+  try {
+    state.toolPolicy = await loadRemoteToolPolicy(
+      url,
+      state.remotePolicyToken,
+      state.originalFetch,
+      now,
+    );
+    state.policyUnavailable = undefined;
+    installProcessEnv(state.proxyUrl, state.toolPolicy);
+  } catch (error) {
+    state.toolPolicy = undefined;
+    state.policyUnavailable = error instanceof Error ? error.message : String(error);
+  }
+}
+
+function withShimEnv(
+  env: NodeJS.ProcessEnv | Record<string, unknown> | undefined,
+  proxyUrl: string,
+  toolPolicy: CompiledToolPolicy | undefined,
+): NodeJS.ProcessEnv {
   const nextEnv = { ...(env ?? process.env) } as NodeJS.ProcessEnv;
+  delete nextEnv[TOOL_POLICY_TOKEN_ENV];
+  delete nextEnv[TOOL_POLICY_URL_ENV];
   nextEnv[PROXY_ENV] = proxyUrl;
+  if (toolPolicy) {
+    nextEnv[TOOL_POLICY_ENV] = toolPolicy.serialized;
+  } else {
+    delete nextEnv[TOOL_POLICY_ENV];
+  }
   const shim = shimImportSpecifier();
   if (shim) {
     nextEnv.NODE_OPTIONS = withNodeImportOption(nextEnv.NODE_OPTIONS, shim);
@@ -97,8 +685,13 @@ function withShimEnv(env: NodeJS.ProcessEnv | Record<string, unknown> | undefine
   return nextEnv;
 }
 
-function installProcessEnv(proxyUrl: string): void {
+function installProcessEnv(proxyUrl: string, toolPolicy: CompiledToolPolicy | undefined): void {
   process.env[PROXY_ENV] = proxyUrl;
+  if (toolPolicy) {
+    process.env[TOOL_POLICY_ENV] = toolPolicy.serialized;
+  } else {
+    delete process.env[TOOL_POLICY_ENV];
+  }
   const shim = shimImportSpecifier();
   if (shim) {
     process.env.NODE_OPTIONS = withNodeImportOption(process.env.NODE_OPTIONS, shim);
@@ -110,10 +703,11 @@ function isOptions(value: unknown): value is Record<string, unknown> {
 }
 
 function injectOptionsEnv(args: unknown[], optionIndex: number, proxyUrl: string): unknown[] {
+  const state = getState();
   const nextArgs = [...args];
   const callback = typeof nextArgs.at(-1) === "function" ? nextArgs.pop() : undefined;
   const existing = isOptions(nextArgs[optionIndex]) ? { ...(nextArgs[optionIndex] as Record<string, unknown>) } : {};
-  existing.env = withShimEnv(existing.env as NodeJS.ProcessEnv | undefined, proxyUrl);
+  existing.env = withShimEnv(existing.env as NodeJS.ProcessEnv | undefined, proxyUrl, state?.toolPolicy);
 
   if (isOptions(nextArgs[optionIndex])) {
     nextArgs[optionIndex] = existing;
@@ -127,12 +721,665 @@ function injectOptionsEnv(args: unknown[], optionIndex: number, proxyUrl: string
   return nextArgs;
 }
 
+function normalizedCommandName(command: string): string {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return "";
+  }
+  return path.basename(trimmed).toLowerCase();
+}
+
+function commandMatches(command: string, patterns: string[] | undefined): boolean {
+  if (!patterns?.length) {
+    return true;
+  }
+  const normalized = normalizedCommandName(command);
+  const lowered = command.trim().toLowerCase();
+  return patterns.some((pattern) => {
+    const candidate = pattern.toLowerCase();
+    return candidate === lowered || candidate === normalized || path.basename(candidate) === normalized;
+  });
+}
+
+function shellTokens(commandLine: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote = "";
+  for (let index = 0; index < commandLine.length; index += 1) {
+    const char = commandLine[index];
+    if (quote) {
+      if (char === quote) quote = "";
+      else if (char === "\\" && quote === '"' && index + 1 < commandLine.length) {
+        current += commandLine[++index];
+      } else current += char;
+    } else if (char === "'" || char === '"') {
+      quote = char;
+    } else if (char === "\r" || char === "\n") {
+      if (current) tokens.push(current);
+      current = "";
+      tokens.push(";");
+      if (char === "\r" && commandLine[index + 1] === "\n") index += 1;
+    } else if (/\s/.test(char)) {
+      if (current) tokens.push(current);
+      current = "";
+    } else if (";&|".includes(char)) {
+      if (current) tokens.push(current);
+      current = "";
+      if (commandLine[index + 1] === char) tokens.push(char + commandLine[++index]);
+      else tokens.push(char);
+    } else {
+      current += char;
+    }
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+const SHELL_OPERATORS = new Set([";", "&&", "||", "|", "&"]);
+const COMMAND_WRAPPERS = new Set(["command", "env", "nohup", "sudo", "time"]);
+const SHELL_WRAPPERS = new Set(["bash", "cmd", "dash", "ksh", "powershell", "pwsh", "sh", "zsh"]);
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+const WRAPPER_OPTIONS_WITH_VALUE: Record<string, Set<string>> = {
+  env: new Set(["-C", "--chdir", "-S", "--split-string", "-u", "--unset"]),
+  sudo: new Set([
+    "-C",
+    "--close-from",
+    "-g",
+    "--group",
+    "-h",
+    "--host",
+    "-p",
+    "--prompt",
+    "-R",
+    "--chroot",
+    "-r",
+    "--role",
+    "-T",
+    "--command-timeout",
+    "-t",
+    "--type",
+    "-u",
+    "--user",
+  ]),
+  time: new Set(["-f", "--format", "-o", "--output"]),
+};
+
+function shellCommandSubstitutions(commandLine: string): string[] {
+  const substitutions: string[] = [];
+  let quote = "";
+  for (let index = 0; index < commandLine.length; index += 1) {
+    const char = commandLine[index];
+    if (char === "\\") {
+      index += 1;
+      continue;
+    }
+    if (quote === "'") {
+      if (char === "'") quote = "";
+      continue;
+    }
+    if (char === "'" && !quote) {
+      quote = char;
+      continue;
+    }
+    if (char === '"') {
+      quote = quote === '"' ? "" : '"';
+      continue;
+    }
+    if (char === "`") {
+      let end = index + 1;
+      for (; end < commandLine.length; end += 1) {
+        if (commandLine[end] === "\\") {
+          end += 1;
+        } else if (commandLine[end] === "`") {
+          break;
+        }
+      }
+      if (end < commandLine.length) {
+        substitutions.push(commandLine.slice(index + 1, end));
+        index = end;
+      }
+      continue;
+    }
+    if (char !== "$" || commandLine[index + 1] !== "(") {
+      continue;
+    }
+    if (commandLine[index + 2] === "(") {
+      index += 2;
+      continue;
+    }
+    let depth = 1;
+    let nestedQuote = "";
+    let end = index + 2;
+    for (; end < commandLine.length; end += 1) {
+      const nestedChar = commandLine[end];
+      if (nestedChar === "\\") {
+        end += 1;
+        continue;
+      }
+      if (nestedQuote) {
+        if (nestedChar === nestedQuote) nestedQuote = "";
+        continue;
+      }
+      if (nestedChar === "'" || nestedChar === '"') {
+        nestedQuote = nestedChar;
+      } else if (nestedChar === "(") {
+        depth += 1;
+      } else if (nestedChar === ")" && --depth === 0) {
+        break;
+      }
+    }
+    if (depth === 0) {
+      substitutions.push(commandLine.slice(index + 2, end));
+      index = end;
+    }
+  }
+  return substitutions;
+}
+
+export function shellCommandBinaries(commandLine: string): string[] {
+  const segments: string[][] = [[]];
+  for (const token of shellTokens(commandLine)) {
+    if (SHELL_OPERATORS.has(token)) {
+      if (segments.at(-1)?.length) segments.push([]);
+    } else {
+      segments.at(-1)!.push(token);
+    }
+  }
+  const binaries: string[] = [];
+  for (const segment of segments) {
+    let index = 0;
+    while (index < segment.length && ENV_ASSIGNMENT.test(segment[index])) index += 1;
+    while (index < segment.length && COMMAND_WRAPPERS.has(normalizedCommandName(segment[index]))) {
+      const wrapper = normalizedCommandName(segment[index]);
+      index += 1;
+      while (index < segment.length) {
+        const token = segment[index];
+        if (token === "--") {
+          index += 1;
+          break;
+        }
+        if (ENV_ASSIGNMENT.test(token)) {
+          index += 1;
+          continue;
+        }
+        const optionName = token.split("=", 1)[0];
+        if (token.startsWith("-")) {
+          index += 1;
+          if (
+            !token.includes("=") &&
+            WRAPPER_OPTIONS_WITH_VALUE[wrapper]?.has(optionName) &&
+            index < segment.length
+          ) {
+            if (wrapper === "env" && ["-S", "--split-string"].includes(optionName)) {
+              binaries.push(...shellCommandBinaries(segment[index]));
+            }
+            index += 1;
+          }
+          continue;
+        }
+        break;
+      }
+    }
+    if (index >= segment.length) continue;
+    const command = segment[index];
+    binaries.push(command);
+    if (SHELL_WRAPPERS.has(normalizedCommandName(command))) {
+      for (let flagIndex = index + 1; flagIndex < segment.length - 1; flagIndex += 1) {
+        if (["-c", "/c", "-command"].includes(segment[flagIndex].toLowerCase())) {
+          binaries.push(...shellCommandBinaries(segment[flagIndex + 1]));
+          break;
+        }
+      }
+    }
+  }
+  for (const substitution of shellCommandSubstitutions(commandLine)) {
+    binaries.push(...shellCommandBinaries(substitution));
+  }
+  return [...new Set(binaries)];
+}
+
+function matchesDomain(hostname: string, patterns: string[] | undefined): boolean {
+  if (!patterns?.length) {
+    return true;
+  }
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  return patterns.some((pattern) => {
+    const candidate = pattern.toLowerCase();
+    if (candidate.startsWith("*.")) {
+      const suffix = candidate.slice(2);
+      return normalized === suffix || normalized.endsWith(`.${suffix}`);
+    }
+    return normalized === candidate;
+  });
+}
+
+function hashPolicyResource(resource: string): string {
+  return createHash("sha256").update(resource).digest("hex").slice(0, 16);
+}
+
+function safePolicyResource(
+  input: ShellPolicyInput | HttpPolicyInput | ToolCallPolicyInput,
+): string {
+  if (input.scope === "shell") {
+    return shellCommandBinaries(input.resource)
+      .map((command) => normalizedCommandName(command))
+      .filter(Boolean)
+      .join(",");
+  }
+  if (input.scope === "tool_call") {
+    return input.toolName;
+  }
+  return input.url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+}
+
+function emitPolicyDecision(decision: HeadroomToolPolicyDecision): void {
+  const record = {
+    event: "headroom_tool_policy_decision",
+    version: decision.version,
+    decision_id: decision.decisionId,
+    authority: decision.authority,
+    timestamp: new Date().toISOString(),
+    agent: "opencode",
+    tool_name: decision.scope,
+    scope: decision.scope,
+    action: decision.action,
+    effective_action: decision.effectiveAction,
+    mode: decision.mode,
+    matched_rule: decision.matchedRuleId ?? "",
+    reason: decision.reason ?? "",
+    request_hash: decision.requestHash,
+    resource: decision.resource,
+    source: decision.source,
+    binding: decision.binding,
+  };
+  try {
+    process.stderr.write(`${JSON.stringify(record)}\n`);
+  } catch {
+    // Never let logging break the transport.
+  }
+
+  try {
+    if (processIsStateless()) {
+      return;
+    }
+    const target = path.join(workspaceDir(), "tool_policy_audit.jsonl");
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.appendFileSync(target, `${JSON.stringify(record)}\n`, "utf8");
+  } catch {
+    // Auditing is best effort and must not affect enforcement.
+  }
+}
+
+function emitPolicyAcknowledgement(
+  acknowledgement: HeadroomToolPolicyAcknowledgement,
+): void {
+  const record = {
+    ...acknowledgement,
+    decision_id: acknowledgement.decisionId,
+    request_hash: acknowledgement.requestHash,
+    decisionId: undefined,
+    requestHash: undefined,
+  };
+  try {
+    process.stderr.write(`${JSON.stringify(record)}\n`);
+  } catch {
+    // Enforcement remains authoritative if diagnostic output is unavailable.
+  }
+  try {
+    if (processIsStateless()) return;
+    const target = path.join(workspaceDir(), "tool_policy_audit.jsonl");
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.appendFileSync(target, `${JSON.stringify(record)}\n`, "utf8");
+  } catch {
+    // The adapter has already enforced the decision; auditing is best effort.
+  }
+}
+
+function policyDecisionId(
+  requestHash: string,
+  action: ToolPolicyAction,
+  authority: "authoritative" | "advisory",
+  binding?: HeadroomToolPolicyBinding,
+): string {
+  return createHash("sha256")
+    .update(stableJson({ version: 1, requestHash, action, authority, binding }))
+    .digest("hex");
+}
+
+function evaluatePolicy(
+  policy: CompiledToolPolicy | undefined,
+  input: ShellPolicyInput | HttpPolicyInput | ToolCallPolicyInput,
+  authority: "authoritative" | "advisory" = "advisory",
+  binding?: HeadroomToolPolicyBinding,
+): HeadroomToolPolicyDecision | undefined {
+  if (!policy) {
+    return undefined;
+  }
+  const hasDynamicShellExecution =
+    input.scope === "shell" &&
+    policy.rules.some(
+      (rule) =>
+        rule.action !== "allow" && (rule.scope === "shell" || rule.scope === "tool_call"),
+    ) &&
+    /(?:\\[A-Za-z0-9]|\$(?:\{|[A-Za-z_('" ])|`|%[^%\r\n]+%|(?:^|[\s;&|])%[A-Za-z]|![A-Za-z_][A-Za-z0-9_]*!|\b(?:eval|exec|source|invoke-expression|iex|get-command|call|if|then|else|elif|fi|for|while|until|do|done|case|esac|select|function|coproc)\b|[<>]\s*\(|(?:^|[;&|]\s*)&\s*\(|[{}])/i.test(
+      input.resource,
+    );
+  const matchedRule = policy.rules.find((rule) => {
+        if (
+          (input.scope === "tool_call" && rule.scope !== "tool_call") ||
+          (input.scope !== "tool_call" &&
+            rule.scope !== "tool_call" &&
+            rule.scope !== input.scope)
+        ) {
+          return false;
+        }
+        if (rule.tools?.length) {
+          if (
+            !("toolName" in input) ||
+            !rule.tools.includes((input.toolName ?? "").trim().toLowerCase())
+          ) {
+            return false;
+          }
+        }
+        if (input.scope === "shell") {
+          const commands = shellCommandBinaries(input.resource);
+          if (rule.commands?.length) {
+            const commandsMatch =
+              rule.action === "allow"
+                ? commands.length > 0 &&
+                  commands.every((candidate) => commandMatches(candidate, rule.commands))
+                : commands.some((candidate) => commandMatches(candidate, rule.commands));
+            if (!commandsMatch) {
+              return false;
+            }
+          }
+          if (rule.argsPattern && !rule.argsPattern.test(input.argsText)) {
+            return false;
+          }
+          if (rule.cwdPattern && !rule.cwdPattern.test(input.cwd ?? "")) {
+            return false;
+          }
+          if (
+            rule.envKeys?.length &&
+            !rule.envKeys.every((entry) =>
+              Object.keys(input.env ?? process.env).some(
+                (key) => key.toLowerCase() === entry,
+              ),
+            )
+          ) {
+            return false;
+          }
+          return true;
+        }
+        if (input.scope === "tool_call") {
+          if (rule.commands?.length) {
+            return false;
+          }
+          if (rule.argsPattern && !rule.argsPattern.test(input.argsText)) {
+            return false;
+          }
+          if (rule.cwdPattern && !rule.cwdPattern.test(input.cwd ?? "")) {
+            return false;
+          }
+          if (
+            rule.envKeys?.length &&
+            !rule.envKeys.every((entry) =>
+              Object.keys(input.env ?? process.env).some(
+                (key) => key.toLowerCase() === entry,
+              ),
+            )
+          ) {
+            return false;
+          }
+          return true;
+        }
+        if (rule.tools?.length) {
+          return false;
+        }
+        if (!matchesDomain(input.url.hostname, rule.domains)) {
+          return false;
+        }
+        if (rule.urlPattern && !rule.urlPattern.test(input.url.href)) {
+          return false;
+        }
+        return true;
+    });
+  const dynamicShellDenied =
+    hasDynamicShellExecution && (!matchedRule || matchedRule.action === "allow");
+  const action = dynamicShellDenied
+    ? "deny"
+    : (matchedRule?.action ?? policy.defaultAction);
+  const effectiveAction = policy.mode === "report_only" && action !== "allow" ? "allow" : action;
+  const requestHash = hashPolicyResource(input.resource);
+  return {
+    version: 1,
+    decisionId: policyDecisionId(requestHash, action, authority, binding),
+    authority,
+    scope: input.scope,
+    action,
+    effectiveAction,
+    mode: policy.mode,
+    matchedRuleId: matchedRule?.id,
+    reason: dynamicShellDenied
+      ? "dynamic or escaped shell execution cannot be safely authorized"
+      : matchedRule?.reason,
+    resource: safePolicyResource(input),
+    requestHash,
+    source: policy.source,
+    binding,
+  };
+}
+
+function enforcePolicy(
+  policy: CompiledToolPolicy | undefined,
+  input: ShellPolicyInput | HttpPolicyInput | ToolCallPolicyInput,
+  authority: "authoritative" | "advisory" = "advisory",
+  binding?: HeadroomToolPolicyBinding,
+): HeadroomToolPolicyPreflight | undefined {
+  const state = getState();
+  if (state?.policyUnavailable) {
+    throw new Error(`[headroom] Tool policy unavailable; failing closed: ${state.policyUnavailable}`);
+  }
+  if (policy?.validUntil !== undefined && Date.now() / 1000 >= policy.validUntil) {
+    throw new Error("[headroom] Remote tool policy expired; failing closed until it is refreshed");
+  }
+  const decision = evaluatePolicy(policy, input, authority, binding);
+  if (!decision) {
+    return;
+  }
+
+  emitPolicyDecision(decision);
+  const blockedAcknowledgement =
+    decision.authority === "authoritative" &&
+    decision.binding &&
+    decision.effectiveAction !== "allow"
+      ? {
+          version: 1 as const,
+          event: "headroom_tool_policy_enforcement_acknowledgement" as const,
+          decisionId: decision.decisionId,
+          authority: "authoritative" as const,
+          effect: "blocked" as const,
+          requestHash: decision.requestHash,
+          binding: decision.binding,
+          timestamp: new Date().toISOString(),
+        }
+      : undefined;
+  if (decision.effectiveAction === "allow") {
+    return { decision };
+  }
+  if (blockedAcknowledgement) emitPolicyAcknowledgement(blockedAcknowledgement);
+  const suffix =
+    (decision.matchedRuleId ? ` (rule=${decision.matchedRuleId})` : "") +
+    (decision.reason ? `: ${decision.reason}` : "");
+  if (decision.effectiveAction === "require_approval") {
+    const message =
+      `[headroom] Tool policy requires approval for ${decision.scope} target ${decision.resource}` +
+      suffix +
+      ". No approval handler is installed in the OpenCode transport yet.";
+    if (blockedAcknowledgement) {
+      throw new ToolPolicyEnforcementError(message, decision, blockedAcknowledgement);
+    }
+    throw new Error(message);
+  }
+
+  const message =
+    `[headroom] Tool policy denied ${decision.scope} target ${decision.resource}` +
+    suffix;
+  if (blockedAcknowledgement) {
+    throw new ToolPolicyEnforcementError(message, decision, blockedAcknowledgement);
+  }
+  throw new Error(message);
+}
+
+export async function enforceNativeToolExecution(
+  toolName: string,
+  args: Record<string, unknown>,
+  cwd?: string,
+  execution?: { sessionID: string; callID: string },
+): Promise<HeadroomToolPolicyPreflight | undefined> {
+  await refreshHeadroomToolPolicy();
+  const state = getState();
+  const canonicalArgs = stableJson(args);
+  const binding = execution
+    ? {
+        caller: "opencode" as const,
+        adapter: "tool.execute.before" as const,
+        sessionID: execution.sessionID,
+        taskID: execution.callID,
+        callID: execution.callID,
+        toolName,
+        cwd,
+        canonicalArgsHash: hashPolicyResource(canonicalArgs),
+      }
+    : undefined;
+  return enforcePolicy(
+    state?.toolPolicy,
+    nativePolicyInput(toolName, args, cwd),
+    binding ? "authoritative" : "advisory",
+    binding,
+  );
+}
+
+export function acknowledgeNativeToolExecution(
+  preflight: HeadroomToolPolicyPreflight,
+  toolName: string,
+  args: Record<string, unknown>,
+  cwd: string | undefined,
+  execution: { sessionID: string; callID: string },
+): HeadroomToolPolicyAcknowledgement {
+  const binding = preflight.decision.binding;
+  const canonicalArgsHash = hashPolicyResource(stableJson(args));
+  if (
+    preflight.decision.authority !== "authoritative" ||
+    !binding ||
+    binding.caller !== "opencode" ||
+    binding.adapter !== "tool.execute.before" ||
+    binding.sessionID !== execution.sessionID ||
+    binding.callID !== execution.callID ||
+    binding.taskID !== execution.callID ||
+    binding.toolName !== toolName ||
+    binding.cwd !== cwd ||
+    binding.canonicalArgsHash !== canonicalArgsHash
+  ) {
+    throw new Error(
+      "[headroom] OpenCode execution acknowledgement did not match the bound preflight decision",
+    );
+  }
+  const acknowledgement: HeadroomToolPolicyAcknowledgement = {
+    version: 1,
+    event: "headroom_tool_policy_enforcement_acknowledgement",
+    decisionId: preflight.decision.decisionId,
+    authority: "authoritative",
+    effect: "allowed",
+    requestHash: preflight.decision.requestHash,
+    binding,
+    timestamp: new Date().toISOString(),
+  };
+  emitPolicyAcknowledgement(acknowledgement);
+  return acknowledgement;
+}
+
+export function evaluateNativeToolPolicy(
+  policy: HeadroomToolPolicyConfig,
+  toolName: string,
+  args: Record<string, unknown>,
+  cwd?: string,
+): HeadroomToolPolicyDecision {
+  const compiled = compileToolPolicy(policy, cwd, "explicit")!;
+  return evaluatePolicy(compiled, nativePolicyInput(toolName, args, cwd))!;
+}
+
+function nativePolicyInput(
+  toolName: string,
+  args: Record<string, unknown>,
+  cwd?: string,
+): ShellPolicyInput | ToolCallPolicyInput {
+  const stableArgs = stableJson(args);
+  if (!["bash", "shell", "powershell", "sh"].includes(toolName.toLowerCase())) {
+    return {
+      scope: "tool_call",
+      resource: `${toolName} ${stableArgs}`,
+      toolName,
+      argsText: stableArgs,
+      cwd,
+      env: isOptions(args.env) ? args.env : undefined,
+    };
+  }
+  const commandLine = typeof args.command === "string" ? args.command : "";
+  return {
+    scope: "shell",
+    resource: commandLine,
+    command: shellCommandBinaries(commandLine)[0] ?? "",
+    argsText: commandLine,
+    cwd,
+    env: isOptions(args.env) ? args.env : undefined,
+    toolName,
+  };
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function effectiveChildCwd(value: unknown): string {
+  if (typeof value === "string") {
+    return path.resolve(process.cwd(), value);
+  }
+  if (value instanceof URL && value.protocol === "file:") {
+    return path.resolve(fileURLToPath(value));
+  }
+  return process.cwd();
+}
+
 function wrapSpawn(originalSpawn: ChildSpawn): ChildSpawn {
   return function headroomSpawn(this: unknown, ...args: unknown[]) {
     const state = getState();
     if (!state) {
       return Reflect.apply(originalSpawn, this, args);
     }
+    const command = String(args[0] ?? "");
+    const commandArgs = Array.isArray(args[1]) ? args[1].map((entry) => String(entry)) : [];
+    const resource = [command, ...commandArgs].join(" ").trim() || command;
+    const options = isOptions(args[Array.isArray(args[1]) ? 2 : 1])
+      ? (args[Array.isArray(args[1]) ? 2 : 1] as Record<string, unknown>)
+      : undefined;
+    enforcePolicy(state.toolPolicy, {
+      scope: "shell",
+      resource,
+      command,
+      argsText: resource,
+      cwd: effectiveChildCwd(options?.cwd),
+      env: options?.env as NodeJS.ProcessEnv | Record<string, unknown> | undefined,
+    });
     const optionIndex = Array.isArray(args[1]) ? 2 : 1;
     return Reflect.apply(originalSpawn, this, injectOptionsEnv(args, optionIndex, state.proxyUrl));
   } as ChildSpawn;
@@ -144,6 +1391,16 @@ function wrapExec(originalExec: ChildExec): ChildExec {
     if (!state) {
       return Reflect.apply(originalExec, this, args);
     }
+    const commandLine = String(args[0] ?? "");
+    const options = isOptions(args[1]) ? (args[1] as Record<string, unknown>) : undefined;
+    enforcePolicy(state.toolPolicy, {
+      scope: "shell",
+      resource: commandLine,
+      command: shellCommandBinaries(commandLine)[0] ?? "",
+      argsText: commandLine,
+      cwd: effectiveChildCwd(options?.cwd),
+      env: options?.env as NodeJS.ProcessEnv | Record<string, unknown> | undefined,
+    });
     return Reflect.apply(originalExec, this, injectOptionsEnv(args, 1, state.proxyUrl));
   } as ChildExec;
 }
@@ -154,6 +1411,20 @@ function wrapExecFile(originalExecFile: ChildExecFile): ChildExecFile {
     if (!state) {
       return Reflect.apply(originalExecFile, this, args);
     }
+    const command = String(args[0] ?? "");
+    const commandArgs = Array.isArray(args[1]) ? args[1].map((entry) => String(entry)) : [];
+    const resource = [command, ...commandArgs].join(" ").trim() || command;
+    const options = isOptions(args[Array.isArray(args[1]) ? 2 : 1])
+      ? (args[Array.isArray(args[1]) ? 2 : 1] as Record<string, unknown>)
+      : undefined;
+    enforcePolicy(state.toolPolicy, {
+      scope: "shell",
+      resource,
+      command,
+      argsText: resource,
+      cwd: effectiveChildCwd(options?.cwd),
+      env: options?.env as NodeJS.ProcessEnv | Record<string, unknown> | undefined,
+    });
     const optionIndex = Array.isArray(args[1]) ? 2 : 1;
     return Reflect.apply(originalExecFile, this, injectOptionsEnv(args, optionIndex, state.proxyUrl));
   } as ChildExecFile;
@@ -165,6 +1436,20 @@ function wrapFork(originalFork: ChildFork): ChildFork {
     if (!state) {
       return Reflect.apply(originalFork, this, args);
     }
+    const command = String(args[0] ?? "");
+    const commandArgs = Array.isArray(args[1]) ? args[1].map((entry) => String(entry)) : [];
+    const resource = [command, ...commandArgs].join(" ").trim() || command;
+    const options = isOptions(args[Array.isArray(args[1]) ? 2 : 1])
+      ? (args[Array.isArray(args[1]) ? 2 : 1] as Record<string, unknown>)
+      : undefined;
+    enforcePolicy(state.toolPolicy, {
+      scope: "shell",
+      resource,
+      command,
+      argsText: resource,
+      cwd: effectiveChildCwd(options?.cwd),
+      env: options?.env as NodeJS.ProcessEnv | Record<string, unknown> | undefined,
+    });
     const optionIndex = Array.isArray(args[1]) ? 2 : 1;
     return Reflect.apply(originalFork, this, injectOptionsEnv(args, optionIndex, state.proxyUrl));
   } as ChildFork;
@@ -390,6 +1675,13 @@ function wrapRequest(
 
     const proxy = normalizeProxyUrl(state.proxyUrl);
     const parts = splitNodeArgs(args);
+    if (parts.url) {
+      enforcePolicy(state.toolPolicy, {
+        scope: "http",
+        resource: parts.url.href,
+        url: parts.url,
+      });
+    }
     const nextOptions = routedNodeOptions(parts, proxy, state.project);
     if (!nextOptions) {
       return Reflect.apply(originalRequest, this, args);
@@ -415,9 +1707,14 @@ function wrapHttp2Connect(originalConnect: Http2Connect): Http2Connect {
     if (state) {
       const proxy = normalizeProxyUrl(state.proxyUrl);
       const upstream = authority instanceof URL ? authority : new URL(String(authority));
+      enforcePolicy(state.toolPolicy, {
+        scope: "http",
+        resource: upstream.href,
+        url: upstream,
+      });
       if (shouldRoute(upstream, proxy)) {
         throw new Error(
-          `Headroom OpenCode wrap blocked direct HTTP/2 connection to ${upstream.origin}. ` +
+          `Headroom OpenCode wrap blocked direct HTTP/2 connection to ${upstream.hostname}. ` +
             "Use fetch, http, or https so traffic can be routed through Headroom.",
         );
       }
@@ -428,20 +1725,68 @@ function wrapHttp2Connect(originalConnect: Http2Connect): Http2Connect {
 
 export function installHeadroomTransport(options: InstallOptions): () => void {
   const existing = getState();
+  const remotePolicyUrl =
+    options.toolPolicy === undefined
+      ? process.env[TOOL_POLICY_URL_ENV]?.trim() || undefined
+      : undefined;
+  const remotePolicyToken =
+    options.toolPolicy === undefined
+      ? process.env[TOOL_POLICY_TOKEN_ENV]?.trim() ?? ""
+      : "";
+  const policyContextKey = createHash("sha256")
+    .update(
+      stableJson({
+        policyProject: options.policyProject ?? options.project,
+        remotePolicyUrl,
+        remotePolicyToken,
+      }),
+    )
+    .digest("hex");
+  let toolPolicy: CompiledToolPolicy | undefined;
+  let policyUnavailable: string | undefined;
+  try {
+    toolPolicy = compileToolPolicy(options.toolPolicy, options.policyProject ?? options.project);
+  } catch (error) {
+    policyUnavailable = error instanceof Error ? error.message : String(error);
+  }
+  if (remotePolicyUrl && !toolPolicy) {
+    policyUnavailable ??= "remote Headroom tool policy has not been loaded";
+  }
   if (existing) {
+    const existingPolicy = existing.toolPolicy?.serialized;
+    const nextPolicy = toolPolicy?.serialized;
+    if (
+      existingPolicy !== nextPolicy ||
+      existing.policyUnavailable !== policyUnavailable ||
+      existing.policyContextKey !== policyContextKey
+    ) {
+      throw new Error(
+        "[headroom] Multiple OpenCode workspaces with different tool policies share one " +
+          "process; refusing to replace the active policy",
+      );
+    }
     existing.refs += 1;
     existing.proxyUrl = options.proxyUrl;
     existing.project = options.project;
     existing.debug = Boolean(options.debug);
-    installProcessEnv(options.proxyUrl);
+    installProcessEnv(options.proxyUrl, toolPolicy);
     return () => uninstallHeadroomTransport();
   }
 
   const state: TransportState = {
     refs: 1,
+    policyContextKey,
     proxyUrl: options.proxyUrl,
     project: options.project,
     debug: Boolean(options.debug),
+    toolPolicy,
+    toolPolicyInput: options.toolPolicy,
+    remotePolicyUrl,
+    remotePolicyToken,
+    policyUnavailable,
+    previousNodeOptions: process.env.NODE_OPTIONS,
+    previousProxyUrlEnv: process.env[PROXY_ENV],
+    previousToolPolicyEnv: process.env[TOOL_POLICY_ENV],
     originalFetch: globalThis.fetch,
     originalHttpRequest: http.request,
     originalHttpGet: http.get,
@@ -455,12 +1800,19 @@ export function installHeadroomTransport(options: InstallOptions): () => void {
   };
 
   setState(state);
-  installProcessEnv(options.proxyUrl);
+  installProcessEnv(options.proxyUrl, toolPolicy);
   globalThis.fetch = async (...args: FetchArgs) => {
     const current = getState();
     if (!current) {
       return state.originalFetch(...args);
     }
+    await refreshHeadroomToolPolicy();
+    const upstream = requestUrl(args[0]);
+    enforcePolicy(current.toolPolicy, {
+      scope: "http",
+      resource: upstream.href,
+      url: upstream,
+    });
     const proxy = normalizeProxyUrl(current.proxyUrl);
     const [nextInput, nextInit] = withRoutedFetchInput(args[0], args[1], proxy, current.project);
     return state.originalFetch(nextInput, nextInit);
@@ -502,5 +1854,20 @@ export function uninstallHeadroomTransport(): void {
   childProcess.execFile = state.originalChildExecFile;
   childProcess.fork = state.originalChildFork;
   syncBuiltinESMExports();
+  if (state.previousNodeOptions === undefined) {
+    delete process.env.NODE_OPTIONS;
+  } else {
+    process.env.NODE_OPTIONS = state.previousNodeOptions;
+  }
+  if (state.previousProxyUrlEnv === undefined) {
+    delete process.env[PROXY_ENV];
+  } else {
+    process.env[PROXY_ENV] = state.previousProxyUrlEnv;
+  }
+  if (state.previousToolPolicyEnv === undefined) {
+    delete process.env[TOOL_POLICY_ENV];
+  } else {
+    process.env[TOOL_POLICY_ENV] = state.previousToolPolicyEnv;
+  }
   setState(undefined);
 }

--- a/plugins/opencode/src/transport.ts
+++ b/plugins/opencode/src/transport.ts
@@ -165,7 +165,14 @@ export interface HeadroomToolPolicyAcknowledgement {
   event: "headroom_tool_policy_enforcement_acknowledgement";
   decisionId: string;
   authority: "authoritative";
-  effect: "allowed" | "blocked";
+  effect: "allowed" | "blocked" | "unknown";
+  reason?:
+    | "postflight_timeout"
+    | "postflight_mismatch"
+    | "ambiguous_reused_call"
+    | "capacity_evicted"
+    | "plugin_disposed"
+    | "call_replaced";
   requestHash: string;
   binding: HeadroomToolPolicyBinding;
   timestamp: string;
@@ -485,6 +492,9 @@ interface RemotePolicyCache {
 }
 
 function readRemotePolicyCache(url: string, token: string): RemotePolicyCache | undefined {
+  if (processIsStateless()) {
+    return undefined;
+  }
   const cachePath = remoteToolPolicyCachePath(url, token);
   if (!fs.existsSync(cachePath)) {
     return undefined;
@@ -1043,6 +1053,7 @@ function policyDecisionId(
 ): string {
   return createHash("sha256")
     .update(stableJson({ version: 1, requestHash, action, authority, binding }))
+    .update(binding ? randomUUID() : "")
     .digest("hex");
 }
 
@@ -1291,6 +1302,35 @@ export function acknowledgeNativeToolExecution(
     decisionId: preflight.decision.decisionId,
     authority: "authoritative",
     effect: "allowed",
+    requestHash: preflight.decision.requestHash,
+    binding,
+    timestamp: new Date().toISOString(),
+  };
+  emitPolicyAcknowledgement(acknowledgement);
+  return acknowledgement;
+}
+
+export function acknowledgeUnknownNativeToolExecution(
+  preflight: HeadroomToolPolicyPreflight,
+  reason: NonNullable<HeadroomToolPolicyAcknowledgement["reason"]>,
+): HeadroomToolPolicyAcknowledgement {
+  const binding = preflight.decision.binding;
+  if (
+    preflight.decision.authority !== "authoritative" ||
+    preflight.decision.effectiveAction !== "allow" ||
+    !binding
+  ) {
+    throw new Error(
+      "[headroom] Cannot record an unknown outcome for an unbound or blocked preflight",
+    );
+  }
+  const acknowledgement: HeadroomToolPolicyAcknowledgement = {
+    version: 1,
+    event: "headroom_tool_policy_enforcement_acknowledgement",
+    decisionId: preflight.decision.decisionId,
+    authority: "authoritative",
+    effect: "unknown",
+    reason,
     requestHash: preflight.decision.requestHash,
     binding,
     timestamp: new Date().toISOString(),

--- a/plugins/opencode/test/fixtures/tool_policy_conformance.json
+++ b/plugins/opencode/test/fixtures/tool_policy_conformance.json
@@ -1,0 +1,277 @@
+[
+  {
+    "name": "deny direct shell command",
+    "policy": {
+      "version": 1,
+      "rules": [
+        {
+          "id": "deny-curl",
+          "scope": "shell",
+          "action": "deny",
+          "command": "curl"
+        }
+      ]
+    },
+    "request": {
+      "tool": "bash",
+      "input": {
+        "command": "curl https://example.com"
+      }
+    },
+    "expected": {
+      "action": "deny",
+      "effectiveAction": "deny",
+      "matchedRule": "deny-curl"
+    }
+  },
+  {
+    "name": "deny command in compound shell line",
+    "policy": {
+      "version": 1,
+      "rules": [
+        {
+          "id": "deny-curl",
+          "scope": "shell",
+          "action": "deny",
+          "command": "curl"
+        }
+      ]
+    },
+    "request": {
+      "tool": "bash",
+      "input": {
+        "command": "echo ready && env TOKEN=x curl https://example.com"
+      }
+    },
+    "expected": {
+      "action": "deny",
+      "effectiveAction": "deny",
+      "matchedRule": "deny-curl"
+    }
+  },
+  {
+    "name": "deny command nested in shell wrapper",
+    "policy": {
+      "version": 1,
+      "rules": [
+        {
+          "id": "deny-rm",
+          "scope": "shell",
+          "action": "deny",
+          "command": "rm"
+        }
+      ]
+    },
+    "request": {
+      "tool": "bash",
+      "input": {
+        "command": "bash -c \"echo checking; rm -rf build\""
+      }
+    },
+    "expected": {
+      "action": "deny",
+      "effectiveAction": "deny",
+      "matchedRule": "deny-rm"
+    }
+  },
+  {
+    "name": "deny command substitution on later line",
+    "policy": {
+      "version": 1,
+      "rules": [
+        {
+          "id": "deny-curl",
+          "scope": "shell",
+          "action": "deny",
+          "command": "curl"
+        }
+      ]
+    },
+    "request": {
+      "tool": "bash",
+      "input": {
+        "command": "echo ready\nvalue=$(curl https://example.com)"
+      }
+    },
+    "expected": {
+      "action": "deny",
+      "effectiveAction": "deny",
+      "matchedRule": "deny-curl"
+    }
+  },
+  {
+    "name": "match non-shell native tool",
+    "policy": {
+      "version": 1,
+      "rules": [
+        {
+          "id": "protect-production",
+          "scope": "tool_call",
+          "action": "require_approval",
+          "tool": [
+            "write_file",
+            "apply_patch"
+          ],
+          "argsPattern": "production"
+        }
+      ]
+    },
+    "request": {
+      "tool": "write_file",
+      "input": {
+        "path": "config/production.env"
+      }
+    },
+    "expected": {
+      "action": "require_approval",
+      "effectiveAction": "require_approval",
+      "matchedRule": "protect-production"
+    }
+  },
+  {
+    "name": "first matching rule wins",
+    "policy": {
+      "version": 1,
+      "rules": [
+        {
+          "id": "allow-status",
+          "scope": "shell",
+          "action": "allow",
+          "command": "git",
+          "argsPattern": "\\bstatus\\b"
+        },
+        {
+          "id": "deny-git",
+          "scope": "shell",
+          "action": "deny",
+          "command": "git"
+        }
+      ]
+    },
+    "request": {
+      "tool": "bash",
+      "input": {
+        "command": "git status"
+      }
+    },
+    "expected": {
+      "action": "allow",
+      "effectiveAction": "allow",
+      "matchedRule": "allow-status"
+    }
+  },
+  {
+    "name": "tool cwd constraint prevents broad allow",
+    "policy": {
+      "version": 1,
+      "rules": [
+        {
+          "id": "allow-safe-write",
+          "scope": "tool_call",
+          "action": "allow",
+          "tool": "write_file",
+          "cwdPattern": "^/safe$"
+        },
+        {
+          "id": "deny-other-writes",
+          "scope": "tool_call",
+          "action": "deny",
+          "tool": "write_file"
+        }
+      ]
+    },
+    "request": {
+      "tool": "write_file",
+      "cwd": "/unsafe",
+      "input": {
+        "path": "settings.json"
+      }
+    },
+    "expected": {
+      "action": "deny",
+      "effectiveAction": "deny",
+      "matchedRule": "deny-other-writes"
+    }
+  },
+  {
+    "name": "tool environment constraint prevents broad allow",
+    "policy": {
+      "version": 1,
+      "rules": [
+        {
+          "id": "allow-ci-deploy",
+          "scope": "tool_call",
+          "action": "allow",
+          "tool": "deploy",
+          "envKeys": [
+            "CI"
+          ]
+        },
+        {
+          "id": "deny-local-deploy",
+          "scope": "tool_call",
+          "action": "deny",
+          "tool": "deploy"
+        }
+      ]
+    },
+    "request": {
+      "tool": "deploy",
+      "env": {},
+      "input": {
+        "environment": "production"
+      }
+    },
+    "expected": {
+      "action": "deny",
+      "effectiveAction": "deny",
+      "matchedRule": "deny-local-deploy"
+    }
+  },
+  {
+    "name": "report only preserves recorded denial",
+    "policy": {
+      "version": 1,
+      "mode": "report_only",
+      "rules": [
+        {
+          "id": "audit-push",
+          "scope": "shell",
+          "action": "deny",
+          "command": "git",
+          "argsPattern": "\\bpush\\b"
+        }
+      ]
+    },
+    "request": {
+      "tool": "powershell",
+      "input": {
+        "command": "git push origin main"
+      }
+    },
+    "expected": {
+      "action": "deny",
+      "effectiveAction": "allow",
+      "matchedRule": "audit-push"
+    }
+  },
+  {
+    "name": "default deny unmatched tool",
+    "policy": {
+      "version": 1,
+      "defaultAction": "deny",
+      "rules": []
+    },
+    "request": {
+      "tool": "read_file",
+      "input": {
+        "path": "README.md"
+      }
+    },
+    "expected": {
+      "action": "deny",
+      "effectiveAction": "deny",
+      "matchedRule": null
+    }
+  }
+]


### PR DESCRIPTION
## Description

Adds an external OpenCode policy adapter for commands and native tool calls, following the direction discussed in #3279. Policies can come from an explicit plugin option, environment JSON/path, a machine-global or repository file, or an authenticated remote service with credential-bound ETag caching.

The native OpenCode lifecycle is the authority boundary: decisions bind caller, session, call/task, tool, effective cwd, and canonical arguments. Blocked calls acknowledge the committed throw; successful calls are acknowledged only after OpenCode reports completion with the same frozen arguments. Calls with no observable postflight receive a bounded, terminal `unknown` outcome. Process transport checks are explicitly advisory.

Closes #3279

### Scope: OpenCode MVP only

This PR intentionally implements **one host adapter: OpenCode**. It does not add policy enforcement to Headroom core, Claude Code, Copilot CLI, Codex, VS Code, or other agent hosts.

That scope directly follows the issue guidance:

> “The smallest first slice may be a generic decision/acknowledgement envelope plus one host adapter, before adding broad shell/URL matchers.”
>
> “We would like this to be an external plugin - for Headroom within its repo.”

The reusable concepts in this PR are the policy schema, decision/binding envelope, terminal acknowledgement model, source precedence, remote cache behavior, and conformance fixtures. OpenCode is the first authoritative executor adapter because it exposes native tool lifecycle hooks.

A broader cross-tool prototype already exists on the separate [`ewassef-agent-command-policies`](https://github.com/ewassef/headroom/tree/ewassef-agent-command-policies) branch, including experimental Claude Code, Copilot CLI, and Codex adapters. It is deliberately excluded from this PR and is **not presented as production-ready or approved design**. After this MVP contract is accepted, those hosts can be proposed as separate, reviewable follow-ups using the accepted generic contract and each host's actual enforcement boundary.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add local/global/remote policy loading with deterministic precedence, redirect rejection, bounded refresh, ETag revalidation, atomic credential-bound caching, expiry, and fail-closed outages.
- Enforce bound native decisions in `tool.execute.before`, freeze authorized arguments against later-hook mutation, and acknowledge successful execution only from `tool.execute.after`.
- Bind independently supplied task and call IDs; retain a call-ID fallback for current OpenCode hooks that expose no separate task ID.
- Bound pending preflights to 1,024 entries and five minutes by default; emit terminal `unknown` outcomes for timeout, capacity eviction, disposal, replacement, mismatch, and ambiguous reused calls.
- Use unique authoritative decision IDs and frozen argument-object correlation so a late postflight cannot acknowledge a newer reused call.
- Treat `fetch`/Node HTTP and child-process interception as advisory defense in depth; include a negative native-plus-alternate-path denial test.
- Fail closed on shell grammar that cannot be statically authorized, including default-deny allowlists, and require allow rules to cover every executable in compound commands.
- Keep logical project metadata separate from filesystem policy roots, normalize effective native and child-process working directories, and prevent cross-workspace singleton policy replacement.
- Keep remote bearer tokens and signed policy URLs out of shell and child environments and secret-safe audits.
- Replace the package README with getting-started, individual, team, and enterprise how-tos plus policy reference, rollout, audit, recovery, and troubleshooting guidance.

## Testing

- [ ] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
cd plugins/opencode
npm test -- --reporter=dot --silent

Test Files  2 passed (2)
Tests  70 passed (70)

npm run typecheck
> node node_modules/@typescript/native/bin/tsc --noEmit

npm run build
ESM Build success
DTS Build success

npm pack --dry-run --json
name: headroom-opencode
version: 0.37.0
entryCount: 12
size: 214386 bytes
```

The same test, typecheck, build, and package validation passed again after rebasing onto current `upstream/main`; the branch is zero commits behind.

Python `pytest`, Ruff, and mypy are not checked because this external-plugin-only diff changes no Python files.

## Real Behavior Proof

- Environment: Windows NT 10.0.26200.0; Node v22.9.0; npm 10.8.3; built `plugins/opencode/dist/index.js`; inline enforce-mode policy denying `node` shell invocations.
- Exact command / steps: `npm run build`, then `node C:\Users\eddie\.copilot\session-state\c216e1c5-8385-4026-8be9-6757f6c449d4\files\opencode-policy-proof.mjs`. The script invokes the built plugin's native before/after hooks and the wrapped `child_process.exec` alternate path.
- Observed result: The built plugin blocked the native invocation with an authoritative bound receipt, blocked the alternate child-process path with advisory authority, left the safe preflight pending, and acknowledged it only after the matching postflight.

```text
native=DENIED authority=authoritative ack=blocked session=proof-session call=proof-call-deny
alternate=DENIED authority=advisory
safe_preflight=ALLOWED acknowledgement=pending
safe=COMPLETED authoritative_ack_emitted=true
```

The emitted JSON records used matching decision/request/binding hashes; the allowed acknowledgement appeared only after `tool.execute.after`.

- Not tested: macOS/Linux runtime; a live hosted remote-policy endpoint; interactive approval (currently fails closed); an end-user OpenCode UI session; VS Code or other agent hosts.

## Runtime Rollout Safety

- Rollout-managed feature(s): OpenCode tool-policy enforcement only.
- Minimum rollout channel: Explicit plugin installation plus a configured policy; no policy means existing behavior.
- Stable/default behavior changed: No behavior change for users without a policy. Restrictive shell policies intentionally fail closed on unsupported dynamic grammar.
- Kill switch / disable path: Remove the policy option/environment/file, or remove the plugin from OpenCode configuration.
- Unsafe override required: None.
- Qualification impact: OpenCode plugin tests, typecheck, production build, package dry-run, built-artifact behavior proof, and blocking-only code review.
- Rollback path: Revert the feature commits or remove the optional plugin/policy configuration; no data migration is involved.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A. Concrete terminal output is included above.

## Additional Notes

### Maintainer feedback mapping

- External plugin: all changes are contained in `plugins/opencode/**`; no core policy engine or cross-agent initialization changes are included.
- Authorization boundary: native OpenCode lifecycle decisions are authoritative and fully bound; proxy/transport filtering is advisory and acknowledgement-free.
- Executor acknowledgement: blocked acknowledgement follows the committed throw; successful acknowledgement requires a matching `tool.execute.after` callback.
- Error-path design: OpenCode has no error hook, so pending preflights are bounded and expiring. Every removal path emits exactly one terminal `allowed` or `unknown` outcome; `unknown` never claims whether execution succeeded or failed.
- Reused call safety: authoritative decisions are unique and frozen argument graphs are weakly retired, preventing late postflights from acknowledging newer generations.
- Alternate path proof: tests and the built-artifact run deny the same `node` action through the native hook and wrapped child-process path while preserving authority labels.
- Dynamic shell authorization: unsupported grammar fails closed for both explicit deny/approval policies and default-deny allowlists.
- Project and task binding: logical project IDs are not replaced with absolute filesystem roots, and independently supplied task IDs are distinct from call IDs.
- Documentation: the README includes a five-minute getting started path, personal and repository policies, enterprise remote-service deployment, rollout checklist, audit operations, recovery, and troubleshooting.

### User stories and failure modes

- Given a repository or global policy denying a command, when OpenCode requests it directly, then the bound invocation is blocked and audited.
- Given a safe native request, when final arguments still match the frozen preflight, then completion receives a matching acknowledgement.
- Given an allowed request that fails or is cancelled without a postflight, then its bounded preflight terminates as `unknown` rather than leaking or falsely claiming success.
- Given a stale remote cache and unavailable service, when the cache expires, then policy evaluation fails closed rather than silently allowing.
- Given a second workspace with an incompatible policy/credential context in the same process, then installation is rejected rather than weakening the active workspace.

No dependencies or lockfiles are changed.