### PR TITLE
fix(learn): retry LLM analysis with a smaller digest when the prompt overflows the context window

### DIFF
--- a/headroom/learn/analyzer.py
+++ b/headroom/learn/analyzer.py
@@ -48,6 +48,10 @@ _MODEL_DEFAULTS: list[tuple[str, str]] = [
 ]
 
 _MAX_DIGEST_TOKENS = 80_000  # Budget for the digest (leave room for prompt + output)
+# Smallest digest budget worth retrying with after a context overflow. The
+# budget halves on each "prompt is too long" failure; below this the digest
+# carries too little signal to produce useful recommendations.
+_MIN_DIGEST_TOKENS = 10_000
 
 # CLI tools to try when no API key is set (checked in order).
 # Each entry: (binary_name, model_identifier, command_prefix). The claude-cli
@@ -187,26 +191,38 @@ class SessionAnalyzer:
         if not failed_calls and not loops and not any(s.events for s in sessions):
             return result
 
-        # Build compact digest of all sessions, leading with detected loops.
-        digest = _build_digest(project, sessions, loops=loops)
-
         # Resolve model (auto-detect if not specified)
         model = self.model or _detect_default_model()
 
-        # Call LLM for analysis
-        try:
-            raw = _call_llm(digest, model)
-            result.recommendations = _parse_llm_response(raw)
-            # Weight loop guardrails above one-off rules using MEASURED waste.
-            apply_loop_weighting(result.recommendations, loops)
-            result.recommendations.sort(key=lambda r: r.estimated_tokens_saved, reverse=True)
-        except Exception as e:
-            logger.warning("LLM analysis failed: %s", e)
-            # Preserve the stats so multi-project runs can continue, but retain
-            # the failure so the CLI cannot report an empty result as success.
-            result.analysis_error = str(e) or type(e).__name__
-
-        return result
+        # Call LLM for analysis. The digest budget only bounds our side of the
+        # prompt: CLI backends (claude -p) load the user's own context on top
+        # (CLAUDE.md, MCP tool definitions), so a full-budget digest can still
+        # overflow the model's window. On a context-overflow error, rebuild the
+        # digest at half the budget and retry.
+        budget = _MAX_DIGEST_TOKENS
+        while True:
+            # Build compact digest of all sessions, leading with detected loops.
+            digest = _build_digest(project, sessions, loops=loops, max_tokens=budget)
+            try:
+                raw = _call_llm(digest, model)
+                result.recommendations = _parse_llm_response(raw)
+                # Weight loop guardrails above one-off rules using MEASURED waste.
+                apply_loop_weighting(result.recommendations, loops)
+                result.recommendations.sort(key=lambda r: r.estimated_tokens_saved, reverse=True)
+            except Exception as e:
+                if _is_prompt_too_long(e) and budget > _MIN_DIGEST_TOKENS:
+                    budget //= 2
+                    logger.info(
+                        "Prompt too long for %s; retrying with a %d-token digest budget",
+                        model,
+                        budget,
+                    )
+                    continue
+                logger.warning("LLM analysis failed: %s", e)
+                # Preserve the stats so multi-project runs can continue, but retain
+                # the failure so the CLI cannot report an empty result as success.
+                result.analysis_error = str(e) or type(e).__name__
+            return result
 
 
 # =============================================================================
@@ -253,10 +269,32 @@ def _build_prior_patterns_section(project: ProjectInfo) -> str:
     return "\n".join(lines)
 
 
+def _is_prompt_too_long(exc: Exception) -> bool:
+    """True when *exc* signals the prompt overflowed the model's context window.
+
+    Matches the known phrasings across backends: claude CLI ("Prompt is too
+    long"), Anthropic via LiteLLM ("prompt is too long: N tokens > M maximum"),
+    OpenAI ("context_length_exceeded" / "maximum context length"), and Gemini
+    ("input token count exceeds the maximum").
+    """
+    msg = str(exc).lower()
+    return any(
+        needle in msg
+        for needle in (
+            "prompt is too long",
+            "context_length_exceeded",
+            "maximum context length",
+            "context window",
+            "token count exceeds",
+        )
+    )
+
+
 def _build_digest(
     project: ProjectInfo,
     sessions: list[SessionData],
     loops: list[LoopPattern] | None = None,
+    max_tokens: int = _MAX_DIGEST_TOKENS,
 ) -> str:
     """Build a token-efficient text digest of all session events.
 
@@ -306,7 +344,7 @@ def _build_digest(
 
     # Budget tracking — stop adding events when we approach the limit
     # Rough estimate: 4 chars per token
-    char_budget = _MAX_DIGEST_TOKENS * 4
+    char_budget = max_tokens * 4
     chars_used = sum(len(ln) for ln in lines)
 
     for session in sessions:

--- a/tests/test_learn/test_analyzer.py
+++ b/tests/test_learn/test_analyzer.py
@@ -476,6 +476,67 @@ class TestSessionAnalyzer:
         assert result.analysis_error == "API key not set"
 
     @patch("headroom.learn.analyzer._call_llm")
+    def test_retries_smaller_digest_on_prompt_too_long(self, mock_call_llm: MagicMock):
+        """A context-overflow error rebuilds the digest at half the budget and retries."""
+        mock_call_llm.side_effect = [
+            RuntimeError("`claude -p` failed (exit 1):\nPrompt is too long"),
+            {"context_file_rules": [], "memory_file_rules": []},
+        ]
+
+        analyzer = SessionAnalyzer(model="test-model")
+        sessions = [
+            SessionData(
+                session_id="s1",
+                tool_calls=[
+                    # Enough volume to overflow even the halved (40k-token) budget,
+                    # so the retry digest is visibly shorter than the first.
+                    _tc(msg_index=i, is_error=True, output="x" * 200)
+                    for i in range(2000)
+                ],
+            )
+        ]
+        result = analyzer.analyze(_project(), sessions)
+
+        assert mock_call_llm.call_count == 2
+        first_digest = mock_call_llm.call_args_list[0][0][0]
+        second_digest = mock_call_llm.call_args_list[1][0][0]
+        assert len(second_digest) < len(first_digest)
+        assert result.recommendations == []
+
+    @patch("headroom.learn.analyzer._call_llm")
+    def test_gives_up_when_min_digest_budget_still_too_long(self, mock_call_llm: MagicMock):
+        """Persistent overflow stops at the minimum budget instead of looping forever."""
+        mock_call_llm.side_effect = RuntimeError("Prompt is too long")
+
+        analyzer = SessionAnalyzer(model="test-model")
+        sessions = [
+            SessionData(
+                session_id="s1",
+                tool_calls=[_tc(msg_index=0, is_error=True, output="error")],
+            )
+        ]
+        result = analyzer.analyze(_project(), sessions)
+
+        # Budgets: 80k, 40k, 20k, 10k — then give up.
+        assert mock_call_llm.call_count == 4
+        assert result.recommendations == []
+
+    @patch("headroom.learn.analyzer._call_llm")
+    def test_non_overflow_failure_does_not_retry(self, mock_call_llm: MagicMock):
+        mock_call_llm.side_effect = RuntimeError("API key not set")
+
+        analyzer = SessionAnalyzer(model="test-model")
+        sessions = [
+            SessionData(
+                session_id="s1",
+                tool_calls=[_tc(msg_index=0, is_error=True, output="error")],
+            )
+        ]
+        analyzer.analyze(_project(), sessions)
+
+        mock_call_llm.assert_called_once()
+
+    @patch("headroom.learn.analyzer._call_llm")
     def test_passes_events_to_digest(self, mock_call_llm: MagicMock):
         """User messages and subagent events should appear in the digest."""
         mock_call_llm.return_value = {"context_file_rules": [], "memory_file_rules": []}


### PR DESCRIPTION
## Description

`headroom learn` dies with zero recommendations when the analysis prompt overflows the model's context window. Field report (desktop telemetry): a 4-session / 443-call scan failed with ``LLM analysis failed: `claude -p --output-format stream-json --verbose` failed (exit 1): Prompt is too long``, and the whole project's analysis was lost.

The root cause is that `_build_digest` budgets `_MAX_DIGEST_TOKENS` (80k) for the digest as if the prompt had the window to itself. CLI backends do not work that way: `claude -p` loads the user's own context on top - CLAUDE.md files, MCP tool definitions, skills. The digest budget cannot know how big that share is, and the 4-chars-per-token estimate also runs hot on dense tool-call lines. On installs with heavy context the combined prompt overflows a 200k window and the analysis fails outright, every scan, until the user's sessions age out.

The fix makes the budget adaptive instead of guessing a universally safe constant: when the backend reports a context overflow, rebuild the digest at half the budget and retry, down to a 10k-token floor (80k -> 40k -> 20k -> 10k, then give up). A truncated digest that produces recommendations beats a full digest that produces an error. Non-overflow failures are re-raised on the first attempt exactly as before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `SessionAnalyzer.analyze` wraps the LLM call in a shrinking-budget retry loop; overflow detection via new `_is_prompt_too_long(exc)`, which matches the known phrasings across backends: claude CLI ("Prompt is too long"), Anthropic via LiteLLM ("prompt is too long: N tokens > M maximum"), OpenAI ("context_length_exceeded" / "maximum context length"), Gemini ("input token count exceeds the maximum").
- `_build_digest` gains a `max_tokens` parameter (default `_MAX_DIGEST_TOKENS`, so all other callers are unchanged); the char budget derives from it.
- New `_MIN_DIGEST_TOKENS = 10_000` floor so a persistent overflow terminates after 4 attempts instead of looping.
- Tests: retry produces a strictly shorter second digest and succeeds; persistent overflow stops after the 10k floor (4 calls) and returns stats-only; non-overflow failures still fail on the first call with no retry.

## Testing

- [x] Unit tests pass (`pytest`)

### Test Output

```text
uv run --frozen --extra dev pytest tests/test_learn/ -q
216 passed, 3 skipped in 8.18s
```

## Real Behavior Proof

- Environment: macOS (arm64), Python 3.12 via uv, this branch's worktree, real `claude` CLI installed.
- Exact command / steps: Drove the real CLI through `_call_cli_llm` with oversized digests to verify the trigger end-to-end.
- Observed result: Could not force the overflow on this machine - the account resolves to a 1M-context model, so even a ~950k-token prompt succeeds (confirmed via the stream-json `result` event's `contextWindow: 1000000`). The failure is real on 200k-window installs: the field telemetry's stderr carries `Prompt is too long` verbatim, which is the exact string `_is_prompt_too_long` matches and the exact `RuntimeError` message the retry test injects through the real `analyze` -> `_call_llm` path.
- Not tested: a live end-to-end overflow against a 200k-window account (none at hand); the gemini/codex CLI phrasings are covered by the pattern list, not live runs.

## Runtime Rollout Safety

- Rollout-managed feature(s): None; `learn` is not rollout-gated.
- Minimum rollout channel: Stable.
- Stable/default behavior changed: Only on the previously-failing path: an overflow now retries with a smaller digest instead of aborting the analysis. Successful analyses are byte-identical (same budget, same digest).
- Kill switch / disable path: Not needed; a persistent overflow degrades to today's behavior (stats-only result, warning logged) after 4 attempts.
- Unsafe override required: No.
- Qualification impact: Heavy-context installs (large CLAUDE.md, many MCP servers) go from 100% learn failure to a truncated-digest analysis.
- Rollback path: Revert the commit; no persisted formats touched.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
