### PR TITLE
fix(proxy): honor compression controls for Anthropic auxiliary passes

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -2849,7 +2849,12 @@ class AnthropicHandlerMixin:
                 from headroom.proxy.tool_schema_compaction import compact_tools
 
                 _pre_compaction_tools = body.get("tools")
-                body, _tools_modified, _tools_before_bytes, _tools_after_bytes = compact_tools(body)
+                _tools_modified = False
+                # Auxiliary passes honor the same disable/bypass decision as messages.
+                if _decision.should_compress:
+                    body, _tools_modified, _tools_before_bytes, _tools_after_bytes = compact_tools(
+                        body
+                    )
                 if _tools_modified:
                     tools = body["tools"]
                     transforms_applied.append("anthropic:tool_schema_compaction")
@@ -2880,7 +2885,7 @@ class AnthropicHandlerMixin:
                 )
 
                 _desc_max = tool_desc_max_chars()
-                if _desc_max > 0:
+                if _decision.should_compress and _desc_max > 0:
                     _pre_desc_tools = body.get("tools")
                     body, _desc_modified, _desc_before, _desc_after = compact_tool_descriptions(
                         body, _desc_max
@@ -2918,7 +2923,7 @@ class AnthropicHandlerMixin:
                 )
                 from headroom.transforms.compression_units import find_content_router
 
-                if system_compact_enabled():
+                if _decision.should_compress and system_compact_enabled():
                     _sys_router = find_content_router(self.anthropic_pipeline)
                     if _sys_router is not None:
                         body, _sys_modified, _sys_before, _sys_after = compact_system_prompt(

--- a/tests/test_anthropic_compaction_transforms.py
+++ b/tests/test_anthropic_compaction_transforms.py
@@ -217,9 +217,9 @@ from fastapi.testclient import TestClient  # noqa: E402
 from headroom.proxy.server import ProxyConfig, create_app  # noqa: E402
 
 
-def _make_proxy_client() -> TestClient:
+def _make_proxy_client(*, optimize: bool = True) -> TestClient:
     config = ProxyConfig(
-        optimize=True,
+        optimize=optimize,
         mode="token",
         cache_enabled=False,
         rate_limit_enabled=False,
@@ -318,3 +318,79 @@ class TestAnthropicHandlerReportsL1Transform:
         assert "anthropic:tool_schema_compaction" in transforms_header, (
             f"expected L1 label in x-headroom-transforms, got: {transforms_header!r}"
         )
+
+
+@pytest.mark.parametrize(
+    ("optimize", "headers", "should_compact"),
+    [
+        pytest.param(False, {}, False, id="no-optimize"),
+        pytest.param(True, {"x-headroom-bypass": "true"}, False, id="bypass"),
+        pytest.param(True, {"x-headroom-mode": "passthrough"}, False, id="passthrough"),
+        pytest.param(True, {}, True, id="optimization-enabled"),
+    ],
+)
+def test_handler_auxiliary_compaction_respects_optimization_decision(
+    monkeypatch: pytest.MonkeyPatch,
+    optimize: bool,
+    headers: dict[str, str],
+    should_compact: bool,
+) -> None:
+    """Opt-in tool/system passes must also honor the request's disable controls."""
+    import copy
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    import headroom.proxy.tool_schema_compaction as tool_compaction
+
+    monkeypatch.setenv("HEADROOM_TOOL_DESC_MAX_CHARS", "20")
+    monkeypatch.setenv("HEADROOM_SYSTEM_COMPACT", "1")
+    monkeypatch.setattr(tool_compaction, "_TOOL_DESC_MAX_CHARS", None)
+    router = SimpleNamespace(compress=Mock(return_value=SimpleNamespace(compressed="short system")))
+    monkeypatch.setattr(
+        "headroom.transforms.compression_units.find_content_router", lambda _: router
+    )
+    payload = _make_anthropic_payload_with_tools()
+    payload["system"] = _make_anthropic_payload_with_long_system()["system"]
+    captured = []
+
+    with _make_proxy_client(optimize=optimize) as client:
+        proxy = client.app.state.proxy
+        proxy.anthropic_pipeline.apply = lambda **kwargs: SimpleNamespace(
+            messages=kwargs["messages"],
+            transforms_applied=[],
+            timing={},
+            tokens_before=10,
+            tokens_after=10,
+            waste_signals=None,
+        )
+
+        async def capture(method, url, headers, body, stream=False, **kwargs):
+            captured.append(copy.deepcopy(body))
+            return _ok_response("msg_compaction_controls")
+
+        proxy._retry_request = capture
+        response = client.post("/v1/messages", headers=headers, json=payload)
+        assert response.status_code == 200, response.text
+        summary = client.get("/stats").json()["summary"]
+
+    forwarded = captured[0]
+    transforms = response.headers.get("x-headroom-transforms", "")
+    labels = (
+        "anthropic:tool_schema_compaction",
+        "anthropic:tool_desc_compaction",
+        "anthropic:system_prompt_compaction",
+    )
+    if should_compact:
+        assert "title" not in forwarded["tools"][0]["input_schema"]
+        assert len(forwarded["tools"][0]["description"]) < len(payload["tools"][0]["description"])
+        assert forwarded["system"][0]["text"] == "short system"
+        assert all(label in transforms for label in labels)
+        router.compress.assert_called_once()
+        assert summary["compression"]["total_tokens_removed"] > 0
+    else:
+        assert forwarded["tools"] == payload["tools"]
+        assert forwarded["system"] == payload["system"]
+        assert all(label not in transforms for label in labels)
+        router.compress.assert_not_called()
+        assert summary["compression"]["requests_compressed"] == 0
+        assert summary["compression"]["total_tokens_removed"] == 0

--- a/tests/test_proxy_byte_faithful_forwarding.py
+++ b/tests/test_proxy_byte_faithful_forwarding.py
@@ -711,7 +711,7 @@ def test_untouched_thinking_lets_tool_compaction_reach_the_wire(
     """
     monkeypatch.delenv("HEADROOM_THINKING_PRESERVING_MUTATIONS", raising=False)
     config = ProxyConfig(
-        optimize=False,
+        optimize=True,
         cache_enabled=False,
         rate_limit_enabled=False,
         cost_tracking_enabled=False,


### PR DESCRIPTION
## Description

Anthropic tool-schema compaction, opt-in tool-description truncation, and opt-in system-prompt compaction still ran when `--no-optimize` or a per-request passthrough header disabled message compression. Gate these passes on the existing `CompressionDecision` so disabled requests preserve their tools/system content and do not accrue auxiliary compression savings.

Closes #3337.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Apply the existing compression decision to all three Anthropic auxiliary passes. OpenAI chat and Responses already guard their corresponding passes.
- Add handler regressions for `optimize=False`, `x-headroom-bypass: true`, `x-headroom-mode: passthrough`, and an enabled positive control.
- Explicitly enable optimization in the existing signed-thinking/tool-compaction positive test.

## Testing

- [x] Focused pytest suite passes: 125 passed, 1 skipped; the entire suite was not run.
- [x] Ruff lint and format checks pass for all three changed files.
- [x] Type checking passes (`mypy headroom`, run by the repository pre-commit hook).
- [x] Regression tests fail before the fix and pass afterward.
- [x] Manual HTTP testing performed using the real proxy and a loopback upstream.

### Test Output

```text
python -m pytest tests/test_anthropic_compaction_transforms.py tests/test_tool_schema_compaction.py tests/test_system_compaction.py tests/test_proxy/test_anthropic_no_optimize_history_passthrough.py tests/test_proxy_byte_faithful_forwarding.py -q --tb=line
125 passed, 1 skipped
```

The skip is an optional `zstandard` dependency test. All four new handler cases passed. The three disabled cases reproduced tool mutations before the fix. Both opt-in passes are enabled in the handler tests, with a deterministic system compressor.

Repository pre-commit and commit-msg hooks passed: version synchronization, Ruff version alignment, merge-conflict checks, Ruff, whole-package mypy, and commitlint. `git diff --check` also passed.

## Real Behavior Proof

- Environment: Windows, Python 3.12.14, source checkout using the published headroom-ai 0.37.0 Windows native extension. Model field `claude-sonnet-4-6`; the upstream is a loopback HTTP server returning an Anthropic-format response, with no external provider credentials.
- Exact command / steps: Start the real Uvicorn proxy with `anthropic_api_url` pointing at a loopback server that captures raw request bytes. Set `HEADROOM_TOOL_DESC_MAX_CHARS=20`, `HEADROOM_SYSTEM_COMPACT=0`, and `HEADROOM_BEACON=off`; disable cache, image compression, prefix freeze, and CCR injection. POST indented JSON to `/v1/messages`, including a tool with `$schema`, `title`, `examples`, and a long description. Compare upstream bytes with the submitted bytes and GET `/stats`. Repeat for `optimize=False`, each bypass header, and optimization enabled. No handler or HTTP transport mocks were used in this check.
- Observed result: All four requests returned HTTP 200. Each disabled case forwarded identical bytes and recorded zero compressed requests / zero tokens removed. The enabled control modified the body and recorded one compressed request / 45 tokens removed. Captured output follows below.
- Not tested: Real Anthropic/Claude Code traffic, a real system-prompt compression model, a source rebuild of the native extension, the entire Python suite, or Rust gates. System-prompt gating is covered by the handler regression with a deterministic compressor. The pre-push `make ci-precheck` stopped because `make` was not on PATH; this Draft push used the hook's documented `--no-verify` option. Pre-commit and commit-msg hooks were not bypassed.

```json
{"case": "no-optimize", "http_status": 200, "byte_identical": true, "api_requests": 1, "requests_compressed": 0, "tokens_removed": 0}
{"case": "bypass", "http_status": 200, "byte_identical": true, "api_requests": 1, "requests_compressed": 0, "tokens_removed": 0}
{"case": "passthrough", "http_status": 200, "byte_identical": true, "api_requests": 1, "requests_compressed": 0, "tokens_removed": 0}
{"case": "enabled", "http_status": 200, "byte_identical": false, "api_requests": 1, "requests_compressed": 1, "tokens_removed": 45}
```

## Runtime Rollout Safety

- Rollout-managed feature(s): No new rollout-managed feature. This repairs existing Anthropic auxiliary compaction controls.
- Minimum rollout channel: No new channel requirement; the existing proxy configuration and opt-in settings continue to apply.
- Stable/default behavior changed: Requests with compression disabled or bypassed now skip auxiliary compaction. Requests whose compression decision permits optimization retain the existing passes.
- Kill switch / disable path: `--no-optimize`, `x-headroom-bypass: true`, or `x-headroom-mode: passthrough` disables these passes. Existing `HEADROOM_TOOL_DESC_MAX_CHARS=0` and `HEADROOM_SYSTEM_COMPACT=0` disable their respective opt-in stages.
- Unsafe override required: No unsafe override is needed to use the fix.
- Qualification impact: Focused handler/helper tests and local HTTP proof passed. Full CI, source-native build verification, and real-provider qualification remain incomplete; this PR stays in draft.
- Rollback path: Revert this commit to restore the prior auxiliary-pass behavior; no data migration or new dependency is involved.

## Review Readiness

- [x] I have performed a self-review
- [ ] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] I did not edit `CHANGELOG.md`
- [ ] The complete test suite and native build pass

## Additional Notes

No dependencies or generated changelog files changed. The PR remains a draft until the remaining validation is complete.
