### PR TITLE
fix(binaries): align codebase-memory-mcp platform keys

### DIFF
--- a/headroom/tools.json
+++ b/headroom/tools.json
@@ -105,22 +105,22 @@
       "source": "DeusData/codebase-memory-mcp",
       "_comment": "No Windows build published for v0.8.1.",
       "assets": {
-        "darwin-arm64": {
+        "darwin-aarch64": {
           "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-darwin-arm64.tar.gz",
           "member": "codebase-memory-mcp",
           "sha256": "fbd047509852021b5446a11141bcb0a3d1dcaebf6e5112460960f29f052c1c58"
         },
-        "darwin-amd64": {
+        "darwin-x86_64": {
           "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-darwin-amd64.tar.gz",
           "member": "codebase-memory-mcp",
           "sha256": "fb62da3016ea12b948351208759b5c083fb1446cf6e78d6db8b7cd28fe86fd54"
         },
-        "linux-arm64": {
+        "linux-aarch64-gnu": {
           "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-linux-arm64.tar.gz",
           "member": "codebase-memory-mcp",
           "sha256": "d2f842d1365da5c35d9c5796f57a821c9745267350994346735e1e6e04d46091"
         },
-        "linux-amd64": {
+        "linux-x86_64-gnu": {
           "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-linux-amd64.tar.gz",
           "member": "codebase-memory-mcp",
           "sha256": "dbd3b92ea870ef240b63059f26bda15015f76ef9978931bebc3a0f9d09470973"

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -138,6 +138,15 @@ def test_unsupported_platform_raises(monkeypatch):
         binaries._asset_for_platform("difft", binaries.detect_platform())
 
 
+def test_codebase_memory_mcp_uses_platform_key_names():
+    for platform, asset_suffix in (
+        (binaries.PlatformKey("darwin", "aarch64", "n/a"), "darwin-arm64"),
+        (binaries.PlatformKey("linux", "aarch64", "gnu"), "linux-arm64"),
+    ):
+        asset = binaries._asset_for_platform("codebase-memory-mcp", platform)
+        assert asset["url"].endswith(f"codebase-memory-mcp-{asset_suffix}.tar.gz")
+
+
 def test_pypi_only_tool_raises_with_helpful_message(monkeypatch):
     _set_platform(monkeypatch, sys_plat="darwin", machine="arm64")
     with pytest.raises(binaries.PlatformNotSupported) as exc:


### PR DESCRIPTION
## Description

Fixes #3409.

`codebase-memory-mcp` release filenames use Go architecture names, while the bundled binary registry is indexed by `PlatformKey.key()`. The manifest used the release names as registry keys, so the generic resolver skipped the available Darwin and glibc Linux assets. This aligns the registry keys without changing download URLs or SHA-256 pins.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Normalize the four `codebase-memory-mcp` registry keys to the existing `PlatformKey` convention.
- Add regression coverage for Darwin and Linux ARM64 resolution.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
uv run --frozen pytest tests/test_binaries.py -q
23 passed in 2.22s

uv run --frozen ruff check tests/test_binaries.py
All checks passed!

uv run --frozen ruff format --check tests/test_binaries.py
1 file already formatted
```

## Real Behavior Proof

- Environment: macOS on Apple Silicon, Python 3.13.14.
- Exact command / steps: resolved `codebase-memory-mcp` through `binaries._asset_for_platform("codebase-memory-mcp", binaries.detect_platform())`.
- Observed result: before, `darwin-aarch64` reported no prebuilt binary. After, it resolves `codebase-memory-mcp-darwin-arm64.tar.gz` from the pinned v0.8.1 release.
- Not tested: a network download or proxy startup. The direct resolver is the production manifest lookup used before fetching.

## Runtime Rollout Safety

- Rollout-managed feature(s): None.
- Minimum rollout channel: Standard release.
- Stable/default behavior changed: `ensure_tools()` can resolve the already-published `codebase-memory-mcp` binary on supported Darwin and glibc Linux platforms instead of skipping it.
- Kill switch / disable path: `HEADROOM_BINARIES_OFFLINE=1` retains the existing no-download path.
- Unsafe override required: No.
- Qualification impact: Existing proxy startup can install the pinned binary without a manifest change by users.
- Rollback path: Revert this change; the resolver returns to treating these manifest entries as unsupported.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A: manifest-key rename and focused regression test)
- [ ] I have made corresponding changes to the documentation (N/A: no public interface or documentation changes)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

The existing generic binary resolver continues to reject Linux musl because this release has no musl asset entry.
