### PR TITLE
feat(copilot): honour GitHub's advertised Business/Enterprise host by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,13 +278,12 @@ export GITHUB_COPILOT_ENTERPRISE_URL=https://ghe.example.com
 ```
 
 Business and Enterprise accounts are advertised a per-plan host
-(`api.business.githubcopilot.com` / `api.enterprise.githubcopilot.com`). Headroom
-routes them through the generic host by default; `--subscription`, `--native`
-and `wrap vscode` print the advertised host at launch when they override it. If
-your network uses GitHub's subscription-based network routing,
-which blocks the generic host, set `GITHUB_COPILOT_USE_ADVERTISED_HOST=1` or pin
-`GITHUB_COPILOT_API_URL` to the advertised host. Data-residency hosts
-(`copilot-api.<tenant>.ghe.com`) are always honored.
+(`api.business.githubcopilot.com` / `api.enterprise.githubcopilot.com`), and
+Headroom routes through it, the same as GitHub's own clients. If that host
+rejects a model your seat should have, set
+`GITHUB_COPILOT_USE_ADVERTISED_HOST=0` to route through the generic
+`api.githubcopilot.com` instead, or pin `GITHUB_COPILOT_API_URL` explicitly.
+Data-residency hosts (`copilot-api.<tenant>.ghe.com`) are always honored.
 
 `headroom wrap copilot` refuses to launch when `~/.copilot/settings.json` (or
 `$COPILOT_HOME`) pins a different `copilotUrl`: the CLI ranks that setting above

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -3996,8 +3996,9 @@ def _echo_copilot_host_notice(resolution: CopilotSubscriptionTokenResolution | N
     """Tell the user when GitHub advertised a per-plan host Headroom is not using.
 
     Business and Enterprise tokens come with ``api.business.`` /
-    ``api.enterprise.githubcopilot.com``; Headroom routes to the generic host by
-    default (see ``copilot_auth._SEGMENTED_PLAN_HOSTS``). Networks that use
+    ``api.enterprise.githubcopilot.com`` and Headroom honours them by default.
+    With ``GITHUB_COPILOT_USE_ADVERTISED_HOST=0`` it folds them into the generic
+    host instead (see ``copilot_auth._SEGMENTED_PLAN_HOSTS``). Networks that use
     GitHub's subscription-based routing block the generic host, and that
     failure surfaces only as connection errors inside the agent, so say it here.
     """
@@ -4006,8 +4007,9 @@ def _echo_copilot_host_notice(resolution: CopilotSubscriptionTokenResolution | N
         return
     click.echo(
         f"  Note: GitHub advertised {advertised} for this account; Headroom routes via "
-        f"{resolution.api_url}. If your network uses subscription-based routing, set "
-        f"{_USE_ADVERTISED_HOST_ENV}=1 or GITHUB_COPILOT_API_URL={advertised}."
+        f"{resolution.api_url} because {_USE_ADVERTISED_HOST_ENV} is disabled. Unset it "
+        f"(or set GITHUB_COPILOT_API_URL={advertised}) if your network uses "
+        "subscription-based routing."
     )
 
 

--- a/headroom/copilot_auth.py
+++ b/headroom/copilot_auth.py
@@ -1019,14 +1019,14 @@ def _api_url_from_payload(payload: dict[str, Any] | None) -> str | None:
 #: advertises for them instead of the generic public host.
 USE_ADVERTISED_HOST_ENV = "GITHUB_COPILOT_USE_ADVERTISED_HOST"
 
-#: Per-plan chat hosts GitHub advertises in ``endpoints.api``. The generic host
-#: serves all of them, and it is the one Headroom routes to by default: the
-#: segmented hosts regressed model availability for wrapped sessions (#610 for
-#: individual, #2441 for Business/Enterprise) and the official client's results
-#: could not be reproduced through them at the time. Enterprises whose firewall
-#: uses GitHub's subscription-based network routing block the generic host, so
-#: they need the advertised host — hence the opt-in above and the explicit
-#: ``GITHUB_COPILOT_API_URL`` pin.
+#: Per-plan chat hosts GitHub advertises in ``endpoints.api`` for Business and
+#: Enterprise seats. Headroom honours them by default: it is the host GitHub's
+#: own clients route with, and enterprises whose firewall uses GitHub's
+#: subscription-based network routing block the generic host entirely. The
+#: opt-out above (``GITHUB_COPILOT_USE_ADVERTISED_HOST=0``) folds them back into
+#: the generic host for accounts where the segmented host still lags on model
+#: availability (#2441 reported that for Claude models in 2026-05); an explicit
+#: ``GITHUB_COPILOT_API_URL`` pin wins over both.
 _SEGMENTED_PLAN_HOSTS: frozenset[str] = frozenset(
     {
         "api.business.githubcopilot.com",
@@ -1036,9 +1036,9 @@ _SEGMENTED_PLAN_HOSTS: frozenset[str] = frozenset(
 
 
 def use_advertised_host() -> bool:
-    """Return True when the operator opted into GitHub's advertised per-plan host."""
+    """Return True unless the operator opted out of GitHub's advertised per-plan host."""
     value = os.environ.get(USE_ADVERTISED_HOST_ENV, "").strip().lower()
-    return value in {"1", "true", "yes", "on"}
+    return value not in {"0", "false", "no", "off"}
 
 
 def advertised_host_is_normalized(api_url: str | None) -> bool:

--- a/tests/test_cli/test_wrap_copilot.py
+++ b/tests/test_cli/test_wrap_copilot.py
@@ -982,7 +982,7 @@ def test_wrap_copilot_subscription_uses_resolved_subscription_endpoint(
     assert env["COPILOT_PROVIDER_BEARER_TOKEN"] == "copilot-api"
 
 
-def test_wrap_copilot_subscription_normalizes_enterprise_host(
+def test_wrap_copilot_subscription_follows_the_advertised_enterprise_host(
     runner: CliRunner,
     wrap_modules: tuple[types.ModuleType, click.Group],
     monkeypatch: pytest.MonkeyPatch,
@@ -1028,9 +1028,9 @@ def test_wrap_copilot_subscription_normalizes_enterprise_host(
     assert result.exit_code == 0, result.output
     env = captured["env"]
     assert isinstance(env, dict)
-    assert captured["openai_api_url"] == DEFAULT_API_URL
-    assert env["OPENAI_TARGET_API_URL"] == DEFAULT_API_URL
-    assert env["GITHUB_COPILOT_API_URL"] == DEFAULT_API_URL
+    assert captured["openai_api_url"] == "https://api.enterprise.githubcopilot.com"
+    assert env["OPENAI_TARGET_API_URL"] == "https://api.enterprise.githubcopilot.com"
+    assert env["GITHUB_COPILOT_API_URL"] == "https://api.enterprise.githubcopilot.com"
 
 
 def test_wrap_copilot_subscription_honors_api_url_override(

--- a/tests/test_cli/test_wrap_opencode.py
+++ b/tests/test_cli/test_wrap_opencode.py
@@ -66,7 +66,7 @@ def _subscription_resolution() -> CopilotSubscriptionTokenResolution:
 # ---------------------------------------------------------------------------
 
 
-def test_wrap_opencode_copilot_subscription_normalizes_enterprise_host_and_handoffs_seed_after_actual_port(
+def test_wrap_opencode_copilot_subscription_follows_enterprise_host_and_handoffs_seed_after_actual_port(
     runner: CliRunner,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -137,7 +137,7 @@ def test_wrap_opencode_copilot_subscription_normalizes_enterprise_host_and_hando
 
     assert result.exit_code == 0, result.output
     ensure = captured["ensure"]
-    assert ensure["openai_api_url"] == "https://api.githubcopilot.com"
+    assert ensure["openai_api_url"] == "https://api.enterprise.githubcopilot.com"
     assert ensure["copilot_api_token"] == "copilot-api-secret"
     assert ensure["copilot_refresh_oauth_token"] == "gho-oauth"
     assert ensure["copilot_api_token_expires_at"] == 123.5

--- a/tests/test_copilot_auth.py
+++ b/tests/test_copilot_auth.py
@@ -335,7 +335,8 @@ def test_subscription_enterprise_host_repro(
     assert resolution.token == "copilot-api"
     assert resolution.source == "headroom-copilot-auth:/tmp/copilot_auth.json:token-exchange"
     assert resolution.confidence == "copilot-token-exchange"
-    assert resolution.api_url == copilot_auth.DEFAULT_API_URL
+    assert resolution.api_url == "https://api.enterprise.githubcopilot.com"
+    assert resolution.advertised_api_url == "https://api.enterprise.githubcopilot.com"
     assert resolution.token_fingerprint == copilot_auth.token_fingerprint("copilot-api")
     assert resolution.refresh_oauth_token == "gho-oauth"
     assert isinstance(resolution.api_token_expires_at, float)
@@ -383,7 +384,7 @@ def test_resolve_subscription_exchange_uses_cloud_enterprise_advertised_api(
     resolution = copilot_auth.resolve_subscription_bearer_token_details()
 
     assert resolution is not None
-    assert resolution.api_url == copilot_auth.DEFAULT_API_URL
+    assert resolution.api_url == "https://api.enterprise.githubcopilot.com"
     assert copilot_auth._token_exchange_url() == "https://api.github.com/copilot_internal/v2/token"
 
 
@@ -404,7 +405,8 @@ def test_api_url_from_exchange_payload_rejects_non_copilot_host(
         oauth_token="gho-oauth",
     )
 
-    assert resolved == copilot_auth.DEFAULT_API_URL
+    # The foreign host is dropped; routing falls back to the host user-info advertises.
+    assert resolved == "https://api.business.githubcopilot.com"
 
 
 def _resolve_subscription_producer_path(
@@ -512,8 +514,6 @@ def test_subscription_unknown_host_passthrough(monkeypatch: pytest.MonkeyPatch) 
     [
         "https://api.githubcopilot.com",
         "https://api.individual.githubcopilot.com",
-        "https://api.business.githubcopilot.com",
-        "https://api.enterprise.githubcopilot.com",
     ],
 )
 def test_subscription_known_hosts_normalize_to_default(payload_host: str) -> None:
@@ -521,6 +521,27 @@ def test_subscription_known_hosts_normalize_to_default(payload_host: str) -> Non
         copilot_auth._subscription_api_url_from_user_info_payload(
             {"endpoints": {"api": payload_host}}
         )
+        == copilot_auth.DEFAULT_API_URL
+    )
+
+
+@pytest.mark.parametrize(
+    "payload_host",
+    [
+        "https://api.business.githubcopilot.com",
+        "https://api.enterprise.githubcopilot.com",
+    ],
+)
+def test_subscription_plan_hosts_are_honoured_unless_opted_out(
+    monkeypatch: pytest.MonkeyPatch, payload_host: str
+) -> None:
+    monkeypatch.delenv(copilot_auth.USE_ADVERTISED_HOST_ENV, raising=False)
+    payload = {"endpoints": {"api": payload_host}}
+    assert copilot_auth._subscription_api_url_from_user_info_payload(payload) == payload_host
+
+    monkeypatch.setenv(copilot_auth.USE_ADVERTISED_HOST_ENV, "0")
+    assert (
+        copilot_auth._subscription_api_url_from_user_info_payload(payload)
         == copilot_auth.DEFAULT_API_URL
     )
 

--- a/tests/test_copilot_cli_gaps.py
+++ b/tests/test_copilot_cli_gaps.py
@@ -389,23 +389,28 @@ def test_ghe_host_from_a_token_exchange_is_honoured() -> None:
     "advertised",
     ["https://api.business.githubcopilot.com", "https://api.enterprise.githubcopilot.com"],
 )
-def test_segmented_plan_hosts_normalize_by_default_and_honour_the_opt_in(
+def test_segmented_plan_hosts_are_honoured_by_default_and_normalized_on_opt_out(
     monkeypatch: pytest.MonkeyPatch, advertised: str
 ) -> None:
     payload = {"endpoints": {"api": advertised}}
+    assert copilot_auth._subscription_api_url_from_user_info_payload(payload) == advertised
+    assert copilot_auth.advertised_host_is_normalized(advertised) is False
+
+    monkeypatch.setenv(copilot_auth.USE_ADVERTISED_HOST_ENV, "0")
     assert (
         copilot_auth._subscription_api_url_from_user_info_payload(payload)
         == copilot_auth.DEFAULT_API_URL
     )
     assert copilot_auth.advertised_host_is_normalized(advertised) is True
 
-    monkeypatch.setenv(copilot_auth.USE_ADVERTISED_HOST_ENV, "1")
-    assert copilot_auth._subscription_api_url_from_user_info_payload(payload) == advertised
-    assert copilot_auth.advertised_host_is_normalized(advertised) is False
+
+@pytest.mark.parametrize("value", ["0", "false", "NO", "off"])
+def test_opt_out_spellings(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv(copilot_auth.USE_ADVERTISED_HOST_ENV, value)
+    assert copilot_auth.use_advertised_host() is False
 
 
-def test_explicit_pin_still_beats_the_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(copilot_auth.USE_ADVERTISED_HOST_ENV, "1")
+def test_explicit_pin_still_beats_the_advertised_host(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GITHUB_COPILOT_API_URL", "https://egress.corp.example")
     assert (
         copilot_auth._subscription_api_url_from_user_info_payload(
@@ -415,11 +420,9 @@ def test_explicit_pin_still_beats_the_opt_in(monkeypatch: pytest.MonkeyPatch) ->
     )
 
 
-def test_individual_host_stays_normalized_even_with_the_opt_in(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_individual_host_stays_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
     """#610: the individual segmented host did not serve newer models."""
-    monkeypatch.setenv(copilot_auth.USE_ADVERTISED_HOST_ENV, "true")
+    monkeypatch.delenv(copilot_auth.USE_ADVERTISED_HOST_ENV, raising=False)
     assert (
         copilot_auth._subscription_api_url_from_user_info_payload(
             {"endpoints": {"api": "https://api.individual.githubcopilot.com"}}
@@ -457,14 +460,17 @@ def test_resolution_records_the_advertised_host(monkeypatch: pytest.MonkeyPatch)
     resolution = copilot_auth.resolve_subscription_bearer_token_details()
 
     assert resolution is not None
-    assert resolution.api_url == copilot_auth.DEFAULT_API_URL
+    assert resolution.api_url == "https://api.business.githubcopilot.com"
     assert resolution.advertised_api_url == "https://api.business.githubcopilot.com"
 
 
-def test_wrap_prints_the_advertised_host_notice(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_wrap_prints_the_advertised_host_notice_when_opted_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from headroom.cli import wrap as wrap_mod
     from headroom.cli.main import main
 
+    monkeypatch.setenv(copilot_auth.USE_ADVERTISED_HOST_ENV, "0")
     monkeypatch.setattr(wrap_mod.shutil, "which", lambda _name: "/usr/bin/copilot")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
     monkeypatch.setattr(
@@ -584,6 +590,7 @@ def test_subscription_lane_drops_a_durable_installs_native_hook_and_prints_the_n
 
     captured: dict[str, object] = {}
     monkeypatch.setenv(COPILOT_NATIVE_API_URL_ENV, "http://127.0.0.1:9999")
+    monkeypatch.setenv(copilot_auth.USE_ADVERTISED_HOST_ENV, "0")  # the notice fires on opt-out
     monkeypatch.setattr(wrap_mod.shutil, "which", lambda _name: "/usr/bin/copilot")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
     monkeypatch.setattr(


### PR DESCRIPTION
> **Parked.** Stacked on #3402. Do not merge until a real Business or Enterprise seat confirms the segmented host serves the models it should (see "Verification needed").

## What this changes

GitHub's token exchange advertises a per-plan chat host in `endpoints.api`: `api.business.githubcopilot.com` for Business seats and `api.enterprise.githubcopilot.com` for Enterprise seats. GitHub's own clients route with that value. Since #2441 (#2455) Headroom has folded both into the hardcoded generic `api.githubcopilot.com`, because at the time the segmented hosts returned "model not supported" for newer Claude models.

That hardcoding breaks enterprises on GitHub's subscription-based network routing, whose firewall allows only the per-plan host. They cannot reach the generic host at all, and the failure looks like a random connection error.

This PR flips the default:

- Business and Enterprise advertised hosts are honoured.
- `GITHUB_COPILOT_USE_ADVERTISED_HOST=0` (also `false`/`no`/`off`) restores the generic-host fold for seats where the segmented host still lags.
- An explicit `GITHUB_COPILOT_API_URL` or enterprise-domain pin still wins over both.
- The individual host stays normalized (#610 is unchanged).
- The launch notice from #3402 now fires only when the opt-out is active.
- GHE.com data-residency hosts were already always honoured; unchanged.

## Verification needed before un-parking

On a Business or Enterprise seat, with this branch:

```bash
headroom copilot-auth login
headroom wrap copilot --native -- --model claude-sonnet-4.6 -s -p "Reply with exactly: OK"
headroom wrap copilot --subscription -- --model claude-sonnet-4.6 -s -p "Reply with exactly: OK"
```

Both should print `COPILOT_PROVIDER_API_URL=https://api.business...` (or `api.enterprise...`) and return `OK`. If either fails with "the requested model is not supported", the #2441 condition still holds and this PR should stay parked (or become opt-in again).

## Test plan

- [x] `tests/test_copilot_auth.py`, `tests/test_copilot_cli_gaps.py`, `tests/test_copilot_auto_passthrough.py`, `tests/test_cli/test_wrap_copilot.py`, `tests/test_cli/test_copilot_auth.py`, `tests/test_cli/test_wrap_persistent.py`: pass
- [x] `tests/test_cli/test_wrap_opencode.py` subscription test updated and passing
- [x] `uvx ruff@0.16.3 format --check` and `check` clean
- [ ] Live Business or Enterprise seat run (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rSdvTck9uJAzNJ8Y2M5mx
