### PR TITLE
fix(codex): preserve remote compaction in init config

### DIFF
--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -332,7 +332,10 @@ def _ensure_codex_provider(path: Path, port: int) -> None:
         'model_provider = "headroom"\n'
         f'openai_base_url = "http://127.0.0.1:{port}/v1"\n\n'
         "[model_providers.headroom]\n"
-        'name = "Headroom init proxy"\n'
+        # Codex derives remote-compaction support from the provider display
+        # name. Keep the proxy's provider id as ``headroom`` for routing, but
+        # use the built-in OpenAI name so the capability is preserved.
+        'name = "OpenAI"\n'
         f'base_url = "http://127.0.0.1:{port}/v1"\n'
         "supports_websockets = true\n"
         f"{requires_openai_auth}"

--- a/tests/test_cli/test_init_cli.py
+++ b/tests/test_cli/test_init_cli.py
@@ -228,6 +228,7 @@ def test_init_codex_creates_hooks_feature_flag_on_first_init(
     parsed = tomllib.loads(content)
     assert parsed["model_provider"] == "headroom"
     assert parsed["features"]["hooks"] is True
+    assert parsed["model_providers"]["headroom"]["name"] == "OpenAI"
     assert "codex_hooks" not in content
 
 


### PR DESCRIPTION
## Description

Closes #3407.

`headroom init codex` writes a custom provider named `Headroom init proxy`. Codex 0.152.1 derives remote-compaction capability from the provider display name, so this configuration routes ordinary Responses traffic through Headroom but silently falls back to local compaction.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (breaking change that changes existing functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Keep the `headroom` provider id and loopback URLs unchanged for routing.
- Emit the built-in `OpenAI` provider display name so Codex retains its remote-compaction capability detection.
- Add a regression assertion covering the generated Codex configuration.

## Testing

- [x] Focused unit tests pass (`tests/test_cli/test_init_cli.py`)
- [x] Focused linting passes (`ruff check`)
- [x] Focused formatting passes (`ruff format --check`)
- [x] New regression coverage added
- [ ] Full test suite
- [ ] Live Codex 0.152.1 compaction run

### Test Output

```text
PYTHONPATH=. python -m pytest tests/test_cli/test_init_cli.py -q
73 passed in 22.15s

ruff check headroom/cli/init.py tests/test_cli/test_init_cli.py
All checks passed!

ruff format --check headroom/cli/init.py tests/test_cli/test_init_cli.py
2 files already formatted
```

The repository's documented `uv run --frozen --extra dev` setup was also attempted, but dependency resolution stopped while building `hnswlib==0.8.0`: its build environment raised `AttributeError: module 'pkgutil' has no attribute 'ImpImporter'`. The focused tests and checks ran successfully with the already-installed Python 3.11 environment.

## Real Behavior Proof

- Environment: Windows 10, Python 3.11.9, generated temporary Codex configuration.
- Exact command / steps: invoked `_ensure_codex_provider` against a temporary config with port `8787`, parsed the result with Python `tomllib`, and checked the provider id, display name, and loopback base URL.
- Observed result: the generated `[model_providers.headroom]` section contains `name = "OpenAI"`, `base_url = "http://127.0.0.1:8787/v1"`, and `supports_websockets = true`; the root `model_provider` remains `headroom`.
- Not tested: a live Codex 0.152.1 session against `/v1/responses/compact`, because Codex 0.152.1 is not installed in this environment.

## Runtime Rollout Safety

- Rollout-managed feature(s): None.
- Minimum rollout channel: Stable; this only changes the generated display name for new or regenerated init configurations.
- Stable/default behavior changed: Codex-initialized Headroom configurations now advertise the OpenAI-compatible capability name expected by Codex while preserving the existing Headroom routing id and URLs.
- Kill switch / disable path: Run `headroom unwrap codex` or revert the generated config.
- Unsafe override required: No.
- Qualification impact: Existing generated configs need to be regenerated with `headroom init codex` to receive the corrected name.
- Rollback path: Revert this commit.

## Review Readiness

- [x] I have performed a self-review
- [ ] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] Focused unit tests pass locally
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

The provider remains registered as `headroom`; only its display name changes. This preserves Headroom's proxy URLs, WebSocket setting, and conditional `requires_openai_auth` behavior for both ChatGPT OAuth and API-key users.
