### PR TITLE
fix(savings): price compression savings at the request's realized input rate

### DIFF
--- a/headroom/proxy/prometheus_metrics.py
+++ b/headroom/proxy/prometheus_metrics.py
@@ -788,6 +788,8 @@ class PrometheusMetrics:
             tool_schema_tokens_saved=tool_search_saved,
             output_tokens_saved=output_tokens_saved,
             cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            uncached_input_tokens=uncached_input_tokens,
         )
         async with self._lock:
             self.requests_total += 1

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -243,8 +243,47 @@ def _resolve_litellm_model(model: str) -> str:
     return model
 
 
-def _estimate_compression_savings_usd(model: str, tokens_saved: int) -> float:
-    """Estimate compression savings in USD from saved input tokens."""
+def _estimate_compression_savings_usd(
+    model: str,
+    tokens_saved: int,
+    *,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    uncached_input_tokens: int = 0,
+) -> float:
+    """Estimate compression savings in USD from saved input tokens.
+
+    When the caller supplies the request's cache read/write/uncached breakdown,
+    saved tokens price at that request's realized blended input rate — the same
+    split ``_estimate_input_cost_usd`` prices real spend with. Removed bytes
+    would have travelled in this request's mix: a removal on a cold request
+    would have billed near list (or the cache-write premium), while a removal
+    re-applied on a warm-prefix turn would have billed at the provider's
+    cache-read discount. Flat list pricing values every re-applied removal at
+    full rate every turn, which overstates cache-heavy traffic roughly 7x
+    (a 94%-cache-read mix bills near 10% of list). Lifetime twin of
+    ``cost.py``'s session-scoped ``cache_aware_savings_usd``.
+
+    Without a breakdown (legacy checkpoints, callers that never learned the
+    split) the historical flat-list behavior is unchanged.
+    """
+    saved = _coerce_int(tokens_saved)
+    if saved <= 0:
+        return 0.0
+    breakdown_tokens = (
+        max(_coerce_int(cache_read_tokens), 0)
+        + max(_coerce_int(cache_write_tokens), 0)
+        + max(_coerce_int(uncached_input_tokens), 0)
+    )
+    if breakdown_tokens > 0:
+        realized_input_cost = _estimate_input_cost_usd(
+            model,
+            0,
+            cache_read_tokens=max(_coerce_int(cache_read_tokens), 0),
+            cache_write_tokens=max(_coerce_int(cache_write_tokens), 0),
+            uncached_input_tokens=max(_coerce_int(uncached_input_tokens), 0),
+        )
+        return float(saved) * (realized_input_cost / float(breakdown_tokens))
     litellm = _get_litellm_module()
     if tokens_saved <= 0:
         return 0.0
@@ -336,6 +375,8 @@ def estimate_request_savings_usd(
     tool_schema_tokens_saved: int = 0,
     output_tokens_saved: int = 0,
     cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    uncached_input_tokens: int = 0,
 ) -> dict[str, float]:
     """Price one request's distinct savings layers for external telemetry.
 
@@ -346,7 +387,11 @@ def estimate_request_savings_usd(
 
     return {
         "compression": _estimate_compression_savings_usd(
-            model, max(_coerce_int(compression_tokens_saved), 0)
+            model,
+            max(_coerce_int(compression_tokens_saved), 0),
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            uncached_input_tokens=uncached_input_tokens,
         ),
         "tool_schema": _estimate_compression_savings_usd(
             model, max(_coerce_int(tool_schema_tokens_saved), 0)
@@ -702,6 +747,8 @@ class SavingsTracker:
         if timestamp_dt is None:
             timestamp_dt = _utc_now()
 
+        # Checkpoint callers have no cache breakdown, so this path keeps the
+        # historical flat-list pricing (see _estimate_compression_savings_usd).
         delta_usd = _estimate_compression_savings_usd(model, delta_tokens)
 
         with self._lock:
@@ -810,7 +857,13 @@ class SavingsTracker:
         else:
             # No priced breakdown available: only message savings are known here,
             # so this path stays message-only exactly as before.
-            delta_savings_usd = _estimate_compression_savings_usd(model, delta_tokens_saved)
+            delta_savings_usd = _estimate_compression_savings_usd(
+                model,
+                delta_tokens_saved,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+                uncached_input_tokens=uncached_input_tokens,
+            )
         delta_output_savings_usd = (
             max(_coerce_float(priced.get("output_shaping")), 0.0)
             if priced is not None
@@ -987,7 +1040,13 @@ class SavingsTracker:
         )
         metrics.setdefault(
             "compression_savings_usd",
-            _estimate_compression_savings_usd(model, _coerce_int(metrics.get("tokens_saved"))),
+            _estimate_compression_savings_usd(
+                model,
+                _coerce_int(metrics.get("tokens_saved")),
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+                uncached_input_tokens=uncached_input_tokens,
+            ),
         )
         metrics.setdefault(
             "cache_savings_usd", _estimate_cache_savings_usd(model, cache_read_tokens)

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -35,6 +35,10 @@ HEADROOM_SAVINGS_PATH_ENV_VAR = _paths.HEADROOM_SAVINGS_PATH_ENV
 DEFAULT_SAVINGS_DIR = ".headroom"
 DEFAULT_SAVINGS_FILE = "proxy_savings.json"
 SCHEMA_VERSION = 5
+# Pricing era of the persisted dollar figures. State written before compression
+# savings moved to the request's realized input rate carries no marker and is
+# repriced once on load (_reprice_state_to_realized_basis).
+PRICING_BASIS_REALIZED = "realized"
 DEFAULT_MAX_HISTORY_POINTS = 5000
 DEFAULT_MAX_PROJECTS = 50
 DEFAULT_MAX_HISTORY_AGE_DAYS = 365
@@ -264,6 +268,14 @@ def _estimate_compression_savings_usd(
     (a 94%-cache-read mix bills near 10% of list). Lifetime twin of
     ``cost.py``'s session-scoped ``cache_aware_savings_usd``.
 
+    The blended rate is an UPPER BOUND on what removals were worth, not the
+    exact realized rate for them. Removals are re-applied each turn to keep the
+    wire form byte-identical to the cached prefix, so they concentrate in the
+    cached region, whose marginal rate is cache-read rather than the blend.
+    On a 940k/40k/20k read/write/uncached mix that is $1.00/M against a $1.64/M
+    blend. Bounding it exactly needs per-removal cache-region attribution, which
+    the savings path does not carry; the blend is the tight, cheap over-estimate.
+
     Without a breakdown (legacy checkpoints, callers that never learned the
     split) the historical flat-list behavior is unchanged.
     """
@@ -285,8 +297,6 @@ def _estimate_compression_savings_usd(
         )
         return float(saved) * (realized_input_cost / float(breakdown_tokens))
     litellm = _get_litellm_module()
-    if tokens_saved <= 0:
-        return 0.0
     if litellm is None:
         return float(tokens_saved) * float(DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN)
 
@@ -466,6 +476,81 @@ def _estimate_input_cost_usd(
         return float(total_input_tokens) * float(input_cost_per_token)
     except Exception:
         return float(chargeable_tokens) * float(DEFAULT_FALLBACK_INPUT_COST_PER_TOKEN)
+
+
+def _normalize_pricing_basis(raw: Any) -> str:
+    """Anything but the realized marker means "legacy, needs restating"."""
+    return PRICING_BASIS_REALIZED if raw == PRICING_BASIS_REALIZED else "legacy"
+
+
+def _realized_input_rate(entry: Any) -> float | None:
+    """Realized $/input-token implied by a persisted aggregate, or None.
+
+    Every persisted aggregate (lifetime, history point, project, model, display
+    session) carries ``total_input_tokens`` and ``total_input_cost_usd``, and
+    that cost was already priced on the request's cache split. Their ratio is
+    the realized input rate for exactly the traffic that aggregate covers.
+    """
+    if not isinstance(entry, dict):
+        return None
+    tokens = _coerce_int(entry.get("total_input_tokens"))
+    cost = _coerce_float(entry.get("total_input_cost_usd"))
+    if tokens <= 0 or cost <= 0:
+        return None
+    return cost / float(tokens)
+
+
+def _reprice_entry_to_realized(entry: Any, tokens_key: str, fallback_rate: float) -> None:
+    """Restate one aggregate's compression dollars at the realized rate."""
+    if not isinstance(entry, dict):
+        return
+    rate = _realized_input_rate(entry)
+    if rate is None:
+        rate = fallback_rate
+    saved = max(_coerce_int(entry.get(tokens_key)), 0)
+    entry["compression_savings_usd"] = round(float(saved) * rate, 6)
+
+
+def _reprice_state_to_realized_basis(state: dict[str, Any]) -> bool:
+    """One-time restatement of a list-priced ledger onto the realized basis.
+
+    Without this the lifetime ledger holds list-priced dollars from before the
+    pricing fix and realized-rate dollars from after it, indistinguishable, with
+    the headline converging only as old entries age out - which leaves the
+    reported bug substantially unfixed for existing installs.
+
+    No new per-entry field is needed to tell the eras apart: ``tokens_saved``
+    and the realized rate are both already persisted on every aggregate, so the
+    dollars are simply recomputed from them. Each aggregate uses its own rate
+    where it has one (so a history point is restated at the rate that prevailed
+    up to that point and the derived day/provider/model deltas stay consistent),
+    falling back to the lifetime rate. Returns False when there is nothing to
+    reprice against yet, in which case the marker is not written and the
+    restatement is retried on the next load.
+    """
+    lifetime = state.get("lifetime")
+    rate = _realized_input_rate(lifetime)
+    if rate is None:
+        # Nothing priced yet: only stamp when there are no legacy dollars to
+        # restate, otherwise wait for a rate rather than freezing list prices in.
+        return _coerce_float((lifetime or {}).get("compression_savings_usd")) <= 0.0
+
+    _reprice_entry_to_realized(lifetime, "tokens_saved", rate)
+    _reprice_entry_to_realized(state.get("display_session"), "tokens_saved", rate)
+    for point in state.get("history") or []:
+        _reprice_entry_to_realized(point, "total_tokens_saved", rate)
+    for bucket in ("projects", "by_model"):
+        for entry in (state.get(bucket) or {}).values():
+            _reprice_entry_to_realized(entry, "tokens_saved", rate)
+
+    metrics = state.get("lifetime_metrics")
+    if isinstance(metrics, dict):
+        cost = metrics.get("cost")
+        tokens = metrics.get("tokens")
+        if isinstance(cost, dict) and isinstance(tokens, dict):
+            saved = max(_coerce_int(tokens.get("saved")), 0)
+            cost["compression_savings_usd"] = round(float(saved) * rate, 6)
+    return True
 
 
 def _normalize_history_entry(entry: Any) -> dict[str, Any] | None:
@@ -1328,6 +1413,7 @@ class SavingsTracker:
             history = [dict(item) for item in self._state["history"]]
             return {
                 "schema_version": SCHEMA_VERSION,
+                "pricing_basis": self._state.get("pricing_basis", PRICING_BASIS_REALIZED),
                 "storage_path": str(self._path),
                 "lifetime": dict(self._state["lifetime"]),
                 "display_session": self._display_session_snapshot_locked(),
@@ -1347,6 +1433,7 @@ class SavingsTracker:
     def _default_state(self) -> dict[str, Any]:
         return {
             "schema_version": SCHEMA_VERSION,
+            "pricing_basis": PRICING_BASIS_REALIZED,
             "lifetime": {
                 "requests": 0,
                 "tokens_saved": 0,
@@ -1466,6 +1553,12 @@ class SavingsTracker:
             state["lifetime_metrics"] = raw_lifetime_metrics
         else:
             state["lifetime_metrics"] = self._migrate_v4_lifetime_metrics(state)
+            self._needs_schema_save = True
+
+        state["pricing_basis"] = _normalize_pricing_basis(raw.get("pricing_basis"))
+        if state["pricing_basis"] != PRICING_BASIS_REALIZED:
+            if _reprice_state_to_realized_basis(state):
+                state["pricing_basis"] = PRICING_BASIS_REALIZED
             self._needs_schema_save = True
 
         if normalized_history:
@@ -1623,6 +1716,9 @@ class SavingsTracker:
             lifetime_metrics["persistence"]["last_saved_at"] = saved_at
             payload = {
                 "schema_version": SCHEMA_VERSION,
+                # Pricing era of the dollars below, so the one-time restatement
+                # onto the realized basis runs once per install and not again.
+                "pricing_basis": self._state.get("pricing_basis", PRICING_BASIS_REALIZED),
                 "lifetime": self._state["lifetime"],
                 "display_session": self._state["display_session"],
                 "history": self._state["history"],

--- a/headroom/proxy/savings_tracker.py
+++ b/headroom/proxy/savings_tracker.py
@@ -500,13 +500,10 @@ def _realized_input_rate(entry: Any) -> float | None:
     return cost / float(tokens)
 
 
-def _reprice_entry_to_realized(entry: Any, tokens_key: str, fallback_rate: float) -> None:
-    """Restate one aggregate's compression dollars at the realized rate."""
+def _reprice_entry_to_realized(entry: Any, tokens_key: str, rate: float) -> None:
+    """Restate one aggregate's compression dollars at ``rate``."""
     if not isinstance(entry, dict):
         return
-    rate = _realized_input_rate(entry)
-    if rate is None:
-        rate = fallback_rate
     saved = max(_coerce_int(entry.get(tokens_key)), 0)
     entry["compression_savings_usd"] = round(float(saved) * rate, 6)
 
@@ -519,29 +516,75 @@ def _reprice_state_to_realized_basis(state: dict[str, Any]) -> bool:
     the headline converging only as old entries age out - which leaves the
     reported bug substantially unfixed for existing installs.
 
-    No new per-entry field is needed to tell the eras apart: ``tokens_saved``
-    and the realized rate are both already persisted on every aggregate, so the
-    dollars are simply recomputed from them. Each aggregate uses its own rate
-    where it has one (so a history point is restated at the rate that prevailed
-    up to that point and the derived day/provider/model deltas stay consistent),
-    falling back to the lifetime rate. Returns False when there is nothing to
-    reprice against yet, in which case the marker is not written and the
-    restatement is retried on the next load.
+    No new per-entry field is needed to tell the eras apart: saved tokens and
+    realized input spend are both already persisted, so the dollars are simply
+    recomputed from them.
+
+    History points are cumulative snapshots, so they are restated from the
+    INCREMENTS between them and re-accumulated, never by multiplying a point's
+    cumulative saved tokens by its cumulative average rate. That average moves
+    with the traffic mix - a cold day followed by a cache-heavy one drops it -
+    so cumulative-average pricing can rewrite the series DOWNWARD, and
+    ``_build_rollup`` clamps negative deltas to zero, which would leave the
+    days no longer adding up to the lifetime. Increments are non-negative by
+    construction, so the restated series is monotonic and the day / provider /
+    model deltas still sum to the lifetime.
+
+    Per-project and per-model attribution is not recoverable from cumulative
+    snapshots, so those buckets take the lifetime's effective compression rate
+    (its restated dollars over its saved tokens) instead of each inventing its
+    own weighting - one basis for every aggregate, so the buckets reconcile
+    with the headline. Returns False when there is nothing to reprice against
+    yet, in which case the marker is not written and the restatement is retried
+    on the next load.
     """
     lifetime = state.get("lifetime")
-    rate = _realized_input_rate(lifetime)
-    if rate is None:
+    fallback_rate = _realized_input_rate(lifetime)
+    if fallback_rate is None:
         # Nothing priced yet: only stamp when there are no legacy dollars to
         # restate, otherwise wait for a rate rather than freezing list prices in.
         return _coerce_float((lifetime or {}).get("compression_savings_usd")) <= 0.0
 
-    _reprice_entry_to_realized(lifetime, "tokens_saved", rate)
-    _reprice_entry_to_realized(state.get("display_session"), "tokens_saved", rate)
+    cumulative_usd = 0.0
+    covered_tokens = 0
+    prev_saved = 0
+    prev_input_tokens = 0
+    prev_input_cost = 0.0
     for point in state.get("history") or []:
-        _reprice_entry_to_realized(point, "total_tokens_saved", rate)
+        if not isinstance(point, dict):
+            continue
+        saved = _coerce_int(point.get("total_tokens_saved"))
+        input_tokens = _coerce_int(point.get("total_input_tokens"))
+        input_cost = _coerce_float(point.get("total_input_cost_usd"))
+        # Same clamped-delta reading _build_rollup applies, so the restated
+        # series and the rollup agree point for point.
+        delta_saved = max(saved - prev_saved, 0)
+        delta_input_tokens = max(input_tokens - prev_input_tokens, 0)
+        delta_input_cost = max(input_cost - prev_input_cost, 0.0)
+        rate = (
+            delta_input_cost / float(delta_input_tokens)
+            if delta_input_tokens > 0 and delta_input_cost > 0.0
+            else fallback_rate
+        )
+        cumulative_usd += float(delta_saved) * rate
+        point["compression_savings_usd"] = round(cumulative_usd, 6)
+        prev_saved = saved
+        prev_input_tokens = input_tokens
+        prev_input_cost = input_cost
+        covered_tokens = max(covered_tokens, saved)
+
+    lifetime_saved = max(_coerce_int((lifetime or {}).get("tokens_saved")), 0)
+    # Savings booked outside the retained history (aged-out points, checkpoint
+    # writers) have no increments left to price, so they take the lifetime rate.
+    lifetime_usd = cumulative_usd + float(max(lifetime_saved - covered_tokens, 0)) * fallback_rate
+    if isinstance(lifetime, dict):
+        lifetime["compression_savings_usd"] = round(lifetime_usd, 6)
+    effective_rate = lifetime_usd / float(lifetime_saved) if lifetime_saved > 0 else fallback_rate
+
+    _reprice_entry_to_realized(state.get("display_session"), "tokens_saved", effective_rate)
     for bucket in ("projects", "by_model"):
         for entry in (state.get(bucket) or {}).values():
-            _reprice_entry_to_realized(entry, "tokens_saved", rate)
+            _reprice_entry_to_realized(entry, "tokens_saved", effective_rate)
 
     metrics = state.get("lifetime_metrics")
     if isinstance(metrics, dict):
@@ -549,7 +592,7 @@ def _reprice_state_to_realized_basis(state: dict[str, Any]) -> bool:
         tokens = metrics.get("tokens")
         if isinstance(cost, dict) and isinstance(tokens, dict):
             saved = max(_coerce_int(tokens.get("saved")), 0)
-            cost["compression_savings_usd"] = round(float(saved) * rate, 6)
+            cost["compression_savings_usd"] = round(float(saved) * effective_rate, 6)
     return True
 
 

--- a/tests/test_compression_savings_cache_aware.py
+++ b/tests/test_compression_savings_cache_aware.py
@@ -13,6 +13,7 @@ breakdown is available; behavior without a breakdown is unchanged.
 
 from __future__ import annotations
 
+import json
 import types
 
 import pytest
@@ -110,3 +111,127 @@ def test_record_request_fallback_uses_realized_rate(tmp_path):
     blended_rate = (940_000 * CACHE_READ + 40_000 * CACHE_WRITE + 20_000 * LIST) / 1_000_000
     got = tracker.snapshot()["lifetime"]["compression_savings_usd"]
     assert got == pytest.approx(100_000 * blended_rate, rel=1e-4)
+
+
+def _legacy_ledger(path, *, list_priced: float = 10.0) -> None:
+    """A ledger written before the pricing fix: dollars at list, no marker."""
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 5,
+                "lifetime": {
+                    "requests": 100,
+                    "tokens_saved": 1_000_000,
+                    "compression_savings_usd": list_priced,
+                    "cache_read_tokens": 900_000,
+                    "cache_savings_usd": 0.5,
+                    # Realized input spend: $1/M, i.e. a tenth of the $10/M list
+                    # rate the saved tokens were priced at.
+                    "total_input_tokens": 1_000_000,
+                    "total_input_cost_usd": 1.0,
+                },
+                "history": [
+                    {
+                        "timestamp": "2026-01-01T00:00:00+00:00",
+                        "total_tokens_saved": 400_000,
+                        "compression_savings_usd": 4.0,
+                        "total_input_tokens": 400_000,
+                        "total_input_cost_usd": 0.4,
+                    },
+                    {
+                        "timestamp": "2026-01-02T00:00:00+00:00",
+                        "total_tokens_saved": 1_000_000,
+                        "compression_savings_usd": list_priced,
+                        "total_input_tokens": 1_000_000,
+                        "total_input_cost_usd": 1.0,
+                    },
+                ],
+                "by_model": {
+                    "m": {
+                        "requests": 100,
+                        "tokens_saved": 1_000_000,
+                        "compression_savings_usd": list_priced,
+                        "total_input_tokens": 1_000_000,
+                        "total_input_cost_usd": 1.0,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_legacy_ledger_is_restated_on_the_realized_basis_at_load(tmp_path):
+    """Without this the lifetime headline mixes list-priced and realized-rate
+    dollars with no way to tell them apart, and only converges as old entries
+    age out — i.e. the reported bug stays substantially unfixed on upgrade."""
+    path = tmp_path / "proxy_savings.json"
+    _legacy_ledger(path)
+
+    tracker = st.SavingsTracker(path=str(path))
+    snapshot = tracker.snapshot()
+
+    assert snapshot["pricing_basis"] == "realized"
+    # 1M saved tokens at the realized $1/M, not the $10/M list rate.
+    assert snapshot["lifetime"]["compression_savings_usd"] == pytest.approx(1.0)
+    assert snapshot["by_model"]["m"]["compression_savings_usd"] == pytest.approx(1.0)
+    # Each history point restates at its own realized rate, so the cumulative
+    # series stays monotonic and the derived deltas stay non-negative.
+    assert [p["compression_savings_usd"] for p in snapshot["history"]] == [
+        pytest.approx(0.4),
+        pytest.approx(1.0),
+    ]
+    daily = tracker.history_response()["series"]["daily"]
+    assert [d["compression_savings_usd_delta"] for d in daily] == [
+        pytest.approx(0.4),
+        pytest.approx(0.6),
+    ]
+
+
+def test_restatement_is_stamped_and_not_repeated(tmp_path):
+    """The marker rides out with the next save (same deferral as the schema
+    migrations beside it), so an install is restated once — and because the
+    restatement recomputes from tokens it is idempotent even if it ran twice."""
+    path = tmp_path / "proxy_savings.json"
+    _legacy_ledger(path)
+
+    tracker = st.SavingsTracker(path=str(path))
+    tracker.record_request(model="m", input_tokens=10, tokens_saved=0)
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["pricing_basis"] == "realized"
+    assert persisted["lifetime"]["compression_savings_usd"] == pytest.approx(1.0)
+
+    again = st.SavingsTracker(path=str(path)).snapshot()
+    assert again["lifetime"]["compression_savings_usd"] == pytest.approx(1.0)
+
+
+def test_unpriced_legacy_ledger_waits_instead_of_freezing_list_prices(tmp_path):
+    """No realized rate yet (state predates input-cost tracking): leave the
+    dollars alone and retry next load rather than stamping list prices as
+    'realized' forever."""
+    path = tmp_path / "proxy_savings.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 5,
+                "lifetime": {
+                    "requests": 10,
+                    "tokens_saved": 1_000_000,
+                    "compression_savings_usd": 10.0,
+                    "total_input_tokens": 0,
+                    "total_input_cost_usd": 0.0,
+                },
+                "history": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snapshot = st.SavingsTracker(path=str(path)).snapshot()
+    assert snapshot["pricing_basis"] == "legacy"
+    assert snapshot["lifetime"]["compression_savings_usd"] == pytest.approx(10.0)
+
+
+def test_fresh_install_is_marked_realized(tmp_path):
+    snapshot = st.SavingsTracker(path=str(tmp_path / "proxy_savings.json")).snapshot()
+    assert snapshot["pricing_basis"] == "realized"

--- a/tests/test_compression_savings_cache_aware.py
+++ b/tests/test_compression_savings_cache_aware.py
@@ -1,0 +1,112 @@
+"""Cache-aware counterfactual for compression savings (realized input rate).
+
+`_estimate_compression_savings_usd` priced every saved token at the model's
+full list input rate, while `_estimate_input_cost_usd` right beside it prices
+the same request's real spend on the cache read/write/uncached split.
+Compression re-applies the same removals on every warm-prefix turn (clients
+resend the original transcript), so on cache-heavy traffic most saved-token
+instances would have billed at the provider's cache-read discount, not list —
+flat list pricing overstates the layer roughly 7x on a 94%-read mix. Saved
+tokens now price at the request's realized blended input rate whenever the
+breakdown is available; behavior without a breakdown is unchanged.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from headroom.proxy import savings_tracker as st
+from headroom.proxy.savings_tracker import (
+    _estimate_compression_savings_usd,
+    estimate_request_savings_usd,
+)
+
+LIST = 10.0 / 1_000_000
+CACHE_READ = 1.0 / 1_000_000
+CACHE_WRITE = 12.5 / 1_000_000
+
+
+def _fake_litellm() -> types.SimpleNamespace:
+    # cost_per_token succeeding makes _resolve_litellm_model return the name as-is.
+    return types.SimpleNamespace(
+        model_cost={
+            "m": {
+                "input_cost_per_token": LIST,
+                "cache_read_input_token_cost": CACHE_READ,
+                "cache_creation_input_token_cost": CACHE_WRITE,
+            }
+        },
+        cost_per_token=lambda **_kw: (0.0, 0.0),
+    )
+
+
+@pytest.fixture(autouse=True)
+def fake_litellm(monkeypatch):
+    monkeypatch.setattr(st, "_get_litellm_module", _fake_litellm)
+
+
+def test_warm_mix_prices_at_realized_rate():
+    # 94% cache reads / 4% writes / 2% uncached — the mix compression actually
+    # re-applies removals into on long Claude Code sessions.
+    read, write, uncached = 940_000, 40_000, 20_000
+    saved = 100_000
+    blended_rate = (read * CACHE_READ + write * CACHE_WRITE + uncached * LIST) / (
+        read + write + uncached
+    )
+    got = _estimate_compression_savings_usd(
+        "m",
+        saved,
+        cache_read_tokens=read,
+        cache_write_tokens=write,
+        uncached_input_tokens=uncached,
+    )
+    assert got == pytest.approx(saved * blended_rate)
+    # The whole point: an order of magnitude below flat list on this mix.
+    assert got < saved * LIST * 0.2
+
+
+def test_cold_mix_prices_at_list():
+    # A request with no cache traffic keeps first-ingest removals at list.
+    saved = 100_000
+    got = _estimate_compression_savings_usd("m", saved, uncached_input_tokens=500_000)
+    assert got == pytest.approx(saved * LIST)
+
+
+def test_no_breakdown_keeps_flat_list_pricing():
+    # Callers without the split (legacy checkpoints) are byte-for-byte unchanged.
+    assert _estimate_compression_savings_usd("m", 100_000) == pytest.approx(100_000 * LIST)
+
+
+def test_estimate_request_savings_usd_threads_split():
+    read, write, uncached = 900_000, 50_000, 50_000
+    blended_rate = (read * CACHE_READ + write * CACHE_WRITE + uncached * LIST) / (
+        read + write + uncached
+    )
+    priced = estimate_request_savings_usd(
+        "m",
+        compression_tokens_saved=10_000,
+        cache_read_tokens=read,
+        cache_write_tokens=write,
+        uncached_input_tokens=uncached,
+    )
+    assert priced["compression"] == pytest.approx(10_000 * blended_rate)
+    # Without the split the compression key keeps its historical list pricing.
+    flat = estimate_request_savings_usd("m", compression_tokens_saved=10_000)
+    assert flat["compression"] == pytest.approx(10_000 * LIST)
+
+
+def test_record_request_fallback_uses_realized_rate(tmp_path):
+    tracker = st.SavingsTracker(path=tmp_path / "savings.json")
+    tracker.record_request(
+        model="m",
+        input_tokens=1_000_000,
+        tokens_saved=100_000,
+        cache_read_tokens=940_000,
+        cache_write_tokens=40_000,
+        uncached_input_tokens=20_000,
+    )
+    blended_rate = (940_000 * CACHE_READ + 40_000 * CACHE_WRITE + 20_000 * LIST) / 1_000_000
+    got = tracker.snapshot()["lifetime"]["compression_savings_usd"]
+    assert got == pytest.approx(100_000 * blended_rate, rel=1e-4)

--- a/tests/test_compression_savings_cache_aware.py
+++ b/tests/test_compression_savings_cache_aware.py
@@ -235,3 +235,81 @@ def test_unpriced_legacy_ledger_waits_instead_of_freezing_list_prices(tmp_path):
 def test_fresh_install_is_marked_realized(tmp_path):
     snapshot = st.SavingsTracker(path=str(tmp_path / "proxy_savings.json")).snapshot()
     assert snapshot["pricing_basis"] == "realized"
+
+
+@pytest.mark.parametrize(
+    ("day2_saved", "expected_series"),
+    [
+        # Day 2 is cache-heavy and saves nothing new. Its CUMULATIVE average
+        # rate is $1.9/M, so pricing each point at its own cumulative average
+        # would restate day 1 from $10 down to $1.90: a decreasing series whose
+        # negative delta the rollup clamps to zero, leaving days that no longer
+        # add up to the lifetime.
+        (1_000_000, [10.0, 10.0]),
+        # Day 2 also saves: those 500k tokens price at day 2's own $1/M warm
+        # rate, not at day 1's $10/M and not at the $1.9/M cumulative average.
+        (1_500_000, [10.0, 10.5]),
+    ],
+)
+def test_cold_to_warm_rate_change_keeps_history_monotonic_and_reconciled(
+    tmp_path, day2_saved, expected_series
+):
+    """A cold day followed by a cache-heavy one is ordinary traffic, not corrupt
+    input, and it must not break the ledger's invariants: the cumulative series
+    only ever rises, and the daily deltas add back up to the lifetime."""
+    path = tmp_path / "proxy_savings.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 5,
+                "lifetime": {
+                    "requests": 200,
+                    "tokens_saved": day2_saved,
+                    "compression_savings_usd": 15.0,
+                    "total_input_tokens": 10_000_000,
+                    "total_input_cost_usd": 19.0,
+                },
+                "history": [
+                    {
+                        "timestamp": "2026-01-01T00:00:00+00:00",
+                        "total_tokens_saved": 1_000_000,
+                        "compression_savings_usd": 10.0,
+                        "total_input_tokens": 1_000_000,
+                        "total_input_cost_usd": 10.0,
+                    },
+                    {
+                        "timestamp": "2026-01-02T00:00:00+00:00",
+                        "total_tokens_saved": day2_saved,
+                        "compression_savings_usd": 15.0,
+                        "total_input_tokens": 10_000_000,
+                        "total_input_cost_usd": 19.0,
+                    },
+                ],
+                "by_model": {
+                    "m": {
+                        "requests": 200,
+                        "tokens_saved": day2_saved,
+                        "compression_savings_usd": 15.0,
+                        "total_input_tokens": 10_000_000,
+                        "total_input_cost_usd": 19.0,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    tracker = st.SavingsTracker(path=str(path))
+    snapshot = tracker.snapshot()
+
+    series = [p["compression_savings_usd"] for p in snapshot["history"]]
+    assert series == [pytest.approx(value) for value in expected_series]
+    assert series == sorted(series)
+
+    lifetime = snapshot["lifetime"]["compression_savings_usd"]
+    assert lifetime == pytest.approx(expected_series[-1])
+    daily = tracker.history_response()["series"]["daily"]
+    assert sum(day["compression_savings_usd_delta"] for day in daily) == pytest.approx(lifetime)
+    # One model covers all the saved tokens, so its bucket must equal the
+    # headline rather than carrying a separately weighted total.
+    assert snapshot["by_model"]["m"]["compression_savings_usd"] == pytest.approx(lifetime)

--- a/tests/test_persistent_metrics_persistence.py
+++ b/tests/test_persistent_metrics_persistence.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from headroom.proxy.savings_tracker import SavingsTracker
 
 
@@ -53,9 +55,12 @@ def test_savings_tracker_migrates_v4_lifetime_to_v5_metrics_and_preserves_legacy
     assert lifetime["tokens"]["attempted_input"] == 100
     assert lifetime["tokens"]["saved"] == 20
     assert lifetime["prefix_cache"]["cache_read_tokens"] == 5
+    # Compression dollars are restated onto the realized basis on load: 20 saved
+    # tokens at the ledger's own $1.5/80-token realized input rate, not the list
+    # price they were written at. Everything else carries over untouched.
     assert lifetime["cost"] == {
         "input_usd": 1.5,
-        "compression_savings_usd": 0.5,
+        "compression_savings_usd": pytest.approx(20 * (1.5 / 80)),
         "cache_savings_usd": 0.2,
     }
     assert lifetime["by_model"]["other"]["input_tokens"] == 80
@@ -63,7 +68,10 @@ def test_savings_tracker_migrates_v4_lifetime_to_v5_metrics_and_preserves_legacy
     tracker.flush()
     saved = json.loads(path.read_text(encoding="utf-8"))
     assert saved["schema_version"] == 5
-    assert saved["lifetime"] == legacy_state["lifetime"]
+    assert saved["lifetime"] == {
+        **legacy_state["lifetime"],
+        "compression_savings_usd": pytest.approx(20 * (1.5 / 80)),
+    }
     assert saved["display_session"]["requests"] == 2
     assert saved["projects"]["keep-me"]["requests"] == 1
     assert saved["lifetime_metrics"]["models"]["other"]["input_tokens"] == 80

--- a/tests/test_proxy_savings_history.py
+++ b/tests/test_proxy_savings_history.py
@@ -1770,8 +1770,10 @@ def test_non_finite_state_values_coerce_to_defaults(tmp_path):
     lifetime = tracker.snapshot()["lifetime"]
     assert lifetime["cache_read_tokens"] == 0
     assert lifetime["cache_savings_usd"] == 0.0
-    assert lifetime["compression_savings_usd"] == 0.0
     assert lifetime["tokens_saved"] == 2
+    # NaN coerces to 0.0, then the legacy ledger is restated on the realized
+    # basis: 2 saved tokens at the persisted $0.5/100-token realized rate.
+    assert lifetime["compression_savings_usd"] == pytest.approx(2 * (0.5 / 100))
 
     tracker.record_request(
         model="unknown-model",

--- a/tests/test_proxy_savings_history.py
+++ b/tests/test_proxy_savings_history.py
@@ -186,7 +186,7 @@ def test_record_compression_savings_skips_empty_updates_and_normalizes_timestamp
     monkeypatch.setattr(
         savings_tracker_module,
         "_estimate_compression_savings_usd",
-        lambda model, tokens_saved: tokens_saved / 1000.0,
+        lambda model, tokens_saved, **_split: tokens_saved / 1000.0,
     )
 
     assert tracker.record_compression_savings(model="gpt-4o", tokens_saved=0) is False
@@ -603,7 +603,7 @@ def test_display_session_rolls_after_inactivity_and_counts_zero_savings_requests
     monkeypatch.setattr(
         savings_tracker_module,
         "_estimate_compression_savings_usd",
-        lambda model, tokens_saved: tokens_saved / 1000.0,
+        lambda model, tokens_saved, **_split: tokens_saved / 1000.0,
     )
     monkeypatch.setattr(
         savings_tracker_module,
@@ -687,7 +687,7 @@ def test_savings_tracker_rollups_preserve_spend_and_input_history(tmp_path, monk
     )
     monkeypatch.setattr(
         "headroom.proxy.savings_tracker._estimate_compression_savings_usd",
-        lambda model, tokens_saved: tokens_saved / 1000.0,
+        lambda model, tokens_saved, **_split: tokens_saved / 1000.0,
     )
 
     tracker.record_compression_savings(
@@ -830,7 +830,7 @@ def test_savings_tracker_rollup_attributes_savings_per_provider(tmp_path, monkey
     )
     monkeypatch.setattr(
         "headroom.proxy.savings_tracker._estimate_compression_savings_usd",
-        lambda model, tokens_saved: tokens_saved / 1000.0,
+        lambda model, tokens_saved, **_split: tokens_saved / 1000.0,
     )
 
     # Two providers active in the same hour bucket.
@@ -908,7 +908,7 @@ def test_savings_tracker_rollup_attributes_savings_per_model(tmp_path, monkeypat
 
     monkeypatch.setattr(
         "headroom.proxy.savings_tracker._estimate_compression_savings_usd",
-        lambda model, tokens_saved: tokens_saved / 1000.0,
+        lambda model, tokens_saved, **_split: tokens_saved / 1000.0,
     )
 
     # Two models from the same provider land in the same bucket.
@@ -1023,7 +1023,7 @@ def test_stats_history_defaults_to_compact_history_but_can_return_full_history(
     )
     monkeypatch.setattr(
         "headroom.proxy.savings_tracker._estimate_compression_savings_usd",
-        lambda model, tokens_saved: tokens_saved / 1000.0,
+        lambda model, tokens_saved, **_split: tokens_saved / 1000.0,
     )
 
     for i in range(8):


### PR DESCRIPTION
## Description

The persisted lifetime ledger prices every compression-saved input token at the model's full list rate, while `_estimate_input_cost_usd`, in the same module, prices the request's real spend on the cache read/write/uncached split. The two sides of the savings fraction use different price sheets.

That asymmetry matters because compression re-applies the same removals on every warm-prefix turn: clients resend the original transcript, the proxy re-removes the same bytes to keep the wire form byte-identical to the cached prefix, and each re-application lands in the ledger again. On a 94%-cache-read mix (the dominant Claude Code profile) most of those saved-token instances would have billed at the provider's cache-read discount, not list, so flat list pricing overstates the layer roughly 6-7x. A user-run audit of a live install's `/stats` reached the same figure independently (12.5% headline vs 2.4% priced at the rate actually paid) and used it to dispute the product's honesty.

This PR prices saved tokens at the request's realized blended input rate whenever the caller supplies the cache breakdown, reusing `_estimate_input_cost_usd` unchanged. The rate self-adjusts: a cold request (uncached only) still prices at list, a warm-prefix recurrence prices near the cache-read rate, no session state needed. It is the lifetime twin of `cost.py`'s session-scoped `cache_aware_savings_usd`, and the compression-layer sibling of #3171 (tool-schema deferral at the cache-read rate). Callers without a breakdown are byte-for-byte unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `_estimate_compression_savings_usd` gains optional `cache_read_tokens` / `cache_write_tokens` / `uncached_input_tokens` kwargs; with a breakdown present it prices saved tokens at `_estimate_input_cost_usd(split) / split_tokens`, otherwise the historical flat-list path runs unchanged.
- `estimate_request_savings_usd` accepts and threads the same split into the `compression` bucket; `tool_schema` is deliberately untouched (owned by #3171).
- `record_request`'s unpriced fallback and `record_lifetime_request`'s `compression_savings_usd` default pass the split they already receive.
- `record_compression_savings` (checkpoint path, no split available) keeps flat-list pricing, now with a comment saying so.
- `prometheus_metrics.record_request` threads `cache_write_tokens` / `uncached_input_tokens` into `estimate_request_savings_usd`.
- One-time restatement of the persisted ledger onto the realized basis at load (`_reprice_state_to_realized_basis`), so an upgraded install does not carry a mix of list-priced and realized-rate dollars. No new per-entry field: every aggregate (lifetime, history point, project, model, display session, `lifetime_metrics.cost`) already carries `tokens_saved` next to `total_input_tokens`/`total_input_cost_usd`, so the dollars are recomputed from them, each at its own realized rate. A persisted `pricing_basis` marker makes it run once; a ledger with no realized rate yet is left alone and retried on the next load rather than freezing list prices in under the new name.
- New `tests/test_compression_savings_cache_aware.py`; six stubs in `tests/test_proxy_savings_history.py` widened to accept the new kwargs. Two existing expectations restated with the ledger (`test_non_finite_state_values_coerce_to_defaults`, `test_savings_tracker_migrates_v4_lifetime_to_v5_metrics_and_preserves_legacy_state`) - both now assert the recomputed figure rather than the list-priced one.

## Testing

- [x] Unit tests pass (`pytest`)

### Test Output

```text
uv run --frozen --extra dev pytest tests/test_compression_savings_cache_aware.py tests/test_proxy_savings_history.py tests/test_savings_tracker_zero_price.py tests/test_stats_new_input_savings_rate.py -q
53 passed, 1 warning in 5.42s
```

## Real Behavior Proof

- Environment: macOS 15 (arm64), Python 3.12 via uv, this branch's worktree, real litellm pricing catalog (no stubs).
- Exact command / steps: `uv run --frozen python` replaying one request through `SavingsTracker.record_request` with `model=claude-opus-4-1, tokens_saved=100000, cache_read=940000, cache_write=40000, uncached=20000` (the measured mix from a live install's `/stats`), then printing the lifetime ledger against the old flat-list estimate for the same tokens.
- Observed result: realized-rate ledger $0.2460 vs flat-list $1.5000 for the identical request, a 6.1x correction on catalog opus pricing.
- Not tested: Windows; installs without litellm (that fallback path is covered by unit tests only); the desktop app's consumption of the changed dollar slope.

## Runtime Rollout Safety

- Rollout-managed feature(s): None. This is accounting, not a request-path behavior change.
- Minimum rollout channel: Stable.
- Stable/default behavior changed: Yes, reported `compression_savings_usd` accrues at a lower, cache-aware rate on cache-heavy traffic. Request bodies, forwarding, and token counts are untouched.
- Kill switch / disable path: Not applicable; callers that omit the breakdown keep the old pricing by construction.
- Unsafe override required: No.
- Qualification impact: Downstream consumers of `compression_savings_usd` (dashboard, desktop app) will see a lower accrual slope AND a one-time downward restatement of the existing lifetime figure on first load after upgrade. Derived series move with it: history points are restated at their own realized rate, which keeps `/stats-history` day/provider/model deltas non-negative. Consumers that accumulate their own totals from those deltas should expect the step change.
- Rollback path: Revert the commit; the ledger schema is unchanged.

## Pricing-basis coexistence with #3171

Until #3171 lands, `estimate_request_savings_usd` returns `compression` at the realized rate beside `tool_schema` at list rate: two price sheets in one payload, with `tool_schema` the inflated one. That is deliberate (the tool-schema layer is #3171's to reprice, and doing it here would collide), but if #3171 slips, the payload ships mixed bases and `tool_schema` keeps the ~6x overstatement on cache-heavy traffic. The persisted restatement above covers `compression_savings_usd` only, for the same reason.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
