### PR TITLE
chore(ci): align the pre-commit mypy hook with CI's mypy 1.20.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: ruff-format
         exclude: ^experiments/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.20.2
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]


### PR DESCRIPTION
## Description

CI's lint job installs `mypy==1.20.2` (`.github/workflows/ci.yml`), but the pre-commit `mirrors-mypy` hook was pinned at `v1.14.1`. Both run in bare environments with `--ignore-missing-imports`, so the version was the only difference between the hook and CI. Six minor releases can add checks or change `type: ignore` matching, so a commit that passes the hook can still fail CI. This aligns the pin so the local hook is a faithful mirror of the CI gate.

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring (no functional changes)

## Changes Made

- `.pre-commit-config.yaml`: `mirrors-mypy` hook `rev` bumped `v1.14.1` → `v1.20.2`. No other changes.

## Testing

- [x] Unit tests pass (`pytest`) — N/A, no Python code changed
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality — N/A
- [x] Manual testing performed

### Test Output

```text
$ pre-commit run mypy --all-files
mypy.....................................................................Passed

$ ~/.cache/pre-commit/repo7ssf3856/py_env-python3.12/bin/mypy --version
mypy 1.20.2 (compiled: yes)

$ uv run --isolated --no-project --with mypy==1.20.2 mypy headroom --ignore-missing-imports
Success: no issues found in 531 source files
```

## Real Behavior Proof

- Environment: macOS, pre-commit 4.5.1, Python 3.12 hook env, tree at upstream `main` (aebe9895)
- Exact command / steps: bump `rev`, `pre-commit run mypy --all-files`, confirm the hook's venv reports mypy 1.20.2, compare against a CI-equivalent isolated run
- Observed result: hook environment builds from the `v1.20.2` tag, hook passes, and its result matches the isolated CI-style run on the same tree
- Not tested: nothing else changes; CI itself does not run pre-commit

## Runtime Rollout Safety

- Rollout-managed feature(s): none — developer tooling only
- Minimum rollout channel: N/A
- Stable/default behavior changed: no; no runtime code touched
- Kill switch / disable path: revert the one-line pin
- Unsafe override required: no
- Qualification impact: none
- Rollback path: revert this commit

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas — N/A
- [x] I have made corresponding changes to the documentation — N/A
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works — N/A
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A

## Additional Notes

Contributors with hooks installed will rebuild the mypy hook environment once on their next commit. Split out from #3366, where the mismatch was noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
