### PR TITLE
fix(ccr): scan non-text tool_result blocks so markers stay redeemable

### DIFF
--- a/headroom/ccr/tool_injection.py
+++ b/headroom/ccr/tool_injection.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, ClassVar, Protocol, runtime_checkable
 
 # Tool name constant - used for matching tool calls
 CCR_TOOL_NAME = "headroom_retrieve"
@@ -178,6 +178,10 @@ class CCRToolInjector:
             messages = injector.inject_system_instructions(messages)
     """
 
+    # Depth bound for `_scan_any`. Real tool results nest a few levels;
+    # this only stops a pathological payload recursing without limit.
+    MAX_SCAN_DEPTH: ClassVar[int] = 32
+
     provider: str = "anthropic"
     inject_tool: bool = True
     inject_system_instructions: bool = True
@@ -266,15 +270,22 @@ class CCRToolInjector:
                         # Text blocks
                         if block.get("type") == "text":
                             self._scan_text(block.get("text", ""))
-                        # Tool result blocks
+                        # Tool result blocks. Walked structurally rather than
+                        # by block type: the writer side
+                        # (`DocumentCompactor::walk_string`) classifies EVERY
+                        # string in the payload tree, so it can leave a marker
+                        # under `resource.text` of an MCP `resource` block
+                        # (Slack's `text/html;profile=mcp-app`), inside a
+                        # nested container, or under any key it never had to
+                        # know the name of. Matching only `type == "text"`
+                        # here made those markers invisible to the scan, so
+                        # the retrieve tool was never injected and the model
+                        # got a marker it could not redeem — the silent-loss
+                        # class of #1006 reached through a different block
+                        # type. Over-collecting is safe: `verify_ownership`
+                        # drops every hash this proxy did not store.
                         elif block.get("type") == "tool_result":
-                            tool_content = block.get("content", "")
-                            if isinstance(tool_content, str):
-                                self._scan_text(tool_content)
-                            elif isinstance(tool_content, list):
-                                for item in tool_content:
-                                    if isinstance(item, dict) and item.get("type") == "text":
-                                        self._scan_text(item.get("text", ""))
+                            self._scan_any(block.get("content", ""))
 
             # Handle Google/Gemini format with parts
             parts = message.get("parts", [])
@@ -318,6 +329,26 @@ class CCRToolInjector:
                     hash_key = match  # Single capture group (generic pattern)
                 if hash_key and hash_key not in self._detected_hashes:
                     self._detected_hashes.append(hash_key)
+
+    def _scan_any(self, node: Any, _depth: int = 0) -> None:
+        """Recursively scan every string reachable under ``node``.
+
+        Mirrors the writer's own generality: the compactor walks the
+        payload tree without caring which key a string sits under, so the
+        scan has to as well. Depth is bounded to keep a pathological
+        (or hostile) payload from blowing the Python stack; real tool
+        results nest a few levels at most.
+        """
+        if _depth > self.MAX_SCAN_DEPTH:
+            return
+        if isinstance(node, str):
+            self._scan_text(node)
+        elif isinstance(node, dict):
+            for value in node.values():
+                self._scan_any(value, _depth + 1)
+        elif isinstance(node, list):
+            for item in node:
+                self._scan_any(item, _depth + 1)
 
     def verify_ownership(self, store: _HashOwnershipStore | None = None) -> list[str]:
         """Drop any detected hash the compression store doesn't recognize.

--- a/tests/test_ccr_tool_injection.py
+++ b/tests/test_ccr_tool_injection.py
@@ -795,3 +795,71 @@ class TestVerifyOwnership:
         result = injector.verify_ownership()
 
         assert result == []
+
+
+class TestScanReachesNonTextBlocks:
+    """The scan must reach every string the compactor can write a marker
+    into, not just `type: "text"` blocks.
+
+    `DocumentCompactor::walk_string` classifies EVERY string in the
+    payload tree, so a marker can land under `resource.text` of an MCP
+    `resource` block (Slack returns `text/html;profile=mcp-app`) or
+    inside an arbitrarily nested container. Scanning only text blocks
+    left those markers undetected, so `headroom_retrieve` was never
+    injected and the model got a marker it could not redeem.
+    """
+
+    MARKER = "<<ccr:d418eab1ee6e,html,13.8KB>>"
+
+    def _scan(self, tool_content):
+        injector = CCRToolInjector(provider="anthropic")
+        return injector.scan_for_markers(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": tool_content,
+                        }
+                    ],
+                }
+            ]
+        )
+
+    def test_marker_in_text_block_still_detected(self):
+        assert self._scan([{"type": "text", "text": self.MARKER}]) == ["d418eab1ee6e"]
+
+    def test_marker_in_mcp_resource_block_is_detected(self):
+        assert self._scan(
+            [
+                {
+                    "type": "resource",
+                    "resource": {
+                        "mimeType": "text/html;profile=mcp-app",
+                        "text": self.MARKER,
+                    },
+                }
+            ]
+        ) == ["d418eab1ee6e"]
+
+    def test_marker_in_deeply_nested_container_is_detected(self):
+        assert self._scan(
+            [
+                {"type": "text", "text": "summary line"},
+                {"type": "resource", "resource": {"blob": {"rows": [{"cell": self.MARKER}]}}},
+            ]
+        ) == ["d418eab1ee6e"]
+
+    def test_string_tool_content_still_detected(self):
+        assert self._scan(self.MARKER) == ["d418eab1ee6e"]
+
+    def test_unmarked_content_detects_nothing(self):
+        assert self._scan([{"type": "resource", "resource": {"text": "no marker here"}}]) == []
+
+    def test_recursion_is_depth_bounded(self):
+        node = self.MARKER
+        for _ in range(CCRToolInjector.MAX_SCAN_DEPTH * 2):
+            node = {"nested": node}
+        assert self._scan(node) == []


### PR DESCRIPTION
## Description

`CCRToolInjector.scan_for_markers` only inspected `tool_result` items whose `type == "text"`. The writer side (`DocumentCompactor::walk_string`) classifies **every** string in the payload tree, so it can leave a marker in a string the scanner never looks at — `resource.text` of an MCP `resource` block, for instance. The hash then goes undetected, `has_compressed_content` stays `False`, `headroom_retrieve` is never injected, and the model is left holding a marker it cannot redeem.

Concrete trigger: Slack's MCP server returns `text/html;profile=mcp-app` resource blocks. Those classify as `OpaqueKind::HtmlChunk`, get marked, and then vanish from the scan. Same silent-loss class as #1006, reached through a different block type.

Closes #3383

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `scan_for_markers` now walks `tool_result` content structurally via a new `_scan_any`, instead of matching `type == "text"` — mirroring the writer's own generality.
- Added `_scan_any`: recursive walk over `str` / `dict` / `list`, bounded by `MAX_SCAN_DEPTH` (`ClassVar`, 32) so a pathological or hostile payload cannot blow the Python stack.
- No change to `verify_ownership`. Over-collecting is safe by construction — it already drops every hash this proxy did not store (#2836), so widening the scan cannot adopt a foreign marker.
- Added `TestScanReachesNonTextBlocks` with six cases: text block, MCP resource block, deeply nested container, plain-string content, an unmarked-content negative, and the depth bound.
- Untouched: the Google/Gemini `parts` path, the OpenAI path, and the marker regexes.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_ccr_tool_injection.py tests/test_ccr_marker_policy.py \
    tests/test_ccr_tool_always_on.py tests/test_ccr_golden_policy.py -q
============================== 76 passed in 0.55s ==============================

# the three new cases, run against the pre-patch scanner:
$ git show main:headroom/ccr/tool_injection.py > headroom/ccr/tool_injection.py
$ python -m pytest tests/test_ccr_tool_injection.py -q -k ScanReachesNonTextBlocks
================== 3 failed, 3 passed, 47 deselected in 0.34s ==================

$ ruff check .
All checks passed!

$ python -m mypy headroom
Success: no issues found in 529 source files
```

## Real Behavior Proof

- Environment: macOS 26.5.2 (arm64), Python 3.11.16, headroom `0.38.0-dev` @ `1390d89`, installed with `uv pip install -e ".[proxy]"`, Rust core present (`headroom._core` imports), provider Anthropic.
- Exact command / steps: drove the real Rust `SmartCrusher` (via `headroom._core`) and the real `CCRToolInjector` — no mocks, stubs, or fixtures — over a 400-row HTML payload placed in `resource.text` of an MCP resource block inside an Anthropic `tool_result`, then handed the crusher's actual output to the injector. Script and full output below.
- Observed result: identical marker in both runs, but the tool list gains `headroom_retrieve` only after the patch. Before: scanner detects nothing, tools stay `['slack_read_thread']`, marker is a dead end. After: scanner detects `78ab6642defb`, ownership confirms it, tools become `['slack_read_thread', 'headroom_retrieve']`, marker is redeemable. Full transcript below.
- Not tested: no live Claude Code session end-to-end through a running proxy (the HTTP layer between crusher and injector is not exercised); whether Slack's real resource blocks reliably clear `opaque_min_bytes` (my payload was sized to cross it deliberately); no Rust-side change and no `cargo test`, since `tool_injection.py` has no Rust port per `crates/headroom-parity/src/lib.rs:158`; other providers, as the Google/Gemini `parts` path and the OpenAI path are unchanged.

The steps, verbatim:

```python
crushed = json.loads(SmartCrusher(SmartCrusherConfig()).crush(json.dumps([
    {"type": "text", "text": "Thread loaded."},
    {"type": "resource", "resource": {"mimeType": "text/html;profile=mcp-app", "text": HTML}},
])).compressed)

inj = CCRToolInjector(provider="anthropic")
hashes = inj.scan_for_markers([{"role": "user", "content": [
    {"type": "tool_result", "tool_use_id": "toolu_e2e", "content": crushed}]}])
inj.verify_ownership()                  # store stands in for the hash the crusher stashed
tools, _ = inj.inject_tool_definition([{"name": "slack_read_thread", ...}])
```

Before the fix, on unmodified `1390d89`:

```text
1. SmartCrusher wrote : <<ccr:78ab6642defb,html,29.5KB>>
   (into resource.text of an audience=user mcp-app block)
2. Scanner detected   : NOTHING
3. After ownership    : NOTHING
4. Tools sent to model: ['slack_read_thread']
5. VERDICT            : headroom_retrieve MISSING — marker is a dead end
```

After the fix:

```text
1. SmartCrusher wrote : <<ccr:78ab6642defb,html,29.5KB>>
2. Scanner detected   : ['78ab6642defb']
3. After ownership    : ['78ab6642defb']
4. Tools sent to model: ['slack_read_thread', 'headroom_retrieve']
5. VERDICT            : headroom_retrieve INJECTED — marker redeemable
```

The crusher reports `strategy = string_ccr:html`, confirming it really does write into `resource.text` rather than this being a hypothetical shape:

```text
compressed = [{"type":"text","text":"Thread loaded."},
              {"type":"resource","resource":{"mimeType":"text/html;profile=mcp-app",
               "text":"<<ccr:060d3e833b25,html,17.8KB>>"}}]
strategy   = string_ccr:html
```

Also confirmed in a shipped build: an independently installed `0.33.0` on the same machine reports `scans resource blocks: False`, `has _scan_any: False`, `only-text gate present: True`. So this is live in a released version, not only on `main`.

I did stand up a local proxy against a fake upstream first; in `--mode cache` every request came back `prefix_frozen`, which is correct behavior and simply not the path under test, so the direct-component route above is what the evidence rests on.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. This is a defect fix inside the existing CCR marker scan; it adds no flag and is not gated behind a rollout channel.
- Minimum rollout channel: N/A, ships with the normal release.
- Stable/default behavior changed: yes, narrowly and intentionally — markers that were previously undetected are now detected, so `headroom_retrieve` is injected where it previously was not. Reviewer's eye welcome here: that changes the `body["tools"]` bytes, which is prompt-cache-relevant. I believe this is the situation the `session_has_done_ccr` sticky-on path (PR-B7) already exists to handle, since the tool must stay pinned once a session has done CCR, but I have not measured cache-hit rate before and after and you know that machinery better than I do.
- Kill switch / disable path: unchanged and several — `enable_ccr_marker=false` / `opaque_markers_enabled()` false suppresses markers at the source so there is nothing to scan; `config.optimize=False` disables compression entirely; the `x-headroom-bypass: true` and `x-headroom-mode: passthrough` headers bypass per request.
- Unsafe override required: no.
- Qualification impact: none expected — no dependency, schema, wire-format, or config-surface change, and the only new public-ish surface is the `MAX_SCAN_DEPTH` class attribute.
- Rollback path: revert this commit. It touches one function plus one new private helper in a single module, with no migration and no persisted state.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

Documentation is left unchecked deliberately: this restores intended behavior rather than changing a documented contract, and I found nothing in `docs/` made stale by it. Happy to add something if you disagree.

There is a design question I deliberately kept out of this PR. Those `mcp-app` blocks are annotated `audience: ["user"]` — UI payloads the model never needed. Making them *retrievable* may be the wrong repair; not marking them at all would be better. That is a behavior change, so per CONTRIBUTING I raised it in #3383 rather than bundling it here. Happy to follow up if you would rather go that route, in which case this PR becomes the narrower safety net underneath it.

`mypy headroom` emits pre-existing `annotation-unchecked` notes in `headroom/proxy/server.py`; those are untouched by this change and it still reports success.
