### PR TITLE
fix(langchain): make the integration work on LangChain 1.x, and document it

### DIFF
--- a/docs/content/docs/langchain.mdx
+++ b/docs/content/docs/langchain.mdx
@@ -1,19 +1,32 @@
 ---
-title: LangChain
-description: Automatic context compression for LangChain chat models, memory, retrievers, and agents.
+title: LangChain & LangGraph
+description: Compress context in LangChain chat models, memory, retrievers, and LangGraph agents.
 ---
 
-Headroom integrates with LangChain to compress context across all LangChain patterns: chat models, memory, retrievers, agents, and streaming.
+Headroom plugs into LangChain at four points: the chat model, tool output, retrieved documents, and conversation history. In LangGraph it also works as a graph node, compressing `ToolMessage` content between the tool step and the agent step.
 
-## Installation
+## Install
 
 ```bash
-pip install "headroom-ai[langchain]"
+pip install "headroom-ai[langchain]"    # langchain-core + langchain-openai
+pip install "headroom-ai[langgraph]"    # the above, plus langgraph
 ```
 
-## Quick start
+Provider packages are separate, as they are in LangChain itself:
 
-Wrap any chat model in one line:
+```bash
+pip install langchain-anthropic         # ChatAnthropic
+pip install langchain                   # create_agent, init_chat_model
+pip install langchain-classic           # ContextualCompressionRetriever
+```
+
+<Callout type="warn">
+LangChain 1.0 removed several modules that older Headroom docs referenced. `langchain.memory` and `langchain.retrievers` no longer exist, and `create_openai_tools_agent` and `AgentExecutor` are gone from `langchain.agents`. The [migration table](#migrating-from-langchain-0x) at the bottom of this page maps each one to its replacement. Verified against langchain-core 1.6.1, langchain 1.3.18 and langgraph 1.2.11.
+</Callout>
+
+## Chat model
+
+`HeadroomChatModel` wraps any LangChain chat model. Messages are compressed on the way out; everything else about the model is unchanged.
 
 ```python
 from langchain_openai import ChatOpenAI
@@ -21,135 +34,69 @@ from headroom.integrations import HeadroomChatModel
 
 llm = HeadroomChatModel(ChatOpenAI(model="gpt-4o"))
 
-# Use exactly like before
 response = llm.invoke("Hello!")
 
-# Check savings
 print(llm.get_savings_summary())
-# {'total_requests': 50, 'total_tokens_saved': 12500, 'average_savings_percent': 45.2,
-#  'total_tokens_before': 27700, 'total_tokens_after': 15200}
+# {'total_requests': 1, 'total_tokens_saved': 0, 'average_savings_percent': 0.0,
+#  'total_tokens_before': 9, 'total_tokens_after': 9}
 ```
 
-Works with any provider:
+Short prompts compress to nothing, which is the intended behaviour — savings appear once tool output and history are in the context.
+
+Any provider works:
 
 ```python
 from langchain_anthropic import ChatAnthropic
+from headroom.integrations import HeadroomChatModel
 
 llm = HeadroomChatModel(ChatAnthropic(model="claude-sonnet-4-20250514"))
 ```
 
-## Memory integration
+Tool binding is forwarded to the underlying model, so `llm.bind_tools(...)` and the agent runtimes built on it behave the same as the unwrapped model.
 
-`HeadroomChatMessageHistory` wraps any chat history with automatic compression. Long conversations stay under your token budget:
+## Agents
 
-```python
-from langchain.memory import ConversationBufferMemory
-from langchain_community.chat_message_histories import ChatMessageHistory
-from headroom.integrations import HeadroomChatMessageHistory
-
-base_history = ChatMessageHistory()
-compressed_history = HeadroomChatMessageHistory(
-    base_history,
-    compress_threshold_tokens=4000,  # Compress when over 4K tokens
-    keep_recent_turns=5,             # Always keep last 5 turns
-)
-
-memory = ConversationBufferMemory(chat_memory=compressed_history)
-```
-
-After usage:
+`wrap_tools_with_headroom` compresses tool output before it re-enters the agent's context. The wrapped tool keeps the original argument schema, so the model sees the same parameters.
 
 ```python
-print(compressed_history.get_compression_stats())
-# {'compression_count': 12, 'total_tokens_saved': 28000,
-#  'threshold_tokens': 4000, 'keep_recent_turns': 5}
-```
-
-## Retriever integration
-
-`HeadroomDocumentCompressor` filters retrieved documents by relevance. Retrieve many for recall, keep the best for precision:
-
-```python
-from langchain.retrievers import ContextualCompressionRetriever
-from langchain_community.vectorstores import FAISS
-from headroom.integrations import HeadroomDocumentCompressor
-
-base_retriever = vectorstore.as_retriever(search_kwargs={"k": 50})
-
-compressor = HeadroomDocumentCompressor(
-    max_documents=10,
-    min_relevance=0.3,
-    prefer_diverse=True,  # MMR-style diversity
-)
-
-retriever = ContextualCompressionRetriever(
-    base_compressor=compressor,
-    base_retriever=base_retriever,
-)
-
-# Retrieves 50 docs, returns best 10
-docs = retriever.invoke("What is Python?")
-```
-
-## Agent tool wrapping
-
-`wrap_tools_with_headroom` compresses tool outputs before they re-enter the agent's context:
-
-```python
+import json
 from langchain_core.tools import tool
-from headroom.integrations import wrap_tools_with_headroom
+from langchain_openai import ChatOpenAI
+from langchain.agents import create_agent
+from headroom.integrations import HeadroomChatModel, wrap_tools_with_headroom
 
 @tool
-def search_database(query: str) -> str:
-    """Search the database."""
-    return json.dumps({"results": [...], "total": 1000})
+def query_database(query: str) -> str:
+    """Query the users database. Returns JSON rows."""
+    return json.dumps({"results": [...], "total": 300})
 
-wrapped_tools = wrap_tools_with_headroom(
-    [search_database],
-    min_chars_to_compress=1000,
-)
+llm = HeadroomChatModel(ChatOpenAI(model="gpt-4o-mini"))
+tools = wrap_tools_with_headroom([query_database], min_chars_to_compress=1000)
 
-agent = create_openai_tools_agent(llm, wrapped_tools, prompt)
-executor = AgentExecutor(agent=agent, tools=wrapped_tools)
+agent = create_agent(llm, tools)
+result = agent.invoke({
+    "messages": [("user", "How many users signed up last week?")]
+})
 ```
 
-Per-tool metrics:
+`create_agent` comes from the `langchain` package. LangGraph's `create_react_agent` still works and is a drop-in substitute, but it is deprecated as of LangGraph 1.0 and slated for removal in 2.0.
+
+Per-tool metrics are collected globally:
 
 ```python
 from headroom.integrations import get_tool_metrics
 
-metrics = get_tool_metrics()
-print(metrics.get_summary())
-# {
-#   'total_invocations': 25,
-#   'total_compressions': 18,
-#   'total_chars_saved': 450000,
-#   'average_compression_ratio': 0.35,
-#   'by_tool': {
-#     'search_database': {'invocations': 15, 'compressions': 12, 'chars_saved': 320000},
-#   }
-# }
+print(get_tool_metrics().get_summary())
+# {'total_invocations': 1, 'total_compressions': 1, 'total_chars_saved': 4202,
+#  'average_compression_ratio': 0.901,
+#  'by_tool': {'query_database': {'invocations': 1, 'compressions': 1, 'chars_saved': 4202}}}
 ```
 
-## LangGraph ReAct agent
+Async agents work too — the wrapped tool exposes a coroutine, so `await agent.ainvoke(...)` compresses on the async path as well.
 
-```python
-from langchain_openai import ChatOpenAI
-from langgraph.prebuilt import create_react_agent
-from headroom.integrations import HeadroomChatModel, wrap_tools_with_headroom
+## LangGraph compression node
 
-llm = HeadroomChatModel(ChatOpenAI(model="gpt-4o"))
-tools = wrap_tools_with_headroom([search_web, query_database])
-
-agent = create_react_agent(llm, tools)
-result = agent.invoke({
-    "messages": [("user", "Find users who signed up last week")]
-})
-```
-
-## LangGraph custom graph
-
-Insert a compression node between tools and the agent in a custom `StateGraph`:
+Wrapping tools compresses each tool's own return value. Compressing at the graph level instead lets Headroom see every `ToolMessage` in state at once, which usually removes more.
 
 ```python
 from langgraph.graph import StateGraph, MessagesState, START, END
@@ -162,36 +109,125 @@ graph.add_node("compress", create_compress_tool_messages_node(
     min_tokens_to_compress=100,
 ))
 
-# Wire: tools -> compress -> agent
 graph.add_edge(START, "agent")
 graph.add_edge("tools", "compress")
 graph.add_edge("compress", "agent")
+
+app = graph.compile()
 ```
+
+On a 300-row JSON tool result — 42,597 characters — the node returns 18,390, a 57% reduction, with `tool_call_id` preserved so the graph stays valid.
+
+To call it directly rather than as a node:
+
+```python
+from headroom.integrations.langchain import compress_tool_messages
+
+result = compress_tool_messages(state["messages"], min_tokens_to_compress=100)
+
+result.messages            # the rewritten message list
+result.messages_compressed # 1
+result.total_tokens_saved  # 6052
+```
+
+Messages below the threshold are returned unchanged.
+
+## Memory
+
+`HeadroomChatMessageHistory` wraps any `BaseChatMessageHistory` and compresses older turns once the history crosses a token budget.
+
+```python
+from langchain_core.chat_history import InMemoryChatMessageHistory
+from headroom.integrations import HeadroomChatMessageHistory
+
+history = HeadroomChatMessageHistory(
+    InMemoryChatMessageHistory(),
+    compress_threshold_tokens=4000,   # start compressing above 4K tokens
+    keep_recent_turns=5,              # never touch the last 5 turns
+)
+
+history.add_user_message("...")
+history.add_ai_message("...")
+
+print(history.get_compression_stats())
+# {'compression_count': 0, 'total_tokens_saved': 0,
+#  'threshold_tokens': 4000, 'keep_recent_turns': 5}
+```
+
+Use it anywhere a chat history is accepted:
+
+```python
+from langchain_core.runnables.history import RunnableWithMessageHistory
+
+chain = RunnableWithMessageHistory(llm, lambda session_id: history)
+```
+
+`ConversationBufferMemory` was removed in LangChain 1.0. `RunnableWithMessageHistory`, or a LangGraph checkpointer, replaces it.
+
+## Retriever
+
+`HeadroomDocumentCompressor` scores retrieved documents against the query and keeps the best. Retrieve widely for recall, then narrow for precision.
+
+```python
+from headroom.integrations import HeadroomDocumentCompressor
+
+compressor = HeadroomDocumentCompressor(
+    max_documents=10,
+    min_relevance=0.3,
+    prefer_diverse=True,   # MMR-style diversity
+)
+
+docs = compressor.compress_documents(retrieved_docs, "What is Python?")
+```
+
+It is a real `langchain_core.documents.compressor.BaseDocumentCompressor`, so it also drops into the classic retriever pattern:
+
+```python
+from langchain_classic.retrievers import ContextualCompressionRetriever
+
+retriever = ContextualCompressionRetriever(
+    base_compressor=compressor,
+    base_retriever=vectorstore.as_retriever(search_kwargs={"k": 50}),
+)
+
+docs = retriever.invoke("What is Python?")   # retrieves 50, returns 10
+```
+
+`ContextualCompressionRetriever` moved out of `langchain.retrievers` in 1.0 and now ships in `langchain-classic`.
 
 ## Streaming
 
-Full async support:
-
 ```python
-# Async invoke
+for chunk in llm.stream("Tell me a story"):
+    print(chunk.content, end="", flush=True)
+
 response = await llm.ainvoke("Hello!")
 
-# Async streaming
 async for chunk in llm.astream("Tell me a story"):
     print(chunk.content, end="", flush=True)
 ```
 
-## Custom configuration
+## Configuration
 
 ```python
 from headroom import HeadroomConfig, HeadroomMode
+from headroom.integrations import HeadroomChatModel
+from langchain_openai import ChatOpenAI
 
-config = HeadroomConfig(
-    default_mode=HeadroomMode.OPTIMIZE,
-)
+config = HeadroomConfig(default_mode=HeadroomMode.OPTIMIZE)
 
-llm = HeadroomChatModel(
-    ChatOpenAI(model="gpt-4o"),
-    config=config,
-)
+llm = HeadroomChatModel(ChatOpenAI(model="gpt-4o"), config=config)
 ```
+
+## Migrating from LangChain 0.x
+
+| Removed in LangChain 1.0 | Use instead | Package |
+|---|---|---|
+| `langchain.memory.ConversationBufferMemory` | `RunnableWithMessageHistory`, or a LangGraph checkpointer | `langchain-core` |
+| `langchain_community.chat_message_histories.ChatMessageHistory` | `langchain_core.chat_history.InMemoryChatMessageHistory` | `langchain-core` |
+| `langchain.retrievers.ContextualCompressionRetriever` | same class, moved | `langchain-classic` |
+| `langchain.agents.create_openai_tools_agent` + `AgentExecutor` | `langchain.agents.create_agent` | `langchain` |
+| `langgraph.prebuilt.create_react_agent` | `langchain.agents.create_agent` (the old name still works, deprecated in LangGraph 1.0) | `langchain` |
+| `langchain_community.vectorstores.*` | provider packages, or `langchain_core.vectorstores.InMemoryVectorStore` for tests | varies |
+
+Headroom's own API did not change across the LangChain 1.0 boundary. `HeadroomChatModel`, `HeadroomChatMessageHistory`, `HeadroomDocumentCompressor` and `wrap_tools_with_headroom` take the same arguments they always did.

--- a/docs/content/docs/langchain.mdx
+++ b/docs/content/docs/langchain.mdx
@@ -96,7 +96,16 @@ Async agents work too — the wrapped tool exposes a coroutine, so `await agent.
 
 ## LangGraph compression node
 
-Wrapping tools compresses each tool's own return value. Compressing at the graph level instead lets Headroom see every `ToolMessage` in state at once, which usually removes more.
+Wrapping tools and compressing in the graph are not equivalent, and the difference is large. On the same 300-row JSON result:
+
+| Path | Result | Saved |
+|---|---:|---:|
+| `wrap_tools_with_headroom` | 38,395 chars | 10% |
+| `create_compress_tool_messages_node` | 18,390 chars | 57% |
+
+The tool wrapper routes through the MCP compressor, which deliberately keeps its output parseable as JSON for downstream tool consumers. That rules out the schema-hoisting rewrite — the one that turns 300 repeated objects into a single schema line plus CSV rows — so on an array of similar records it mostly removes whitespace. The graph node has no such constraint, because the value only has to be read by the model.
+
+Use the graph node when the output is going to the model and nothing else parses it. Use tool wrapping when something downstream still needs JSON.
 
 ```python
 from langgraph.graph import StateGraph, MessagesState, START, END

--- a/headroom/integrations/langchain/agents.py
+++ b/headroom/integrations/langchain/agents.py
@@ -5,21 +5,20 @@ for wrapping LangChain tools to automatically compress their outputs
 and track per-tool compression metrics.
 
 Example:
-    from langchain.agents import create_openai_tools_agent
-    from langchain.tools import Tool
+    from langchain_core.tools import tool
     from headroom.integrations import wrap_tools_with_headroom
 
-    # Define tools
-    tools = [
-        Tool(name="search", func=search_func, description="Search"),
-        Tool(name="database", func=db_func, description="Query DB"),
-    ]
+    @tool
+    def search(query: str) -> str:
+        # docstring becomes the tool description
+        return json.dumps(results)
 
-    # Wrap with Headroom compression
-    wrapped_tools = wrap_tools_with_headroom(tools)
+    # Wrap with Headroom compression; the argument schema is preserved,
+    # so the wrapped tool is a drop-in replacement.
+    wrapped_tools = wrap_tools_with_headroom([search])
 
-    # Use in agent - outputs are automatically compressed
-    agent = create_openai_tools_agent(llm, wrapped_tools, prompt)
+    # Use in any agent - outputs are compressed before re-entering context
+    agent = create_agent(llm, wrapped_tools)
 """
 
 from __future__ import annotations
@@ -143,7 +142,7 @@ class HeadroomToolWrapper:
     database queries, etc.).
 
     Example:
-        from langchain.tools import Tool
+        from langchain_core.tools import tool
         from headroom.integrations import HeadroomToolWrapper
 
         def search(query: str) -> str:
@@ -198,7 +197,7 @@ class HeadroomToolWrapper:
             Compressed tool output as string.
         """
         # Invoke underlying tool
-        result = self.tool.invoke(*args, **kwargs)
+        result = self.tool.invoke(self._as_tool_input(*args, **kwargs))
 
         # Convert to string if needed
         if not isinstance(result, str):
@@ -215,9 +214,48 @@ class HeadroomToolWrapper:
 
         return compressed
 
+    @staticmethod
+    def _as_tool_input(*args: Any, **kwargs: Any) -> Any:
+        """Rebuild the single input argument ``BaseTool.invoke`` expects.
+
+        ``StructuredTool`` calls its ``func`` with the parsed schema fields
+        unpacked (``func(query="x")``), while ``BaseTool.invoke`` takes one
+        positional ``input``. Passing the unpacked form straight through raises
+        ``TypeError: BaseTool.invoke() missing 1 required positional argument``.
+        """
+        if args and kwargs:
+            if len(args) == 1 and isinstance(args[0], dict):
+                return {**args[0], **kwargs}
+            raise TypeError(
+                "Cannot map mixed positional and keyword arguments onto a tool "
+                f"input: args={args!r}, kwargs={list(kwargs)!r}"
+            )
+        if kwargs:
+            return kwargs
+        if len(args) == 1:
+            return args[0]
+        if not args:
+            return {}
+        raise TypeError(f"Expected a single tool input, got {len(args)} positional arguments")
+
     def invoke(self, *args: Any, **kwargs: Any) -> str:
         """Invoke the tool (alias for __call__)."""
         return self(*args, **kwargs)
+
+    async def acall(self, *args: Any, **kwargs: Any) -> str:
+        """Async counterpart of ``__call__``, used for ``ainvoke``."""
+        result = await self.tool.ainvoke(self._as_tool_input(*args, **kwargs))
+
+        if not isinstance(result, str):
+            result = str(result)
+
+        if len(result) < self.min_chars_to_compress:
+            self._record_metrics(result, result, was_compressed=False)
+            return str(result)
+
+        compressed = self._compress_output(result)
+        self._record_metrics(result, compressed, was_compressed=True)
+        return compressed
 
     def _compress_output(self, output: str) -> str:
         """Apply compression to tool output.
@@ -267,19 +305,54 @@ class HeadroomToolWrapper:
                 f"({chars_saved} saved, {metric.compression_ratio:.1%} of original)"
             )
 
+    @staticmethod
+    def _usable_args_schema(tool: Any) -> Any:
+        """Return the tool's args_schema only if LangChain will accept it.
+
+        StructuredTool requires a pydantic model class or a JSON-schema dict.
+        Tools built by hand (or test doubles) may carry something else, and
+        passing that through turns a working tool into a construction error, so
+        fall back to inferring the schema instead.
+        """
+        schema = getattr(tool, "args_schema", None)
+        if schema is None:
+            return None
+        if isinstance(schema, dict):
+            return schema
+        try:
+            from pydantic import BaseModel
+
+            if isinstance(schema, type) and issubclass(schema, BaseModel):
+                return schema
+        except Exception:  # pragma: no cover - pydantic always present with langchain
+            pass
+        logger.debug(
+            "Tool %r has an args_schema LangChain cannot use (%s); inferring instead",
+            getattr(tool, "name", tool),
+            type(schema).__name__,
+        )
+        return None
+
     def as_langchain_tool(self) -> StructuredTool:
         """Convert wrapper back to a LangChain tool.
 
-        Useful when you need to pass the wrapped tool to APIs
-        that expect a LangChain tool type.
+        The wrapped tool keeps the original tool's argument schema, so a model
+        still sees the same typed parameters. Inferring the schema from
+        ``__call__`` instead would advertise ``(*args, **kwargs)`` and leave the
+        model with no parameters to fill in.
 
         Returns:
             StructuredTool that wraps this wrapper.
         """
+        args_schema = self._usable_args_schema(self.tool)
         return StructuredTool.from_function(
             func=self.__call__,
+            coroutine=self.acall,
             name=self.name,
             description=self.description,
+            args_schema=args_schema,
+            infer_schema=args_schema is None,
+            return_direct=getattr(self.tool, "return_direct", False),
         )
 
 
@@ -301,14 +374,14 @@ def wrap_tools_with_headroom(
         List of wrapped tools as StructuredTools.
 
     Example:
-        from langchain.tools import Tool
+        from langchain.agents import create_agent
         from headroom.integrations import wrap_tools_with_headroom
 
         tools = [search_tool, database_tool, api_tool]
         wrapped = wrap_tools_with_headroom(tools)
 
         # Use wrapped tools in agent
-        agent = create_openai_tools_agent(llm, wrapped, prompt)
+        agent = create_agent(llm, wrapped)
     """
     _check_langchain_available()
 

--- a/headroom/integrations/langchain/chat_model.py
+++ b/headroom/integrations/langchain/chat_model.py
@@ -49,7 +49,7 @@ try:
         ToolMessage,
     )
     from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult  # noqa: F401
-    from langchain_core.runnables import RunnableLambda
+    from langchain_core.runnables import RunnableBinding, RunnableLambda
     from pydantic import ConfigDict, Field, PrivateAttr
 
     LANGCHAIN_AVAILABLE = True
@@ -60,6 +60,7 @@ except ImportError:
     ConfigDict = lambda **kwargs: {}  # type: ignore[assignment,misc]  # noqa: E731
     Field = lambda **kwargs: None  # type: ignore[assignment]  # noqa: E731
     PrivateAttr = lambda **kwargs: None  # type: ignore[assignment]  # noqa: E731
+    RunnableBinding = ()  # type: ignore[misc,assignment]
 
 from headroom import HeadroomConfig, HeadroomMode
 from headroom.providers import OpenAIProvider
@@ -375,6 +376,31 @@ class HeadroomChatModel(BaseChatModel):
 
         return optimized_messages, metrics
 
+    @staticmethod
+    def _unwrap_binding(model: Any) -> tuple[Any, dict[str, Any]]:
+        """Split a ``RunnableBinding`` into its model and the kwargs bound to it.
+
+        ``bind_tools()`` and ``bind()`` return a ``RunnableBinding`` that holds the
+        extra kwargs and only applies them through the public Runnable interface
+        (``invoke``/``stream``). Attribute access proxies straight through to
+        ``.bound``, so calling the private ``_generate`` on the binding reaches the
+        underlying model with the bound kwargs silently dropped — a model wrapped
+        after ``bind_tools`` would emit no tool calls at all.
+
+        Returns the innermost model plus the accumulated kwargs, so callers can
+        pass them explicitly.
+        """
+        bound_kwargs: dict[str, Any] = {}
+        if not RunnableBinding:
+            return model, bound_kwargs
+        # isinstance, not hasattr: a Mock answers hasattr("bound") truthfully
+        # and would be unwrapped into one of its own auto-created children.
+        while isinstance(model, RunnableBinding):
+            # Outer bindings win over inner ones, matching Runnable semantics.
+            bound_kwargs = {**(model.kwargs or {}), **bound_kwargs}
+            model = model.bound
+        return model, bound_kwargs
+
     def _generate(
         self,
         messages: list[BaseMessage],
@@ -394,12 +420,14 @@ class HeadroomChatModel(BaseChatModel):
             f"({metrics.savings_percent:.1f}% saved)"
         )
 
-        # Call wrapped model with optimized messages
-        result: ChatResult = self.wrapped_model._generate(
+        # Call wrapped model with optimized messages. Bound kwargs (tools,
+        # tool_choice, response_format) must be re-applied explicitly.
+        target, bound_kwargs = self._unwrap_binding(self.wrapped_model)
+        result: ChatResult = target._generate(
             optimized_messages,
             stop=stop,
             run_manager=run_manager,
-            **kwargs,
+            **{**bound_kwargs, **kwargs},
         )
 
         return result
@@ -421,7 +449,9 @@ class HeadroomChatModel(BaseChatModel):
         )
 
         # Stream from wrapped model
-        yield from self.wrapped_model._stream(
+        target, bound_kwargs = self._unwrap_binding(self.wrapped_model)
+        kwargs = {**bound_kwargs, **kwargs}
+        yield from target._stream(
             optimized_messages,
             stop=stop,
             run_manager=run_manager,
@@ -455,18 +485,20 @@ class HeadroomChatModel(BaseChatModel):
         # with streaming=False. This avoids mutating shared state across an
         # await, which would race with concurrent ainvoke() calls on the
         # same HeadroomChatModel instance. (GitHub #1285, review feedback)
-        model_to_call = self.wrapped_model
-        if getattr(self.wrapped_model, "streaming", False):
+        model_to_call, bound_kwargs = self._unwrap_binding(self.wrapped_model)
+        kwargs = {**bound_kwargs, **kwargs}
+        if getattr(model_to_call, "streaming", False):
+            unbound = model_to_call
             try:
-                model_to_call = self.wrapped_model.model_copy(update={"streaming": False})
+                model_to_call = unbound.model_copy(update={"streaming": False})
             except Exception:
                 # model_copy not available (non-pydantic model) — try shallow copy
-                model_to_call = copy.copy(self.wrapped_model)
+                model_to_call = copy.copy(unbound)
                 try:
                     model_to_call.streaming = False
                 except Exception:
                     # Cannot override streaming — fall through with original model
-                    model_to_call = self.wrapped_model
+                    model_to_call = unbound
 
         # Call the (possibly copied) model's async generate
         result: ChatResult = await model_to_call._agenerate(
@@ -501,7 +533,9 @@ class HeadroomChatModel(BaseChatModel):
         )
 
         # Async stream from wrapped model
-        async for chunk in self.wrapped_model._astream(
+        target, bound_kwargs = self._unwrap_binding(self.wrapped_model)
+        kwargs = {**bound_kwargs, **kwargs}
+        async for chunk in target._astream(
             optimized_messages,
             stop=stop,
             run_manager=run_manager,

--- a/headroom/integrations/langchain/memory.py
+++ b/headroom/integrations/langchain/memory.py
@@ -5,16 +5,16 @@ chat message history that automatically compresses conversation history
 when it exceeds a token threshold.
 
 Example:
-    from langchain.memory import ConversationBufferMemory
-    from langchain_community.chat_message_histories import ChatMessageHistory
+    from langchain_core.chat_history import InMemoryChatMessageHistory
+    from langchain_core.runnables.history import RunnableWithMessageHistory
     from headroom.integrations import HeadroomChatMessageHistory
 
-    # Wrap any chat message history
-    base_history = ChatMessageHistory()
+    # Wrap any BaseChatMessageHistory
+    base_history = InMemoryChatMessageHistory()
     compressed_history = HeadroomChatMessageHistory(base_history)
 
-    # Use with ConversationBufferMemory (zero code changes to chain)
-    memory = ConversationBufferMemory(chat_memory=compressed_history)
+    # Use anywhere a chat history is accepted
+    chain = RunnableWithMessageHistory(llm, lambda sid: compressed_history)
 """
 
 from __future__ import annotations
@@ -67,30 +67,26 @@ class HeadroomChatMessageHistory(BaseChatMessageHistory):
     refactor in PR-B1+ replaces the old RollingWindow strategy with).
 
     This works with ANY memory type because it wraps at the storage layer:
-    - ConversationBufferMemory
-    - ConversationSummaryMemory
-    - ConversationBufferWindowMemory
+    - InMemoryChatMessageHistory
+    - RunnableWithMessageHistory, and LangGraph checkpointers
     - Redis, PostgreSQL, or any custom history
 
     Example:
-        from langchain.memory import ConversationBufferMemory
-        from langchain_community.chat_message_histories import ChatMessageHistory
+        from langchain_core.chat_history import InMemoryChatMessageHistory
+        from langchain_core.runnables.history import RunnableWithMessageHistory
         from headroom.integrations import HeadroomChatMessageHistory
 
         # Wrap base history
-        base = ChatMessageHistory()
+        base = InMemoryChatMessageHistory()
         compressed = HeadroomChatMessageHistory(
             base,
             compress_threshold_tokens=4000,
             keep_recent_turns=5,
         )
 
-        # Use with any memory class
-        memory = ConversationBufferMemory(chat_memory=compressed)
-
         # Messages are compressed automatically when accessed
-        chain = ConversationChain(llm=llm, memory=memory)
-        chain.invoke({"input": "Hello!"})
+        chain = RunnableWithMessageHistory(llm, lambda sid: compressed)
+        chain.invoke({"input": "Hello!"}, config={"configurable": {"session_id": "s1"}})
 
     Attributes:
         base_history: The underlying chat message history

--- a/headroom/integrations/langchain/retriever.py
+++ b/headroom/integrations/langchain/retriever.py
@@ -5,12 +5,10 @@ that reduces retrieved documents based on relevance scoring while preserving
 the most important information.
 
 Example:
-    from langchain.retrievers import ContextualCompressionRetriever
-    from langchain_community.vectorstores import Chroma
+    from langchain_classic.retrievers import ContextualCompressionRetriever
     from headroom.integrations import HeadroomDocumentCompressor
 
-    # Create vector store retriever
-    vectorstore = Chroma.from_documents(documents, embeddings)
+    # Any retriever will do
     base_retriever = vectorstore.as_retriever(search_kwargs={"k": 50})
 
     # Wrap with Headroom compression
@@ -52,21 +50,33 @@ else:
         from langchain_core.callbacks import Callbacks
         from langchain_core.documents import Document
 
-        # BaseDocumentCompressor location varies by langchain version
+        # BaseDocumentCompressor location varies by langchain version.
+        # langchain-core 1.x: langchain_core.documents.compressor (singular)
+        # older langchain-core: langchain_core.documents.compressors
+        # umbrella package:    langchain.retrievers.document_compressors
+        # The order matters: resolving the real base class is what makes
+        # HeadroomDocumentCompressor acceptable to ContextualCompressionRetriever,
+        # which validates base_compressor against it. Falling through to the stub
+        # below produces a compressor LangChain silently rejects.
         try:
-            from langchain.retrievers.document_compressors import BaseDocumentCompressor
+            from langchain_core.documents.compressor import BaseDocumentCompressor
         except ImportError:
             try:
                 from langchain_core.documents.compressors import BaseDocumentCompressor
             except ImportError:
-                # Fallback: create a minimal base class
-                class BaseDocumentCompressor:
-                    """Minimal base class for document compression."""
+                try:
+                    from langchain.retrievers.document_compressors import (
+                        BaseDocumentCompressor,
+                    )
+                except ImportError:
+                    # Fallback: create a minimal base class
+                    class BaseDocumentCompressor:  # type: ignore[no-redef]
+                        """Minimal base class for document compression."""
 
-                    def compress_documents(
-                        self, documents: Sequence[Any], query: str, callbacks: Any = None
-                    ) -> Sequence[Any]:
-                        raise NotImplementedError
+                        def compress_documents(
+                            self, documents: Sequence[Any], query: str, callbacks: Any = None
+                        ) -> Sequence[Any]:
+                            raise NotImplementedError
 
         LANGCHAIN_AVAILABLE = True
     except ImportError:
@@ -109,7 +119,7 @@ class HeadroomDocumentCompressor(BaseDocumentCompressor):
     Works with LangChain's ContextualCompressionRetriever pattern.
 
     Example:
-        from langchain.retrievers import ContextualCompressionRetriever
+        from langchain_classic.retrievers import ContextualCompressionRetriever
         from headroom.integrations import HeadroomDocumentCompressor
 
         compressor = HeadroomDocumentCompressor(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,14 @@ langchain = [
     "langchain-core>=1.3.3,<4.0",
     "langchain-openai>=1.1.14,<2.0",
 ]
+# LangGraph integration (headroom.integrations.langchain.langgraph)
+# LangGraph ships its own langchain-core pin, so this only adds langgraph itself
+# on top of the langchain extra.
+langgraph = [
+    "langchain-core>=1.3.3,<4.0",
+    "langchain-openai>=1.1.14,<2.0",
+    "langgraph>=1.0,<2.0",
+]
 # Agno agent framework integration
 agno = [
     "agno>=1.0.0",

--- a/tests/test_integrations/langchain/test_langchain_1x_compat.py
+++ b/tests/test_integrations/langchain/test_langchain_1x_compat.py
@@ -1,0 +1,176 @@
+"""Regression tests for the LangChain 1.x compatibility fixes.
+
+Each test here corresponds to a defect that shipped in 0.37.0 and was found by
+running the documented examples against langchain-core 1.6:
+
+1. ``HeadroomChatModel.bind_tools()`` returned a model that emitted no tool
+   calls, because ``_generate`` called the private method on the
+   ``RunnableBinding`` and the bound kwargs were dropped.
+2. ``wrap_tools_with_headroom`` produced tools that raised ``TypeError`` on
+   invoke, because ``StructuredTool`` calls its ``func`` with unpacked kwargs
+   while ``BaseTool.invoke`` takes a single input.
+3. The wrapped tool lost the original ``args_schema``, so a model saw a tool
+   with no parameters.
+4. ``HeadroomDocumentCompressor`` silently subclassed a local stub rather than
+   LangChain's ``BaseDocumentCompressor``, so retrievers rejected it.
+"""
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+try:
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+    from langchain_core.messages import AIMessage
+    from langchain_core.tools import tool
+
+    LANGCHAIN_AVAILABLE = True
+except ImportError:
+    LANGCHAIN_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not LANGCHAIN_AVAILABLE, reason="LangChain not installed")
+
+
+BIG_RESULT = json.dumps(
+    {
+        "results": [
+            {"id": i, "user": f"user{i}", "plan": "pro", "status": "active"} for i in range(300)
+        ],
+        "total": 300,
+    }
+)
+
+
+@tool
+def query_database(query: str) -> str:
+    """Query the users database. Returns JSON rows."""
+    return BIG_RESULT
+
+
+class _RecordingModel(GenericFakeChatModel):
+    """Fake model that records the kwargs its _generate actually received."""
+
+    last_kwargs: dict[str, Any] = {}
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        type(self).last_kwargs = dict(kwargs)
+        kwargs.pop("tools", None)
+        return super()._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
+    def bind_tools(self, tools, **kwargs):
+        # Mirrors what real providers do: return a RunnableBinding carrying the
+        # tools in .kwargs rather than a new model instance.
+        return self.bind(tools=list(tools), **kwargs)
+
+
+class TestBindToolsSurvivesWrapping:
+    """Defect 1: bound kwargs must reach the underlying model."""
+
+    def test_bound_tools_reach_generate(self):
+        from headroom.integrations import HeadroomChatModel
+
+        _RecordingModel.last_kwargs = {}
+        inner = _RecordingModel(messages=iter([AIMessage("ok")]))
+        wrapped = HeadroomChatModel(inner).bind_tools([query_database])
+
+        wrapped.invoke("call the tool")
+
+        assert "tools" in _RecordingModel.last_kwargs, (
+            "bind_tools kwargs were dropped before reaching the wrapped model; "
+            "an agent built on this model would never call a tool"
+        )
+
+    def test_unbound_model_passes_no_tools(self):
+        from headroom.integrations import HeadroomChatModel
+
+        _RecordingModel.last_kwargs = {}
+        inner = _RecordingModel(messages=iter([AIMessage("ok")]))
+        HeadroomChatModel(inner).invoke("hello")
+
+        assert "tools" not in _RecordingModel.last_kwargs
+
+    def test_unwrap_binding_ignores_non_bindings(self):
+        from headroom.integrations import HeadroomChatModel
+
+        inner = GenericFakeChatModel(messages=iter([AIMessage("ok")]))
+        model, kwargs = HeadroomChatModel._unwrap_binding(inner)
+
+        assert model is inner
+        assert kwargs == {}
+
+
+class TestWrappedToolIsUsable:
+    """Defects 2 and 3: the wrapped tool must invoke, and keep its schema."""
+
+    def test_invoke_with_keyword_arguments(self):
+        from headroom.integrations import wrap_tools_with_headroom
+
+        wrapped = wrap_tools_with_headroom([query_database], min_chars_to_compress=1000)[0]
+        out = wrapped.invoke({"query": "signups"})
+
+        assert isinstance(out, str) and out
+        assert len(out) < len(BIG_RESULT)
+
+    def test_argument_schema_is_preserved(self):
+        from headroom.integrations import wrap_tools_with_headroom
+
+        wrapped = wrap_tools_with_headroom([query_database])[0]
+
+        assert sorted(wrapped.args_schema.model_fields) == ["query"], (
+            "the wrapped tool advertises different parameters than the original, "
+            "so a model cannot call it correctly"
+        )
+
+    def test_async_invoke_compresses(self):
+        from headroom.integrations import wrap_tools_with_headroom
+
+        wrapped = wrap_tools_with_headroom([query_database], min_chars_to_compress=1000)[0]
+        out = asyncio.run(wrapped.ainvoke({"query": "signups"}))
+
+        assert len(out) < len(BIG_RESULT)
+
+    def test_unusable_args_schema_falls_back_to_inference(self):
+        """A tool carrying a schema LangChain cannot use must still wrap."""
+        from headroom.integrations.langchain.agents import HeadroomToolWrapper
+
+        class OddTool:
+            name = "odd"
+            description = "a tool with a schema LangChain will not accept"
+            args_schema = object()
+
+            def invoke(self, value):
+                return "small"
+
+        wrapper = HeadroomToolWrapper(tool=OddTool())
+        assert wrapper.as_langchain_tool().name == "odd"
+
+
+class TestDocumentCompressorBaseClass:
+    """Defect 4: the compressor must be a real LangChain compressor."""
+
+    def test_is_langchain_base_document_compressor(self):
+        from langchain_core.documents.compressor import BaseDocumentCompressor
+
+        from headroom.integrations import HeadroomDocumentCompressor
+
+        compressor = HeadroomDocumentCompressor(max_documents=10)
+
+        assert isinstance(compressor, BaseDocumentCompressor), (
+            "HeadroomDocumentCompressor fell back to the local stub base class; "
+            "ContextualCompressionRetriever validates against the real one and "
+            "would reject this compressor"
+        )
+
+    def test_compresses_down_to_max_documents(self):
+        from langchain_core.documents import Document
+
+        from headroom.integrations import HeadroomDocumentCompressor
+
+        docs = [Document(page_content=f"Python is a language. item {i}") for i in range(50)]
+        out = HeadroomDocumentCompressor(max_documents=10, min_relevance=0.0).compress_documents(
+            docs, "What is Python?"
+        )
+
+        assert len(out) <= 10

--- a/uv.lock
+++ b/uv.lock
@@ -280,12 +280,12 @@ name = "any-llm-sdk"
 version = "1.12.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "httpx", marker = "python_full_version >= '3.11'" },
-    { name = "openai", marker = "python_full_version >= '3.11'" },
-    { name = "openresponses-types", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "rich", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "httpx" },
+    { name = "openai" },
+    { name = "openresponses-types" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/d5/21ef27d031b72f0054ba0015a66cc1f10cda9410e4a3acb6e795d848ad0d/any_llm_sdk-1.12.1.tar.gz", hash = "sha256:76e043fcaa56fccfb375a908511869dc7dbf393dd97a82d06bb764d8201724e8", size = 152078, upload-time = "2026-03-18T13:13:01.735Z" }
 wheels = [
@@ -811,7 +811,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "humanfriendly", marker = "python_full_version < '3.11'" },
+    { name = "humanfriendly" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -823,7 +823,7 @@ name = "colorlog"
 version = "6.10.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
 wheels = [
@@ -1045,7 +1045,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -1080,43 +1080,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusolver", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -1220,7 +1220,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1637,7 +1637,7 @@ name = "gunicorn"
 version = "26.0.0"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "packaging", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
 wheels = [
@@ -1668,7 +1668,7 @@ wheels = [
 
 [[package]]
 name = "headroom-ai"
-version = "0.36.0"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "ast-grep-cli" },
@@ -1792,6 +1792,11 @@ image = [
 langchain = [
     { name = "langchain-core" },
     { name = "langchain-openai" },
+]
+langgraph = [
+    { name = "langchain-core" },
+    { name = "langchain-openai" },
+    { name = "langgraph" },
 ]
 mcp = [
     { name = "httpx" },
@@ -1946,8 +1951,11 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'ml'", specifier = ">=1.5.0,<2.0" },
     { name = "jinja2", marker = "extra == 'reports'", specifier = ">=3.0.0" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.3.3,<4.0" },
+    { name = "langchain-core", marker = "extra == 'langgraph'", specifier = ">=1.3.3,<4.0" },
     { name = "langchain-ollama", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "langchain-openai", marker = "extra == 'langchain'", specifier = ">=1.1.14,<2.0" },
+    { name = "langchain-openai", marker = "extra == 'langgraph'", specifier = ">=1.1.14,<2.0" },
+    { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0,<2.0" },
     { name = "litellm", marker = "python_full_version < '3.14'", specifier = ">=1.86.2,<2.0" },
     { name = "litellm", marker = "python_full_version < '3.14' and extra == 'dev'", specifier = ">=1.86.2,<2.0" },
     { name = "magika", marker = "extra == 'proxy'", specifier = ">=0.6.0" },
@@ -2021,7 +2029,7 @@ requires-dist = [
     { name = "xlrd", marker = "extra == 'spreadsheet'", specifier = ">=2.0.1" },
     { name = "zstandard", marker = "extra == 'proxy'", specifier = ">=0.20.0" },
 ]
-provides-extras = ["proxy", "proxy-prod", "code", "ml", "memory", "vector", "memory-stack", "pytorch-mps", "relevance", "image", "reports", "spreadsheet", "otel", "anyllm", "langchain", "agno", "strands", "crewai", "autogen", "mcp", "voice", "voice-train", "evals", "bedrock", "html", "dev", "all", "sandbox"]
+provides-extras = ["proxy", "proxy-prod", "code", "ml", "memory", "vector", "memory-stack", "pytorch-mps", "relevance", "image", "reports", "spreadsheet", "otel", "anyllm", "langchain", "langgraph", "agno", "strands", "crewai", "autogen", "mcp", "voice", "voice-train", "evals", "bedrock", "html", "dev", "all", "sandbox"]
 
 [[package]]
 name = "hf-xet"
@@ -2207,7 +2215,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "pyreadline3", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -2530,9 +2538,10 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.2"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
+    { name = "httpx" },
     { name = "jsonpatch" },
     { name = "langchain-protocol" },
     { name = "langsmith" },
@@ -2543,9 +2552,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/13/446580dc9f26e4e524d57f727a9007b4c2484decd2c00269b7fd4f51326d/langchain_core-1.4.2.tar.gz", hash = "sha256:242abe763db71de05fe0d7ecff03f9cc6022fbceba8be15902fb89e35b7292f9", size = 935103, upload-time = "2026-06-08T18:19:41.611Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/12/aff76ca89c219ebe6f9dd3c5dbc4e3b1cf5450e9fc7037dccad23d45cd7a/langchain_core-1.6.1.tar.gz", hash = "sha256:1b156cb395aac4f009a8a1b38a574c7d948fe2d5f74c96e0d8a5017b4149e04f", size = 1003359, upload-time = "2026-08-27T19:31:14.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/2c/92a6a6f5af07f1c347021d81aea307d405ed9d34a4f8ea6b78cfa3c3b189/langchain_core-1.4.2-py3-none-any.whl", hash = "sha256:a2906d339514e02a46d6c0888021dd2651ed5acc661a1f546fe33e1453adfcb9", size = 550103, upload-time = "2026-06-08T18:19:40.197Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/25/f50dd65673c819aa33d3c34df58c115dbb6ec627d19f93e6e401dd0fc8d7/langchain_core-1.6.1-py3-none-any.whl", hash = "sha256:954a84132a5cb0435d27b910e336347b6744ecc18fbeef1e2de7029a0959841a", size = 571478, upload-time = "2026-08-27T19:31:13.34Z" },
 ]
 
 [[package]]
@@ -2577,14 +2586,73 @@ wheels = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.16"
+version = "0.0.19"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/e7/8300ba22d968653051fd06e3117d783872dddf3dcebdd6b1d386836eb43c/langchain_protocol-0.0.16.tar.gz", hash = "sha256:806c7cdd951b1c4f692fa40fce60821ff0f221d4360e27673ddf2c2b99c2b7ff", size = 5969, upload-time = "2026-05-28T23:05:11.121Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/56/913599f2f9cec8524868929f12d72b2ede377a6056ca8a40a32bdadfa535/langchain_protocol-0.0.19.tar.gz", hash = "sha256:79d90a1425122ac87e8052e2ec054fbd09c3edbf341bdfb6397112a495c7bf8c", size = 6265, upload-time = "2026-08-26T21:12:00.703Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/9c/06dfcc88d02a6364e8d864c421ddd3736305cb0a6c853f75c302c80fe17c/langchain_protocol-0.0.16-py3-none-any.whl", hash = "sha256:3658c142c5d0fb3a023a4be442ce4c15c6d626aab6135eb79a76dc64ad19c3c3", size = 7037, upload-time = "2026-05-28T23:05:10.163Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c9/f6cbf357d48ccbd18bb394433b1fd7ad9be004eed9377ad08bb85777e5e6/langchain_protocol-0.0.19-py3-none-any.whl", hash = "sha256:4cdf879a492a35980fd859ae792d3c65458ccaae504e183c9a10d7eac1f0720f", size = 7327, upload-time = "2026-08-26T21:11:59.781Z" },
+]
+
+[[package]]
+name = "langgraph"
+version = "1.2.11"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/0d/c8e7ee98896659e1b6555db0ab115a9ca899844744645d5d894032bab1d7/langgraph-1.2.11.tar.gz", hash = "sha256:9ecfe11e50d338b34b15cf4d8a442642de103e8ae6971320efba84e4542eb363", size = 725753, upload-time = "2026-08-11T14:00:36.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7f/c5c30e4be99ff821029c7ac872a480676bb179c9f3df85ea3f38d13f86d4/langgraph-1.2.11-py3-none-any.whl", hash = "sha256:8bab70de7b2d00b5300fb289bcf38d8b241400f3184c1e95e8ce706fb0e8686b", size = 248854, upload-time = "2026-08-11T14:00:35.494Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/e1/089c4c9e0a2fec7f883f82ae8e6a727138d50074cfeb6644bc2d13b1019b/langgraph_checkpoint-4.2.0.tar.gz", hash = "sha256:51a593b6bee684b0818e5d6e58e28ab340c6db7794575056ce7bd1b746a84ed7", size = 180239, upload-time = "2026-08-07T20:05:03.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/71/3b475f09bd57d3a5649792c66353312b4432afd843f301739dfcebd157f0/langgraph_checkpoint-4.2.0-py3-none-any.whl", hash = "sha256:0547fd228935a0b758865de3a3d6d7a2537c308895d0f9ab092ce9151b5da942", size = 56833, upload-time = "2026-08-07T20:05:02.655Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-protocol" },
+    { name = "orjson" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/ae/91446c1fffa04a2dc1f81afbfb5bfff3590452891a72bd9098a656ab2657/langgraph_sdk-0.4.4.tar.gz", hash = "sha256:4e651ffa09de695681579396375377bdde23bedbc8e35b070e615cbd5af7da8b", size = 345789, upload-time = "2026-08-27T21:25:22.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/d5/2ad7f3a835c6fcebf58b6669552536ecd52d2dfe4cf49c6c36648fd83572/langgraph_sdk-0.4.4-py3-none-any.whl", hash = "sha256:39afe416c91742925e6f8a93715f566d499b36e1b636b804a4ffe3190e4f4e64", size = 162270, upload-time = "2026-08-27T21:25:21.072Z" },
 ]
 
 [[package]]
@@ -2690,18 +2758,18 @@ name = "litellm"
 version = "1.88.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.14'" },
-    { name = "click", marker = "python_full_version < '3.14'" },
-    { name = "fastuuid", marker = "python_full_version < '3.14'" },
-    { name = "httpx", marker = "python_full_version < '3.14'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.14'" },
-    { name = "jinja2", marker = "python_full_version < '3.14'" },
-    { name = "jsonschema", marker = "python_full_version < '3.14'" },
-    { name = "openai", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.14'" },
-    { name = "tiktoken", marker = "python_full_version < '3.14'" },
-    { name = "tokenizers", marker = "python_full_version < '3.14'" },
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/ea/f99ececb7f22703fe120f1d8be9ffb749ec9453fbbbbbebc0d6a6b4d7864/litellm-1.88.1.tar.gz", hash = "sha256:89c6b74cc7912d6365793006ff951c0450fe847625008dfe49de8a7dc4529aa5", size = 13885969, upload-time = "2026-06-09T01:06:25.192Z" }
 wheels = [
@@ -3583,7 +3651,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -3622,7 +3690,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -3634,7 +3702,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3664,9 +3732,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3678,7 +3746,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3757,8 +3825,8 @@ name = "omegaconf"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "antlr4-python3-runtime", marker = "python_full_version >= '3.13'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.13'" },
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
 wheels = [
@@ -3773,12 +3841,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "coloredlogs", marker = "python_full_version < '3.11'" },
-    { name = "flatbuffers", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "protobuf", marker = "python_full_version < '3.11'" },
-    { name = "sympy", marker = "python_full_version < '3.11'" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple/" } },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -3824,10 +3892,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple/" } },
+    { name = "packaging" },
+    { name = "protobuf" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/81/29a9eb470994a75eb7b3ccf32be314d7c66675a00ac7b50294816cc2db27/onnxruntime-1.26.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ee1109ef4ef27cad90e823399e61e03b3c6c7bfe0fb820b4baf3678c15be8b3c", size = 18005108, upload-time = "2026-05-08T19:08:11.728Z" },
@@ -3911,7 +3979,7 @@ name = "openresponses-types"
 version = "2.3.0.post1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/26/b612c3215f5599714fa94d63eb5ee59b4eb66dbdeeaf86bb4d848359484d/openresponses_types-2.3.0.post1.tar.gz", hash = "sha256:11b8896d3621d2ac2439f6ff106f34ddcb1bbd517c317a6c852a9df2e98a0753", size = 19254, upload-time = "2026-01-22T20:02:03.933Z" }
 wheels = [
@@ -4129,6 +4197,62 @@ wheels = [
 ]
 
 [[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/fa/a91f70829ebccf6387c4946e0a1a109f6ba0d6a28d65f628bedfad94b890/ormsgpack-1.12.2-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c1429217f8f4d7fcb053523bbbac6bed5e981af0b85ba616e6df7cce53c19657", size = 378262, upload-time = "2026-01-18T20:55:22.284Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/62/3698a9a0c487252b5c6a91926e5654e79e665708ea61f67a8bdeceb022bf/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f13034dc6c84a6280c6c33db7ac420253852ea233fc3ee27c8875f8dd651163", size = 203034, upload-time = "2026-01-18T20:55:53.324Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3a/f716f64edc4aec2744e817660b317e2f9bb8de372338a95a96198efa1ac1/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:59f5da97000c12bc2d50e988bdc8576b21f6ab4e608489879d35b2c07a8ab51a", size = 210538, upload-time = "2026-01-18T20:55:20.097Z" },
+    { url = "https://files.pythonhosted.org/packages/72/30/a436be9ce27d693d4e19fa94900028067133779f09fc45776db3f689c822/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e4459c3f27066beadb2b81ea48a076a417aafffff7df1d3c11c519190ed44f2", size = 212401, upload-time = "2026-01-18T20:55:46.447Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c5/cde98300fd33fee84ca71de4751b19aeeca675f0cf3c0ec4b043f40f3b76/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a1c460655d7288407ffa09065e322a7231997c0d62ce914bf3a96ad2dc6dedd", size = 387080, upload-time = "2026-01-18T20:56:00.884Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/31/30bf445ef827546747c10889dd254b3d84f92b591300efe4979d792f4c41/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:458e4568be13d311ef7d8877275e7ccbe06c0e01b39baaac874caaa0f46d826c", size = 482346, upload-time = "2026-01-18T20:55:39.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f5/e1745ddf4fa246c921b5ca253636c4c700ff768d78032f79171289159f6e/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8cde5eaa6c6cbc8622db71e4a23de56828e3d876aeb6460ffbcb5b8aff91093b", size = 425178, upload-time = "2026-01-18T20:55:27.106Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a2/e6532ed7716aed03dede8df2d0d0d4150710c2122647d94b474147ccd891/ormsgpack-1.12.2-cp310-cp310-win_amd64.whl", hash = "sha256:dc7a33be14c347893edbb1ceda89afbf14c467d593a5ee92c11de4f1666b4d4f", size = 117183, upload-time = "2026-01-18T20:55:55.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/08/8b68f24b18e69d92238aa8f258218e6dfeacf4381d9d07ab8df303f524a9/ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9", size = 378266, upload-time = "2026-01-18T20:55:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/24/29fc13044ecb7c153523ae0a1972269fcd613650d1fa1a9cec1044c6b666/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a", size = 203035, upload-time = "2026-01-18T20:55:30.59Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c2/00169fb25dd8f9213f5e8a549dfb73e4d592009ebc85fbbcd3e1dcac575b/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5", size = 210539, upload-time = "2026-01-18T20:55:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/33/543627f323ff3c73091f51d6a20db28a1a33531af30873ea90c5ac95a9b5/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181", size = 212401, upload-time = "2026-01-18T20:56:10.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5d/f70e2c3da414f46186659d24745483757bcc9adccb481a6eb93e2b729301/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b", size = 387082, upload-time = "2026-01-18T20:56:12.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d6/06e8dc920c7903e051f30934d874d4afccc9bb1c09dcaf0bc03a7de4b343/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92", size = 482346, upload-time = "2026-01-18T20:56:05.152Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c4/f337ac0905eed9c393ef990c54565cd33644918e0a8031fe48c098c71dbf/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a", size = 425181, upload-time = "2026-01-18T20:55:37.83Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/6d5758fabef3babdf4bbbc453738cc7de9cd3334e4c38dd5737e27b85653/ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c", size = 117182, upload-time = "2026-01-18T20:55:31.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/17a15549233c37e7fd054c48fe9207492e06b026dbd872b826a0b5f833b6/ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd", size = 111464, upload-time = "2026-01-18T20:55:38.811Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/24d18851334be09c25e87f74307c84950f18c324a4d3c0b41dabdbf19c29/ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c", size = 378717, upload-time = "2026-01-18T20:55:26.164Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a2/88b9b56f83adae8032ac6a6fa7f080c65b3baf9b6b64fd3d37bd202991d4/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553", size = 203183, upload-time = "2026-01-18T20:55:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/43e4555963bf602e5bdc79cbc8debd8b6d5456c00d2504df9775e74b450b/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13", size = 210814, upload-time = "2026-01-18T20:55:33.973Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e1/7cfbf28de8bca6efe7e525b329c31277d1b64ce08dcba723971c241a9d60/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d", size = 212634, upload-time = "2026-01-18T20:55:28.634Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/30ae5716e88d792a4e879debee195653c26ddd3964c968594ddef0a3cc7e/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede", size = 387139, upload-time = "2026-01-18T20:56:02.013Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/81/aee5b18a3e3a0e52f718b37ab4b8af6fae0d9d6a65103036a90c2a8ffb5d/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e", size = 482578, upload-time = "2026-01-18T20:55:35.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/71c9ba472d5d45f7546317f467a5fc941929cd68fb32796ca3d13dcbaec2/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285", size = 425539, upload-time = "2026-01-18T20:56:04.009Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/ac99cd7fe77e822fed5250ff4b86fa66dd4238937dd178d2299f10b69816/ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f", size = 117493, upload-time = "2026-01-18T20:56:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/67/339872846a1ae4592535385a1c1f93614138566d7af094200c9c3b45d1e5/ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c", size = 111579, upload-time = "2026-01-18T20:55:21.161Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c2/6feb972dc87285ad381749d3882d8aecbde9f6ecf908dd717d33d66df095/ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8", size = 378721, upload-time = "2026-01-18T20:55:52.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
+]
+
+[[package]]
 name = "overrides"
 version = "7.7.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -4154,10 +4278,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple/" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4229,9 +4353,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple/" } },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/da/b1dc0481ab8d55d0f46e343cfe67d4551a0e14fcee52bd38ca1bd73258d8/pandas-3.0.0.tar.gz", hash = "sha256:0facf7e87d38f721f0af46fe70d97373a37701b1c09f7ed7aeeb292ade5c050f", size = 4633005, upload-time = "2026-01-21T15:52:04.726Z" }
 wheels = [
@@ -5393,17 +5517,17 @@ name = "rapidocr"
 version = "3.8.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "colorlog", marker = "python_full_version >= '3.13'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.13'" },
-    { name = "omegaconf", marker = "python_full_version >= '3.13'" },
-    { name = "opencv-python", marker = "python_full_version >= '3.13'" },
-    { name = "pillow", marker = "python_full_version >= '3.13'" },
-    { name = "pyclipper", marker = "python_full_version >= '3.13'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.13'" },
-    { name = "requests", marker = "python_full_version >= '3.13'" },
-    { name = "shapely", marker = "python_full_version >= '3.13'" },
-    { name = "six", marker = "python_full_version >= '3.13'" },
-    { name = "tqdm", marker = "python_full_version >= '3.13'" },
+    { name = "colorlog" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple/" } },
+    { name = "omegaconf" },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "pyclipper" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "shapely" },
+    { name = "six" },
+    { name = "tqdm" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/4a/fa521d947f0fc7bb304bf11bec4cb66266bd81494588b4cb48dc01001719/rapidocr-3.8.1-py3-none-any.whl", hash = "sha256:650044b1fbce9e6bae5cae462dcf8be754cde11e2f23fc51f65dcc08deae2c46", size = 15080319, upload-time = "2026-04-11T07:13:22.56Z" },
@@ -5414,17 +5538,17 @@ name = "rapidocr-onnxruntime"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "opencv-python", marker = "python_full_version < '3.13'" },
-    { name = "pillow", marker = "python_full_version < '3.13'" },
-    { name = "pyclipper", marker = "python_full_version < '3.13'" },
-    { name = "pyyaml", marker = "python_full_version < '3.13'" },
-    { name = "shapely", marker = "python_full_version < '3.13'" },
-    { name = "six", marker = "python_full_version < '3.13'" },
-    { name = "tqdm", marker = "python_full_version < '3.13'" },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "pyclipper" },
+    { name = "pyyaml" },
+    { name = "shapely" },
+    { name = "six" },
+    { name = "tqdm" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/12/1e5497183bdbe782dbb91bad1d0d2297dba4d2831b2652657f7517bfc6df/rapidocr_onnxruntime-1.4.4-py3-none-any.whl", hash = "sha256:971d7d5f223a7a808662229df1ef69893809d8457d834e6373d3854bc1782cbf", size = 14915192, upload-time = "2025-01-17T01:48:25.104Z" },
@@ -5821,10 +5945,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple/" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple/" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -5879,10 +6003,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple/" } },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple/" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -5932,7 +6056,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple/" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -6002,7 +6126,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple/" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
 wheels = [


### PR DESCRIPTION
## How this started

The docs page said `pip install "headroom-ai[langchain]"`. That extra resolves to **langchain-core and langchain-openai, and nothing else**. Five of the page's eleven examples imported packages it does not provide. Running them properly turned up three defects in shipped code, not just bad docs.

```
$ uv venv && uv pip install "headroom-ai[langchain]"
headroom-ai            0.37.0
langchain-core         1.6.1
langchain-openai       1.6.0
langchain              NOT INSTALLED
langgraph              NOT INSTALLED
langchain-community    NOT INSTALLED
```

## Three shipped defects

### 1. `bind_tools()` returned a model that never called a tool

The most serious one — it makes every agent built on a wrapped model inert, silently.

```python
base.bind_tools(tools).invoke("Use query_database with query='x'.")
# tool_calls: [{'name': 'query_database', 'args': {'query': 'x'}, ...}]

HeadroomChatModel(base).bind_tools(tools).invoke("Use query_database with query='x'.")
# tool_calls: []
```

`_generate` called `self.wrapped_model._generate(...)`. After `bind_tools`, `wrapped_model` is a `RunnableBinding` carrying the tools in `.kwargs`, and attribute access proxies straight through to `.bound` — so the bound kwargs were dropped on the floor. Fixed on all four paths (`_generate`, `_stream`, `_agenerate`, `_astream`) by unwrapping the binding and re-applying its kwargs.

Detection is `isinstance(RunnableBinding)` rather than `hasattr("bound")`, because a `Mock` answers `hasattr` truthfully and would be unwrapped into one of its own auto-created children. The existing suite caught that when I got it wrong the first time.

### 2. Wrapped tools raised `TypeError` on invoke

```
TypeError: BaseTool.invoke() missing 1 required positional argument: 'input'
```

`StructuredTool` calls its `func` with the parsed schema fields **unpacked** (`func(query="x")`), while `BaseTool.invoke` takes a **single** positional input. `self.tool.invoke(*args, **kwargs)` therefore arrived with nothing to bind to `input`. Inputs are normalised before the call now.

### 3. Wrapped tools lost their argument schema

`StructuredTool.from_function(func=self.__call__)` inferred the schema from `(*args, **kwargs)`, so the model saw a tool with no parameters to fill in. The original `args_schema` is carried over, along with `return_direct`, and validated first so a tool carrying something LangChain cannot use still wraps rather than failing to construct.

### 4. `HeadroomDocumentCompressor` was not a LangChain compressor

The base-class lookup tried `langchain.retrievers.document_compressors`, then `langchain_core.documents.compressors`. In core 1.x it lives at `langchain_core.documents.compressor` — **singular**. Both lookups failed and the class quietly subclassed a local stub, so `ContextualCompressionRetriever`, which validates `base_compressor` against the real base class, would reject it. Order corrected.

## Packaging

Adds a `[langgraph]` extra. `headroom/integrations/langchain/langgraph.py` already ships LangGraph helpers and there was no way to install their dependency through Headroom.

## Docs

`langchain.mdx` rewritten against APIs that exist, retitled **LangChain & LangGraph**, with a migration table for the 1.0 removals:

| Removed in LangChain 1.0 | Use instead | Package |
|---|---|---|
| `langchain.memory.ConversationBufferMemory` | `RunnableWithMessageHistory`, or a LangGraph checkpointer | `langchain-core` |
| `langchain_community.chat_message_histories.ChatMessageHistory` | `langchain_core.chat_history.InMemoryChatMessageHistory` | `langchain-core` |
| `langchain.retrievers.ContextualCompressionRetriever` | same class, moved | `langchain-classic` |
| `create_openai_tools_agent` + `AgentExecutor` | `langchain.agents.create_agent` | `langchain` |
| `langgraph.prebuilt.create_react_agent` | `create_agent` (old name works, deprecated in LangGraph 1.0) | `langchain` |

The same dead imports were in the module docstrings, which is where they came from. Those are fixed too.

## Verification

- **Existing suite: 233 passed / 21 skipped** — identical to baseline, no regressions.
- **9 new regression tests**, of which **6 fail** when the source fixes are stashed.
- **Every import in all 12 docs code blocks resolves** against a real install, checked by script.
- **Printed outputs are measured, not illustrative.** One number in my first draft was wrong (`total_tokens_before: 8`, actually `9`) and was corrected against a real run.
- **A real gpt-4o-mini agent run**: calls the tool, Headroom compresses the output in flight, the model still answers correctly.
  ```
  tool called 1x, compressed 1x, 4202 chars saved; answer='The query returned a total of 300 rows.'
  ```
- **LangGraph node on a 300-row JSON result**: 42,597 → 18,390 chars (57%), `tool_call_id` preserved, inside a compiled `StateGraph`.
- **Docs site builds**: 164 pages, exit 0.
- `ruff check` and `ruff format --check` clean at the pinned 0.16.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRaEPjQcCSAwD2xbQMNENu