### PR TITLE
fix(copilot): close the CLI native-lane gaps and route Copilot bearers to Copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,9 @@ export GITHUB_COPILOT_ENTERPRISE_URL=https://ghe.example.com
 
 Business and Enterprise accounts are advertised a per-plan host
 (`api.business.githubcopilot.com` / `api.enterprise.githubcopilot.com`). Headroom
-routes them through the generic host by default and prints the advertised host
-at launch. If your network uses GitHub's subscription-based network routing,
+routes them through the generic host by default; `--subscription`, `--native`
+and `wrap vscode` print the advertised host at launch when they override it. If
+your network uses GitHub's subscription-based network routing,
 which blocks the generic host, set `GITHUB_COPILOT_USE_ADVERTISED_HOST=1` or pin
 `GITHUB_COPILOT_API_URL` to the advertised host. Data-residency hosts
 (`copilot-api.<tenant>.ghe.com`) are always honored.

--- a/README.md
+++ b/README.md
@@ -277,6 +277,19 @@ export GITHUB_COPILOT_ENTERPRISE_DOMAIN=ghe.example.com
 export GITHUB_COPILOT_ENTERPRISE_URL=https://ghe.example.com
 ```
 
+Business and Enterprise accounts are advertised a per-plan host
+(`api.business.githubcopilot.com` / `api.enterprise.githubcopilot.com`). Headroom
+routes them through the generic host by default and prints the advertised host
+at launch. If your network uses GitHub's subscription-based network routing,
+which blocks the generic host, set `GITHUB_COPILOT_USE_ADVERTISED_HOST=1` or pin
+`GITHUB_COPILOT_API_URL` to the advertised host. Data-residency hosts
+(`copilot-api.<tenant>.ghe.com`) are always honored.
+
+`headroom wrap copilot` refuses to launch when `~/.copilot/settings.json` (or
+`$COPILOT_HOME`) pins a different `copilotUrl`: the CLI ranks that setting above
+`COPILOT_API_URL`, so the session would silently bypass the proxy. The wrapper
+also exempts `127.0.0.1` from any `HTTP_PROXY`/`HTTPS_PROXY` in effect.
+
 For GitHub.com Enterprise Cloud URLs such as
 `github.com/enterprises/your-enterprise`, set neither — Headroom uses GitHub's
 normal token-exchange endpoint and the Copilot API endpoint advertised for the

--- a/docs/content/docs/persistent-installs.mdx
+++ b/docs/content/docs/persistent-installs.mdx
@@ -107,6 +107,14 @@ Provider scope is intentionally conservative. The current direct adapters are:
 
 For Copilot, Aider, Cursor, and broader env-driven setups, prefer `--scope user` or `--scope system`.
 
+Copilot installs use the CLI's native lane by default: the manifest sets only
+`COPILOT_API_URL`, so the CLI keeps its model picker and Auto mode and the proxy
+forwards the developer's own Copilot token to GitHub. The proxy recognizes Copilot
+credentials on its OpenAI and Anthropic routes, so the shared proxy's targets stay
+on the stock hosts for other tools. The single-model BYOK lane is used only when
+`COPILOT_PROVIDER_API_KEY` is present at install time or the backend is a
+translated one (any-llm, LiteLLM).
+
 ## Provider selection
 
 | Option | Meaning |

--- a/docs/content/docs/persistent-installs.mdx
+++ b/docs/content/docs/persistent-installs.mdx
@@ -107,7 +107,7 @@ Provider scope is intentionally conservative. The current direct adapters are:
 
 For Copilot, Aider, Cursor, and broader env-driven setups, prefer `--scope user` or `--scope system`.
 
-Copilot installs use the CLI's native lane by default: the manifest sets only
+`headroom install` puts Copilot on the CLI's native lane by default: the manifest sets only
 `COPILOT_API_URL`, so the CLI keeps its model picker and Auto mode and the proxy
 forwards the developer's own Copilot token to GitHub. The proxy recognizes Copilot
 credentials on its OpenAI and Anthropic routes, so the shared proxy's targets stay

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -72,6 +72,12 @@ from headroom.copilot_auth import (
     resolve_copilot_api_url,
     resolve_subscription_bearer_token_details,
 )
+from headroom.copilot_auth import (
+    USE_ADVERTISED_HOST_ENV as _USE_ADVERTISED_HOST_ENV,
+)
+from headroom.copilot_auth import (
+    advertised_host_is_normalized as _advertised_host_is_normalized,
+)
 from headroom.providers.aider import build_launch_env as _build_aider_launch_env
 from headroom.providers.claude import (
     REMOTE_CONTROL_BASE_URL_ENV,
@@ -100,6 +106,9 @@ from headroom.providers.copilot import (
     build_launch_env as _build_copilot_launch_env,
 )
 from headroom.providers.copilot import (
+    check_copilot_url_setting as _check_copilot_url_setting,
+)
+from headroom.providers.copilot import (
     configure_vscode_proxy_settings,
     remove_vscode_proxy_settings,
     vscode_proxy_url,
@@ -113,6 +122,9 @@ from headroom.providers.copilot import (
 )
 from headroom.providers.copilot import (
     detect_running_proxy_backend as _copilot_detect_running_proxy_backend,
+)
+from headroom.providers.copilot import (
+    ensure_loopback_no_proxy as _ensure_loopback_no_proxy,
 )
 from headroom.providers.copilot import (
     is_auto_model as _is_auto_model,
@@ -3972,10 +3984,31 @@ def _build_copilot_native_launch_env(
     return build_native_launch_env(port=port, environ=environ, project=project)
 
 
-def _native_api_url_supported(*, environ: Mapping[str, str] | None = None) -> bool | None:
+def _native_api_url_supported(
+    *, environ: Mapping[str, str] | None = None, copilot_bin: str | None = None
+) -> bool | None:
     from headroom.providers.copilot.wrap import native_api_url_supported
 
-    return native_api_url_supported(environ=environ)
+    return native_api_url_supported(environ=environ, copilot_bin=copilot_bin)
+
+
+def _echo_copilot_host_notice(resolution: CopilotSubscriptionTokenResolution | None) -> None:
+    """Tell the user when GitHub advertised a per-plan host Headroom is not using.
+
+    Business and Enterprise tokens come with ``api.business.`` /
+    ``api.enterprise.githubcopilot.com``; Headroom routes to the generic host by
+    default (see ``copilot_auth._SEGMENTED_PLAN_HOSTS``). Networks that use
+    GitHub's subscription-based routing block the generic host, and that
+    failure surfaces only as connection errors inside the agent, so say it here.
+    """
+    advertised = getattr(resolution, "advertised_api_url", None)
+    if resolution is None or not _advertised_host_is_normalized(advertised):
+        return
+    click.echo(
+        f"  Note: GitHub advertised {advertised} for this account; Headroom routes via "
+        f"{resolution.api_url}. If your network uses subscription-based routing, set "
+        f"{_USE_ADVERTISED_HOST_ENV}=1 or GITHUB_COPILOT_API_URL={advertised}."
+    )
 
 
 def _should_use_copilot_oauth(
@@ -5806,11 +5839,16 @@ def copilot(
             env["OPENAI_TARGET_API_URL"] = openai_api_url
             env["ANTHROPIC_TARGET_API_URL"] = openai_api_url
             anthropic_api_url = openai_api_url
+            # The CLI ranks its `copilotUrl` setting above COPILOT_API_URL; a
+            # pre-existing pin would make this launch look routed while every
+            # request bypassed the proxy.
+            _check_copilot_url_setting(env["COPILOT_API_URL"], environ=os.environ)
+            _echo_copilot_host_notice(subscription_resolution)
             copilot_proxy_token = client_bearer
             if subscription_resolution is not None:
                 copilot_refresh_oauth_token = subscription_resolution.refresh_oauth_token
                 copilot_api_token_expires_at = subscription_resolution.api_token_expires_at
-            support = _native_api_url_supported(environ=os.environ)
+            support = _native_api_url_supported(environ=os.environ, copilot_bin=copilot_bin)
             if support is False:
                 raise click.ClickException(
                     "This Copilot CLI build does not reference COPILOT_API_URL; refusing "
@@ -5853,6 +5891,7 @@ def copilot(
             env["COPILOT_PROVIDER_BEARER_TOKEN"] = client_bearer
             env["GITHUB_COPILOT_USE_TOKEN_EXCHANGE"] = "false"
             env.pop("COPILOT_PROVIDER_API_KEY", None)
+            _ensure_loopback_no_proxy(env)
             # Hand the exact token we resolved (and, for --subscription, validated
             # against GitHub) to the proxy explicitly via copilot_proxy_token below.
             # The proxy pins it as GITHUB_COPILOT_API_TOKEN, so upstream auth is
@@ -5888,6 +5927,7 @@ def copilot(
             env["GITHUB_COPILOT_API_URL"] = openai_api_url
             env["OPENAI_TARGET_API_URL"] = openai_api_url
             env_vars_display.append(f"COPILOT_PROVIDER_API_URL={openai_api_url}")
+            _echo_copilot_host_notice(subscription_resolution)
     else:
         env, env_vars_display = _build_copilot_launch_env(
             port=port,
@@ -5985,6 +6025,7 @@ def vscode_copilot(
     model selected in VS Code. It does not edit Codex settings.
     """
     resolution = _require_copilot_subscription_resolution()
+    _echo_copilot_host_notice(resolution)
     target_settings = settings_file or vscode_settings_path()
 
     def _print_setup(actual_port: int) -> None:

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -5891,6 +5891,10 @@ def copilot(
             env["COPILOT_PROVIDER_BEARER_TOKEN"] = client_bearer
             env["GITHUB_COPILOT_USE_TOKEN_EXCHANGE"] = "false"
             env.pop("COPILOT_PROVIDER_API_KEY", None)
+            # Chat goes through COPILOT_PROVIDER_BASE_URL here; a durable
+            # install's COPILOT_API_URL would send the CLI's ancillary CAPI
+            # calls to a proxy that may not be running.
+            env.pop("COPILOT_API_URL", None)
             _ensure_loopback_no_proxy(env)
             # Hand the exact token we resolved (and, for --subscription, validated
             # against GitHub) to the proxy explicitly via copilot_proxy_token below.

--- a/headroom/copilot_auth.py
+++ b/headroom/copilot_auth.py
@@ -1575,7 +1575,8 @@ def _is_forwardable_copilot_bearer_token(token: str) -> bool:
     """Return True when a bearer token should be forwarded as-is for Copilot inference.
 
     Unlike _is_copilot_api_token() (used only for subscription/user-info
-    resolution), this accepts both short-lived Copilot API tokens (`tid_`)
+    resolution), this accepts both short-lived Copilot API tokens (the
+    ``tid=<hex>;exp=…`` claim string GitHub mints, or the ``tid_`` prefix form)
     AND GitHub OAuth tokens (`gho_`, `ghs_`, `ghp_`, `github_pat_`) as valid,
     forwardable Copilot bearer credentials for chat-completion/inference
     requests.
@@ -1601,7 +1602,26 @@ def _is_forwardable_copilot_bearer_token(token: str) -> bool:
     if not normalized:
         return False
 
-    return normalized.startswith(("tid_", "gho_", "ghs_", "ghp_", "github_pat_"))
+    return _is_copilot_api_token_shape(normalized) or normalized.startswith(
+        ("gho_", "ghs_", "ghp_", "github_pat_")
+    )
+
+
+def _is_copilot_api_token_shape(token: str) -> bool:
+    """Return True for the wire shape of a Copilot API token.
+
+    The token GitHub mints at ``/copilot_internal/v2/token`` is a
+    semicolon-separated claim string, ``tid=<hex>;exp=<unix>;sku=...:<sig>``;
+    the CLI and VS Code send it verbatim as the bearer. The ``tid_`` prefix form
+    is kept for callers and fixtures that already use it.
+    """
+    normalized = token.strip()
+    if normalized.startswith("tid_"):
+        return True
+    if not normalized.startswith("tid="):
+        return False
+    claim, sep, _rest = normalized[4:].partition(";")
+    return bool(sep) and bool(claim) and all(c in "0123456789abcdefABCDEF" for c in claim)
 
 
 def _token_kind(token: str) -> str:
@@ -1613,13 +1633,20 @@ def _token_kind(token: str) -> str:
     return "unknown" if t else "empty"
 
 
-#: Bearer prefixes that identify a Copilot client's own credential on the wire:
-#: the short-lived Copilot API token (``tid_``) and the GitHub OAuth tokens the
-#: Copilot apps mint (``gho_``/``ghu_``). Narrower than
-#: :func:`_is_forwardable_copilot_bearer_token` on purpose — personal access
-#: tokens are also valid GitHub credentials for other products (GitHub Models),
-#: so they must not be taken as proof that a request was meant for Copilot.
-_COPILOT_ROUTING_BEARER_PREFIXES: tuple[str, ...] = ("tid_", "gho_", "ghu_")
+def _is_copilot_routing_bearer(token: str) -> bool:
+    """Return True for a bearer whose presence means "this client is a Copilot client".
+
+    Deliberately narrower than :func:`_is_forwardable_copilot_bearer_token` and a
+    strict subset of it: a Copilot API token (``tid=…``) or the ``gho_`` OAuth
+    token the CLI and VS Code hold. Every token accepted here must also be
+    forwardable, otherwise redirecting it to Copilot would make
+    :func:`apply_copilot_api_auth` substitute the operator's own credential for an
+    arbitrary caller's — the redirect must never widen who can spend the
+    operator's seat. ``ghp_``/``github_pat_``/``ghs_`` are forwardable but say
+    nothing about which provider the caller meant, so they do not route.
+    """
+    return _is_copilot_api_token_shape(token) or token.startswith("gho_")
+
 
 #: Stock provider hosts a Copilot credential can never authenticate against.
 _STOCK_PROVIDER_HOSTS: frozenset[str] = frozenset({"api.openai.com", "api.anthropic.com"})
@@ -1649,6 +1676,10 @@ def copilot_bearer_upstream(
     redirecting it to Copilot can only turn a certain 401 into the request the
     client intended. Anything else — an operator-pinned gateway, an explicit
     per-request ``x-headroom-base-url``, a non-Copilot token — is left alone.
+
+    Callers that go on to merge operator ``*_extra_headers`` must withhold them
+    when this returns a URL: those secrets belong to the configured target, not
+    to the host the request was redirected to.
     """
     if _header_value(headers, "x-headroom-base-url"):
         return None
@@ -1657,7 +1688,7 @@ def copilot_bearer_upstream(
         if host not in _STOCK_PROVIDER_HOSTS:
             return None
     token = _bearer_token(headers)
-    if not token or not token.startswith(_COPILOT_ROUTING_BEARER_PREFIXES):
+    if not token or not _is_copilot_routing_bearer(token):
         return None
     return copilot_api_url()
 

--- a/headroom/copilot_auth.py
+++ b/headroom/copilot_auth.py
@@ -122,6 +122,10 @@ class CopilotSubscriptionTokenResolution:
     token_fingerprint: str
     refresh_oauth_token: str | None = None
     api_token_expires_at: float | None = None
+    #: The ``endpoints.api`` host GitHub advertised for this account, before
+    #: Headroom's routing policy chose ``api_url``. Lets callers tell the user
+    #: when the two differ (subscription-based network routing, data residency).
+    advertised_api_url: str | None = None
 
 
 def token_fingerprint(token: str) -> str:
@@ -1011,6 +1015,40 @@ def _api_url_from_payload(payload: dict[str, Any] | None) -> str | None:
     return None
 
 
+#: Opt-in: route Business/Enterprise accounts through the segmented host GitHub
+#: advertises for them instead of the generic public host.
+USE_ADVERTISED_HOST_ENV = "GITHUB_COPILOT_USE_ADVERTISED_HOST"
+
+#: Per-plan chat hosts GitHub advertises in ``endpoints.api``. The generic host
+#: serves all of them, and it is the one Headroom routes to by default: the
+#: segmented hosts regressed model availability for wrapped sessions (#610 for
+#: individual, #2441 for Business/Enterprise) and the official client's results
+#: could not be reproduced through them at the time. Enterprises whose firewall
+#: uses GitHub's subscription-based network routing block the generic host, so
+#: they need the advertised host — hence the opt-in above and the explicit
+#: ``GITHUB_COPILOT_API_URL`` pin.
+_SEGMENTED_PLAN_HOSTS: frozenset[str] = frozenset(
+    {
+        "api.business.githubcopilot.com",
+        "api.enterprise.githubcopilot.com",
+    }
+)
+
+
+def use_advertised_host() -> bool:
+    """Return True when the operator opted into GitHub's advertised per-plan host."""
+    value = os.environ.get(USE_ADVERTISED_HOST_ENV, "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def advertised_host_is_normalized(api_url: str | None) -> bool:
+    """Return True when ``api_url`` is a per-plan host Headroom would fold into the generic one."""
+    if not api_url:
+        return False
+    host = urlparse(api_url).netloc.lower()
+    return host in _SEGMENTED_PLAN_HOSTS and not use_advertised_host()
+
+
 def _subscription_api_url_from_user_info_payload(payload: dict[str, Any] | None) -> str:
     configured = _configured_api_url_override()
     if configured:
@@ -1021,14 +1059,20 @@ def _subscription_api_url_from_user_info_payload(payload: dict[str, Any] | None)
         return DEFAULT_API_URL
 
     host = urlparse(api_url).netloc.lower()
+    if host in _SEGMENTED_PLAN_HOSTS and use_advertised_host():
+        return api_url
     if host in {
         "api.githubcopilot.com",
         "api.individual.githubcopilot.com",
-        "api.business.githubcopilot.com",
-        "api.enterprise.githubcopilot.com",
+        *_SEGMENTED_PLAN_HOSTS,
     }:
         return DEFAULT_API_URL
     if host.endswith(".githubcopilot.com"):
+        return api_url
+    if _is_ghe_copilot_api_host(host):
+        # A data-residency tenant's token is minted by that tenant's GHE.com
+        # deployment; the public host cannot validate it. Folding it into the
+        # generic host guarantees a 401, so keep the advertised host.
         return api_url
     return DEFAULT_API_URL
 
@@ -1062,6 +1106,7 @@ def _subscription_resolution(
     api_url: str,
     refresh_oauth_token: str | None = None,
     api_token_expires_at: float | None = None,
+    advertised_api_url: str | None = None,
 ) -> CopilotSubscriptionTokenResolution:
     return CopilotSubscriptionTokenResolution(
         token=token,
@@ -1071,6 +1116,7 @@ def _subscription_resolution(
         token_fingerprint=token_fingerprint(token),
         refresh_oauth_token=refresh_oauth_token,
         api_token_expires_at=api_token_expires_at,
+        advertised_api_url=advertised_api_url,
     )
 
 
@@ -1104,6 +1150,7 @@ def _subscription_resolution_from_token_exchange(
         api_url=_api_url_from_exchange_payload(payload, oauth_token=candidate.token),
         refresh_oauth_token=candidate.token,
         api_token_expires_at=_parse_expiry(payload.get("expires_at")),
+        advertised_api_url=_api_url_from_payload(payload),
     )
 
 
@@ -1121,6 +1168,7 @@ def resolve_subscription_bearer_token_details() -> CopilotSubscriptionTokenResol
                 source=f"env:{env_var}",
                 confidence="explicit-api-token",
                 api_url=_subscription_api_url_from_user_info_payload(payload),
+                advertised_api_url=_api_url_from_payload(payload),
             )
 
     for candidate in iter_oauth_token_candidates():
@@ -1139,6 +1187,7 @@ def resolve_subscription_bearer_token_details() -> CopilotSubscriptionTokenResol
                     source=candidate.source,
                     confidence=candidate.confidence,
                     api_url=_subscription_api_url_from_user_info_payload(payload),
+                    advertised_api_url=_api_url_from_payload(payload),
                 )
             continue
 
@@ -1562,6 +1611,55 @@ def _token_kind(token: str) -> str:
         if t.startswith(prefix):
             return prefix + "***"
     return "unknown" if t else "empty"
+
+
+#: Bearer prefixes that identify a Copilot client's own credential on the wire:
+#: the short-lived Copilot API token (``tid_``) and the GitHub OAuth tokens the
+#: Copilot apps mint (``gho_``/``ghu_``). Narrower than
+#: :func:`_is_forwardable_copilot_bearer_token` on purpose — personal access
+#: tokens are also valid GitHub credentials for other products (GitHub Models),
+#: so they must not be taken as proof that a request was meant for Copilot.
+_COPILOT_ROUTING_BEARER_PREFIXES: tuple[str, ...] = ("tid_", "gho_", "ghu_")
+
+#: Stock provider hosts a Copilot credential can never authenticate against.
+_STOCK_PROVIDER_HOSTS: frozenset[str] = frozenset({"api.openai.com", "api.anthropic.com"})
+
+
+def _bearer_token(headers: Mapping[str, str]) -> str | None:
+    for key, value in headers.items():
+        if key.lower() == "authorization":
+            scheme, _, token = value.partition(" ")
+            if scheme.lower() == "bearer" and token.strip():
+                return token.strip()
+            return None
+    return None
+
+
+def copilot_bearer_upstream(
+    headers: Mapping[str, str], configured_target: str | None
+) -> str | None:
+    """Return the Copilot API base when a Copilot-authenticated request would otherwise hit a stock provider.
+
+    A persistent (shared) proxy keeps its OpenAI and Anthropic targets on the
+    stock hosts so Codex, aider, and SDK clients keep working. The Copilot CLI
+    in native mode and the VS Code extension send GitHub's own credential
+    (``tid_``/``gho_``) on ``/chat/completions``, ``/responses``,
+    ``/v1/messages``, ``/models``, ``/models/session`` and ``/auto``. That
+    credential cannot succeed at ``api.openai.com`` or ``api.anthropic.com``, so
+    redirecting it to Copilot can only turn a certain 401 into the request the
+    client intended. Anything else — an operator-pinned gateway, an explicit
+    per-request ``x-headroom-base-url``, a non-Copilot token — is left alone.
+    """
+    if _header_value(headers, "x-headroom-base-url"):
+        return None
+    if configured_target:
+        host = (urlparse(configured_target).hostname or "").lower()
+        if host not in _STOCK_PROVIDER_HOSTS:
+            return None
+    token = _bearer_token(headers)
+    if not token or not token.startswith(_COPILOT_ROUTING_BEARER_PREFIXES):
+        return None
+    return copilot_api_url()
 
 
 def _is_managed_copilot_seeded_bearer(token: str) -> bool:

--- a/headroom/providers/copilot/__init__.py
+++ b/headroom/providers/copilot/__init__.py
@@ -9,14 +9,18 @@ from .vscode import (
 )
 from .wrap import (
     build_launch_env,
+    check_copilot_url_setting,
     copilot_model_from_args,
     default_wire_api_for_model,
     detect_running_proxy_backend,
+    ensure_loopback_no_proxy,
     is_auto_model,
     model_configured,
     model_prefers_responses_api,
     provider_key_source,
     query_proxy_config,
+    read_copilot_url_setting,
+    read_copilot_url_settings,
     resolve_provider_type,
     strip_auto_model_args,
     validate_configuration,
@@ -24,6 +28,10 @@ from .wrap import (
 
 __all__ = [
     "build_launch_env",
+    "check_copilot_url_setting",
+    "ensure_loopback_no_proxy",
+    "read_copilot_url_setting",
+    "read_copilot_url_settings",
     "copilot_model_from_args",
     "default_wire_api_for_model",
     "detect_running_proxy_backend",

--- a/headroom/providers/copilot/install.py
+++ b/headroom/providers/copilot/install.py
@@ -2,11 +2,54 @@
 
 from __future__ import annotations
 
-from .wrap import build_launch_env, resolve_provider_type
+import os
+from collections.abc import Mapping
+
+from .wrap import (
+    COPILOT_NATIVE_API_URL_ENV,
+    build_launch_env,
+    build_native_launch_env,
+    resolve_provider_type,
+)
+
+#: Backends that speak Anthropic/OpenAI wire formats natively and can therefore
+#: forward the Copilot CLI's own GitHub-authenticated traffic to GitHub's API.
+#: Translated backends (any-llm, LiteLLM, Bedrock, Vertex) cannot serve
+#: GitHub's hosted models, so they keep the single-model BYOK lane.
+_NATIVE_CAPABLE_BACKENDS: frozenset[str] = frozenset({"", "anthropic"})
 
 
-def build_install_env(*, port: int, backend: str) -> dict[str, str]:
-    """Build the persistent install environment for Copilot."""
+def install_uses_native_lane(backend: str, environ: Mapping[str, str] | None = None) -> bool:
+    """Decide between the native (GitHub-hosted) and BYOK lanes for an install.
+
+    Native is the default: an installed Copilot CLI keeps its model picker and
+    Auto mode, and the proxy forwards the developer's own Copilot token to
+    GitHub. BYOK is chosen only when the operator has stated that intent with
+    ``COPILOT_PROVIDER_API_KEY`` in the install-time environment, or when the
+    proxy backend is a translated one that cannot reach GitHub's hosted API.
+    """
+    env = environ if environ is not None else os.environ
+    if (env.get("COPILOT_PROVIDER_API_KEY") or "").strip():
+        return False
+    return (backend or "").strip().lower() in _NATIVE_CAPABLE_BACKENDS
+
+
+def build_install_env(
+    *, port: int, backend: str, environ: Mapping[str, str] | None = None
+) -> dict[str, str]:
+    """Build the persistent install environment for Copilot.
+
+    Native lane: ``COPILOT_API_URL`` only. The CLI resolves its API host as
+    ``settings.copilotUrl || COPILOT_API_URL || token.endpoints.api``, so this
+    variable redirects GitHub-authenticated traffic through the proxy without
+    touching model selection. The proxy recognises the CLI's Copilot bearer
+    token and forwards it to GitHub even when its OpenAI target is the stock
+    ``api.openai.com``, so no target pin is needed in the manifest.
+    """
+    if install_uses_native_lane(backend, environ):
+        env, _lines = build_native_launch_env(port=port, environ={})
+        return {COPILOT_NATIVE_API_URL_ENV: env[COPILOT_NATIVE_API_URL_ENV]}
+
     provider_type = resolve_provider_type(backend, "auto", {"HEADROOM_BACKEND": backend})
     env, _lines = build_launch_env(
         port=port,

--- a/headroom/providers/copilot/wrap.py
+++ b/headroom/providers/copilot/wrap.py
@@ -2,16 +2,138 @@
 
 from __future__ import annotations
 
+import glob
 import json
 import os
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
 import click
 
 from headroom.proxy.project_context import with_project_prefix
+
+#: Hosts a corporate HTTP(S) proxy must never be asked to reach on our behalf.
+#: The Copilot CLI honours ``HTTP_PROXY``/``HTTPS_PROXY`` (and applies its own
+#: ``proxyUrl`` setting to those variables), so without an explicit exemption a
+#: fleet-wide proxy setting sends the loopback hop to the corporate proxy, which
+#: cannot connect to ``127.0.0.1`` on the developer's machine.
+LOOPBACK_NO_PROXY_HOSTS: tuple[str, ...] = ("127.0.0.1", "localhost", "::1")
+
+
+def ensure_loopback_no_proxy(env: dict[str, str]) -> dict[str, str]:
+    """Exempt the loopback proxy hop from any HTTP(S) proxy configuration.
+
+    Idempotent: hosts already listed are not duplicated. ``NO_PROXY`` is always
+    written (Node's fetch and reqwest both read it); a pre-existing lowercase
+    ``no_proxy`` is kept in sync so the two never disagree. Mutates and returns
+    ``env`` for call-site convenience.
+    """
+    for variable in ("NO_PROXY", "no_proxy"):
+        current = env.get(variable)
+        if current is None and variable == "no_proxy":
+            continue
+        entries = [entry.strip() for entry in (current or "").split(",") if entry.strip()]
+        for host in LOOPBACK_NO_PROXY_HOSTS:
+            if host not in entries:
+                entries.append(host)
+        env[variable] = ",".join(entries)
+    return env
+
+
+def copilot_home(environ: Mapping[str, str] | None = None) -> Path:
+    """Return the Copilot CLI config directory (``$COPILOT_HOME`` or ``~/.copilot``)."""
+    env = environ if environ is not None else os.environ
+    configured = (env.get("COPILOT_HOME") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    home = env.get("HOME") or env.get("USERPROFILE")
+    return (Path(home) if home else Path.home()) / ".copilot"
+
+
+#: Settings key the CLI consults for its Copilot API host. Undocumented, but the
+#: 1.0.8x bundle resolves ``settings.copilotUrl || COPILOT_API_URL ||
+#: token.endpoints.api`` — the file beats the environment variable Headroom sets.
+COPILOT_URL_SETTING_KEY = "copilotUrl"
+
+
+def read_copilot_url_settings(environ: Mapping[str, str] | None = None) -> list[tuple[Path, str]]:
+    """Return every ``(file, value)`` pin of the CLI's Copilot API host.
+
+    Both ``settings.json`` (the current user-settings file) and the legacy
+    ``config.json`` are consulted: the CLI migrates keys from the latter at
+    startup but still reports a legacy value as shadowing the new one when both
+    exist, so a pin in either file can be the effective one. Unreadable or
+    malformed files contribute nothing — the CLI would ignore them too, so they
+    cannot redirect its traffic.
+    """
+    home = copilot_home(environ)
+    pins: list[tuple[Path, str]] = []
+    for name in ("settings.json", "config.json"):
+        path = home / name
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        value = payload.get(COPILOT_URL_SETTING_KEY)
+        if isinstance(value, str) and value.strip():
+            pins.append((path, value.strip()))
+    return pins
+
+
+def read_copilot_url_setting(environ: Mapping[str, str] | None = None) -> tuple[Path, str] | None:
+    """Return the first ``copilotUrl`` pin (``settings.json`` before ``config.json``), if any."""
+    pins = read_copilot_url_settings(environ)
+    return pins[0] if pins else None
+
+
+def _origin(url: str) -> str:
+    """Return ``scheme://host[:port]`` lowercased, so two spellings of one proxy compare equal."""
+    parsed = urllib.parse.urlsplit(url.strip())
+    if not parsed.scheme or not parsed.netloc:
+        return url.strip().rstrip("/").lower()
+    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+
+
+def check_copilot_url_setting(base_url: str, *, environ: Mapping[str, str] | None = None) -> None:
+    """Refuse a native launch that the CLI's own ``copilotUrl`` setting would bypass.
+
+    Headroom points the CLI at itself through ``COPILOT_API_URL``. The CLI ranks
+    the ``copilotUrl`` settings key above that variable, so a pre-existing pin
+    makes the wrapper print a successful launch while every request goes
+    straight to the pinned host. Fail closed on any pin whose origin is not this
+    proxy. A pin on the same origin but a different path (a durable install that
+    wrote the bare proxy URL, without this launch's ``/p/<project>`` prefix)
+    still routes through Headroom; it is accepted with a note, because only the
+    per-project attribution differs.
+    """
+    proxy_origin = _origin(base_url)
+    foreign: list[tuple[Path, str]] = []
+    same_origin_other_path: list[tuple[Path, str]] = []
+    for path, value in read_copilot_url_settings(environ):
+        if _origin(value) != proxy_origin:
+            foreign.append((path, value))
+        elif value.rstrip("/").lower() != base_url.rstrip("/").lower():
+            same_origin_other_path.append((path, value))
+    if foreign:
+        described = "; ".join(
+            f"{path} sets {COPILOT_URL_SETTING_KEY}={value!r}" for path, value in foreign
+        )
+        raise click.ClickException(
+            f"{described}. The Copilot CLI prefers that setting over COPILOT_API_URL, so this "
+            f"launch would bypass Headroom. Remove the key, or set it to {base_url!r} to route "
+            "through this proxy."
+        )
+    for path, value in same_origin_other_path:
+        click.echo(
+            f"  Note: {path} pins {COPILOT_URL_SETTING_KEY}={value!r}; the CLI will use that URL "
+            f"instead of {base_url!r}, so per-project savings attribution follows the pinned path."
+        )
 
 
 def resolve_provider_type(
@@ -189,14 +311,74 @@ def build_native_launch_env(
     env[COPILOT_NATIVE_API_URL_ENV] = base_url
     for variable in COPILOT_BYOK_ENV_VARS:
         env.pop(variable, None)
+    ensure_loopback_no_proxy(env)
     return env, [
         f"{COPILOT_NATIVE_API_URL_ENV}={base_url}",
         "COPILOT_AUTH_MODE=github-native",
     ]
 
 
-def native_api_url_supported(*, environ: Mapping[str, str] | None = None) -> bool | None:
-    """Best-effort tri-state probe for the CLI's native API URL override."""
+def _copilot_bundle_candidates(copilot_bin: str | None) -> list[str]:
+    """Return ``app.js`` paths that belong to the CLI binary actually on PATH.
+
+    The CLI stopped being a single ``app.js`` under a ``pkg`` directory: since
+    the 1.0.8x line ``@github/copilot`` is an npm shim (``npm-loader.js``) that
+    spawns a per-platform package (``@github/copilot-<os>-<arch>``) holding a
+    native ``copilot`` binary next to the JavaScript ``app.js`` it embeds. Both
+    layouts are covered by looking beside the resolved binary and in sibling
+    ``copilot-*`` packages of the directory it lives in.
+    """
+    if not copilot_bin:
+        return []
+    try:
+        resolved = os.path.realpath(copilot_bin)
+    except OSError:
+        return []
+    bin_dir = os.path.dirname(resolved)
+    parent = os.path.dirname(bin_dir)
+    candidates: list[str] = [
+        # A native platform binary sits next to its own bundle.
+        os.path.join(bin_dir, "app.js"),
+        # `npm-loader.js` (resolved through the `bin/copilot` symlink) lives in
+        # the shim package; the platform packages are its siblings under the
+        # same `@github/` scope directory.
+        *sorted(glob.glob(os.path.join(parent, "copilot-*", "app.js"))),
+        # Windows npm shims (`copilot.cmd`, `copilot.ps1`) are scripts in the
+        # npm prefix, not symlinks, so the packages hang off that directory.
+        *sorted(glob.glob(os.path.join(bin_dir, "node_modules", "@github", "copilot-*", "app.js"))),
+    ]
+    seen: set[str] = set()
+    unique: list[str] = []
+    for path in candidates:
+        if path not in seen and os.path.isfile(path):
+            seen.add(path)
+            unique.append(path)
+    return unique
+
+
+def _bundle_mentions_native_api_url(path: str) -> bool | None:
+    """Return True/False for a readable bundle, None when it cannot be read."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as bundle:
+            while chunk := bundle.read(1 << 20):
+                if COPILOT_NATIVE_API_URL_ENV in chunk:
+                    return True
+    except OSError:
+        return None
+    return False
+
+
+def native_api_url_supported(
+    *, environ: Mapping[str, str] | None = None, copilot_bin: str | None = None
+) -> bool | None:
+    """Best-effort tri-state probe for the CLI's native API URL override.
+
+    Returns True when a bundle references ``COPILOT_API_URL``, False when at
+    least one bundle was read and none did, and None when no bundle could be
+    located — the caller then proceeds but cannot promise the redirect took.
+    ``copilot_bin`` (the binary about to be launched) is checked first so the
+    verdict describes that build rather than a stale installer copy.
+    """
     env = environ if environ is not None else os.environ
     local = env.get("LOCALAPPDATA") or env.get("HOME") or os.path.expanduser("~")
     roots = (
@@ -204,6 +386,10 @@ def native_api_url_supported(*, environ: Mapping[str, str] | None = None) -> boo
         os.path.join(os.path.expanduser("~"), ".local", "share", "copilot", "pkg"),
     )
     found_bundle = False
+    for path in _copilot_bundle_candidates(copilot_bin):
+        found_bundle = True
+        if _bundle_mentions_native_api_url(path):
+            return True
     for root in roots:
         if not os.path.isdir(root):
             continue
@@ -211,15 +397,8 @@ def native_api_url_supported(*, environ: Mapping[str, str] | None = None) -> boo
             if "app.js" not in filenames:
                 continue
             found_bundle = True
-            try:
-                with open(
-                    os.path.join(dirpath, "app.js"), encoding="utf-8", errors="replace"
-                ) as bundle:
-                    while chunk := bundle.read(1 << 20):
-                        if COPILOT_NATIVE_API_URL_ENV in chunk:
-                            return True
-            except OSError:
-                continue
+            if _bundle_mentions_native_api_url(os.path.join(dirpath, "app.js")):
+                return True
     return False if found_bundle else None
 
 
@@ -244,6 +423,7 @@ def build_launch_env(
     env = dict(environ if environ is not None else os.environ)
     env["COPILOT_PROVIDER_TYPE"] = provider_type
     env.pop("COPILOT_PROVIDER_WIRE_API", None)
+    ensure_loopback_no_proxy(env)
 
     if not env.get("COPILOT_PROVIDER_API_KEY"):
         key = env.get(provider_key_source(provider_type), "")

--- a/headroom/providers/copilot/wrap.py
+++ b/headroom/providers/copilot/wrap.py
@@ -28,29 +28,42 @@ def ensure_loopback_no_proxy(env: dict[str, str]) -> dict[str, str]:
     """Exempt the loopback proxy hop from any HTTP(S) proxy configuration.
 
     Idempotent: hosts already listed are not duplicated. ``NO_PROXY`` is always
-    written (Node's fetch and reqwest both read it); a pre-existing lowercase
-    ``no_proxy`` is kept in sync so the two never disagree. Mutates and returns
-    ``env`` for call-site convenience.
+    written; a pre-existing lowercase ``no_proxy`` is kept in sync. Readers
+    disagree on which spelling wins (undici prefers lowercase, reqwest and Go
+    prefer uppercase), so both are seeded from the union of the two — writing a
+    fresh ``NO_PROXY`` that lacked the entries of an existing ``no_proxy`` would
+    silently drop the corporate exemptions for anything the CLI spawns. Mutates
+    and returns ``env`` for call-site convenience.
     """
+    entries: list[str] = []
     for variable in ("NO_PROXY", "no_proxy"):
-        current = env.get(variable)
-        if current is None and variable == "no_proxy":
-            continue
-        entries = [entry.strip() for entry in (current or "").split(",") if entry.strip()]
-        for host in LOOPBACK_NO_PROXY_HOSTS:
-            if host not in entries:
-                entries.append(host)
-        env[variable] = ",".join(entries)
+        for entry in (env.get(variable) or "").split(","):
+            entry = entry.strip()
+            if entry and entry not in entries:
+                entries.append(entry)
+    for host in LOOPBACK_NO_PROXY_HOSTS:
+        if host not in entries:
+            entries.append(host)
+    merged = ",".join(entries)
+    env["NO_PROXY"] = merged
+    if "no_proxy" in env:
+        env["no_proxy"] = merged
     return env
 
 
-def copilot_home(environ: Mapping[str, str] | None = None) -> Path:
-    """Return the Copilot CLI config directory (``$COPILOT_HOME`` or ``~/.copilot``)."""
+def copilot_home(environ: Mapping[str, str] | None = None, *, windows: bool | None = None) -> Path:
+    """Return the Copilot CLI config directory (``$COPILOT_HOME`` or ``~/.copilot``).
+
+    Matches Node's ``os.homedir()``, which the CLI uses: ``USERPROFILE`` on
+    Windows (``HOME`` is ignored there, even when Git-for-Windows sets it),
+    ``HOME`` elsewhere. ``windows`` defaults to the running platform.
+    """
     env = environ if environ is not None else os.environ
     configured = (env.get("COPILOT_HOME") or "").strip()
     if configured:
         return Path(configured).expanduser()
-    home = env.get("HOME") or env.get("USERPROFILE")
+    on_windows = os.name == "nt" if windows is None else windows
+    home = env.get("USERPROFILE") if on_windows else env.get("HOME")
     return (Path(home) if home else Path.home()) / ".copilot"
 
 
@@ -126,8 +139,8 @@ def check_copilot_url_setting(base_url: str, *, environ: Mapping[str, str] | Non
         )
         raise click.ClickException(
             f"{described}. The Copilot CLI prefers that setting over COPILOT_API_URL, so this "
-            f"launch would bypass Headroom. Remove the key, or set it to {base_url!r} to route "
-            "through this proxy."
+            f"launch would bypass Headroom. Remove the key, or set it to {proxy_origin!r} to "
+            "route every project through this proxy."
         )
     for path, value in same_origin_other_path:
         click.echo(
@@ -357,12 +370,21 @@ def _copilot_bundle_candidates(copilot_bin: str | None) -> list[str]:
 
 
 def _bundle_mentions_native_api_url(path: str) -> bool | None:
-    """Return True/False for a readable bundle, None when it cannot be read."""
+    """Return True/False for a readable bundle, None when it cannot be read.
+
+    Reads in chunks, carrying the tail of each chunk into the next so a match
+    that straddles a chunk boundary is not missed — a miss here now refuses the
+    launch rather than merely leaving the verdict unknown.
+    """
+    needle = COPILOT_NATIVE_API_URL_ENV
+    carry = ""
     try:
         with open(path, encoding="utf-8", errors="replace") as bundle:
             while chunk := bundle.read(1 << 20):
-                if COPILOT_NATIVE_API_URL_ENV in chunk:
+                window = carry + chunk
+                if needle in window:
                     return True
+                carry = window[-(len(needle) - 1) :]
     except OSError:
         return None
     return False
@@ -376,20 +398,26 @@ def native_api_url_supported(
     Returns True when a bundle references ``COPILOT_API_URL``, False when at
     least one bundle was read and none did, and None when no bundle could be
     located — the caller then proceeds but cannot promise the redirect took.
-    ``copilot_bin`` (the binary about to be launched) is checked first so the
-    verdict describes that build rather than a stale installer copy.
+    ``copilot_bin`` (the binary about to be launched) decides on its own when its
+    bundle can be read: a stale installer copy under the legacy ``pkg`` roots
+    must not vouch for a build that dropped the hook. Those roots are consulted
+    only when no readable bundle sits beside the launched binary.
     """
     env = environ if environ is not None else os.environ
-    local = env.get("LOCALAPPDATA") or env.get("HOME") or os.path.expanduser("~")
+    home = env.get("HOME") or os.path.expanduser("~")
+    local = env.get("LOCALAPPDATA") or home
     roots = (
         os.path.join(local, "copilot", "pkg"),
-        os.path.join(os.path.expanduser("~"), ".local", "share", "copilot", "pkg"),
+        os.path.join(home, ".local", "share", "copilot", "pkg"),
     )
+    launched_verdicts = [
+        _bundle_mentions_native_api_url(path) for path in _copilot_bundle_candidates(copilot_bin)
+    ]
+    if True in launched_verdicts:
+        return True
+    if False in launched_verdicts:
+        return False
     found_bundle = False
-    for path in _copilot_bundle_candidates(copilot_bin):
-        found_bundle = True
-        if _bundle_mentions_native_api_url(path):
-            return True
     for root in roots:
         if not os.path.isdir(root):
             continue
@@ -412,6 +440,11 @@ def build_launch_env(
 ) -> tuple[dict[str, str], list[str]]:
     """Build the Copilot BYOK environment for the selected provider type.
 
+    A durable ``headroom install`` exports ``COPILOT_API_URL`` into the shell so
+    the native lane works everywhere; this lane routes chat through the BYOK
+    variables instead and drops that hook, so the CLI's ancillary CAPI calls
+    are not sent to a proxy that may not be running.
+
     ``project`` (the wrap launch directory) is encoded as a ``/p/<name>``
     base-URL prefix because the Copilot CLI cannot send custom headers; the
     proxy strips it and attributes savings per project.
@@ -421,6 +454,7 @@ def build_launch_env(
     # charge of which keys to seed). The previous `environ or os.environ`
     # collapsed those two cases because `bool({}) is False`.
     env = dict(environ if environ is not None else os.environ)
+    env.pop(COPILOT_NATIVE_API_URL_ENV, None)
     env["COPILOT_PROVIDER_TYPE"] = provider_type
     env.pop("COPILOT_PROVIDER_WIRE_API", None)
     ensure_loopback_no_proxy(env)

--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -9,6 +9,7 @@ from typing import Any
 from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.responses import Response
 
+from headroom.copilot_auth import copilot_bearer_upstream as _copilot_bearer_upstream
 from headroom.providers.cloudcode import normalize_cloudcode_passthrough_path
 from headroom.providers.codex.endpoints import codex_backend_url
 from headroom.providers.codex.headers import drop_header
@@ -273,6 +274,14 @@ def register_provider_routes(app: FastAPI, proxy: Any) -> None:
             return await proxy.handle_anthropic_messages(
                 request, upstream_base_url=custom_base.rstrip("/")
             )
+        # Claude models on Copilot travel this route with GitHub's bearer token.
+        # On a shared proxy whose Anthropic target is the stock host that token
+        # cannot succeed; hand the handler the Copilot base the same way a
+        # per-request override would, so auth, `/v1` handling and provider
+        # labelling all follow the existing Copilot path.
+        copilot_base = _copilot_bearer_upstream(dict(request.headers), proxy.ANTHROPIC_API_URL)
+        if copilot_base is not None:
+            return await proxy.handle_anthropic_messages(request, upstream_base_url=copilot_base)
         return await proxy.handle_anthropic_messages(request)
 
     @app.post("/anthropic/v1/messages")

--- a/headroom/providers/proxy_routes.py
+++ b/headroom/providers/proxy_routes.py
@@ -281,7 +281,9 @@ def register_provider_routes(app: FastAPI, proxy: Any) -> None:
         # labelling all follow the existing Copilot path.
         copilot_base = _copilot_bearer_upstream(dict(request.headers), proxy.ANTHROPIC_API_URL)
         if copilot_base is not None:
-            return await proxy.handle_anthropic_messages(request, upstream_base_url=copilot_base)
+            return await proxy.handle_anthropic_messages(
+                request, upstream_base_url=copilot_base, copilot_redirect=True
+            )
         return await proxy.handle_anthropic_messages(request)
 
     @app.post("/anthropic/v1/messages")
@@ -477,6 +479,14 @@ def register_provider_routes(app: FastAPI, proxy: Any) -> None:
             VERTEX_STREAM_RAW_PREDICT.name,
         )
 
+    def _model_metadata_target(request: Request, provider_name: str) -> str:
+        target = _api_target(proxy, provider_name)
+        if provider_name == "openai":
+            # Same rule as the unprefixed `/models` passthrough: a Copilot
+            # credential against the stock OpenAI target belongs at Copilot.
+            return _copilot_bearer_upstream(dict(request.headers), target) or target
+        return target
+
     @app.get("/v1/models")
     async def list_models(request: Request):
         provider_name = proxy.provider_runtime.model_metadata_provider(dict(request.headers))
@@ -484,7 +494,7 @@ def register_provider_routes(app: FastAPI, proxy: Any) -> None:
             proxy,
             request,
             endpoint=MODEL_METADATA_LIST_ENDPOINT,
-            provider_api_base_url=_api_target(proxy, provider_name),
+            provider_api_base_url=_model_metadata_target(request, provider_name),
             provider_name=provider_name,
         )
 
@@ -495,7 +505,7 @@ def register_provider_routes(app: FastAPI, proxy: Any) -> None:
             proxy,
             request,
             endpoint=model_metadata_get_endpoint(model_id),
-            provider_api_base_url=_api_target(proxy, provider_name),
+            provider_api_base_url=_model_metadata_target(request, provider_name),
             provider_name=provider_name,
         )
 

--- a/headroom/providers/proxy_targets.py
+++ b/headroom/providers/proxy_targets.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 from headroom.copilot_auth import (
+    copilot_bearer_upstream,
     copilot_completions_base_url,
     is_copilot_completions_host,
     is_copilot_completions_path,
@@ -61,6 +62,15 @@ def select_passthrough_base_url(
             logger.warning("ignoring unsafe x-headroom-base-url override: %r", azure_base)
     provider_name = proxy.provider_runtime.model_metadata_provider(headers)
     target = api_target(proxy, provider_name)
+    if provider_name == "openai":
+        # Copilot's ancillary CAPI calls (`/models`, `/models/session`, `/auto`,
+        # `/agents/*`, `/embeddings`) land here with GitHub's own bearer token
+        # and no provider header. On a shared proxy whose OpenAI target is the
+        # stock host that token cannot succeed, so route it to Copilot — the
+        # same rule the chat and responses handlers apply.
+        copilot_target = copilot_bearer_upstream(headers, target)
+        if copilot_target is not None:
+            target = copilot_target
     if (
         path is not None
         and provider_name == "openai"

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -886,8 +886,17 @@ class AnthropicHandlerMixin:
         provider_name: str = "anthropic",
         model_override: str | None = None,
         force_stream: bool = False,
+        copilot_redirect: bool = False,
     ) -> Response | StreamingResponse:
-        """Handle Anthropic /v1/messages endpoint."""
+        """Handle Anthropic /v1/messages endpoint.
+
+        ``copilot_redirect`` marks an ``upstream_base_url`` the proxy chose itself
+        because the caller presented a Copilot credential against the stock
+        Anthropic target (see ``copilot_bearer_upstream``). The operator's
+        ``anthropic_extra_headers`` are secrets for the configured target and
+        are withheld from such a request, without the trust check that a
+        client-supplied override goes through.
+        """
         if not hasattr(self, "pipeline_extensions"):
             from headroom.pipeline import PipelineExtensionManager
 
@@ -1209,10 +1218,11 @@ class AnthropicHandlerMixin:
             headers = _strip_internal_headers(headers)
             # `upstream_base_url` is the per-request `x-headroom-base-url`
             # override when the client sent one. These headers are secrets, so
-            # they only travel to a host the operator designated.
+            # they only travel to a host the operator designated — and never
+            # with a request the proxy redirected to Copilot on its own.
             headers = merge_extra_headers(
                 headers,
-                self.config.anthropic_extra_headers,
+                None if copilot_redirect else self.config.anthropic_extra_headers,
                 upstream_url=upstream_base_url,
                 config=self.config,
             )

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -29,7 +29,11 @@ import httpx
 from headroom.agent_savings import proxy_pipeline_kwargs
 from headroom.ccr.context_tracker import looks_like_claude_code_compact_summary
 from headroom.ccr.marker_resolution import resolve_markers_in_response
-from headroom.copilot_auth import apply_copilot_api_auth, build_copilot_upstream_url
+from headroom.copilot_auth import (
+    apply_copilot_api_auth,
+    build_copilot_upstream_url,
+    is_copilot_api_url,
+)
 from headroom.pipeline import PipelineStage, summarize_routing_markers
 from headroom.proxy.auth_mode import (
     classify_auth_mode,
@@ -3275,6 +3279,10 @@ class AnthropicHandlerMixin:
                             not upstream_base_url
                             or getattr(self, "anthropic_backend", None) is not None
                             or _is_googleapis_endpoint(upstream_base_url)
+                            # Copilot's Anthropic surface enforces Anthropic's
+                            # wire contract; a redirected request must get the
+                            # same model-aware relocation as a configured one.
+                            or is_copilot_api_url(upstream_base_url)
                         )
                         else None
                     ),

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -53,6 +53,7 @@ from headroom.config import unwrap_tool_call_name
 from headroom.copilot_auth import (
     apply_copilot_api_auth,
     build_copilot_upstream_url,
+    copilot_bearer_upstream,
     is_copilot_api_url,
 )
 from headroom.pipeline import PipelineStage, summarize_routing_markers
@@ -400,6 +401,21 @@ def _resolve_openai_upstream_base(request_headers: dict[str, str]) -> str | None
         logger.warning("ignoring unsafe x-headroom-base-url override: %r", raw_base_url)
         return None
     return normalized
+
+
+def _extra_headers_unless_redirected(
+    extra: dict[str, str] | None, *, redirected_to: str | None
+) -> dict[str, str] | None:
+    """Withhold operator gateway headers from a Copilot-redirected request.
+
+    ``openai_extra_headers`` are secrets configured for the operator's OpenAI
+    target. When a Copilot credential causes the request to be redirected to
+    GitHub instead (``redirected_to`` is set), that target is not where the
+    request goes, so the headers must not travel with it — and, unlike routing
+    the merge through the trust check, this raises no "untrusted upstream"
+    warning for a redirect the proxy chose deliberately.
+    """
+    return None if redirected_to else extra
 
 
 def _resolve_openai_chat_handler_path(base_url: str, model: str | None) -> str:
@@ -1913,7 +1929,11 @@ class OpenAIHandlerMixin:
         not just the generic passthrough route that already honors it. Falls
         back to the configured ``OPENAI_API_URL`` (``OPENAI_TARGET_API_URL``).
         """
-        return _resolve_openai_upstream_base(request.headers) or self.OPENAI_API_URL
+        return (
+            _resolve_openai_upstream_base(request.headers)
+            or copilot_bearer_upstream(request.headers, self.OPENAI_API_URL)
+            or self.OPENAI_API_URL
+        )
 
     @staticmethod
     def _strict_previous_turn_frozen_count(
@@ -3317,7 +3337,18 @@ class OpenAIHandlerMixin:
         messages = body.get("messages", [])
         original_client_messages = copy.deepcopy(messages)
         custom_upstream_base_url = _resolve_openai_upstream_base(request.headers)
-        upstream_base_url = self._resolve_openai_upstream(request)
+        # A Copilot credential headed for the stock OpenAI host is redirected to
+        # Copilot (see `copilot_bearer_upstream`). Track the redirect separately
+        # from the operator-configured target: it decides both the destination
+        # and whether the operator's gateway headers may travel with the request.
+        copilot_redirect_base_url = (
+            None
+            if custom_upstream_base_url
+            else copilot_bearer_upstream(request.headers, self.OPENAI_API_URL)
+        )
+        upstream_base_url = (
+            custom_upstream_base_url or copilot_redirect_base_url or self.OPENAI_API_URL
+        )
         handler_path_suffix = _resolve_openai_chat_handler_path(
             upstream_base_url,
             model,
@@ -3448,7 +3479,9 @@ class OpenAIHandlerMixin:
         # override resolved above. Secrets only go to designated hosts.
         headers = merge_extra_headers(
             headers,
-            self.config.openai_extra_headers,
+            _extra_headers_unless_redirected(
+                self.config.openai_extra_headers, redirected_to=copilot_redirect_base_url
+            ),
             upstream_url=custom_upstream_base_url,
             config=self.config,
         )
@@ -3457,13 +3490,16 @@ class OpenAIHandlerMixin:
             stripped_count=_pre_strip_count_chat,
             request_id=request_id,
         )
-        upstream_base_url = _resolve_openai_upstream_base(request.headers)
+        # Re-derived after the pre-send hooks: a redirected request keeps the
+        # default path handling because the caller named no custom gateway, so
+        # there is no custom path to preserve.
+        upstream_base_url = custom_upstream_base_url or copilot_redirect_base_url
         handler_path = (
             _resolve_openai_handler_path(
                 request.headers,
                 handler_path=_OPENAI_CHAT_COMPLETIONS_PATH,
             )
-            if upstream_base_url is not None
+            if custom_upstream_base_url is not None
             else "/v1/chat/completions"
         )
         _, custom_chat_provider = _custom_base_passthrough_telemetry(
@@ -5523,13 +5559,23 @@ class OpenAIHandlerMixin:
 
         _pre_strip_count_resp = sum(1 for k in headers if k.lower().startswith("x-headroom-"))
         headers = _strip_internal_headers(headers)
-        # This handler also honors `x-headroom-base-url` (resolved further
-        # below); resolve it here too so the secret headers are gated on the
-        # real destination rather than merged before it is known.
+        # This handler also honors `x-headroom-base-url` (used further below);
+        # resolve it here too so the secret headers are gated on the real
+        # destination rather than merged before it is known. A Copilot
+        # credential headed for the stock OpenAI host is redirected to Copilot,
+        # and the operator's gateway headers must not follow it there.
+        custom_responses_base_url = _resolve_openai_upstream_base(request.headers)
+        copilot_redirect_base_url = (
+            None
+            if custom_responses_base_url
+            else copilot_bearer_upstream(request.headers, self.OPENAI_API_URL)
+        )
         headers = merge_extra_headers(
             headers,
-            self.config.openai_extra_headers,
-            upstream_url=_resolve_openai_upstream_base(request.headers),
+            _extra_headers_unless_redirected(
+                self.config.openai_extra_headers, redirected_to=copilot_redirect_base_url
+            ),
+            upstream_url=custom_responses_base_url,
             config=self.config,
         )
         # Mirror the WS handler: never forward Codex's client-only lite header
@@ -5828,10 +5874,10 @@ class OpenAIHandlerMixin:
         if is_chatgpt_auth:
             url = codex_responses_http_url()
         else:
-            upstream_base_url = _resolve_openai_upstream_base(request.headers)
+            upstream_base_url = custom_responses_base_url or copilot_redirect_base_url
             handler_path = (
                 _resolve_openai_handler_path(request.headers, handler_path=_OPENAI_RESPONSES_PATH)
-                if upstream_base_url is not None
+                if custom_responses_base_url is not None
                 else "/v1/responses"
             )
             url = build_copilot_upstream_url(

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -403,6 +403,21 @@ def _resolve_openai_upstream_base(request_headers: dict[str, str]) -> str | None
     return normalized
 
 
+def _copilot_redirect_base_url(
+    request_headers: Any, custom_base_url: str | None, configured_target: str
+) -> str | None:
+    """Return the Copilot base a request is redirected to, or None.
+
+    Single source of the rule shared by :meth:`OpenAIHandlerMixin._resolve_openai_upstream`
+    and the chat / responses handlers: an explicit ``x-headroom-base-url`` always
+    wins, otherwise a Copilot credential headed for the stock OpenAI host is sent
+    to Copilot (see :func:`copilot_bearer_upstream`).
+    """
+    if custom_base_url:
+        return None
+    return copilot_bearer_upstream(request_headers, configured_target)
+
+
 def _extra_headers_unless_redirected(
     extra: dict[str, str] | None, *, redirected_to: str | None
 ) -> dict[str, str] | None:
@@ -1929,9 +1944,10 @@ class OpenAIHandlerMixin:
         not just the generic passthrough route that already honors it. Falls
         back to the configured ``OPENAI_API_URL`` (``OPENAI_TARGET_API_URL``).
         """
+        custom_base_url = _resolve_openai_upstream_base(request.headers)
         return (
-            _resolve_openai_upstream_base(request.headers)
-            or copilot_bearer_upstream(request.headers, self.OPENAI_API_URL)
+            custom_base_url
+            or _copilot_redirect_base_url(request.headers, custom_base_url, self.OPENAI_API_URL)
             or self.OPENAI_API_URL
         )
 
@@ -3341,14 +3357,10 @@ class OpenAIHandlerMixin:
         # Copilot (see `copilot_bearer_upstream`). Track the redirect separately
         # from the operator-configured target: it decides both the destination
         # and whether the operator's gateway headers may travel with the request.
-        copilot_redirect_base_url = (
-            None
-            if custom_upstream_base_url
-            else copilot_bearer_upstream(request.headers, self.OPENAI_API_URL)
+        copilot_redirect_base_url = _copilot_redirect_base_url(
+            request.headers, custom_upstream_base_url, self.OPENAI_API_URL
         )
-        upstream_base_url = (
-            custom_upstream_base_url or copilot_redirect_base_url or self.OPENAI_API_URL
-        )
+        upstream_base_url = self._resolve_openai_upstream(request)
         handler_path_suffix = _resolve_openai_chat_handler_path(
             upstream_base_url,
             model,
@@ -5565,10 +5577,8 @@ class OpenAIHandlerMixin:
         # credential headed for the stock OpenAI host is redirected to Copilot,
         # and the operator's gateway headers must not follow it there.
         custom_responses_base_url = _resolve_openai_upstream_base(request.headers)
-        copilot_redirect_base_url = (
-            None
-            if custom_responses_base_url
-            else copilot_bearer_upstream(request.headers, self.OPENAI_API_URL)
+        copilot_redirect_base_url = _copilot_redirect_base_url(
+            request.headers, custom_responses_base_url, self.OPENAI_API_URL
         )
         headers = merge_extra_headers(
             headers,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -422,3 +422,16 @@ def sample_request_metrics():
         turns_dropped=0,
         messages_hash="def456",
     )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_copilot_cli_home(monkeypatch, tmp_path_factory):
+    """Keep the developer's real ``~/.copilot`` out of every test.
+
+    ``headroom wrap copilot`` now reads the Copilot CLI's ``settings.json`` for a
+    ``copilotUrl`` pin and refuses to launch a session that pin would bypass. A
+    developer who has such a pin (for example from a durable Headroom install on
+    another port) would otherwise fail unrelated wrap tests on their machine.
+    Tests that exercise the check set ``COPILOT_HOME`` themselves.
+    """
+    monkeypatch.setenv("COPILOT_HOME", str(tmp_path_factory.mktemp("copilot-home")))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -425,7 +425,7 @@ def sample_request_metrics():
 
 
 @pytest.fixture(autouse=True)
-def _isolate_copilot_cli_home(monkeypatch, tmp_path_factory):
+def _isolate_copilot_cli_home(monkeypatch, tmp_path):
     """Keep the developer's real ``~/.copilot`` out of every test.
 
     ``headroom wrap copilot`` now reads the Copilot CLI's ``settings.json`` for a
@@ -434,4 +434,4 @@ def _isolate_copilot_cli_home(monkeypatch, tmp_path_factory):
     another port) would otherwise fail unrelated wrap tests on their machine.
     Tests that exercise the check set ``COPILOT_HOME`` themselves.
     """
-    monkeypatch.setenv("COPILOT_HOME", str(tmp_path_factory.mktemp("copilot-home")))
+    monkeypatch.setenv("COPILOT_HOME", str(tmp_path / "copilot-home"))

--- a/tests/test_copilot_auto_passthrough.py
+++ b/tests/test_copilot_auto_passthrough.py
@@ -151,11 +151,49 @@ def _proxy(openai_target: str):
     return type("Proxy", (), {"OPENAI_API_URL": openai_target, "provider_runtime": Runtime()})()
 
 
-@pytest.mark.parametrize("token", ["tid_session", "gho_oauth", "ghu_user"])
+#: The bearer GitHub actually mints: a semicolon claim string, not a prefix.
+REAL_COPILOT_API_TOKEN = "tid=0123456789abcdef0123456789abcdef;exp=1893456000;sku=copilot_for_business_seat;st=dotcom:9f8e7d6c"
+
+
+@pytest.mark.parametrize("token", [REAL_COPILOT_API_TOKEN, "tid_session", "gho_oauth"])
 def test_copilot_bearer_redirects_away_from_stock_hosts(token: str) -> None:
     headers = {"Authorization": f"Bearer {token}"}
     assert copilot_bearer_upstream(headers, "https://api.openai.com") == COPILOT_API
     assert copilot_bearer_upstream(headers, "https://api.anthropic.com") == COPILOT_API
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "ghu_user_to_server",
+        "ghp_personal",
+        "github_pat_11A",
+        "ghs_installation",
+        "tid=notahex;exp=1",
+    ],
+)
+def test_copilot_bearer_redirect_ignores_tokens_that_do_not_name_copilot(token: str) -> None:
+    """Every routed token must also be forwardable, or the redirect would make
+    ``apply_copilot_api_auth`` swap in the operator's own seat for any caller."""
+    assert (
+        copilot_bearer_upstream({"authorization": f"Bearer {token}"}, "https://api.openai.com")
+        is None
+    )
+
+
+@pytest.mark.parametrize("token", [REAL_COPILOT_API_TOKEN, "tid_session", "gho_oauth"])
+def test_every_routed_token_is_also_forwarded_unchanged(token: str) -> None:
+    assert copilot_auth._is_copilot_routing_bearer(token) is True
+    assert copilot_auth._is_forwardable_copilot_bearer_token(token) is True
+
+
+def test_stock_host_is_recognised_with_a_port_and_path() -> None:
+    assert (
+        copilot_bearer_upstream(
+            {"authorization": f"Bearer {REAL_COPILOT_API_TOKEN}"}, "https://api.openai.com:443/v1"
+        )
+        == COPILOT_API
+    )
 
 
 @pytest.mark.parametrize(
@@ -295,7 +333,9 @@ def _messages_app(anthropic_target: str):
 
         @staticmethod
         def model_metadata_provider(headers) -> str:  # type: ignore[no-untyped-def]
-            return "anthropic"
+            # Mirrors the runtime: only an Anthropic-style key marks the caller
+            # as Anthropic; a bare bearer (Copilot's included) reads as OpenAI.
+            return "anthropic" if headers.get("x-api-key") else "openai"
 
     class Proxy:
         ANTHROPIC_API_URL = anthropic_target
@@ -308,12 +348,19 @@ def _messages_app(anthropic_target: str):
             self.config = SimpleNamespace(bedrock_api_url=None)
             self.provider_runtime = Runtime()
             self.upstreams: list[str | None] = []
+            self.redirect_flags: list[bool] = []
+            self.passthrough_targets: list[tuple[str, str]] = []
+            self.http_client = object()
 
-        async def handle_anthropic_messages(self, request, upstream_base_url=None):  # type: ignore[no-untyped-def]
+        async def handle_anthropic_messages(  # type: ignore[no-untyped-def]
+            self, request, upstream_base_url=None, copilot_redirect=False
+        ):
             self.upstreams.append(upstream_base_url)
+            self.redirect_flags.append(copilot_redirect)
             return JSONResponse({"ok": True})
 
         async def handle_passthrough(self, request, base_url, endpoint_name="", provider=""):  # type: ignore[no-untyped-def]
+            self.passthrough_targets.append((request.url.path, base_url))
             return JSONResponse({"ok": True})
 
     app = FastAPI()
@@ -331,6 +378,7 @@ def test_messages_route_redirects_a_copilot_bearer_to_copilot() -> None:
     )
     assert response.status_code == 200
     assert proxy.upstreams == [COPILOT_API]
+    assert proxy.redirect_flags == [True], "the handler must know the proxy chose this host"
 
 
 def test_messages_route_leaves_anthropic_keys_on_the_default_path() -> None:
@@ -346,6 +394,7 @@ def test_messages_route_leaves_anthropic_keys_on_the_default_path() -> None:
         headers={"Authorization": "Bearer sk-ant-oat-abc"},
     )
     assert proxy.upstreams == [None, None]
+    assert proxy.redirect_flags == [False, False]
 
 
 def test_messages_route_keeps_a_copilot_bearer_on_a_pinned_target() -> None:
@@ -356,3 +405,36 @@ def test_messages_route_keeps_a_copilot_bearer_on_a_pinned_target() -> None:
         headers={"Authorization": "Bearer tid_session"},
     )
     assert proxy.upstreams == [None]
+
+
+@pytest.mark.parametrize("path", AUTO_RESOLUTION_PATHS)
+def test_auto_resolution_calls_reach_copilot_through_the_catch_all_route(path: str) -> None:
+    """A bare ``@app.post`` for one of these paths that skipped the passthrough
+    selector would not show up in ``OPENAI_HANDLER_ROUTES``; drive the router."""
+    client, proxy = _messages_app("https://api.anthropic.com")
+    response = client.post(
+        path,
+        json={"auto_mode": {"model_hints": ["auto"]}},
+        headers={"Authorization": f"Bearer {REAL_COPILOT_API_TOKEN}"},
+    )
+    assert response.status_code == 200
+    assert proxy.passthrough_targets == [(path, COPILOT_API)]
+
+
+def test_prefixed_models_route_follows_the_same_rule(monkeypatch: pytest.MonkeyPatch) -> None:
+    from headroom.providers import proxy_routes
+
+    seen: list[str] = []
+
+    async def fake_metadata(proxy, request, *, endpoint, provider_api_base_url, provider_name):  # type: ignore[no-untyped-def]
+        from fastapi.responses import JSONResponse
+
+        seen.append(provider_api_base_url)
+        return JSONResponse({"data": []})
+
+    monkeypatch.setattr(proxy_routes, "handle_model_metadata_endpoint", fake_metadata)
+    client, _proxy = _messages_app("https://api.anthropic.com")
+    client.get("/v1/models", headers={"Authorization": f"Bearer {REAL_COPILOT_API_TOKEN}"})
+    client.get("/v1/models/gpt-5.5", headers={"Authorization": f"Bearer {REAL_COPILOT_API_TOKEN}"})
+    client.get("/v1/models", headers={"Authorization": "Bearer sk-openai"})
+    assert seen == [COPILOT_API, COPILOT_API, "https://api.openai.com"]

--- a/tests/test_copilot_auto_passthrough.py
+++ b/tests/test_copilot_auto_passthrough.py
@@ -1,0 +1,358 @@
+"""Copilot "Auto" must survive the proxy untouched.
+
+Auto is not a model on the wire. Every Copilot client resolves it to a concrete
+model before the chat request leaves the machine, either through
+``POST /models/session`` (plus the optional ``/models/session/intent`` router) or
+the single-call ``POST /auto``. The chat request then carries the concrete model
+id and a ``Copilot-Session-Token`` header; GitHub grants the Auto discount
+against that token. Three things therefore have to hold through Headroom:
+
+1. the session header (and Copilot's other routing headers) reach upstream;
+2. the resolution calls pass through to Copilot with their paths intact, and
+   are not mistaken for chat turns;
+3. a Copilot-authenticated request never lands on a stock provider host.
+
+Nothing here was pinned before, so a header-policy or routing change could have
+silently cost every Auto user their discount.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from headroom import copilot_auth
+from headroom.copilot_auth import (
+    CopilotAPIToken,
+    apply_copilot_api_auth,
+    build_copilot_upstream_url,
+    copilot_bearer_upstream,
+)
+from headroom.providers.openai_responses import OPENAI_RESPONSES_ROOT_PATHS
+from headroom.providers.proxy_targets import select_passthrough_base_url
+from headroom.providers.route_specs import OPENAI_HANDLER_ROUTES
+from headroom.proxy.internal_header_policy import strip_internal_headers
+
+COPILOT_API = "https://api.githubcopilot.com"
+
+#: Headers the VS Code extension and the Copilot CLI add to a chat request. The
+#: session token is the one Auto depends on; the rest tell CAPI which feature
+#: and interaction flighted the request.
+COPILOT_ROUTING_HEADERS = {
+    "Copilot-Session-Token": "sess_auto_abc",
+    "X-Initiator": "user",
+    "OpenAI-Intent": "conversation-agent",
+    "X-Interaction-Type": "conversation-agent",
+    "X-GitHub-Api-Version": "2026-08-01",
+}
+
+#: CAPI paths Auto resolution uses, plus the ancillary calls the same clients
+#: make. None of them carries a `/v1` prefix, and none may be rewritten.
+AUTO_RESOLUTION_PATHS = ["/models/session", "/models/session/intent", "/auto"]
+ANCILLARY_PATHS = ["/models", "/models/gpt-5.5/policy", "/agents/sessions", "/embeddings"]
+
+
+@pytest.fixture(autouse=True)
+def _clean_copilot_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "GITHUB_COPILOT_API_URL",
+        "GITHUB_COPILOT_ENTERPRISE_URL",
+        "GITHUB_COPILOT_ENTERPRISE_DOMAIN",
+        "GITHUB_COPILOT_API_TOKEN",
+        "GITHUB_COPILOT_REFRESH_OAUTH_TOKEN",
+        "HEADROOM_STRIP_INTERNAL_HEADERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Header survival
+# --------------------------------------------------------------------------- #
+def test_internal_header_strip_leaves_copilot_routing_headers_alone() -> None:
+    headers = {**COPILOT_ROUTING_HEADERS, "x-headroom-bypass": "1", "Authorization": "Bearer tid_x"}
+    stripped = strip_internal_headers(headers, mode="enabled")
+    assert "x-headroom-bypass" not in stripped
+    for name, value in COPILOT_ROUTING_HEADERS.items():
+        assert stripped[name] == value
+
+
+def test_session_token_survives_when_the_client_token_passes_through() -> None:
+    """VS Code and the CLI send their own `tid_` token: Headroom forwards it as-is."""
+    headers = {**COPILOT_ROUTING_HEADERS, "Authorization": "Bearer tid_client_token"}
+    resolved = asyncio.run(apply_copilot_api_auth(headers, url=f"{COPILOT_API}/chat/completions"))
+    assert resolved["Authorization"] == "Bearer tid_client_token"
+    for name, value in COPILOT_ROUTING_HEADERS.items():
+        assert resolved[name] == value
+
+
+def test_session_token_survives_when_headroom_substitutes_its_own_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The replacement branch rewrites Authorization and the integration id only."""
+
+    class Provider:
+        async def get_api_token(self, *, integration_id=None):  # noqa: ANN001
+            return CopilotAPIToken(token="tid_headroom", expires_at=time.time() + 3600)
+
+    monkeypatch.setattr(copilot_auth, "get_copilot_token_provider", lambda: Provider())
+    headers = {**COPILOT_ROUTING_HEADERS, "Authorization": "Bearer not-a-copilot-token"}
+    resolved = asyncio.run(apply_copilot_api_auth(headers, url=f"{COPILOT_API}/responses"))
+    assert resolved["Authorization"] == "Bearer tid_headroom"
+    for name, value in COPILOT_ROUTING_HEADERS.items():
+        assert resolved[name] == value
+
+
+# --------------------------------------------------------------------------- #
+# 2. Resolution calls keep their paths and are not chat routes
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("path", AUTO_RESOLUTION_PATHS + ANCILLARY_PATHS)
+def test_copilot_native_paths_are_forwarded_verbatim(path: str) -> None:
+    assert build_copilot_upstream_url(COPILOT_API, path) == f"{COPILOT_API}{path}"
+
+
+def test_generic_openai_paths_still_lose_their_v1_prefix_at_copilot() -> None:
+    """The `/v1` strip exists for OpenAI-SDK clients; Copilot's own paths never had one."""
+    assert build_copilot_upstream_url(COPILOT_API, "/v1/chat/completions") == (
+        f"{COPILOT_API}/chat/completions"
+    )
+    assert build_copilot_upstream_url(COPILOT_API, "/v1/responses") == f"{COPILOT_API}/responses"
+
+
+@pytest.mark.parametrize("path", AUTO_RESOLUTION_PATHS)
+def test_resolution_paths_are_not_registered_as_chat_handlers(path: str) -> None:
+    """The router and `/auto` bodies carry the raw prompt; they must never be compressed."""
+    handler_paths = {route.path for route in OPENAI_HANDLER_ROUTES}
+    assert path not in handler_paths
+    assert path not in OPENAI_RESPONSES_ROOT_PATHS
+
+
+def test_the_chat_request_that_follows_auto_is_a_compressed_route() -> None:
+    """Both unprefixed CAPI chat paths must hit real handlers, not the passthrough."""
+    handler_paths = {route.path for route in OPENAI_HANDLER_ROUTES}
+    assert "/chat/completions" in handler_paths
+    assert "/responses" in OPENAI_RESPONSES_ROOT_PATHS
+
+
+# --------------------------------------------------------------------------- #
+# 3. A Copilot credential never lands on a stock provider host
+# --------------------------------------------------------------------------- #
+def _proxy(openai_target: str):
+    class Runtime:
+        @staticmethod
+        def api_target(provider: str) -> str:
+            return f"https://runtime.{provider}.test"
+
+        @staticmethod
+        def model_metadata_provider(headers) -> str:  # type: ignore[no-untyped-def]
+            return "anthropic" if headers.get("x-api-key") else "openai"
+
+    return type("Proxy", (), {"OPENAI_API_URL": openai_target, "provider_runtime": Runtime()})()
+
+
+@pytest.mark.parametrize("token", ["tid_session", "gho_oauth", "ghu_user"])
+def test_copilot_bearer_redirects_away_from_stock_hosts(token: str) -> None:
+    headers = {"Authorization": f"Bearer {token}"}
+    assert copilot_bearer_upstream(headers, "https://api.openai.com") == COPILOT_API
+    assert copilot_bearer_upstream(headers, "https://api.anthropic.com") == COPILOT_API
+
+
+@pytest.mark.parametrize(
+    ("headers", "target"),
+    [
+        # A personal access token is a valid GitHub credential for other products.
+        ({"Authorization": "Bearer ghp_personal"}, "https://api.openai.com"),
+        ({"Authorization": "Bearer github_pat_personal"}, "https://api.openai.com"),
+        # An OpenAI key is not Copilot's.
+        ({"Authorization": "Bearer sk-openai"}, "https://api.openai.com"),
+        # The operator pinned a gateway: respect it.
+        ({"Authorization": "Bearer tid_session"}, "https://litellm.corp.example/v1"),
+        # The client named its own upstream for this request.
+        (
+            {"Authorization": "Bearer tid_session", "x-headroom-base-url": "https://gw.example"},
+            "https://api.openai.com",
+        ),
+        ({}, "https://api.openai.com"),
+    ],
+)
+def test_copilot_bearer_redirect_stays_out_of_everything_else(
+    headers: dict[str, str], target: str
+) -> None:
+    assert copilot_bearer_upstream(headers, target) is None
+
+
+def test_copilot_bearer_redirect_honours_the_configured_copilot_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_COPILOT_API_URL", "https://copilot-api.acme.ghe.com")
+    assert (
+        copilot_bearer_upstream({"Authorization": "Bearer tid_session"}, "https://api.openai.com")
+        == "https://copilot-api.acme.ghe.com"
+    )
+
+
+@pytest.mark.parametrize("path", AUTO_RESOLUTION_PATHS + ANCILLARY_PATHS)
+def test_passthrough_sends_copilot_authenticated_calls_to_copilot(path: str) -> None:
+    """On a shared proxy with the stock OpenAI target, Auto resolution must reach GitHub."""
+    proxy = _proxy("https://api.openai.com")
+    headers = {"Authorization": "Bearer tid_session", **COPILOT_ROUTING_HEADERS}
+    assert select_passthrough_base_url(proxy, headers, path) == COPILOT_API
+
+
+def test_passthrough_keeps_a_pinned_copilot_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`wrap copilot` pins the resolved host; the redirect must not override it."""
+    pinned = "https://api.business.githubcopilot.com"
+    proxy = _proxy(pinned)
+    headers = {"Authorization": "Bearer tid_session"}
+    assert select_passthrough_base_url(proxy, headers, "/models/session") == pinned
+
+
+def test_passthrough_leaves_non_copilot_clients_on_the_openai_target() -> None:
+    proxy = _proxy("https://api.openai.com")
+    assert select_passthrough_base_url(proxy, {"Authorization": "Bearer sk-x"}, "/models") == (
+        "https://api.openai.com"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 4. The dedicated handlers honour the redirect, and gateway secrets stay home
+# --------------------------------------------------------------------------- #
+def _openai_handler(openai_target: str):
+    from headroom.proxy.handlers.openai import OpenAIHandlerMixin
+
+    return type("Handler", (OpenAIHandlerMixin,), {"OPENAI_API_URL": openai_target})()
+
+
+def _request_with(headers: dict[str, str]):
+    return type("Request", (), {"headers": headers})()
+
+
+def test_openai_handler_sends_a_copilot_credential_to_copilot() -> None:
+    handler = _openai_handler("https://api.openai.com")
+    upstream = handler._resolve_openai_upstream(
+        _request_with({"authorization": "Bearer tid_session", "copilot-session-token": "s"})
+    )
+    assert upstream == COPILOT_API
+
+
+def test_openai_handler_keeps_a_stock_key_on_the_operator_target() -> None:
+    handler = _openai_handler("https://api.openai.com")
+    upstream = handler._resolve_openai_upstream(_request_with({"authorization": "Bearer sk-abc"}))
+    assert upstream == "https://api.openai.com"
+
+
+def test_openai_handler_keeps_a_copilot_credential_on_a_pinned_gateway() -> None:
+    """An operator who pointed the proxy at a gateway chose where tokens go."""
+    handler = _openai_handler("https://litellm.corp.example/v1")
+    upstream = handler._resolve_openai_upstream(
+        _request_with({"authorization": "Bearer tid_session"})
+    )
+    assert upstream == "https://litellm.corp.example/v1"
+
+
+def test_openai_handler_lets_an_explicit_base_url_header_win(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HEADROOM_ALLOWED_BASE_URLS", "gateway.example")
+    handler = _openai_handler("https://api.openai.com")
+    upstream = handler._resolve_openai_upstream(
+        _request_with(
+            {
+                "authorization": "Bearer tid_session",
+                "x-headroom-base-url": "https://gateway.example",
+            }
+        )
+    )
+    assert upstream == "https://gateway.example"
+
+
+def test_gateway_extra_headers_are_withheld_on_a_copilot_redirect() -> None:
+    from headroom.proxy.handlers.openai import _extra_headers_unless_redirected
+
+    secrets = {"X-Gateway-Key": "operator-secret"}
+    assert _extra_headers_unless_redirected(secrets, redirected_to=COPILOT_API) is None
+    assert _extra_headers_unless_redirected(secrets, redirected_to=None) is secrets
+    assert _extra_headers_unless_redirected(None, redirected_to=None) is None
+
+
+# --------------------------------------------------------------------------- #
+# 5. Route level: /v1/messages with a Copilot bearer reaches the Copilot base
+# --------------------------------------------------------------------------- #
+def _messages_app(anthropic_target: str):
+    from types import SimpleNamespace
+
+    from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
+    from fastapi.testclient import TestClient
+
+    from headroom.providers.proxy_routes import register_provider_routes
+
+    class Runtime:
+        @staticmethod
+        def api_target(provider: str) -> str:
+            return f"https://{provider}.example.test"
+
+        @staticmethod
+        def model_metadata_provider(headers) -> str:  # type: ignore[no-untyped-def]
+            return "anthropic"
+
+    class Proxy:
+        ANTHROPIC_API_URL = anthropic_target
+        OPENAI_API_URL = "https://api.openai.com"
+        GEMINI_API_URL = "https://gemini.example.test"
+        CLOUDCODE_API_URL = "https://cloudcode.example.test"
+        VERTEX_API_URL = "https://vertex.example.test"
+
+        def __init__(self) -> None:
+            self.config = SimpleNamespace(bedrock_api_url=None)
+            self.provider_runtime = Runtime()
+            self.upstreams: list[str | None] = []
+
+        async def handle_anthropic_messages(self, request, upstream_base_url=None):  # type: ignore[no-untyped-def]
+            self.upstreams.append(upstream_base_url)
+            return JSONResponse({"ok": True})
+
+        async def handle_passthrough(self, request, base_url, endpoint_name="", provider=""):  # type: ignore[no-untyped-def]
+            return JSONResponse({"ok": True})
+
+    app = FastAPI()
+    proxy = Proxy()
+    register_provider_routes(app, proxy)
+    return TestClient(app), proxy
+
+
+def test_messages_route_redirects_a_copilot_bearer_to_copilot() -> None:
+    client, proxy = _messages_app("https://api.anthropic.com")
+    response = client.post(
+        "/v1/messages",
+        json={"model": "claude-sonnet-5", "messages": []},
+        headers={"Authorization": "Bearer tid_session", **COPILOT_ROUTING_HEADERS},
+    )
+    assert response.status_code == 200
+    assert proxy.upstreams == [COPILOT_API]
+
+
+def test_messages_route_leaves_anthropic_keys_on_the_default_path() -> None:
+    client, proxy = _messages_app("https://api.anthropic.com")
+    client.post(
+        "/v1/messages",
+        json={"model": "claude-sonnet-5", "messages": []},
+        headers={"x-api-key": "sk-ant-abc"},
+    )
+    client.post(
+        "/v1/messages",
+        json={"model": "claude-sonnet-5", "messages": []},
+        headers={"Authorization": "Bearer sk-ant-oat-abc"},
+    )
+    assert proxy.upstreams == [None, None]
+
+
+def test_messages_route_keeps_a_copilot_bearer_on_a_pinned_target() -> None:
+    client, proxy = _messages_app("https://anthropic.gateway.corp.example")
+    client.post(
+        "/v1/messages",
+        json={"model": "claude-sonnet-5", "messages": []},
+        headers={"Authorization": "Bearer tid_session"},
+    )
+    assert proxy.upstreams == [None]

--- a/tests/test_copilot_cli_gaps.py
+++ b/tests/test_copilot_cli_gaps.py
@@ -21,6 +21,7 @@ import pytest
 from click.testing import CliRunner
 
 from headroom import copilot_auth
+from headroom.providers.copilot import wrap as copilot_wrap
 from headroom.providers.copilot.install import build_install_env, install_uses_native_lane
 from headroom.providers.copilot.wrap import (
     COPILOT_NATIVE_API_URL_ENV,
@@ -218,7 +219,18 @@ def test_read_copilot_url_settings_reports_every_pin(tmp_path: Path) -> None:
     assert read_copilot_url_setting(env) == (tmp_path / "settings.json", "https://current.example/")
 
 
-@pytest.mark.parametrize("payload", ["not json", "[]", json.dumps({"copilotUrl": "  "})])
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not json",
+        "[]",
+        json.dumps({"copilotUrl": "  "}),
+        json.dumps({"copilotUrl": 123}),
+        json.dumps({"copilotUrl": None}),
+        json.dumps({"copilotUrl": ["http://127.0.0.1:1"]}),
+        json.dumps({"copilotUrl": True}),
+    ],
+)
 def test_read_copilot_url_settings_ignores_unusable_files(tmp_path: Path, payload: str) -> None:
     _write(tmp_path / "settings.json", payload)
     assert read_copilot_url_settings({"COPILOT_HOME": str(tmp_path)}) == []
@@ -229,7 +241,10 @@ def test_check_refuses_a_pin_on_another_origin(tmp_path: Path) -> None:
     with pytest.raises(click.ClickException) as excinfo:
         check_copilot_url_setting(PROXY_URL, environ={"COPILOT_HOME": str(tmp_path)})
     assert "copilotUrl" in excinfo.value.message
-    assert PROXY_URL in excinfo.value.message
+    # The remedy names the bare origin, not this launch's project-prefixed URL,
+    # so following it does not pin every future session to one project.
+    assert "'http://127.0.0.1:8787'" in excinfo.value.message
+    assert PROXY_URL not in excinfo.value.message
 
 
 def test_check_refuses_when_only_the_legacy_file_pins_another_origin(tmp_path: Path) -> None:
@@ -259,7 +274,9 @@ def test_check_accepts_the_same_origin_without_the_project_prefix(
     """A durable install wrote the bare proxy URL: traffic still flows through Headroom."""
     _write(tmp_path / "settings.json", {"copilotUrl": "http://127.0.0.1:8787"})
     check_copilot_url_setting(PROXY_URL, environ={"COPILOT_HOME": str(tmp_path)})
-    assert "per-project savings attribution" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert out.startswith("  Note:")
+    assert "copilotUrl='http://127.0.0.1:8787'" in out
 
 
 def test_check_is_silent_without_any_pin(
@@ -339,6 +356,7 @@ def test_install_lane_selection() -> None:
     assert install_uses_native_lane("anyllm", {}) is False
     assert install_uses_native_lane("litellm-vertex", {}) is False
     assert install_uses_native_lane("anthropic", {"COPILOT_PROVIDER_API_KEY": "sk-x"}) is False
+    assert install_uses_native_lane(None, {}) is True  # planner may pass no backend at all
 
 
 def test_native_install_env_is_only_the_api_url_hook() -> None:
@@ -360,7 +378,7 @@ def test_ghe_data_residency_host_is_never_folded_into_the_public_host() -> None:
     )
 
 
-def test_ghe_host_from_a_token_exchange_is_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_ghe_host_from_a_token_exchange_is_honoured() -> None:
     resolved = copilot_auth._api_url_from_exchange_payload(
         {"endpoints": {"api": "https://copilot-api.acme.ghe.com"}}, oauth_token="gho-oauth"
     )
@@ -484,3 +502,103 @@ def test_wrap_stays_quiet_when_the_advertised_host_is_the_one_used(
 
     assert result.exit_code == 0, result.output
     assert copilot_auth.USE_ADVERTISED_HOST_ENV not in result.output
+
+
+# --------------------------------------------------------------------------- #
+# Review follow-ups
+# --------------------------------------------------------------------------- #
+def test_loopback_no_proxy_seeds_uppercase_from_a_lowercase_only_value() -> None:
+    """undici reads ``no_proxy`` first, reqwest and Go read ``NO_PROXY`` first;
+    a fresh uppercase value missing the corporate entries would split them."""
+    env = {"no_proxy": "corp.internal,.example.com"}
+    ensure_loopback_no_proxy(env)
+    assert env["NO_PROXY"] == env["no_proxy"]
+    assert env["NO_PROXY"].split(",")[:2] == ["corp.internal", ".example.com"]
+    assert "127.0.0.1" in env["NO_PROXY"].split(",")
+
+
+def test_loopback_no_proxy_unions_disagreeing_spellings() -> None:
+    env = {"NO_PROXY": "a.internal", "no_proxy": "b.internal"}
+    ensure_loopback_no_proxy(env)
+    assert env["NO_PROXY"] == env["no_proxy"]
+    assert env["NO_PROXY"].split(",")[:2] == ["a.internal", "b.internal"]
+
+
+def test_copilot_home_follows_node_homedir_on_windows() -> None:
+    """Node ignores HOME on Windows; so must the lookup, or a Git-for-Windows
+    shell with HOME set would look in the wrong place and fail open."""
+    env = {"HOME": "/home/from-msys", "USERPROFILE": "C:\\Users\\dev"}
+    assert copilot_home(env, windows=True) == Path("C:\\Users\\dev") / ".copilot"
+    assert copilot_home(env, windows=False) == Path("/home/from-msys") / ".copilot"
+
+
+def _legacy_pkg_root(home: Path, *, mentions_env: bool) -> None:
+    pkg = home / ".local" / "share" / "copilot" / "pkg" / "1.0.60"
+    pkg.mkdir(parents=True)
+    (pkg / "app.js").write_text(
+        "process.env.COPILOT_API_URL" if mentions_env else "nothing", encoding="utf-8"
+    )
+
+
+def test_stale_installer_bundle_cannot_vouch_for_a_launched_build(tmp_path: Path) -> None:
+    """The bundle beside the binary about to run says no; an old installer copy
+    under the legacy root says yes. The launched build decides."""
+    home = tmp_path / "home"
+    _legacy_pkg_root(home, mentions_env=True)
+    shim_link, _native = _npm_layout(tmp_path, mentions_env=False)
+    env = {"HOME": str(home), "LOCALAPPDATA": str(tmp_path / "nowhere")}
+    assert native_api_url_supported(environ=env, copilot_bin=str(shim_link)) is False
+
+
+def test_legacy_root_is_read_from_the_given_environment(tmp_path: Path) -> None:
+    """The probe must not reach for the developer's real home directory."""
+    home = tmp_path / "home"
+    _legacy_pkg_root(home, mentions_env=True)
+    env = {"HOME": str(home), "LOCALAPPDATA": str(tmp_path / "nowhere")}
+    assert native_api_url_supported(environ=env, copilot_bin=None) is True
+    assert native_api_url_supported(environ=_no_legacy_roots(tmp_path), copilot_bin=None) is None
+
+
+def test_bundle_scan_finds_a_mention_that_straddles_a_chunk_boundary(tmp_path: Path) -> None:
+    bundle = tmp_path / "app.js"
+    filler = "x" * ((1 << 20) - 5)  # the needle starts 5 bytes before the first chunk ends
+    bundle.write_text(filler + COPILOT_NATIVE_API_URL_ENV + ";", encoding="utf-8")
+    assert copilot_wrap._bundle_mentions_native_api_url(str(bundle)) is True
+
+
+def test_byok_lane_drops_a_durable_installs_native_hook() -> None:
+    env, _ = build_launch_env(
+        port=8787,
+        provider_type="openai",
+        wire_api=None,
+        environ={COPILOT_NATIVE_API_URL_ENV: "http://127.0.0.1:9999"},
+    )
+    assert COPILOT_NATIVE_API_URL_ENV not in env
+
+
+def test_subscription_lane_drops_a_durable_installs_native_hook_and_prints_the_notice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from headroom.cli import wrap as wrap_mod
+    from headroom.cli.main import main
+
+    captured: dict[str, object] = {}
+    monkeypatch.setenv(COPILOT_NATIVE_API_URL_ENV, "http://127.0.0.1:9999")
+    monkeypatch.setattr(wrap_mod.shutil, "which", lambda _name: "/usr/bin/copilot")
+    monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
+    monkeypatch.setattr(
+        wrap_mod,
+        "_require_copilot_subscription_resolution",
+        lambda: _native_resolution("https://api.enterprise.githubcopilot.com"),
+    )
+    monkeypatch.setattr(wrap_mod, "_launch_tool", lambda **kwargs: captured.update(kwargs))
+
+    result = CliRunner().invoke(
+        main, ["wrap", "copilot", "--subscription", "--", "--model", "gpt-5.5"]
+    )
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert COPILOT_NATIVE_API_URL_ENV not in env
+    assert "api.enterprise.githubcopilot.com" in result.output

--- a/tests/test_copilot_cli_gaps.py
+++ b/tests/test_copilot_cli_gaps.py
@@ -1,0 +1,486 @@
+"""Copilot CLI native-lane hardening.
+
+Each test names the failure it guards against. The Copilot CLI resolves its API
+host as ``settings.copilotUrl || COPILOT_API_URL || token.endpoints.api``, honours
+``HTTP_PROXY``/``HTTPS_PROXY`` for every request (including the loopback hop to
+Headroom), and since 1.0.8x ships as a native binary inside a per-platform npm
+package with ``app.js`` beside it. A wrapper that ignores any of these prints a
+successful launch while traffic never reaches the proxy, or fails with a
+connection error the user cannot attribute.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from headroom import copilot_auth
+from headroom.providers.copilot.install import build_install_env, install_uses_native_lane
+from headroom.providers.copilot.wrap import (
+    COPILOT_NATIVE_API_URL_ENV,
+    LOOPBACK_NO_PROXY_HOSTS,
+    build_launch_env,
+    build_native_launch_env,
+    check_copilot_url_setting,
+    copilot_home,
+    ensure_loopback_no_proxy,
+    native_api_url_supported,
+    read_copilot_url_setting,
+    read_copilot_url_settings,
+)
+
+PROXY_URL = "http://127.0.0.1:8787/p/repo"
+
+
+@pytest.fixture(autouse=True)
+def _clean_copilot_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "GITHUB_COPILOT_API_URL",
+        "GITHUB_COPILOT_ENTERPRISE_URL",
+        "GITHUB_COPILOT_ENTERPRISE_DOMAIN",
+        copilot_auth.USE_ADVERTISED_HOST_ENV,
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _write(path: Path, payload: object) -> None:
+    path.write_text(payload if isinstance(payload, str) else json.dumps(payload), encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Gap 4: the loopback hop must be exempt from a corporate proxy
+# --------------------------------------------------------------------------- #
+def test_loopback_no_proxy_is_added_and_idempotent() -> None:
+    env: dict[str, str] = {}
+    ensure_loopback_no_proxy(env)
+    first = env["NO_PROXY"]
+    assert set(first.split(",")) == set(LOOPBACK_NO_PROXY_HOSTS)
+
+    ensure_loopback_no_proxy(env)
+    assert env["NO_PROXY"] == first, "second call must not duplicate entries"
+    assert "no_proxy" not in env, "lowercase variant is only touched when it already exists"
+
+
+def test_loopback_no_proxy_preserves_existing_entries_and_syncs_lowercase() -> None:
+    env = {"NO_PROXY": "corp.internal, .example.com", "no_proxy": "corp.internal"}
+    ensure_loopback_no_proxy(env)
+    for variable in ("NO_PROXY", "no_proxy"):
+        entries = env[variable].split(",")
+        assert entries[0] == "corp.internal"
+        assert all(host in entries for host in LOOPBACK_NO_PROXY_HOSTS)
+
+
+def test_both_cli_lanes_exempt_loopback_from_proxies() -> None:
+    native_env, _ = build_native_launch_env(
+        port=8787, environ={"HTTPS_PROXY": "http://proxy.corp:3128"}
+    )
+    byok_env, _ = build_launch_env(
+        port=8787,
+        provider_type="openai",
+        wire_api=None,
+        environ={"HTTPS_PROXY": "http://proxy.corp:3128"},
+    )
+    for env in (native_env, byok_env):
+        assert "127.0.0.1" in env["NO_PROXY"].split(",")
+        assert env["HTTPS_PROXY"] == "http://proxy.corp:3128", "the corporate proxy stays"
+
+
+def test_subscription_lane_exempts_loopback_from_proxies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The --subscription branch builds its env inline, outside the shared builders."""
+    from headroom.cli import wrap as wrap_mod
+    from headroom.cli.main import main
+
+    class Resolution:
+        token = "gho-subscription"
+        api_url = copilot_auth.DEFAULT_API_URL
+        refresh_oauth_token = None
+        api_token_expires_at = None
+        advertised_api_url = None
+
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.corp:3128")
+    monkeypatch.setattr(wrap_mod.shutil, "which", lambda _name: "/usr/bin/copilot")
+    monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
+    monkeypatch.setattr(wrap_mod, "_require_copilot_subscription_resolution", lambda: Resolution())
+    monkeypatch.setattr(wrap_mod, "_launch_tool", lambda **kwargs: captured.update(kwargs))
+
+    result = CliRunner().invoke(
+        main, ["wrap", "copilot", "--subscription", "--", "--model", "gpt-5.5"]
+    )
+
+    assert result.exit_code == 0, result.output
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "127.0.0.1" in env["NO_PROXY"].split(",")
+    assert env["HTTPS_PROXY"] == "http://proxy.corp:3128"
+
+
+# --------------------------------------------------------------------------- #
+# Gap 1: the support probe must find the bundle of the binary being launched
+# --------------------------------------------------------------------------- #
+def _npm_layout(root: Path, *, mentions_env: bool) -> tuple[Path, Path]:
+    """Model an ``npm install -g @github/copilot`` tree.
+
+    ``bin/copilot`` is a symlink to the shim package's ``npm-loader.js``; the
+    platform package next to it carries the native binary and ``app.js``.
+    """
+    scope = root / "lib" / "node_modules" / "@github"
+    shim = scope / "copilot"
+    platform = scope / "copilot-darwin-arm64"
+    shim.mkdir(parents=True)
+    platform.mkdir(parents=True)
+    loader = shim / "npm-loader.js"
+    loader.write_text("spawn platform package", encoding="utf-8")
+    (platform / "copilot").write_bytes(b"\xcf\xfa\xed\xfe native binary")
+    (platform / "app.js").write_text(
+        "process.env.COPILOT_API_URL" if mentions_env else "no override here",
+        encoding="utf-8",
+    )
+    bin_dir = root / "bin"
+    bin_dir.mkdir()
+    shim_link = bin_dir / "copilot"
+    os.symlink(loader, shim_link)
+    return shim_link, platform / "copilot"
+
+
+def _no_legacy_roots(tmp_path: Path) -> dict[str, str]:
+    """An environment in which the legacy ``pkg`` directories do not exist."""
+    return {"LOCALAPPDATA": str(tmp_path / "nowhere"), "HOME": str(tmp_path / "nowhere")}
+
+
+def test_probe_follows_the_npm_shim_to_the_platform_bundle(tmp_path: Path) -> None:
+    shim_link, _native = _npm_layout(tmp_path, mentions_env=True)
+    # The old probe answered None here: no `pkg` directory anywhere.
+    assert native_api_url_supported(environ=_no_legacy_roots(tmp_path), copilot_bin=str(shim_link))
+
+
+def test_probe_reads_the_bundle_beside_a_native_binary(tmp_path: Path) -> None:
+    _shim, native = _npm_layout(tmp_path, mentions_env=True)
+    assert native_api_url_supported(environ=_no_legacy_roots(tmp_path), copilot_bin=str(native))
+
+
+def test_probe_handles_a_windows_npm_shim_script(tmp_path: Path) -> None:
+    """``copilot.cmd`` is a script in the npm prefix; the packages hang off it."""
+    prefix = tmp_path / "npm"
+    platform = prefix / "node_modules" / "@github" / "copilot-win32-x64"
+    platform.mkdir(parents=True)
+    (platform / "app.js").write_text("process.env.COPILOT_API_URL", encoding="utf-8")
+    shim = prefix / "copilot.cmd"
+    shim.write_text("@node npm-loader.js %*", encoding="utf-8")
+    assert native_api_url_supported(environ=_no_legacy_roots(tmp_path), copilot_bin=str(shim))
+
+
+def test_probe_reports_unsupported_when_the_launched_bundle_lacks_the_hook(
+    tmp_path: Path,
+) -> None:
+    shim_link, _native = _npm_layout(tmp_path, mentions_env=False)
+    assert (
+        native_api_url_supported(environ=_no_legacy_roots(tmp_path), copilot_bin=str(shim_link))
+        is False
+    )
+
+
+def test_probe_stays_unknown_without_any_bundle(tmp_path: Path) -> None:
+    env = _no_legacy_roots(tmp_path)
+    assert native_api_url_supported(environ=env, copilot_bin=str(tmp_path / "missing")) is None
+    assert native_api_url_supported(environ=env, copilot_bin=None) is None
+
+
+# --------------------------------------------------------------------------- #
+# Gap 2: a `copilotUrl` setting outranks COPILOT_API_URL
+# --------------------------------------------------------------------------- #
+def test_copilot_home_honours_override_then_default(tmp_path: Path) -> None:
+    assert copilot_home({"COPILOT_HOME": str(tmp_path / "cfg")}) == tmp_path / "cfg"
+    assert copilot_home({"HOME": str(tmp_path)}) == tmp_path / ".copilot"
+
+
+def test_read_copilot_url_settings_reports_every_pin(tmp_path: Path) -> None:
+    env = {"COPILOT_HOME": str(tmp_path)}
+    assert read_copilot_url_settings(env) == []
+    assert read_copilot_url_setting(env) is None
+
+    _write(tmp_path / "config.json", {"copilotUrl": "https://legacy.example"})
+    assert read_copilot_url_settings(env) == [(tmp_path / "config.json", "https://legacy.example")]
+
+    _write(tmp_path / "settings.json", {"copilotUrl": "https://current.example/"})
+    assert read_copilot_url_settings(env) == [
+        (tmp_path / "settings.json", "https://current.example/"),
+        (tmp_path / "config.json", "https://legacy.example"),
+    ]
+    assert read_copilot_url_setting(env) == (tmp_path / "settings.json", "https://current.example/")
+
+
+@pytest.mark.parametrize("payload", ["not json", "[]", json.dumps({"copilotUrl": "  "})])
+def test_read_copilot_url_settings_ignores_unusable_files(tmp_path: Path, payload: str) -> None:
+    _write(tmp_path / "settings.json", payload)
+    assert read_copilot_url_settings({"COPILOT_HOME": str(tmp_path)}) == []
+
+
+def test_check_refuses_a_pin_on_another_origin(tmp_path: Path) -> None:
+    _write(tmp_path / "settings.json", {"copilotUrl": "https://api.githubcopilot.com"})
+    with pytest.raises(click.ClickException) as excinfo:
+        check_copilot_url_setting(PROXY_URL, environ={"COPILOT_HOME": str(tmp_path)})
+    assert "copilotUrl" in excinfo.value.message
+    assert PROXY_URL in excinfo.value.message
+
+
+def test_check_refuses_when_only_the_legacy_file_pins_another_origin(tmp_path: Path) -> None:
+    """The CLI still honours a legacy value it has not migrated; so must the check."""
+    _write(tmp_path / "settings.json", {"copilotUrl": PROXY_URL})
+    _write(tmp_path / "config.json", {"copilotUrl": "http://127.0.0.1:9999"})
+    with pytest.raises(click.ClickException) as excinfo:
+        check_copilot_url_setting(PROXY_URL, environ={"COPILOT_HOME": str(tmp_path)})
+    assert "config.json" in excinfo.value.message
+
+
+def test_check_refuses_the_same_host_on_a_different_port(tmp_path: Path) -> None:
+    """Another Headroom instance is still not this one."""
+    _write(tmp_path / "settings.json", {"copilotUrl": "http://127.0.0.1:9999/p/repo"})
+    with pytest.raises(click.ClickException):
+        check_copilot_url_setting(PROXY_URL, environ={"COPILOT_HOME": str(tmp_path)})
+
+
+def test_check_accepts_a_pin_that_names_this_proxy_exactly(tmp_path: Path) -> None:
+    _write(tmp_path / "settings.json", {"copilotUrl": "HTTP://127.0.0.1:8787/p/repo/"})
+    check_copilot_url_setting(PROXY_URL, environ={"COPILOT_HOME": str(tmp_path)})
+
+
+def test_check_accepts_the_same_origin_without_the_project_prefix(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A durable install wrote the bare proxy URL: traffic still flows through Headroom."""
+    _write(tmp_path / "settings.json", {"copilotUrl": "http://127.0.0.1:8787"})
+    check_copilot_url_setting(PROXY_URL, environ={"COPILOT_HOME": str(tmp_path)})
+    assert "per-project savings attribution" in capsys.readouterr().out
+
+
+def test_check_is_silent_without_any_pin(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    check_copilot_url_setting(PROXY_URL, environ={"COPILOT_HOME": str(tmp_path)})
+    assert capsys.readouterr().out == ""
+
+
+def _native_resolution(advertised: str | None = None):
+    class Resolution:
+        token = "copilot-token"
+        api_url = copilot_auth.DEFAULT_API_URL
+        refresh_oauth_token = "refresh-token"
+        api_token_expires_at = 123.0
+        advertised_api_url = advertised
+
+    return Resolution()
+
+
+def test_native_wrap_fails_closed_on_a_foreign_copilot_url_pin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The user-visible contract: refuse rather than launch a bypassed session."""
+    from headroom.cli import wrap as wrap_mod
+    from headroom.cli.main import main
+
+    _write(tmp_path / "settings.json", {"copilotUrl": "https://api.githubcopilot.com"})
+    monkeypatch.setenv("COPILOT_HOME", str(tmp_path))
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(wrap_mod.shutil, "which", lambda _name: "/usr/bin/copilot")
+    monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
+    monkeypatch.setattr(
+        wrap_mod, "_require_copilot_subscription_resolution", lambda: _native_resolution()
+    )
+    monkeypatch.setattr(wrap_mod, "_native_api_url_supported", lambda **_kwargs: True)
+    monkeypatch.setattr(wrap_mod, "_launch_tool", lambda **kwargs: captured.update(kwargs))
+
+    result = CliRunner().invoke(main, ["wrap", "copilot", "--native", "--port", "8890"])
+
+    assert result.exit_code != 0
+    assert "copilotUrl" in result.output
+    assert not captured, "the CLI must not be launched"
+
+
+def test_native_wrap_passes_copilot_bin_to_the_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    from headroom.cli import wrap as wrap_mod
+    from headroom.cli.main import main
+
+    seen: dict[str, object] = {}
+
+    def probe(**kwargs):  # noqa: ANN003
+        seen.update(kwargs)
+        return True
+
+    monkeypatch.setattr(wrap_mod.shutil, "which", lambda _name: "/opt/copilot/bin/copilot")
+    monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
+    monkeypatch.setattr(
+        wrap_mod, "_require_copilot_subscription_resolution", lambda: _native_resolution()
+    )
+    monkeypatch.setattr(wrap_mod, "_native_api_url_supported", probe)
+    monkeypatch.setattr(wrap_mod, "_launch_tool", lambda **kwargs: None)
+
+    result = CliRunner().invoke(main, ["wrap", "copilot", "--native", "--port", "8890"])
+
+    assert result.exit_code == 0, result.output
+    assert seen["copilot_bin"] == "/opt/copilot/bin/copilot"
+
+
+# --------------------------------------------------------------------------- #
+# Gap 3: persistent installs default to the native lane
+# --------------------------------------------------------------------------- #
+def test_install_lane_selection() -> None:
+    assert install_uses_native_lane("anthropic", {}) is True
+    assert install_uses_native_lane("", {}) is True
+    assert install_uses_native_lane("anyllm", {}) is False
+    assert install_uses_native_lane("litellm-vertex", {}) is False
+    assert install_uses_native_lane("anthropic", {"COPILOT_PROVIDER_API_KEY": "sk-x"}) is False
+
+
+def test_native_install_env_is_only_the_api_url_hook() -> None:
+    env = build_install_env(port=8891, backend="anthropic", environ={})
+    assert env == {COPILOT_NATIVE_API_URL_ENV: "http://127.0.0.1:8891"}
+    assert "NO_PROXY" not in env, "an install must not overwrite the user's NO_PROXY"
+
+
+# --------------------------------------------------------------------------- #
+# Gap 5: advertised per-plan and data-residency hosts
+# --------------------------------------------------------------------------- #
+def test_ghe_data_residency_host_is_never_folded_into_the_public_host() -> None:
+    advertised = "https://copilot-api.acme.ghe.com"
+    assert (
+        copilot_auth._subscription_api_url_from_user_info_payload(
+            {"endpoints": {"api": advertised}}
+        )
+        == advertised
+    )
+
+
+def test_ghe_host_from_a_token_exchange_is_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolved = copilot_auth._api_url_from_exchange_payload(
+        {"endpoints": {"api": "https://copilot-api.acme.ghe.com"}}, oauth_token="gho-oauth"
+    )
+    assert resolved == "https://copilot-api.acme.ghe.com"
+
+
+@pytest.mark.parametrize(
+    "advertised",
+    ["https://api.business.githubcopilot.com", "https://api.enterprise.githubcopilot.com"],
+)
+def test_segmented_plan_hosts_normalize_by_default_and_honour_the_opt_in(
+    monkeypatch: pytest.MonkeyPatch, advertised: str
+) -> None:
+    payload = {"endpoints": {"api": advertised}}
+    assert (
+        copilot_auth._subscription_api_url_from_user_info_payload(payload)
+        == copilot_auth.DEFAULT_API_URL
+    )
+    assert copilot_auth.advertised_host_is_normalized(advertised) is True
+
+    monkeypatch.setenv(copilot_auth.USE_ADVERTISED_HOST_ENV, "1")
+    assert copilot_auth._subscription_api_url_from_user_info_payload(payload) == advertised
+    assert copilot_auth.advertised_host_is_normalized(advertised) is False
+
+
+def test_explicit_pin_still_beats_the_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(copilot_auth.USE_ADVERTISED_HOST_ENV, "1")
+    monkeypatch.setenv("GITHUB_COPILOT_API_URL", "https://egress.corp.example")
+    assert (
+        copilot_auth._subscription_api_url_from_user_info_payload(
+            {"endpoints": {"api": "https://api.business.githubcopilot.com"}}
+        )
+        == "https://egress.corp.example"
+    )
+
+
+def test_individual_host_stays_normalized_even_with_the_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#610: the individual segmented host did not serve newer models."""
+    monkeypatch.setenv(copilot_auth.USE_ADVERTISED_HOST_ENV, "true")
+    assert (
+        copilot_auth._subscription_api_url_from_user_info_payload(
+            {"endpoints": {"api": "https://api.individual.githubcopilot.com"}}
+        )
+        == copilot_auth.DEFAULT_API_URL
+    )
+
+
+def test_resolution_records_the_advertised_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_COPILOT_API_TOKEN", raising=False)
+    monkeypatch.delenv("COPILOT_PROVIDER_BEARER_TOKEN", raising=False)
+    monkeypatch.setattr(
+        copilot_auth,
+        "iter_oauth_token_candidates",
+        lambda: [
+            copilot_auth.CopilotTokenCandidate(
+                token="gho-oauth",
+                source="headroom-copilot-auth:/tmp/copilot_auth.json",
+                confidence="copilot-oauth",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        copilot_auth.CopilotTokenProvider,
+        "_exchange_token_sync",
+        staticmethod(
+            lambda _headers: {
+                "token": "copilot-api",
+                "expires_at": int(time.time()) + 3600,
+                "endpoints": {"api": "https://api.business.githubcopilot.com"},
+            }
+        ),
+    )
+
+    resolution = copilot_auth.resolve_subscription_bearer_token_details()
+
+    assert resolution is not None
+    assert resolution.api_url == copilot_auth.DEFAULT_API_URL
+    assert resolution.advertised_api_url == "https://api.business.githubcopilot.com"
+
+
+def test_wrap_prints_the_advertised_host_notice(monkeypatch: pytest.MonkeyPatch) -> None:
+    from headroom.cli import wrap as wrap_mod
+    from headroom.cli.main import main
+
+    monkeypatch.setattr(wrap_mod.shutil, "which", lambda _name: "/usr/bin/copilot")
+    monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
+    monkeypatch.setattr(
+        wrap_mod,
+        "_require_copilot_subscription_resolution",
+        lambda: _native_resolution("https://api.business.githubcopilot.com"),
+    )
+    monkeypatch.setattr(wrap_mod, "_native_api_url_supported", lambda **_kwargs: True)
+    monkeypatch.setattr(wrap_mod, "_launch_tool", lambda **kwargs: None)
+
+    result = CliRunner().invoke(main, ["wrap", "copilot", "--native", "--port", "8890"])
+
+    assert result.exit_code == 0, result.output
+    assert "api.business.githubcopilot.com" in result.output
+    assert copilot_auth.USE_ADVERTISED_HOST_ENV in result.output
+
+
+def test_wrap_stays_quiet_when_the_advertised_host_is_the_one_used(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from headroom.cli import wrap as wrap_mod
+    from headroom.cli.main import main
+
+    monkeypatch.setattr(wrap_mod.shutil, "which", lambda _name: "/usr/bin/copilot")
+    monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
+    monkeypatch.setattr(
+        wrap_mod,
+        "_require_copilot_subscription_resolution",
+        lambda: _native_resolution(copilot_auth.DEFAULT_API_URL),
+    )
+    monkeypatch.setattr(wrap_mod, "_native_api_url_supported", lambda **_kwargs: True)
+    monkeypatch.setattr(wrap_mod, "_launch_tool", lambda **kwargs: None)
+
+    result = CliRunner().invoke(main, ["wrap", "copilot", "--native", "--port", "8890"])
+
+    assert result.exit_code == 0, result.output
+    assert copilot_auth.USE_ADVERTISED_HOST_ENV not in result.output

--- a/tests/test_copilot_redirect_e2e.py
+++ b/tests/test_copilot_redirect_e2e.py
@@ -1,0 +1,254 @@
+"""End-to-end: a Copilot credential on a stock-target proxy reaches Copilot.
+
+These drive the real application (``create_app`` + the dedicated chat, responses
+and messages handlers) with a capturing transport, so a regression in the
+handlers' own wiring — not just in the helper the handlers call — fails here:
+
+- the request leaves for ``api.githubcopilot.com`` with the client's own token,
+- the operator's gateway secrets (``*_extra_headers``) stay home,
+- the ``Copilot-Session-Token`` header Auto depends on survives the hop,
+- the Anthropic surface gets the same model-aware system relocation as a
+  configured Copilot target.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+pytest.importorskip("fastapi")
+
+COPILOT_API = "https://api.githubcopilot.com"
+COPILOT_TOKEN = (
+    "tid=0123456789abcdef0123456789abcdef;exp=1893456000;sku=copilot_for_business_seat:9f8e7d6c"
+)
+GATEWAY_HEADERS = {"X-Gateway-Key": "operator-secret"}
+
+_CHAT_OK = {
+    "id": "chatcmpl-test",
+    "object": "chat.completion",
+    "model": "gpt-4o",
+    "choices": [
+        {"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}
+    ],
+    "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+}
+_RESPONSES_OK = {
+    "id": "resp_test",
+    "object": "response",
+    "status": "completed",
+    "model": "gpt-5.5",
+    "output": [],
+    "usage": {"input_tokens": 3, "output_tokens": 1},
+}
+_MESSAGES_OK = {
+    "id": "msg_test",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-sonnet-5",
+    "content": [{"type": "text", "text": "ok"}],
+    "stop_reason": "end_turn",
+    "usage": {"input_tokens": 3, "output_tokens": 1},
+}
+
+
+class _CapturingTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        body = b""
+        async for chunk in request.stream:  # type: ignore[union-attr]
+            body += chunk
+        request.extensions["captured_body"] = body
+        self.requests.append(request)
+        path = request.url.path
+        if path.endswith("/chat/completions"):
+            payload: dict[str, Any] = _CHAT_OK
+        elif path.endswith("/responses"):
+            payload = _RESPONSES_OK
+        else:
+            payload = _MESSAGES_OK
+        return httpx.Response(200, json=payload)
+
+
+@pytest.fixture
+def stock_target_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A shared proxy with both targets on the stock hosts and no Copilot seed."""
+    for var in (
+        "OPENAI_TARGET_API_URL",
+        "ANTHROPIC_TARGET_API_URL",
+        "GITHUB_COPILOT_API_URL",
+        "GITHUB_COPILOT_ENTERPRISE_URL",
+        "GITHUB_COPILOT_ENTERPRISE_DOMAIN",
+        "GITHUB_COPILOT_API_TOKEN",
+        "GITHUB_COPILOT_REFRESH_OAUTH_TOKEN",
+        "COPILOT_PROVIDER_BEARER_TOKEN",
+        "HEADROOM_STRIP_INTERNAL_HEADERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _app():
+    from fastapi.testclient import TestClient
+
+    from headroom.proxy.server import ProxyConfig, create_app
+
+    config = ProxyConfig(
+        optimize=True,
+        cache_enabled=False,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+        log_requests=False,
+        ccr_inject_tool=False,
+        ccr_handle_responses=False,
+        ccr_context_tracking=False,
+        image_optimize=False,
+        openai_extra_headers=dict(GATEWAY_HEADERS),
+        anthropic_extra_headers=dict(GATEWAY_HEADERS),
+    )
+    app = create_app(config)
+    with TestClient(app, client=("127.0.0.1", 50000)) as client:
+        proxy = app.state.proxy
+        assert proxy.OPENAI_API_URL.startswith("https://api.openai.com")
+        assert proxy.ANTHROPIC_API_URL.startswith("https://api.anthropic.com")
+        transport = _CapturingTransport()
+        proxy.http_client = httpx.AsyncClient(transport=transport)
+        proxy.http_client_h1 = httpx.AsyncClient(transport=transport)
+        yield client, transport
+
+
+def _copilot_headers() -> dict[str, str]:
+    return {
+        "content-type": "application/json",
+        "authorization": f"Bearer {COPILOT_TOKEN}",
+        "copilot-session-token": "sess_auto_abc",
+        "x-initiator": "user",
+        "user-agent": "GitHubCopilotCLI/1.0.82",
+    }
+
+
+def _sent(transport: _CapturingTransport) -> httpx.Request:
+    assert len(transport.requests) == 1, [str(r.url) for r in transport.requests]
+    return transport.requests[0]
+
+
+def test_chat_completions_with_a_copilot_token_go_to_copilot(stock_target_env: None) -> None:
+    for client, transport in _app():
+        response = client.post(
+            "/v1/chat/completions",
+            headers=_copilot_headers(),
+            json={"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert response.status_code == 200, response.text
+        sent = _sent(transport)
+        assert str(sent.url) == f"{COPILOT_API}/chat/completions"
+        assert sent.headers["authorization"] == f"Bearer {COPILOT_TOKEN}"
+        assert sent.headers["copilot-session-token"] == "sess_auto_abc"
+        assert "x-gateway-key" not in sent.headers
+
+
+def test_chat_completions_with_an_openai_key_stay_on_openai_with_the_gateway_header(
+    stock_target_env: None,
+) -> None:
+    for client, transport in _app():
+        response = client.post(
+            "/v1/chat/completions",
+            headers={
+                "content-type": "application/json",
+                "authorization": "Bearer sk-test-0000000000000000000000000000000000000000000",
+            },
+            json={"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert response.status_code == 200, response.text
+        sent = _sent(transport)
+        assert sent.url.host == "api.openai.com"
+        assert sent.headers["x-gateway-key"] == "operator-secret"
+
+
+def test_responses_with_a_copilot_token_go_to_copilot(stock_target_env: None) -> None:
+    for client, transport in _app():
+        response = client.post(
+            "/v1/responses",
+            headers=_copilot_headers(),
+            json={"model": "gpt-5.5", "input": "hi"},
+        )
+        assert response.status_code == 200, response.text
+        sent = _sent(transport)
+        assert str(sent.url) == f"{COPILOT_API}/responses"
+        assert sent.headers["authorization"] == f"Bearer {COPILOT_TOKEN}"
+        assert sent.headers["copilot-session-token"] == "sess_auto_abc"
+        assert "x-gateway-key" not in sent.headers
+
+
+def test_responses_with_an_openai_key_stay_on_openai_with_the_gateway_header(
+    stock_target_env: None,
+) -> None:
+    for client, transport in _app():
+        client.post(
+            "/v1/responses",
+            headers={
+                "content-type": "application/json",
+                "authorization": "Bearer sk-test-0000000000000000000000000000000000000000000",
+            },
+            json={"model": "gpt-5.5", "input": "hi"},
+        )
+        sent = _sent(transport)
+        assert sent.url.host == "api.openai.com"
+        assert sent.headers["x-gateway-key"] == "operator-secret"
+
+
+def test_messages_with_a_copilot_token_go_to_copilot_and_keep_anthropic_semantics(
+    stock_target_env: None,
+) -> None:
+    """A mid-conversation system turn is legal for claude-sonnet-5; a redirected
+    request must be judged against the model, not hoisted blindly as an
+    unknown upstream would be."""
+    for client, transport in _app():
+        response = client.post(
+            "/v1/messages",
+            headers=_copilot_headers(),
+            json={
+                "model": "claude-sonnet-5",
+                "max_tokens": 16,
+                "messages": [
+                    {"role": "user", "content": "first"},
+                    {"role": "system", "content": "stay terse"},
+                    {"role": "assistant", "content": "ok"},
+                    {"role": "user", "content": "second"},
+                ],
+            },
+        )
+        assert response.status_code == 200, response.text
+        sent = _sent(transport)
+        assert str(sent.url) == f"{COPILOT_API}/v1/messages"
+        assert sent.headers["authorization"] == f"Bearer {COPILOT_TOKEN}"
+        assert "x-gateway-key" not in sent.headers
+        body = json.loads(sent.extensions["captured_body"])
+        assert [m["role"] for m in body["messages"]] == ["user", "system", "assistant", "user"]
+        assert "system" not in body
+
+
+def test_messages_with_an_anthropic_key_stay_on_anthropic_with_the_gateway_header(
+    stock_target_env: None,
+) -> None:
+    for client, transport in _app():
+        client.post(
+            "/v1/messages",
+            headers={
+                "content-type": "application/json",
+                "x-api-key": "sk-ant-test",
+                "anthropic-version": "2023-06-01",
+            },
+            json={
+                "model": "claude-sonnet-5",
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        sent = _sent(transport)
+        assert sent.url.host == "api.anthropic.com"
+        assert sent.headers["x-gateway-key"] == "operator-secret"

--- a/tests/test_install/test_planner.py
+++ b/tests/test_install/test_planner.py
@@ -44,7 +44,8 @@ def test_build_manifest_for_persistent_docker_sets_expected_defaults() -> None:
     assert manifest.base_env["HEADROOM_TELEMETRY"] == "off"
     assert "--no-telemetry" in manifest.proxy_args
     assert manifest.tool_envs["claude"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8787"
-    assert manifest.tool_envs["copilot"]["COPILOT_PROVIDER_TYPE"] == "anthropic"
+    # Native lane by default: the CLI keeps GitHub's model picker and Auto mode.
+    assert manifest.tool_envs["copilot"] == {"COPILOT_API_URL": "http://127.0.0.1:8787"}
     assert "--memory" in manifest.proxy_args
     # A container runtime must NOT carry the host memory DB path: it does not
     # exist inside the container and would keep /readyz at 503 (#2803). The proxy

--- a/tests/test_install/test_providers.py
+++ b/tests/test_install/test_providers.py
@@ -443,18 +443,31 @@ def test_claude_build_install_env_returns_proxy_base_url() -> None:
     }
 
 
-def test_copilot_build_install_env_uses_provider_type_specific_proxy_urls() -> None:
-    anthropic_env = build_copilot_install_env(port=8787, backend="anthropic")
-    openai_env = build_copilot_install_env(port=8787, backend="anyllm")
+def test_copilot_build_install_env_defaults_to_native_lane() -> None:
+    """An installed Copilot CLI keeps GitHub's model picker and Auto mode.
 
-    assert anthropic_env == {
-        "COPILOT_PROVIDER_TYPE": "anthropic",
-        "COPILOT_PROVIDER_BASE_URL": "http://127.0.0.1:8787",
-    }
+    The BYOK variables pin one model and reject ``auto``; the native hook only
+    redirects the CLI's own GitHub-authenticated traffic through the proxy.
+    """
+    native_env = build_copilot_install_env(port=8787, backend="anthropic", environ={})
+
+    assert native_env == {"COPILOT_API_URL": "http://127.0.0.1:8787"}
+
+
+def test_copilot_build_install_env_keeps_byok_for_translated_backends_and_explicit_keys() -> None:
+    openai_env = build_copilot_install_env(port=8787, backend="anyllm", environ={})
+    explicit_byok = build_copilot_install_env(
+        port=8787, backend="anthropic", environ={"COPILOT_PROVIDER_API_KEY": "sk-test"}
+    )
+
     assert openai_env == {
         "COPILOT_PROVIDER_TYPE": "openai",
         "COPILOT_PROVIDER_BASE_URL": "http://127.0.0.1:8787/v1",
         "COPILOT_PROVIDER_WIRE_API": "completions",
+    }
+    assert explicit_byok == {
+        "COPILOT_PROVIDER_TYPE": "anthropic",
+        "COPILOT_PROVIDER_BASE_URL": "http://127.0.0.1:8787",
     }
 
 


### PR DESCRIPTION
## Summary

Closes the six gaps that made `headroom wrap copilot --native` (and `headroom install` for Copilot) look routed while traffic bypassed the proxy or never reached it, and adds tests pinning the Auto-mode passthrough contract. A second commit hardens the change after a deep review (details below).

The Copilot CLI resolves its API host as `settings.copilotUrl` → `COPILOT_API_URL` → token `endpoints.api`, honours `HTTP(S)_PROXY` for the loopback hop, and since 1.0.8x ships as a native binary inside a per-platform npm package. Each of those defeated the native lane silently.

| Gap | What it allowed before | Fix |
|---|---|---|
| Probe scanned only the legacy `pkg` dir | npm installs launched blind (probe answered "unknown") | Follow the launched binary / npm shim (incl. Windows `.cmd`) to the platform package's `app.js`; the launched build's verdict wins over a stale installer copy |
| `copilotUrl` setting outranks the env var | A pre-existing pin bypassed Headroom while the launch banner claimed routing | Read `settings.json` and legacy `config.json`; refuse a foreign origin, note a same-origin pin |
| Loopback hop went through the corporate proxy | Opaque connection errors inside the agent | All CLI lanes add `127.0.0.1`/`localhost`/`::1` to `NO_PROXY`, seeding both spellings from their union |
| `headroom install` used the BYOK lane | Lost Auto and Claude-on-Copilot | Native lane (`COPILOT_API_URL`) for the default and `anthropic` backends; BYOK kept for translated backends or explicit keys |
| Segmented plan hosts always normalized | Networks on GitHub's subscription-based routing blocked the generic host with no hint | Normalization stays the default (#2441, #610); `GITHUB_COPILOT_USE_ADVERTISED_HOST=1` opts in, `--subscription`/`--native`/`wrap vscode` print the advertised host, GHE.com hosts are always honoured. (#3403 proposes flipping the default.) |
| Copilot bearers on a stock-target shared proxy | GitHub tokens were forwarded to `api.openai.com` / `api.anthropic.com` | Chat, Responses, `/v1/messages`, `/v1/models` and the generic passthrough redirect Copilot credentials to Copilot; operator gateway extra headers are withheld on the redirect |

Auto mode already worked through the proxy (concrete model id in the body, `Copilot-Session-Token` survives header stripping, `/models/session` and `/auto` fall to passthrough). `tests/test_copilot_auto_passthrough.py` pins that so it cannot regress unnoticed.

## Review follow-ups (second commit)

Three reviewers went over the diff; every finding below has a test that fails without the fix.

- **Real token shape.** Copilot API tokens are `tid=<hex>;exp=…;sku=…`, not a `tid_` prefix. The redirect and `_is_forwardable_copilot_bearer_token` now accept that shape, so an installed proxy with no Copilot seed forwards the CLI's own token.
- **No seat widening.** `ghu_` was routed but not forwardable, which would have made `apply_copilot_api_auth` substitute the operator's token for any caller presenting a garbage `ghu_` bearer. Routing is now a strict subset of the forwardable set.
- **Anthropic secrets.** `/v1/messages` redirects flag themselves and the handler withholds `anthropic_extra_headers` outright, instead of running them through the trust check where a trusted Copilot host would have leaked them.
- **Live code, real tests.** `_resolve_openai_upstream` had gone dead while its tests kept passing. The chat handler calls it again, both handlers share one redirect helper, and `tests/test_copilot_redirect_e2e.py` drives the real app (chat, responses, messages) asserting destination, token pass-through, `Copilot-Session-Token` survival, withheld secrets and model-aware system relocation.
- **Probe and env hygiene.** Stale installer bundles cannot vouch for a launched build; legacy roots come from the given environment; chunk-boundary matches are not missed; `copilot_home` follows Node's `os.homedir()`; BYOK and `--subscription` lanes drop a durable install's `COPILOT_API_URL`.

## Deliberate non-changes

- The install manifest omits `NO_PROXY` so it never overwrites a user's shell setting; the wrapper covers interactive launches.
- The VS Code WebSocket `/responses` path is not registered; Auto over that transport still falls to the generic passthrough.
- `headroom init copilot -g` still writes the BYOK variables; only `headroom install` moved to the native lane.

## Test plan

- [x] `tests/test_copilot_cli_gaps.py` (45), `tests/test_copilot_auto_passthrough.py` (55), `tests/test_copilot_redirect_e2e.py` (6): new, all passing
- [x] Copilot wrap/auth/install CLI suites, routing/handler suites: 543 passed, 5 skipped
- [x] ~2250 related handler/route/CLI tests across four chunks pass; the only failures (`tests/test_pr208_changes.py`) are a pre-existing websockets-stub ordering issue that passes when the file runs alone
- [x] `uvx ruff@0.16.3 format --check` and `check` clean (CI's pinned version)
- [x] `tests/conftest.py` isolates `COPILOT_HOME` so wrap tests never read a developer's real `~/.copilot/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rSdvTck9uJAzNJ8Y2M5mx
