### PR TITLE
fix(output-savings): tag ledger entries with the shaper's state and estimate only from active ones

### DIFF
--- a/headroom/cli/output_savings.py
+++ b/headroom/cli/output_savings.py
@@ -40,8 +40,19 @@ def output_savings() -> None:
     click.echo(f"\n{'=' * 56}")
     click.echo("Output-token reduction")
     click.echo(f"{'=' * 56}")
+    # Requests recorded while the shaper was inert (level 0 — cache mode, or a
+    # learned/env level of 0). They are real traffic but carry no shaping
+    # signal, so no estimate counts them. Saying so beats leaving an operator to
+    # wonder why a busy proxy reports nothing.
+    inactive = ledger.inactive_requests
+
     if est.n_requests == 0:
         click.echo("  No shaped requests recorded yet.")
+        if inactive:
+            click.echo(
+                f"  {inactive:,} request(s) were recorded while the shaper was inactive (level 0);"
+            )
+            click.echo("  they are excluded — an unshaped request measures nothing about shaping.")
         click.echo(
             f"  Baseline: {ledger.baseline.total_samples} samples, "
             f"{len(ledger.baseline.strata)} strata."
@@ -56,6 +67,8 @@ def output_savings() -> None:
     click.echo(
         f"  Reduction: {est.pct:.1f}%   (95% CI {est.ci_low_pct:.1f}% … {est.ci_high_pct:.1f}%)"
     )
+    if inactive:
+        click.echo(f"  Excluded:  {inactive:,} request(s) recorded while the shaper was inactive")
     if est.kind == "estimated":
         click.echo(
             "\n  Note: estimated vs the learned baseline. For a measured number,"

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -3232,12 +3232,18 @@ class AnthropicHandlerMixin:
                         model=model,
                         has_tools=bool(body.get("tools")),
                     )
-                    # Carry (arm, stratum) on the existing label channel so the
-                    # outcome funnel can feed the savings ledger from any path.
-                    transforms_applied.append(stratum_label(_arm, _stratum))
+                    # Carry (arm, stratum, level) on the existing label channel
+                    # so the outcome funnel can feed the savings ledger from any
+                    # path. The level is resolved for BOTH arms because it is
+                    # what tells the ledger the shaper was live when this
+                    # observation landed — level 0 (cache mode, or a learned/env
+                    # 0) shapes nothing while both arms keep filling, and an
+                    # observation the ledger cannot attribute to shaping is
+                    # excluded from the estimate rather than credited to it.
+                    _level, _src = resolve_verbosity_level(_shaper_settings)
+                    transforms_applied.append(stratum_label(_arm, _stratum, verbosity_level=_level))
 
                     if _arm == "treatment":
-                        _level, _src = resolve_verbosity_level(_shaper_settings)
                         shape_result = shape_request(body, _shaper_settings, level_override=_level)
                         if shape_result.changed:
                             body_mutation_tracker.mark_mutated("output_shaper")

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -746,12 +746,15 @@ def _shape_openai_responses_payload(
             model=model or str(payload.get("model", "")),
             has_tools=bool(payload.get("tools")),
         )
-        labels = [stratum_label(arm, stratum)]
+        # Resolved for both arms: the level tags the ledger entry with whether
+        # the shaper was live (level 0 = inert), and an untagged observation is
+        # excluded from the estimate rather than credited to shaping.
+        level, src = resolve_verbosity_level(settings)
+        labels = [stratum_label(arm, stratum, verbosity_level=level)]
 
         if arm != "treatment":
             return labels, False
 
-        level, src = resolve_verbosity_level(settings)
         shape_result = shape_responses_request(payload, settings, level_override=level)
         if shape_result.changed:
             labels.extend(shape_result.labels or [])
@@ -1459,11 +1462,14 @@ def _shape_openai_responses_for_output(
         model=model or str(payload.get("model") or ""),
         has_tools=bool(payload.get("tools")),
     )
-    result.labels.append(stratum_label(arm, stratum))
+    # Resolve the level BEFORE the arm branch: it tags the ledger entry for
+    # both arms with whether the shaper was live (level 0 = inert), and an
+    # observation the ledger cannot attribute is excluded from the estimate.
+    level, _source = resolve_verbosity_level(settings)
+    result.labels.append(stratum_label(arm, stratum, verbosity_level=level))
     if arm == "control":
         return result
 
-    level, _source = resolve_verbosity_level(settings)
     shaped = shape_openai_responses_request(
         payload,
         settings=settings,
@@ -4522,11 +4528,15 @@ class OpenAIHandlerMixin:
                     model=model,
                     has_tools=bool(body.get("tools")),
                 )
-                # Carry (arm, stratum) on the transforms channel so the outcome
-                # funnel feeds the output-savings ledger from the chat path too.
-                transforms_applied.append(stratum_label(_arm, _stratum))
+                # Carry (arm, stratum, level) on the transforms channel so the
+                # outcome funnel feeds the output-savings ledger from the chat
+                # path too. The level is resolved for BOTH arms: it is the
+                # ledger's record of whether the shaper was live when the
+                # observation landed (level 0 = inert, e.g. cache mode), and an
+                # unattributable observation is excluded from the estimate.
+                _level, _src = resolve_verbosity_level(_shaper_settings)
+                transforms_applied.append(stratum_label(_arm, _stratum, verbosity_level=_level))
                 if _arm == "treatment":
-                    _level, _src = resolve_verbosity_level(_shaper_settings)
                     _shape_result = shape_openai_chat_request(
                         body, _shaper_settings, level_override=_level
                     )

--- a/headroom/proxy/output_savings.py
+++ b/headroom/proxy/output_savings.py
@@ -30,6 +30,18 @@ This module makes the estimate honest by separating three tiers:
    measurable with no counterfactual. "32% of output restated existing context"
    is an honest standalone fact and the shaper's target. See ``echo_ratio``.
 
+Both live tiers rest on a precondition that used to go unchecked: the shaper
+was actually running when the observation was recorded. The stratum label is
+attached whenever the shaper is *configured* on, but the shaping itself can be
+inert — level 0 means no steering at all, which cache mode forces and a learned
+or env level of 0 selects — and traffic still lands in both arms while nothing
+is being shaped. Differencing those arms measures noise and reports it as a
+shaping effect: a rollout-blocked install published a "measured" -147.9%
+reduction over 19,644 requests exactly that way (#3395). So every observation
+carries the shaper's resolved level at record time, only shaper-active
+observations reach ``treatment``/``control``, and the rest accumulate in
+``inactive_treatment``/``inactive_control`` where no estimator can see them.
+
 Stratification uses only features observable at request time (never the output):
 turn kind, input-token bucket, model family, whether tools are present.
 
@@ -251,6 +263,22 @@ class SavingsEstimate:
         return asdict(self)
 
 
+# On-disk schema version for the persisted ledger.
+#
+# 1 (or absent): arms carry no shaper-active tag. Entries from a period when
+#    the shaper was inert are indistinguishable from shaped ones, so the arms
+#    are dropped on load — see :meth:`SavingsLedger.from_dict`.
+# 2: ``treatment``/``control`` hold shaper-active observations only; inactive
+#    ones live in ``inactive_treatment``/``inactive_control``.
+LEDGER_SCHEMA_VERSION = 2
+
+# Warn once per process when legacy arms are dropped. The recorder re-reads the
+# file on every flush and on every ``estimate`` (to pick up a freshly learned
+# baseline), so an un-upgraded file with no traffic to rewrite it would
+# otherwise log the same warning on every /stats poll.
+_legacy_arms_warned = False
+
+
 @dataclass
 class SavingsLedger:
     """Accumulates shaped (treatment) and unshaped (control) observations and
@@ -260,22 +288,63 @@ class SavingsLedger:
     are live per-stratum accumulators of observed output tokens, used both for
     the A/B "measured" number (when a holdout exists) and to keep the ledger
     self-describing.
+
+    **Arm invariant:** ``treatment`` and ``control`` hold only observations
+    recorded while the shaper was active. Observations recorded while it was
+    inert go to ``inactive_treatment``/``inactive_control``, which no estimator
+    reads. Every estimator therefore gets the filtering for free, and a future
+    one cannot silently reintroduce the bug by forgetting to filter — the
+    poisoned data is not in the dicts it reads.
+
+    The inactive arms are kept rather than discarded so an operator can be told
+    *why* ``n`` is small ("19,644 requests recorded while the shaper was
+    inactive") instead of seeing history vanish. They are diagnostic only.
     """
 
     baseline: BaselineModel = field(default_factory=BaselineModel)
     treatment: dict[str, _Accum] = field(default_factory=dict)
     control: dict[str, _Accum] = field(default_factory=dict)
+    inactive_treatment: dict[str, _Accum] = field(default_factory=dict)
+    inactive_control: dict[str, _Accum] = field(default_factory=dict)
 
     # ---- recording -------------------------------------------------------
 
-    def record(self, arm: str, key: str, output_tokens: int) -> None:
-        target = self.treatment if arm == "treatment" else self.control
+    def record(self, arm: str, key: str, output_tokens: int, *, shaper_active: bool) -> None:
+        """File one observation into the arm for *arm* and the shaper's state.
+
+        ``shaper_active`` is required, with no default, on purpose: this is
+        statistical accounting, and a default would let a new call site pick a
+        tag by accident. Tagging is symmetric across arms — it describes the
+        deployment's state at record time, not what the shaper did to this
+        particular body — because filtering one arm on a per-request outcome
+        (say, "the steering block actually got appended") conditions treatment
+        on a post-assignment variable while control keeps every request, which
+        makes the two arms different populations and biases the difference of
+        means. Filtering both arms on the same request-time state is a time
+        restriction, and leaves the comparison causal within what remains.
+        """
+        if shaper_active:
+            target = self.treatment if arm == "treatment" else self.control
+        else:
+            target = self.inactive_treatment if arm == "treatment" else self.inactive_control
         target.setdefault(key, _Accum()).add(output_tokens)
+
+    @property
+    def inactive_requests(self) -> int:
+        """Observations excluded from every estimate as shaper-inactive."""
+        return sum(a.n for a in self.inactive_treatment.values()) + sum(
+            a.n for a in self.inactive_control.values()
+        )
 
     # ---- estimation ------------------------------------------------------
 
     def estimate_from_baseline(self) -> SavingsEstimate:
         """Synthetic-control estimate: treatment output vs. offline baseline.
+
+        Reads ``treatment``, so it sees shaper-active observations only (see
+        the class docstring's arm invariant). An unshaped treatment observation
+        differenced against a pre-shaper baseline is pure traffic drift wearing
+        a savings label.
 
         Aggregate signed delta ``Σ_s n_s·(μ_s − ȳ_s)`` where μ_s is the
         baseline mean and ȳ_s the observed treatment mean. Variance propagates
@@ -308,6 +377,11 @@ class SavingsLedger:
         Only strata with data in BOTH arms contribute. Returns ``None`` if no
         such stratum exists (no holdout traffic yet). Weighted by treatment
         volume; this is the unbiased causal number.
+
+        Both arms are read from the shaper-active dicts, so a stratum whose
+        control samples came from an inactive period cannot pair with treatment
+        samples from an active one. That pairing is what made a blocked install
+        difference two unshaped arms and call the result measured (#3395).
         """
         total_saved = 0.0
         total_baseline = 0.0
@@ -425,18 +499,60 @@ class SavingsLedger:
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "schema_version": LEDGER_SCHEMA_VERSION,
             "baseline": self.baseline.to_dict(),
             "treatment": {k: a.to_dict() for k, a in self.treatment.items()},
             "control": {k: a.to_dict() for k, a in self.control.items()},
+            "inactive_treatment": {k: a.to_dict() for k, a in self.inactive_treatment.items()},
+            "inactive_control": {k: a.to_dict() for k, a in self.inactive_control.items()},
         }
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> SavingsLedger:
+        """Rebuild a ledger, dropping arms written before the shaper tag.
+
+        A schema-1 file (no ``schema_version``) is a real, common case: the
+        ledger persists across restarts, so the first run after an upgrade
+        finds one. Its arms cannot be split into shaped and unshaped entry by
+        entry — the tag they would need is exactly what is missing — so they
+        are excluded rather than adopted. An upgraded install therefore starts
+        from a smaller ``n`` and re-accumulates from live traffic (hours, not
+        weeks) instead of inheriting a claim nobody can attribute. That is the
+        conservative direction: the failure mode we are fixing is a claim that
+        was never earned, and keeping the arms would preserve precisely it.
+
+        The baseline survives. It is learned offline by ``learn --verbosity``
+        from pre-shaper history, it costs a re-run to rebuild, and it was never
+        the poisoned part — it is unshaped by definition.
+        """
+        global _legacy_arms_warned
         ledger = cls(baseline=BaselineModel.from_dict(d.get("baseline") or {}))
+        try:
+            version = int(d.get("schema_version") or 1)
+        except (TypeError, ValueError):
+            version = 1
+        if version < LEDGER_SCHEMA_VERSION:
+            dropped_t = len(d.get("treatment") or {})
+            dropped_c = len(d.get("control") or {})
+            if (dropped_t or dropped_c) and not _legacy_arms_warned:
+                _legacy_arms_warned = True
+                logger.warning(
+                    "output-savings ledger predates the shaper-active tag "
+                    "(schema %d); dropping %d treatment and %d control strata "
+                    "and re-accumulating from live traffic (baseline kept)",
+                    version,
+                    dropped_t,
+                    dropped_c,
+                )
+            return ledger
         for k, a in (d.get("treatment") or {}).items():
             ledger.treatment[k] = _Accum.from_dict(a)
         for k, a in (d.get("control") or {}).items():
             ledger.control[k] = _Accum.from_dict(a)
+        for k, a in (d.get("inactive_treatment") or {}).items():
+            ledger.inactive_treatment[k] = _Accum.from_dict(a)
+        for k, a in (d.get("inactive_control") or {}).items():
+            ledger.inactive_control[k] = _Accum.from_dict(a)
         return ledger
 
     def save(self, path: Any) -> None:
@@ -495,14 +611,23 @@ class SavingsRecorder:
 
     def record_from_labels(self, labels: Any, output_tokens: int) -> bool:
         """Record one outcome given its transforms_applied labels. Returns True
-        if a shaping label was found and recorded."""
+        if a shaping label was found and recorded.
+
+        The label carries the verbosity level the shaper resolved for this
+        request (see ``output_savings_policy.stratum_label``). Level 0, or a
+        label with no level at all, means no steering was applied to anyone on
+        this request — the observation is real, but it is not evidence about
+        shaping, so it is filed in the inactive arms and no estimator sees it.
+        """
         for label in labels or ():
             parsed = parse_stratum_label(str(label))
             if parsed is None:
                 continue
-            arm, key = parsed
+            arm, key, level = parsed
             with self._lock:
-                self._ledger.record(arm, key, output_tokens)
+                self._ledger.record(
+                    arm, key, output_tokens, shaper_active=level is not None and level > 0
+                )
                 self._since_flush += 1
                 if self._since_flush >= self._flush_every:
                     self._flush_locked()
@@ -535,8 +660,15 @@ class SavingsRecorder:
             parsed = parse_stratum_label(str(label))
             if parsed is None:
                 continue
-            arm, key = parsed
+            arm, key, level = parsed
             if arm != "treatment":
+                return 0
+            if level is None or level <= 0:
+                # Shaper inert on this request: the gap to the baseline is
+                # drift, not a saving. Same rule the ledger applies, applied
+                # here too — this number is priced in USD downstream, so
+                # letting it through would put the claim the ledger refuses to
+                # make onto the savings rollup and Prometheus instead (#3395).
                 return 0
             with self._lock:
                 mean, _var, n = self._ledger.baseline.lookup(key)

--- a/headroom/proxy/output_savings_policy.py
+++ b/headroom/proxy/output_savings_policy.py
@@ -12,6 +12,13 @@ _INPUT_BUCKETS = (2_000, 8_000, 32_000, 128_000)
 _STRATUM_LABEL = "output_shaper:stratum:"
 _CONTROL_LABEL = "output_shaper:control:"
 
+# Optional ``:L<n>`` tail on a stratum label carrying the verbosity level the
+# shaper resolved for that request. A stratum key is built from a fixed
+# vocabulary joined with "|" (see :func:`stratum_key`) and can never contain a
+# colon, so the tail is unambiguous: the text after the last colon is the tag
+# if and only if it looks like ``L<digits>``.
+_LEVEL_TAG_PREFIX = "L"
+
 
 def input_bucket(input_tokens: int) -> str:
     """Map an input-token count to a coarse bucket label."""
@@ -165,16 +172,47 @@ def assign_arm(conversation_key: str, holdout_fraction: float) -> str:
     return "control" if frac < holdout_fraction else "treatment"
 
 
-def stratum_label(arm: str, key: str) -> str:
-    """Encode (arm, stratum) as a transforms_applied label."""
+def stratum_label(arm: str, key: str, *, verbosity_level: int | None = None) -> str:
+    """Encode (arm, stratum, shaper level) as a transforms_applied label.
+
+    ``verbosity_level`` is the level :func:`output_shaper.resolve_verbosity_level`
+    returned for THIS request, and it is what tells the ledger whether the
+    shaper was actually live when the observation was recorded. The stratum
+    label is attached whenever the shaper is *configured* on, but shaping can
+    still be inert — level 0 means no steering at all (cache mode forces it, and
+    a learned or env level of 0 selects it), so both arms fill with unshaped
+    traffic that a naive estimator reads as a shaping effect.
+
+    The level rides as a ``:L<n>`` tail rather than a separate label so nothing
+    downstream sees a new transform (``telemetry.session`` counts one entry per
+    label, keyed on the text before the first colon) and existing
+    ``startswith(prefix + key)`` matches keep working.
+
+    Omitting ``verbosity_level`` produces the historical untagged label, which
+    the ledger records as "shaper inactive". That direction is deliberate:
+    activity we cannot prove must never be able to inflate a savings claim.
+    """
     prefix = _STRATUM_LABEL if arm == "treatment" else _CONTROL_LABEL
-    return prefix + key
+    if verbosity_level is None:
+        return prefix + key
+    return f"{prefix}{key}:{_LEVEL_TAG_PREFIX}{int(verbosity_level)}"
 
 
-def parse_stratum_label(label: str) -> tuple[str, str] | None:
-    """Decode a label into ``(arm, stratum)``, or None if not one of ours."""
+def parse_stratum_label(label: str) -> tuple[str, str, int | None] | None:
+    """Decode a label into ``(arm, stratum, verbosity_level)``, or None.
+
+    ``verbosity_level`` is ``None`` for an untagged label — one written before
+    the level tag existed, or by a caller that did not supply it.
+    """
     if label.startswith(_STRATUM_LABEL):
-        return "treatment", label[len(_STRATUM_LABEL) :]
-    if label.startswith(_CONTROL_LABEL):
-        return "control", label[len(_CONTROL_LABEL) :]
-    return None
+        arm, rest = "treatment", label[len(_STRATUM_LABEL) :]
+    elif label.startswith(_CONTROL_LABEL):
+        arm, rest = "control", label[len(_CONTROL_LABEL) :]
+    else:
+        return None
+    key, sep, tail = rest.rpartition(":")
+    if sep and tail.startswith(_LEVEL_TAG_PREFIX):
+        digits = tail[len(_LEVEL_TAG_PREFIX) :]
+        if digits.isdigit():
+            return arm, key, int(digits)
+    return arm, rest, None

--- a/tests/test_output_savings.py
+++ b/tests/test_output_savings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from headroom.proxy.output_savings import (
+    LEDGER_SCHEMA_VERSION,
     BaselineModel,
     SavingsLedger,
     SavingsRecorder,
@@ -235,7 +236,7 @@ class TestEstimateFromBaseline:
     def test_positive_savings_when_treatment_below_baseline(self):
         ledger = self._ledger_with_baseline(1000.0)
         for _ in range(20):
-            ledger.record("treatment", "opus|new_user_ask|s|tools", 700)
+            ledger.record("treatment", "opus|new_user_ask|s|tools", 700, shaper_active=True)
         est = ledger.estimate_from_baseline()
         assert est.kind == "estimated"
         assert est.n_requests == 20
@@ -247,15 +248,15 @@ class TestEstimateFromBaseline:
         # A treatment request LARGER than baseline must reduce the total, not
         # be clamped to zero (clamping would bias the estimate upward).
         ledger = self._ledger_with_baseline(1000.0)
-        ledger.record("treatment", "opus|new_user_ask|s|tools", 700)
-        ledger.record("treatment", "opus|new_user_ask|s|tools", 1400)
+        ledger.record("treatment", "opus|new_user_ask|s|tools", 700, shaper_active=True)
+        ledger.record("treatment", "opus|new_user_ask|s|tools", 1400, shaper_active=True)
         est = ledger.estimate_from_baseline()
         # (1000-700) + (1000-1400) = 300 - 400 = -100
         assert abs(est.tokens_saved - (-100)) < 1e-6
 
     def test_zero_baseline_samples_yields_zero(self):
         ledger = SavingsLedger()
-        ledger.record("treatment", "opus|x|s|tools", 500)
+        ledger.record("treatment", "opus|x|s|tools", 500, shaper_active=True)
         est = ledger.estimate_from_baseline()
         # No baseline at all -> global is empty -> nothing contributes.
         assert est.n_requests == 0
@@ -268,7 +269,7 @@ class TestEstimateFromBaseline:
                 ledger.baseline.observe("opus|new_user_ask|s|tools", v)
         for v in (600, 700, 800):
             for _ in range(20):
-                ledger.record("treatment", "opus|new_user_ask|s|tools", v)
+                ledger.record("treatment", "opus|new_user_ask|s|tools", v, shaper_active=True)
         est = ledger.estimate_from_baseline()
         assert est.ci_low_pct <= est.pct <= est.ci_high_pct
         assert est.ci_low_pct < est.ci_high_pct  # nonzero band given spread
@@ -282,14 +283,14 @@ class TestEstimateFromBaseline:
 class TestEstimateFromHoldout:
     def test_none_without_control_data(self):
         ledger = SavingsLedger()
-        ledger.record("treatment", "opus|x|s|tools", 500)
+        ledger.record("treatment", "opus|x|s|tools", 500, shaper_active=True)
         assert ledger.estimate_from_holdout() is None
 
     def test_measured_difference_of_means(self):
         ledger = SavingsLedger()
         for _ in range(30):
-            ledger.record("control", "opus|new_user_ask|s|tools", 1000)
-            ledger.record("treatment", "opus|new_user_ask|s|tools", 750)
+            ledger.record("control", "opus|new_user_ask|s|tools", 1000, shaper_active=True)
+            ledger.record("treatment", "opus|new_user_ask|s|tools", 750, shaper_active=True)
         est = ledger.estimate_from_holdout()
         assert est is not None
         assert est.kind == "measured"
@@ -300,10 +301,10 @@ class TestEstimateFromHoldout:
     def test_only_strata_present_in_both_arms_contribute(self):
         ledger = SavingsLedger()
         for _ in range(10):
-            ledger.record("control", "opus|a|s|tools", 1000)
-            ledger.record("treatment", "opus|a|s|tools", 800)
+            ledger.record("control", "opus|a|s|tools", 1000, shaper_active=True)
+            ledger.record("treatment", "opus|a|s|tools", 800, shaper_active=True)
         # Treatment-only stratum must not contribute (no control to compare).
-        ledger.record("treatment", "opus|b|m|notools", 50)
+        ledger.record("treatment", "opus|b|m|notools", 50, shaper_active=True)
         est = ledger.estimate_from_holdout()
         assert est is not None
         assert est.n_requests == 10
@@ -312,15 +313,15 @@ class TestEstimateFromHoldout:
         ledger = SavingsLedger()
         for _ in range(10):
             ledger.baseline.observe("opus|a|s|tools", 1000)
-            ledger.record("control", "opus|a|s|tools", 1000)
-            ledger.record("treatment", "opus|a|s|tools", 900)
+            ledger.record("control", "opus|a|s|tools", 1000, shaper_active=True)
+            ledger.record("treatment", "opus|a|s|tools", 900, shaper_active=True)
         assert ledger.best_estimate().kind == "measured"
 
     def test_best_estimate_falls_back_to_estimated(self):
         ledger = SavingsLedger()
         for _ in range(10):
             ledger.baseline.observe("opus|a|s|tools", 1000)
-            ledger.record("treatment", "opus|a|s|tools", 900)
+            ledger.record("treatment", "opus|a|s|tools", 900, shaper_active=True)
         assert ledger.best_estimate().kind == "estimated"
 
 
@@ -333,8 +334,8 @@ class TestLedgerPersistence:
     def test_roundtrip(self, tmp_path):
         ledger = SavingsLedger()
         ledger.baseline.observe("opus|a|s|tools", 1000)
-        ledger.record("treatment", "opus|a|s|tools", 800)
-        ledger.record("control", "opus|a|s|tools", 1000)
+        ledger.record("treatment", "opus|a|s|tools", 800, shaper_active=True)
+        ledger.record("control", "opus|a|s|tools", 1000, shaper_active=True)
         path = tmp_path / "savings.json"
         ledger.save(path)
         loaded = SavingsLedger.load(path)
@@ -352,6 +353,229 @@ class TestLedgerPersistence:
         p.write_text("{not json")
         ledger = SavingsLedger.load(p)
         assert ledger.baseline.total_samples == 0
+
+
+# ---------------------------------------------------------------------------
+# shaper-active tagging (#3395)
+#
+# The arms fill whenever the shaper is *configured* on, but shaping is inert at
+# level 0 (cache mode forces it; a learned or env level selects it). Untagged
+# observations are the same problem one upgrade earlier. Neither may reach an
+# estimate: differencing two unshaped arms is how a rollout-blocked install
+# published a "measured" -147.9% reduction over 19,644 requests.
+# ---------------------------------------------------------------------------
+
+
+class TestShaperActiveTagging:
+    KEY = "opus|new_user_ask|s|tools"
+
+    def _seeded(self) -> SavingsLedger:
+        ledger = SavingsLedger()
+        for _ in range(10):
+            ledger.baseline.observe(self.KEY, 1000)
+        return ledger
+
+    def test_active_observations_are_counted(self):
+        ledger = self._seeded()
+        for _ in range(4):
+            ledger.record("treatment", self.KEY, 700, shaper_active=True)
+
+        est = ledger.estimate_from_baseline()
+        assert est.n_requests == 4
+        assert est.tokens_saved == pytest.approx(4 * 300)
+
+    def test_inactive_observations_reach_no_estimate(self):
+        ledger = self._seeded()
+        for _ in range(4):
+            ledger.record("treatment", self.KEY, 700, shaper_active=False)
+            ledger.record("control", self.KEY, 1000, shaper_active=False)
+
+        assert ledger.estimate_from_baseline().n_requests == 0
+        assert ledger.estimate_from_holdout() is None
+        assert ledger.best_estimate().n_requests == 0
+        # Kept, but only as diagnostics — this is the number that explains a
+        # small n to an operator instead of history appearing to vanish.
+        assert ledger.inactive_requests == 8
+
+    def test_inactive_arm_cannot_pair_with_an_active_one(self):
+        # The era-mixing case: control accumulated while the shaper was inert,
+        # treatment after it was switched on. Pairing them measures the traffic
+        # drift between the two periods and calls it shaping.
+        ledger = self._seeded()
+        for _ in range(6):
+            ledger.record("control", self.KEY, 2000, shaper_active=False)
+        for _ in range(6):
+            ledger.record("treatment", self.KEY, 800, shaper_active=True)
+
+        assert ledger.estimate_from_holdout() is None
+        # The synthetic-control tier still works off the shaped arm alone.
+        assert ledger.estimate_from_baseline().n_requests == 6
+
+    def test_measured_number_uses_active_arms_only(self):
+        ledger = self._seeded()
+        for _ in range(5):
+            ledger.record("control", self.KEY, 1000, shaper_active=True)
+            ledger.record("treatment", self.KEY, 750, shaper_active=True)
+            # Inactive-period traffic in both arms, wildly off, must not move it.
+            ledger.record("control", self.KEY, 10, shaper_active=False)
+            ledger.record("treatment", self.KEY, 9000, shaper_active=False)
+
+        est = ledger.estimate_from_holdout()
+        assert est is not None
+        assert est.kind == "measured"
+        assert est.n_requests == 5
+        assert est.pct == pytest.approx(25.0)
+
+    def test_modelled_tier_ignores_inactive_traffic(self):
+        # The weakest tier multiplies observed treatment output by a benchmark
+        # factor; unshaped output there invents savings out of a constant.
+        ledger = SavingsLedger()
+        for _ in range(3):
+            ledger.record("treatment", self.KEY, 1000, shaper_active=False)
+
+        assert ledger.estimate_from_model(3) is None
+
+
+class TestRecorderTagsFromTheLabel:
+    KEY = "opus|new_user_ask|s|tools"
+
+    def _recorder(self, tmp_path) -> SavingsRecorder:
+        rec = SavingsRecorder(tmp_path / "savings.json", flush_every=1000)
+        for _ in range(10):
+            rec._ledger.baseline.observe(self.KEY, 1000)
+        return rec
+
+    def test_a_shaped_level_records_into_the_active_arm(self, tmp_path):
+        rec = self._recorder(tmp_path)
+        assert (
+            rec.record_from_labels([stratum_label("treatment", self.KEY, verbosity_level=3)], 700)
+            is True
+        )
+
+        assert rec._ledger.treatment[self.KEY].n == 1
+        assert rec.estimate().n_requests == 1
+
+    def test_level_zero_records_into_the_inactive_arm(self, tmp_path):
+        # Level 0 is the documented "no steering" value — what cache mode
+        # forces. The request happened; the shaping did not.
+        rec = self._recorder(tmp_path)
+        assert (
+            rec.record_from_labels([stratum_label("treatment", self.KEY, verbosity_level=0)], 700)
+            is True
+        )
+
+        assert self.KEY not in rec._ledger.treatment
+        assert rec._ledger.inactive_treatment[self.KEY].n == 1
+        assert rec.estimate().n_requests == 0
+
+    def test_an_untagged_label_is_treated_as_inactive(self, tmp_path):
+        # A label with no level carries no evidence that shaping ran, and
+        # unprovable activity must never be able to inflate a claim.
+        rec = self._recorder(tmp_path)
+        assert rec.record_from_labels([stratum_label("treatment", self.KEY)], 700) is True
+
+        assert self.KEY not in rec._ledger.treatment
+        assert rec._ledger.inactive_treatment[self.KEY].n == 1
+        assert rec.estimate().n_requests == 0
+
+    def test_control_is_tagged_the_same_way(self, tmp_path):
+        # Symmetry matters: filtering only the treatment arm would leave the
+        # arms holding different populations and bias the difference of means.
+        rec = self._recorder(tmp_path)
+        rec.record_from_labels([stratum_label("control", self.KEY, verbosity_level=0)], 1000)
+        rec.record_from_labels([stratum_label("control", self.KEY, verbosity_level=3)], 1000)
+
+        assert rec._ledger.control[self.KEY].n == 1
+        assert rec._ledger.inactive_control[self.KEY].n == 1
+
+
+class TestLedgerSchemaMigration:
+    KEY = "opus|new_user_ask|s|tools"
+
+    def _legacy_file(self, tmp_path, *, with_arms: bool = True):
+        """A ledger file in the pre-tag on-disk shape (no ``schema_version``)."""
+        import json
+
+        payload = {
+            "baseline": {
+                "strata": {self.KEY: {"n": 10, "sum": 10_000.0, "sumsq": 10_000_000.0}},
+                "glob": {"n": 10, "sum": 10_000.0, "sumsq": 10_000_000.0},
+            },
+        }
+        if with_arms:
+            payload["treatment"] = {self.KEY: {"n": 19_644, "sum": 12_000_000.0, "sumsq": 1e13}}
+            payload["control"] = {self.KEY: {"n": 500, "sum": 250_000.0, "sumsq": 1e11}}
+        p = tmp_path / "savings.json"
+        p.write_text(json.dumps(payload))
+        return p
+
+    def test_legacy_file_loads_without_error_and_drops_its_arms(self, tmp_path):
+        ledger = SavingsLedger.load(self._legacy_file(tmp_path))
+
+        assert ledger.treatment == {}
+        assert ledger.control == {}
+        assert ledger.estimate_from_holdout() is None
+        assert ledger.best_estimate().n_requests == 0
+
+    def test_legacy_baseline_survives_the_drop(self, tmp_path):
+        # The baseline is learned offline from pre-shaper history — unshaped by
+        # definition, never the poisoned part, and costly to rebuild.
+        ledger = SavingsLedger.load(self._legacy_file(tmp_path))
+
+        assert ledger.baseline.total_samples == 10
+        assert ledger.baseline.lookup(self.KEY)[0] == 1000.0
+
+    def test_dropping_legacy_arms_is_reported(self, tmp_path, caplog, monkeypatch):
+        # Silently discarding accumulated history is exactly the failure mode
+        # #18 fixed for corrupt files; say it out loud.
+        monkeypatch.setattr("headroom.proxy.output_savings._legacy_arms_warned", False)
+        with caplog.at_level("WARNING"):
+            SavingsLedger.load(self._legacy_file(tmp_path))
+
+        assert any("predates the shaper-active tag" in r.message for r in caplog.records)
+
+    def test_a_baseline_only_legacy_file_is_not_warned_about(self, tmp_path, caplog, monkeypatch):
+        # `learn --verbosity --apply` before any traffic writes exactly this.
+        monkeypatch.setattr("headroom.proxy.output_savings._legacy_arms_warned", False)
+        with caplog.at_level("WARNING"):
+            ledger = SavingsLedger.load(self._legacy_file(tmp_path, with_arms=False))
+
+        assert ledger.baseline.total_samples == 10
+        assert caplog.records == []
+
+    def test_upgraded_install_re_accumulates_from_live_traffic(self, tmp_path):
+        # The upgrade contract: a smaller n, not an inherited claim.
+        path = self._legacy_file(tmp_path)
+        rec = SavingsRecorder(path, flush_every=1)
+        rec.record_from_labels([stratum_label("treatment", self.KEY, verbosity_level=3)], 700)
+
+        est = rec.estimate()
+        assert est.n_requests == 1
+        assert est.tokens_saved == pytest.approx(300.0)
+
+    def test_current_schema_round_trips_both_arm_pairs(self, tmp_path):
+        ledger = SavingsLedger()
+        ledger.baseline.observe(self.KEY, 1000)
+        ledger.record("treatment", self.KEY, 800, shaper_active=True)
+        ledger.record("control", self.KEY, 1000, shaper_active=True)
+        ledger.record("treatment", self.KEY, 4000, shaper_active=False)
+        ledger.record("control", self.KEY, 4000, shaper_active=False)
+        path = tmp_path / "savings.json"
+        ledger.save(path)
+
+        loaded = SavingsLedger.load(path)
+        assert loaded.treatment[self.KEY].n == 1
+        assert loaded.control[self.KEY].n == 1
+        assert loaded.inactive_requests == 2
+        assert loaded.estimate_from_holdout().pct == pytest.approx(20.0)
+
+    def test_saved_file_declares_the_schema_version(self, tmp_path):
+        import json
+
+        path = tmp_path / "savings.json"
+        SavingsLedger().save(path)
+
+        assert json.loads(path.read_text())["schema_version"] == LEDGER_SCHEMA_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -399,7 +623,9 @@ class TestRecorderBaselineReload:
 
         recorder = SavingsRecorder(path, flush_every=1)
         for output_tokens in (200, 210, 190):
-            recorder.record_from_labels([stratum_label("treatment", key)], output_tokens)
+            recorder.record_from_labels(
+                [stratum_label("treatment", key, verbosity_level=3)], output_tokens
+            )
 
         # No baseline to compare against yet, so there is nothing to estimate.
         assert recorder.estimate().n_requests == 0
@@ -430,7 +656,7 @@ class TestRecorderBaselineReload:
         learned.save(path)
         assert SavingsLedger.load(path).baseline.total_samples == 4
 
-        recorder.record_from_labels([stratum_label("treatment", key)], 200)
+        recorder.record_from_labels([stratum_label("treatment", key, verbosity_level=3)], 200)
         recorder.flush()
 
         # The flush must keep the learned baseline rather than writing the empty
@@ -459,7 +685,9 @@ class TestRecorderBaselineReload:
 
         recorder = SavingsRecorder(path, flush_every=1)
         for output_tokens in (200, 210, 190):
-            recorder.record_from_labels([stratum_label("treatment", key)], output_tokens)
+            recorder.record_from_labels(
+                [stratum_label("treatment", key, verbosity_level=3)], output_tokens
+            )
 
         # First learn writes a baseline; the recorder adopts it.
         first = SavingsLedger.load(path)
@@ -502,7 +730,7 @@ class TestFlushDurability:
         key = SAMPLE_KEY
 
         recorder = SavingsRecorder(path, flush_every=1)
-        recorder.record_from_labels([stratum_label("treatment", key)], 200)
+        recorder.record_from_labels([stratum_label("treatment", key, verbosity_level=3)], 200)
         recorder.flush()
         assert SavingsLedger.load(path).treatment[key].n == 1
 
@@ -510,7 +738,7 @@ class TestFlushDurability:
             raise OSError(5, "simulated crash before rename")
 
         monkeypatch.setattr(headroom.fsutil.os, "replace", _die_before_rename)
-        recorder.record_from_labels([stratum_label("treatment", key)], 210)
+        recorder.record_from_labels([stratum_label("treatment", key, verbosity_level=3)], 210)
         recorder.flush()  # OSError swallowed by the recorder — fail-open by design
 
         # The pre-crash sample must survive and no temp residue may be left
@@ -568,7 +796,7 @@ class TestFlushDurability:
             output_tokens=50,
             tokens_saved=20,
             attempted_input_tokens=100,
-            transforms_applied=(stratum_label("treatment", SAMPLE_KEY),),
+            transforms_applied=(stratum_label("treatment", SAMPLE_KEY, verbosity_level=3),),
         )
         asyncio.run(emit_request_outcome(_Handler(), outcome))
 
@@ -614,7 +842,7 @@ class TestModelledTier:
             turn_kind="new_user_ask", input_tokens=1000, model="claude-sonnet-5", has_tools=False
         )
         for _ in range(n):
-            ledger.record("treatment", key, observed_total // n)
+            ledger.record("treatment", key, observed_total // n, shaper_active=True)
         return ledger
 
     def test_ships_empty_so_an_unmeasured_deployment_claims_nothing(self):
@@ -702,7 +930,7 @@ class TestModelledTier:
             baseline.observe(key, 2000)
         ledger = SavingsLedger(baseline=baseline)
         for _ in range(10):
-            ledger.record("treatment", key, 1000)
+            ledger.record("treatment", key, 1000, shaper_active=True)
         assert ledger.best_estimate(3).kind == "estimated"
 
     def test_without_a_level_behaviour_is_unchanged(self):

--- a/tests/test_output_savings_cli.py
+++ b/tests/test_output_savings_cli.py
@@ -26,7 +26,7 @@ def test_output_savings_reports_estimate(tmp_path, monkeypatch):
     for _ in range(50):
         ledger.baseline.observe("opus|new_user_ask|s|tools", 1000)
     for _ in range(30):
-        ledger.record("treatment", "opus|new_user_ask|s|tools", 700)
+        ledger.record("treatment", "opus|new_user_ask|s|tools", 700, shaper_active=True)
     ledger.save(tmp_path / "output_savings.json")
 
     result = CliRunner().invoke(main, ["output-savings"])
@@ -41,7 +41,10 @@ def test_recorder_round_trips_via_labels(tmp_path):
     rec = SavingsRecorder(path, flush_every=1)
     # Baseline so the estimate has something to compare against.
     rec._ledger.baseline.observe("opus|new_user_ask|s|tools", 1000)
-    labels = ["compress:smartcrush", stratum_label("treatment", "opus|new_user_ask|s|tools")]
+    labels = [
+        "compress:smartcrush",
+        stratum_label("treatment", "opus|new_user_ask|s|tools", verbosity_level=3),
+    ]
     assert rec.record_from_labels(labels, output_tokens=600) is True
     assert rec.record_from_labels(["no-shaper-label"], output_tokens=999) is False
     est = rec.estimate()

--- a/tests/test_output_savings_policy.py
+++ b/tests/test_output_savings_policy.py
@@ -52,9 +52,36 @@ def test_conversation_key_uses_response_create_payload() -> None:
     assert conversation_key_from_body(http_body) == conversation_key_from_body(ws_body)
 
 
-def test_stratum_label_round_trips_arm_and_key() -> None:
+def test_stratum_label_round_trips_arm_key_and_level() -> None:
     key = "opus|code|m|tools"
 
-    assert parse_stratum_label(stratum_label("treatment", key)) == ("treatment", key)
-    assert parse_stratum_label(stratum_label("control", key)) == ("control", key)
+    assert parse_stratum_label(stratum_label("treatment", key, verbosity_level=3)) == (
+        "treatment",
+        key,
+        3,
+    )
+    assert parse_stratum_label(stratum_label("control", key, verbosity_level=0)) == (
+        "control",
+        key,
+        0,
+    )
     assert parse_stratum_label("unrelated") is None
+
+
+def test_untagged_stratum_label_round_trips_with_no_level() -> None:
+    # The pre-#3395 label shape. It still decodes — the ledger needs the arm and
+    # stratum to file it — but with no level, which is what makes it excluded
+    # from the estimate rather than credited to shaping.
+    key = "opus|code|m|tools"
+
+    assert parse_stratum_label(stratum_label("treatment", key)) == ("treatment", key, None)
+    assert parse_stratum_label(stratum_label("control", key)) == ("control", key, None)
+
+
+def test_level_tag_does_not_disturb_prefix_matching() -> None:
+    # Downstream matchers (and the WS lifecycle tests) match on the label prefix
+    # plus stratum key; the level rides as a tail so those keep working.
+    label = stratum_label("treatment", "gpt|new_user_ask|s|tools", verbosity_level=2)
+
+    assert label.startswith("output_shaper:stratum:gpt|new_user_ask|s|")
+    assert label.endswith(":L2")

--- a/tests/test_output_shaping_rollup.py
+++ b/tests/test_output_shaping_rollup.py
@@ -70,7 +70,7 @@ def test_estimate_request_savings_treatment_uses_baseline(tmp_path):
         rec._ledger.baseline.observe(key, 1000)  # baseline mean ~1000
 
     # Treatment request that emitted 600 -> saved ~400 vs the baseline.
-    saved = rec.estimate_request_savings([stratum_label("treatment", key)], 600)
+    saved = rec.estimate_request_savings([stratum_label("treatment", key, verbosity_level=3)], 600)
     assert saved == 400
 
 
@@ -81,8 +81,13 @@ def test_estimate_request_savings_zero_for_control_and_unknown(tmp_path):
         rec._ledger.baseline.observe(key, 1000)
 
     # Control arm is unshaped -> no attributable saving.
-    assert rec.estimate_request_savings([stratum_label("control", key)], 600) == 0
+    assert (
+        rec.estimate_request_savings([stratum_label("control", key, verbosity_level=3)], 600) == 0
+    )
     # No shaping label at all.
     assert rec.estimate_request_savings(["something-else"], 600) == 0
     # Treatment but output exceeded the baseline -> clamped to 0, never negative.
-    assert rec.estimate_request_savings([stratum_label("treatment", key)], 5000) == 0
+    assert (
+        rec.estimate_request_savings([stratum_label("treatment", key, verbosity_level=3)], 5000)
+        == 0
+    )


### PR DESCRIPTION
## Description

The output-savings estimate is a counterfactual: traffic splits into a shaped treatment arm and an unshaped control arm, and the difference between them is the shaper's effect. `OutputSavingsLedger.record(arm, key, output_tokens)` stored the arm, the stratum and the token count — and nothing about whether the shaper was actually running when the entry was written.

The stratum label is attached whenever the shaper is *configured* on, but the shaping itself can be inert: level 0 means no steering at all, which `mode="cache"` forces and a learned or env level of 0 selects. Both arms keep filling while nothing is being shaped, and differencing them reports noise as a shaping effect. That is how a rollout-blocked stable install published a "measured" -147.9% output reduction over 19,644 requests.

#3386 gates the /stats *display* on the shaper being active, which suppresses the claim while it is off. The entries themselves stay unattributable, so the number returns on the first request after the channel unblocks. This PR fixes the data.

Closes #3395

### Overlap with #3386 — please read before merging both

#3386 gained a second commit (781c27f) after this issue was filed, and it now edits `output_savings.py` too, so these two PRs conflict and one should supersede the other's ledger half. The two take different approaches and the difference is not cosmetic:

- **#3386** drops a treatment observation unless the shaper's `output_shaper:verbosity:` label proves *this request's body* was changed, and records control unconditionally.
- **This PR** tags both arms with the shaper's resolved level at record time and filters both on it.

The asymmetry in #3386 is a bias in the same direction as the bug. `changed` is false for a request whose body offered nothing to steer, so the treatment arm becomes "requests the shaper found something to change" while control stays "every control request" — conditioning one arm on a post-assignment variable, which makes the arms different populations and biases the difference of means. More importantly it does not close the reported hole: while the shaper is configured on but inert (cache mode, level 0), #3386 drops treatment and *keeps* control, so control accumulates through the inactive period and pairs with treatment recorded after activation. #3395's "treat an activation-state transition as a segment boundary" only holds if both arms are segmented.

I have not touched #3386's branch, and `server.py` is untouched here — the /stats gate and this are complementary once the ledger half is resolved one way.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `output_savings_policy.stratum_label(arm, key, *, verbosity_level=None)` appends the resolved level as a `:L<n>` tail; `parse_stratum_label` returns `(arm, stratum, level | None)`. The level rides the existing label rather than a new one so `telemetry.session` (which counts one entry per label, keyed on the text before the first colon) sees no new transform, and existing `startswith(prefix + key)` matches keep working. A stratum key is a fixed vocabulary joined with `|` and cannot contain a colon, so the tail is unambiguous.
- `SavingsLedger.record(..., *, shaper_active: bool)` — required, no default. Active observations go to `treatment`/`control`; inactive ones to new `inactive_treatment`/`inactive_control`, which no estimator reads. Making the arms themselves clean is the point: every current estimator gets the filter for free, and a future one cannot reintroduce the bug by forgetting to apply it.
- The tag is symmetric across arms and describes the deployment's state at record time, not what the shaper did to a particular body — see the overlap note above for why that distinction matters.
- Inactive observations are kept rather than discarded, and surfaced: `SavingsLedger.inactive_requests`, and `headroom output-savings` now prints the excluded count so a small `n` reads as "the shaper was off" instead of history disappearing.
- Persistence: the file carries `schema_version: 2`. A schema-1 file (the first load after any upgrade) cannot have its arms split entry by entry — the tag they would need is exactly what is missing — so they are dropped with a one-time warning and re-accumulated from live traffic. An upgraded install gets a smaller `n` rather than an inherited claim. The offline baseline survives: it is learned from pre-shaper history, is unshaped by definition, and costs a `learn --verbosity` run to rebuild. The warning is once-per-process because the recorder re-reads the file on every flush and every `estimate`.
- `SavingsRecorder.estimate_request_savings` returns 0 when the level says the shaper was inert. That number is priced in USD downstream, so letting it through would move the claim the ledger refuses to make onto the savings rollup and Prometheus instead.
- Three handler sites (`handlers/anthropic.py`, and the chat + Responses paths in `handlers/openai.py`) resolve the verbosity level *before* the arm branch and pass it into the label for both arms. Treatment behaviour is unchanged — same level, resolved once. Control now costs one `resolve_verbosity_level` call it did not make before (a couple of small file reads, and only on holdout traffic).
- Tests: new `TestShaperActiveTagging`, `TestRecorderTagsFromTheLabel` and `TestLedgerSchemaMigration` in `tests/test_output_savings.py`; level round-trip and untagged-label cases in `tests/test_output_savings_policy.py`. Existing call sites updated for the two signature changes.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run --frozen --extra dev pytest tests/test_stateless_writers.py tests/test_proxy_byte_faithful_forwarding.py \
    tests/test_proxy_savings_history.py tests/test_savings_tracker_zero_price.py tests/test_output_shaping_rollup.py \
    tests/test_openai_codex_ws_lifecycle.py tests/test_openai_responses_output_shaper.py tests/test_rollout.py \
    tests/test_cli_learn.py tests/test_output_savings_policy.py tests/test_output_savings_cli.py \
    tests/test_verbosity_learn.py tests/test_output_savings.py tests/test_output_shaper.py tests/test_runtime_env.py \
    tests/test_openai_responses_additional_tools.py tests/test_output_shaper_responses.py -q
463 passed, 1 warning in 22.84s

$ uv run --frozen --extra dev ruff check <touched files>
All checks passed!

$ uv run --frozen --extra dev mypy headroom/proxy/output_savings.py headroom/proxy/output_savings_policy.py headroom/cli/output_savings.py
Success: no issues found in 3 source files
```

Full suite: `pytest tests --ignore=tests/test_memory_eval.py` gives 11673 passed, 15 failed. Eleven are reproduced verbatim on a clean `origin/main` worktree and are environmental or unrelated (litellm not installed here, a Windows-only event-loop assertion, model-registry pricing, route-advice). The other four are `test_proxy_health.py` kompress-readiness tests, which pass in isolation on both trees and fail only inside the full run — order-dependent global state, and nothing this PR touches goes near kompress or `/readyz`. `tests/test_memory_eval.py` fails to import on `origin/main` too (no `litellm`).

## Real Behavior Proof

- Environment: macOS 15 (arm64), Python 3.14 via uv, this branch's worktree.
- Exact command / steps: wrote a schema-1 ledger holding the field shape — treatment `n=19,644` at mean 641 tokens, control `n=1,000` at mean 258, plus a 200-sample baseline — then loaded it, drove 100 requests through `SavingsRecorder` with the shaper inert (`L0`, both arms), then 100 more with it live (`L3`, treatment 700 / control 1000).
- Observed result:

```text
# same arms, unfiltered (pre-fix arithmetic)
unfiltered arms: kind=measured pct=-148.6 n=19644

# after
WARNING output-savings ledger predates the shaper-active tag (schema 1); dropping 1 treatment
        and 1 control strata and re-accumulating from live traffic (baseline kept)
legacy load:               kind=estimated pct=0.0  n=0  baseline_samples=200
100 inert-shaper requests: kind=estimated pct=0.0  n=0  excluded=100
per-request rollup for an inert treatment request: 0 tokens
100 shaped requests:       kind=measured  pct=30.0 n=50 excluded=100
on-disk schema_version=2
```

  The -148.6% is this reconstruction's figure for the field's -147.9%, not the field file itself.
- Not tested: an end-to-end proxy run on a real rollout-blocked install (no blocked-channel machine at hand); the handler label change is covered by the existing shaper/WS/Responses suites rather than by a live request.

## Runtime Rollout Safety

- Rollout-managed feature(s): reads the output shaper's already-resolved settings; changes no rollout behaviour itself.
- Minimum rollout channel: Stable.
- Stable/default behavior changed: Yes, for the reported failure mode. A deployment whose shaper is inert (level 0 / cache mode) reports no output-reduction estimate instead of one built from unshaped traffic, and every install drops its pre-upgrade arms once on first load. Deployments with the shaper live at level > 0 are unchanged apart from the one-time drop.
- Kill switch / disable path: not applicable; the filter follows the shaper's own level, which already has one.
- Unsafe override required: No.
- Qualification impact: blocked or cache-mode installs stop advertising output savings they never performed, in `/stats`, in `headroom output-savings`, and in the per-request USD rollup.
- Rollback path: revert the commit. A schema-2 file read by the reverted code still loads — the extra keys are ignored and the arms it reads hold shaped-only data, i.e. the conservative side.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A: the ledger's on-disk shape is not documented outside the module.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

The verbosity level is carried on the label but the ledger stores only the active/inactive split, not per-level arms. Segmenting strata by level would fragment an already sparse per-stratum baseline for a distinction the arm contrast does not use; the level's job here is to answer "was anything being shaped", and that is a boolean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7Jx24NvP1xXZRSn3WG1vi
