### PR TITLE
fix(read-maturation): book matured Read savings once, not on every replay

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -2307,7 +2307,17 @@ class AnthropicHandlerMixin:
                             maturation.holding_msg_indices,
                         )
                         optimized_tokens = tokenizer.count_messages(optimized_messages)
-                        tokens_saved = max(0, original_tokens - optimized_tokens)
+                        # First-appearance accounting: the client re-sends
+                        # the raw conversation every turn, so this diff
+                        # re-books every replayed marker's removal on every
+                        # request until end of session. Subtract the
+                        # replayed share, tokenized on the same scale as
+                        # the diff; matured content books exactly once, on
+                        # the turn it matures.
+                        replay_debt = maturation_mgr.replayed_token_debt(
+                            maturation, tokenizer.count_text
+                        )
+                        tokens_saved = max(0, original_tokens - optimized_tokens - replay_debt)
                         if maturation.newly_matured:
                             transforms_applied.append(f"read_maturation:{maturation.newly_matured}")
                         logger.debug(
@@ -2315,6 +2325,7 @@ class AnthropicHandlerMixin:
                             f"holding={len(maturation.holding_msg_indices)} "
                             f"matured={maturation.newly_matured} "
                             f"replayed={maturation.replacements_applied} "
+                            f"replay_debt={replay_debt} "
                             f"bytes_saved={maturation.bytes_saved}"
                         )
                 except Exception as e:

--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -2277,6 +2277,11 @@ class AnthropicHandlerMixin:
             # request. Session state (matured markers) rides on the
             # prefix tracker — same affinity and TTL cleanup as the
             # freeze state. Advisory: must never fail the request.
+            # Bound when maturation runs, so the final accounting step below
+            # can charge this request's replayed-marker debt. Every earlier
+            # `tokens_saved` assignment is overwritten by that recount, so the
+            # adjustment belongs there and nowhere else.
+            _maturation_mgr = None
             if self.config.read_maturation and not _bypass:
                 try:
                     from headroom.config import ReadMaturationConfig
@@ -2297,6 +2302,7 @@ class AnthropicHandlerMixin:
                             compression_store=get_compression_store(),
                         )
                         prefix_tracker.read_maturation_manager = maturation_mgr
+                    _maturation_mgr = maturation_mgr
                     maturation = maturation_mgr.apply(
                         optimized_messages,
                         frozen_message_count=frozen_message_count,
@@ -2307,17 +2313,7 @@ class AnthropicHandlerMixin:
                             maturation.holding_msg_indices,
                         )
                         optimized_tokens = tokenizer.count_messages(optimized_messages)
-                        # First-appearance accounting: the client re-sends
-                        # the raw conversation every turn, so this diff
-                        # re-books every replayed marker's removal on every
-                        # request until end of session. Subtract the
-                        # replayed share, tokenized on the same scale as
-                        # the diff; matured content books exactly once, on
-                        # the turn it matures.
-                        replay_debt = maturation_mgr.replayed_token_debt(
-                            maturation, tokenizer.count_text
-                        )
-                        tokens_saved = max(0, original_tokens - optimized_tokens - replay_debt)
+                        tokens_saved = max(0, original_tokens - optimized_tokens)
                         if maturation.newly_matured:
                             transforms_applied.append(f"read_maturation:{maturation.newly_matured}")
                         logger.debug(
@@ -2325,7 +2321,6 @@ class AnthropicHandlerMixin:
                             f"holding={len(maturation.holding_msg_indices)} "
                             f"matured={maturation.newly_matured} "
                             f"replayed={maturation.replacements_applied} "
-                            f"replay_debt={replay_debt} "
                             f"bytes_saved={maturation.bytes_saved}"
                         )
                 except Exception as e:
@@ -3188,7 +3183,27 @@ class AnthropicHandlerMixin:
                 if 0 < _tool_tokens_after < _tool_tokens_before:
                     original_tokens += _tool_tokens_before
                     optimized_tokens += _tool_tokens_after
-                tokens_saved = max(0, original_tokens - optimized_tokens)
+                # First-appearance accounting for matured Reads. The client
+                # re-sends the raw conversation every turn, so this diff would
+                # otherwise re-book a matured Read's removal on every request
+                # until end of session. Charged here, on the request's real
+                # endpoints, because after maturation the marker usually
+                # reaches the wire through the cached-prefix replay rather than
+                # through the maturation pass — and because every earlier
+                # `tokens_saved` assignment is overwritten right here.
+                # tok_before/tok_after stay the honest wire counts; only the
+                # booked saving is first-appearance.
+                _replay_debt = 0
+                if _maturation_mgr is not None:
+                    try:
+                        _replay_debt = _maturation_mgr.replayed_token_debt(
+                            _orig_snapshot, optimized_messages, tokenizer.count_text
+                        )
+                    except Exception:
+                        # Advisory, like the maturation pass itself: a failure
+                        # here must not skip the recount around it.
+                        logger.debug("maturation replay debt skipped", exc_info=True)
+                tokens_saved = max(0, original_tokens - optimized_tokens - _replay_debt)
                 # Attribute the fold to the hook ONLY when the hook itself reduced
                 # tokens (same-tokenizer pre vs post) — not when the recount above
                 # merely normalized a cross-estimator scale difference.

--- a/headroom/transforms/read_maturation.py
+++ b/headroom/transforms/read_maturation.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -100,6 +101,13 @@ class MaturationResult:
     newly_matured: int = 0
     replacements_applied: int = 0
     bytes_saved: int = 0
+    # Replays of markers recorded on EARLIER requests, as
+    # (tool_call_id, original_content, marker). A handler's plain
+    # original-vs-optimized token diff re-books these already-booked
+    # savings on every request -- feed to
+    # ReadMaturationManager.replayed_token_debt to keep the request's
+    # figure first-appearance.
+    replayed_pairs: list[tuple[str, str, str]] = field(default_factory=list)
 
 
 class ReadMaturationManager:
@@ -118,6 +126,9 @@ class ReadMaturationManager:
         self.config = config
         self.store = compression_store
         self._matured: dict[str, MaturedRead] = {}
+        # tool_call_id -> token delta of its replayed marker, tokenized
+        # once per session (content and marker are stable per tool call).
+        self._replay_token_deltas: dict[str, int] = {}
 
     # ─── Per-request entry point ────────────────────────────────────────
 
@@ -158,6 +169,36 @@ class ReadMaturationManager:
         if any_changed:
             result.messages = out
         return result
+
+    def replayed_token_debt(
+        self,
+        result: MaturationResult,
+        count_text: Callable[[str], int],
+    ) -> int:
+        """Tokens this request re-saved by replaying markers recorded on
+        EARLIER requests.
+
+        The client re-sends the raw conversation every turn, so a plain
+        original-vs-optimized token diff books a matured Read's removal
+        again on every replay until end of session; one long session
+        inflated its new-content savings rate from 31.8% to 78.15% the
+        day maturation turned on, with no new removal behind the jump.
+        Subtracting this debt makes the figure first-appearance: matured
+        content books exactly once, on the turn it matures. Newly-matured
+        replacements are not replays and stay fully booked.
+
+        ``count_text`` should be the tokenizer the handler uses for its
+        diff, so the subtraction is on the booked scale. Deltas are
+        tokenized once per tool call and cached for the session.
+        """
+        debt = 0
+        for tc_id, content, marker in result.replayed_pairs:
+            delta = self._replay_token_deltas.get(tc_id)
+            if delta is None:
+                delta = max(0, count_text(content) - count_text(marker))
+                self._replay_token_deltas[tc_id] = delta
+            debt += delta
+        return debt
 
     # ─── Internals ──────────────────────────────────────────────────────
 
@@ -272,6 +313,10 @@ class ReadMaturationManager:
                 return None, False
             result.replacements_applied += 1
             result.bytes_saved += max(0, len(content) - len(matured.marker))
+            # This Read's savings were booked by the request that matured
+            # it; report the replay so the handler can subtract it from
+            # this request's token diff (replayed_token_debt).
+            result.replayed_pairs.append((tc_id, content, matured.marker))
             return matured.marker, False
 
         size = len(content.encode("utf-8", errors="replace"))

--- a/headroom/transforms/read_maturation.py
+++ b/headroom/transforms/read_maturation.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -101,13 +101,26 @@ class MaturationResult:
     newly_matured: int = 0
     replacements_applied: int = 0
     bytes_saved: int = 0
-    # Replays of markers recorded on EARLIER requests, as
-    # (tool_call_id, original_content, marker). A handler's plain
-    # original-vs-optimized token diff re-books these already-booked
-    # savings on every request -- feed to
-    # ReadMaturationManager.replayed_token_debt to keep the request's
-    # figure first-appearance.
-    replayed_pairs: list[tuple[str, str, str]] = field(default_factory=list)
+
+
+def _iter_tool_results(messages: list[dict[str, Any]]) -> Iterator[tuple[str, str]]:
+    """(tool_call_id, content) for every string tool result, both formats."""
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        if msg.get("role") == "tool":
+            if isinstance(content, str):
+                yield str(msg.get("tool_call_id", "")), content
+            continue
+        if isinstance(content, list):
+            for b in content:
+                if (
+                    isinstance(b, dict)
+                    and b.get("type") == "tool_result"
+                    and isinstance(b.get("content"), str)
+                ):
+                    yield str(b.get("tool_use_id", "")), b["content"]
 
 
 class ReadMaturationManager:
@@ -126,6 +139,8 @@ class ReadMaturationManager:
         self.config = config
         self.store = compression_store
         self._matured: dict[str, MaturedRead] = {}
+        # tool_call_ids whose removal has already been booked as savings.
+        self._booked: set[str] = set()
         # tool_call_id -> token delta of its replayed marker, tokenized
         # once per session (content and marker are stable per tool call).
         self._replay_token_deltas: dict[str, int] = {}
@@ -172,30 +187,51 @@ class ReadMaturationManager:
 
     def replayed_token_debt(
         self,
-        result: MaturationResult,
+        original_messages: list[dict[str, Any]],
+        outbound_messages: list[dict[str, Any]],
         count_text: Callable[[str], int],
     ) -> int:
-        """Tokens this request re-saved by replaying markers recorded on
-        EARLIER requests.
+        """Tokens this request re-saved by re-removing content whose removal
+        was already booked on an EARLIER request.
 
         The client re-sends the raw conversation every turn, so a plain
         original-vs-optimized token diff books a matured Read's removal
-        again on every replay until end of session; one long session
+        again on every request until end of session; one long session
         inflated its new-content savings rate from 31.8% to 78.15% the
         day maturation turned on, with no new removal behind the jump.
         Subtracting this debt makes the figure first-appearance: matured
-        content books exactly once, on the turn it matures. Newly-matured
-        replacements are not replays and stay fully booked.
+        content books exactly once, on the turn it matures.
 
-        ``count_text`` should be the tokenizer the handler uses for its
-        diff, so the subtraction is on the booked scale. Deltas are
-        tokenized once per tool call and cached for the session.
+        Measured on the request's own endpoints (the raw client snapshot
+        vs what is actually forwarded) rather than on this pass's
+        replacements, because after a Read matures its marker usually
+        reaches the wire through the cached-prefix replay instead of
+        through :meth:`apply` — the replacement this manager makes is
+        only one of the paths that re-remove it.
+
+        Call this ONCE per request, on the final outbound messages:
+        the first booking is recorded as a side effect, so a second call
+        would charge the request for its own first appearance.
+        ``count_text`` should be the tokenizer the caller diffs with, so
+        the subtraction lands on the booked scale. Deltas are tokenized
+        once per tool call and cached for the session.
         """
+        if not self._matured:
+            return 0
+        forwarded = dict(_iter_tool_results(outbound_messages))
         debt = 0
-        for tc_id, content, marker in result.replayed_pairs:
+        for tc_id, content in _iter_tool_results(original_messages):
+            matured = self._matured.get(tc_id)
+            if matured is None or forwarded.get(tc_id) != matured.marker:
+                continue  # not replaced on the wire this request
+            if content == matured.marker:
+                continue  # the client already held the marker: nothing removed
+            if tc_id not in self._booked:
+                self._booked.add(tc_id)  # first appearance: books in full
+                continue
             delta = self._replay_token_deltas.get(tc_id)
             if delta is None:
-                delta = max(0, count_text(content) - count_text(marker))
+                delta = max(0, count_text(content) - count_text(matured.marker))
                 self._replay_token_deltas[tc_id] = delta
             debt += delta
         return debt
@@ -313,10 +349,6 @@ class ReadMaturationManager:
                 return None, False
             result.replacements_applied += 1
             result.bytes_saved += max(0, len(content) - len(matured.marker))
-            # This Read's savings were booked by the request that matured
-            # it; report the replay so the handler can subtract it from
-            # this request's token diff (replayed_token_debt).
-            result.replayed_pairs.append((tc_id, content, matured.marker))
             return matured.marker, False
 
         size = len(content.encode("utf-8", errors="replace"))

--- a/tests/test_read_maturation.py
+++ b/tests/test_read_maturation.py
@@ -351,3 +351,70 @@ class TestBreakpointRelocation:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestFirstAppearanceAccounting:
+    """A matured Read's savings must book once, on the turn it matures.
+
+    The client re-sends the raw conversation every turn, so the handler's
+    original-vs-optimized diff re-counts a replayed marker's removal on
+    every request until end of session; replayed_pairs plus
+    replayed_token_debt exist so the handler can subtract that share.
+    """
+
+    def _mature_then_replay(self):
+        m = manager(quiesce_turns=5)
+        msgs = [*base_conv(), *quiet(5)]
+        r1 = m.apply(msgs)
+        assert r1.newly_matured == 1
+        # Next request: the client re-sends the raw form.
+        r2 = m.apply(msgs)
+        return m, r1, r2
+
+    def test_newly_matured_is_not_a_replay(self):
+        _, r1, _ = self._mature_then_replay()
+        assert r1.replayed_pairs == []
+
+    def test_replay_reports_the_pair(self):
+        _, r1, r2 = self._mature_then_replay()
+        marker = read_content(r1)
+        assert r2.replayed_pairs == [("r1", CONTENT, marker)]
+
+    def test_marker_echo_is_not_a_replay(self):
+        m, r1, _ = self._mature_then_replay()
+        # Client echoes the marker form back verbatim: nothing is
+        # replaced, so nothing was re-saved.
+        r3 = m.apply(r1.messages)
+        assert r3.replayed_pairs == []
+        assert r3.replacements_applied == 0
+
+    def test_debt_is_tokenized_once_and_summed(self):
+        m, _, r2 = self._mature_then_replay()
+        calls = []
+
+        def count(text: str) -> int:
+            calls.append(text)
+            return len(text)
+
+        marker = r2.replayed_pairs[0][2]
+        expected = len(CONTENT) - len(marker)
+        assert m.replayed_token_debt(r2, count) == expected
+        assert len(calls) == 2  # content + marker, once
+        # Cached: the same replay on the next request tokenizes nothing.
+        assert m.replayed_token_debt(r2, count) == expected
+        assert len(calls) == 2
+
+    def test_replay_request_nets_zero_savings(self):
+        m, _, r2 = self._mature_then_replay()
+        # With a compositional counter, the handler's diff on the replay
+        # request equals exactly the replayed share, so first-appearance
+        # accounting books zero new savings for it.
+        diff = len(CONTENT) - len(read_content(r2))
+        debt = m.replayed_token_debt(r2, len)
+        assert diff == debt
+        assert max(0, diff - debt) == 0
+
+    def test_empty_result_has_zero_debt(self):
+        m = manager()
+        res = m.apply(base_conv())
+        assert m.replayed_token_debt(res, len) == 0

--- a/tests/test_read_maturation.py
+++ b/tests/test_read_maturation.py
@@ -356,65 +356,76 @@ if __name__ == "__main__":
 class TestFirstAppearanceAccounting:
     """A matured Read's savings must book once, on the turn it matures.
 
-    The client re-sends the raw conversation every turn, so the handler's
-    original-vs-optimized diff re-counts a replayed marker's removal on
-    every request until end of session; replayed_pairs plus
-    replayed_token_debt exist so the handler can subtract that share.
+    The client re-sends the raw conversation every turn, so a plain
+    original-vs-optimized token diff re-counts the same removal on every
+    later request. ``replayed_token_debt`` measures that from the
+    request's own endpoints — raw client snapshot vs forwarded messages —
+    rather than from what ``apply`` replaced, because after maturation
+    the marker normally reaches the wire through the cached-prefix replay
+    and ``apply`` replaces nothing at all.
     """
 
-    def _mature_then_replay(self):
+    def _matured(self):
+        """Returns (manager, raw client messages, forwarded messages)."""
         m = manager(quiesce_turns=5)
-        msgs = [*base_conv(), *quiet(5)]
-        r1 = m.apply(msgs)
-        assert r1.newly_matured == 1
-        # Next request: the client re-sends the raw form.
-        r2 = m.apply(msgs)
-        return m, r1, r2
+        raw = [*base_conv(), *quiet(5)]
+        res = m.apply(raw)
+        assert res.newly_matured == 1
+        return m, raw, res.messages
 
-    def test_newly_matured_is_not_a_replay(self):
-        _, r1, _ = self._mature_then_replay()
-        assert r1.replayed_pairs == []
+    @staticmethod
+    def _marker(sent):
+        return sent[2]["content"][0]["content"]
 
-    def test_replay_reports_the_pair(self):
-        _, r1, r2 = self._mature_then_replay()
-        marker = read_content(r1)
-        assert r2.replayed_pairs == [("r1", CONTENT, marker)]
+    def test_first_appearance_books_in_full(self):
+        m, raw, sent = self._matured()
+        assert m.replayed_token_debt(raw, sent, len) == 0
+
+    def test_later_request_is_charged_even_without_a_replacement(self):
+        # The second call passes the same forwarded form WITHOUT running
+        # apply again: that is the cached-prefix replay, the path that
+        # actually re-books the removal in production.
+        m, raw, sent = self._matured()
+        m.replayed_token_debt(raw, sent, len)
+        expected = len(CONTENT) - len(self._marker(sent))
+        assert m.replayed_token_debt(raw, sent, len) == expected
 
     def test_marker_echo_is_not_a_replay(self):
-        m, r1, _ = self._mature_then_replay()
-        # Client echoes the marker form back verbatim: nothing is
-        # replaced, so nothing was re-saved.
-        r3 = m.apply(r1.messages)
-        assert r3.replayed_pairs == []
-        assert r3.replacements_applied == 0
+        # The client echoes the marker form back: nothing was removed this
+        # request, so there is nothing to un-book.
+        m, _, sent = self._matured()
+        assert m.replayed_token_debt(sent, sent, len) == 0
 
-    def test_debt_is_tokenized_once_and_summed(self):
-        m, _, r2 = self._mature_then_replay()
+    def test_unchanged_wire_form_is_not_a_replay(self):
+        # Forwarded verbatim (maturation state lost, hold re-established):
+        # no removal on the wire, no debt.
+        m, raw, _ = self._matured()
+        assert m.replayed_token_debt(raw, raw, len) == 0
+
+    def test_delta_is_tokenized_once_per_tool_call(self):
+        m, raw, sent = self._matured()
+        m.replayed_token_debt(raw, sent, len)
         calls = []
 
         def count(text: str) -> int:
             calls.append(text)
             return len(text)
 
-        marker = r2.replayed_pairs[0][2]
-        expected = len(CONTENT) - len(marker)
-        assert m.replayed_token_debt(r2, count) == expected
+        expected = len(CONTENT) - len(self._marker(sent))
+        assert m.replayed_token_debt(raw, sent, count) == expected
         assert len(calls) == 2  # content + marker, once
-        # Cached: the same replay on the next request tokenizes nothing.
-        assert m.replayed_token_debt(r2, count) == expected
-        assert len(calls) == 2
+        assert m.replayed_token_debt(raw, sent, count) == expected
+        assert len(calls) == 2  # cached for the session
 
     def test_replay_request_nets_zero_savings(self):
-        m, _, r2 = self._mature_then_replay()
-        # With a compositional counter, the handler's diff on the replay
-        # request equals exactly the replayed share, so first-appearance
-        # accounting books zero new savings for it.
-        diff = len(CONTENT) - len(read_content(r2))
-        debt = m.replayed_token_debt(r2, len)
-        assert diff == debt
-        assert max(0, diff - debt) == 0
+        # With a compositional counter the diff on a replay request equals
+        # exactly the debt, so first-appearance accounting books nothing new.
+        m, raw, sent = self._matured()
+        m.replayed_token_debt(raw, sent, len)
+        diff = len(CONTENT) - len(self._marker(sent))
+        assert max(0, diff - m.replayed_token_debt(raw, sent, len)) == 0
 
-    def test_empty_result_has_zero_debt(self):
+    def test_nothing_matured_has_zero_debt(self):
         m = manager()
         res = m.apply(base_conv())
-        assert m.replayed_token_debt(res, len) == 0
+        assert m.replayed_token_debt(base_conv(), res.messages, len) == 0

--- a/tests/test_read_maturation_handler_nobust.py
+++ b/tests/test_read_maturation_handler_nobust.py
@@ -248,9 +248,15 @@ def test_verbatim_read_never_cache_written_before_maturation(monkeypatch):
     )
 
 
-def _drive_session(config, n_turns: int, session_id: str) -> list[list[dict]]:
+def _drive_session(
+    config,
+    n_turns: int,
+    session_id: str,
+    saved_out: list[int] | None = None,
+) -> list[list[dict]]:
     """Drive ``n_turns`` cumulative turns through the real handler with a mocked
-    upstream; return the forwarded message arrays per turn."""
+    upstream; return the forwarded message arrays per turn. When ``saved_out``
+    is given, each turn's emitted ``x-headroom-tokens-saved`` is appended to it."""
     app = create_app(config)
     forwarded: list[list[dict]] = []
     with TestClient(app) as client:
@@ -303,6 +309,8 @@ def _drive_session(config, n_turns: int, session_id: str) -> list[list[dict]]:
                     },
                 )
                 assert r.status_code == 200, f"turn {n}: {r.text[:300]}"
+                if saved_out is not None:
+                    saved_out.append(int(r.headers.get("x-headroom-tokens-saved", 0)))
         finally:
             proxy._retry_request = original_retry
     return forwarded
@@ -386,3 +394,47 @@ def test_read_maturation_env_cannot_bypass_stable_rollout(monkeypatch):
     assert cfg.read_maturation is False
     assert cfg.rollout is not None
     assert cfg.rollout.decision("read_maturation").reason.value == "blocked_by_channel"
+
+
+def test_replayed_marker_is_not_rebooked_in_the_emitted_savings(monkeypatch):
+    """The savings a request EMITS must be first-appearance.
+
+    Subtracting the replay debt inside the maturation block is not enough on
+    its own: the handler recomputes ``tokens_saved`` from the plain
+    original-vs-optimized diff twice more before the outcome is recorded (the
+    pre-send hook recount and the consistency recount), and either one throws
+    the adjustment away — so every replay turn re-books a removal that was
+    already booked when the Read matured. Assert on the emitted header, which
+    is the same figure the outcome and PERF line carry, not on the manager.
+    """
+    from headroom.cache.compression_store import reset_compression_store
+
+    monkeypatch.setenv("HEADROOM_CCR_BACKEND", "memory")
+    reset_compression_store()
+
+    config = ProxyConfig(
+        optimize=True,
+        read_maturation=True,
+        read_maturation_quiesce_turns=2,
+        mode="token",
+        cache_enabled=True,
+        rate_limit_enabled=False,
+        cost_tracking_enabled=False,
+        log_requests=False,
+    )
+    saved: list[int] = []
+    forwarded = _drive_session(config, n_turns=5, session_id="first-appearance-1", saved_out=saved)
+
+    first = _first_matured_turn(forwarded)
+    assert first is not None, "the Read never matured, so there is nothing to replay"
+    replays = saved[first + 1 :]
+    assert replays, "expected at least one replay turn after maturation"
+
+    # The turn that matures the Read books its removal, once.
+    assert saved[first] > 0, "the maturing turn booked nothing"
+    # Later turns forward the same marker instead of the verbatim Read, so the
+    # wire diff is just as large — but it is the SAME removal, already booked.
+    assert max(replays) < saved[first] * 0.2, (
+        f"replayed marker re-booked through the final accounting path: "
+        f"matured turn saved {saved[first]}, replay turns saved {replays}"
+    )


### PR DESCRIPTION
## Description

Read maturation books its savings on every request instead of once. The client re-sends the raw conversation each turn, the transform replays the recorded marker each turn, and the handler's `original_tokens - optimized_tokens` diff therefore re-counts the same matured Read's removal on every request until end of session.

Measured live on one machine the day the feature was enabled (wheel 0.37.0, Claude Code traffic): `tokens.new_input_savings_percent` went 31.8% -> 78.15% same day, same workload, with no new removal behind the jump - pure replay recounting. Chart bars fed by per-request `tokens_saved` inflated the same way (1.2M "saved" in a single hour against 2.9M sent).

This PR makes the accounting first-appearance: a matured Read's savings book exactly once, on the request that matures it. The debt is measured from the request's own endpoints - the raw client snapshot vs what is actually forwarded - and charged once, at the handler's final accounting step, tokenized with the same tokenizer as the diff so the subtraction is on the booked scale. Measuring the endpoints rather than the maturation pass's own replacements matters: after a Read matures, its marker normally reaches the wire through the cached-prefix replay, so the pass replaces nothing on exactly the turns that re-book the removal. Newly-matured replacements and fresh-tail compression are untouched. Forwarded bytes are untouched - this changes what is counted, never what is sent.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ReadMaturationManager.replayed_token_debt(original_messages, outbound_messages, count_text)`: for every matured Read that the client re-sent verbatim and that is forwarded as its marker, books the removal on first appearance (`_booked`) and charges the token delta on every request after that. Deltas are tokenized once per tool call and cached (`_replay_token_deltas`). Marker echoes and unchanged wire forms are not replays.
- `_iter_tool_results`: module-level walk over tool results in both the Anthropic block and OpenAI `role="tool"` shapes, used on both endpoints.
- Anthropic handler: charges the debt exactly once, in the final consistency recount that produces the recorded `tokens_saved` - the pre-send hook and the maturation block both recompute the plain diff before it, so any adjustment made earlier is overwritten. `tok_before`/`tok_after` stay the honest wire counts; only the booked saving is first-appearance. The call is advisory (guarded), so a failure cannot skip the recount around it.
- Tests: `TestFirstAppearanceAccounting` - first appearance books in full, later requests charged without a replacement (the cached-prefix replay path), marker echo and unchanged wire form excluded, tokenize-once caching, replay request nets zero, nothing-matured zero debt. Handler-level `test_replayed_marker_is_not_rebooked_in_the_emitted_savings` drives a 5-turn session through the real handler and asserts on the emitted `x-headroom-tokens-saved`.

## Testing

- [x] Unit tests pass (`pytest`)

### Test Output

```text
uv run --frozen --extra dev pytest tests/test_read_maturation.py tests/test_read_maturation_handler_nobust.py tests/test_cache_ttl_preserved.py
39 passed, 1 warning in 4.88s

uv run --frozen --extra dev pytest tests/ -k "maturation or anthropic"
580 passed, 34 skipped, 11868 deselected, 2 warnings in 90.43s
```

## Real Behavior Proof

- Environment: macOS 15 (arm64), Python 3.11, uv --frozen dev env; live measurement on a desktop deployment of wheel 0.37.0 carrying this patch's arithmetic as a sitecustomize shim, Claude Code traffic.
- Exact command / steps: enabled read_maturation fleet-side for one day, sampled `GET /stats` `tokens.new_input_savings_percent` before and after on the same machine and workload. Then, in-tree, drove a 5-turn session (quiesce_turns=2) through the real Anthropic handler with a mocked upstream that reports honest cache usage, and read the emitted `x-headroom-tokens-saved` and `x-headroom-transforms` per turn, before and after the fix.
- Observed result: rate inflated 31.8% -> 78.15% the day maturation turned on with no new removal. Handler-level, before the fix: saved = [0, 0, 11863, 11863, 11863] - the Read matures on turn 2 and turns 3 and 4 book its removal again with `transforms=router:noop`, i.e. the marker reached the wire through the prefix replay and the maturation pass reported no replay at all. After the fix: saved = [0, 0, 11863, 0, 0], with `x-headroom-tokens-before` unchanged (11974 -> 12018 across the same turns). Reverting only the subtraction turns the new handler test red.
- Not tested: multi-worker deployments (session-state stickiness constraint unchanged); OpenAI-format request paths (maturation is only wired into the Anthropic handler).

## Runtime Rollout Safety

- Rollout-managed feature(s): read_maturation (accounting correction inside the existing feature; no new feature).
- Minimum rollout channel: Beta (unchanged - inherits the feature's existing gate).
- Stable/default behavior changed: No. The feature is flag-gated default-off; with it off this code never runs, and with it on only the reported `tokens_saved` changes - forwarded bytes are identical.
- Kill switch / disable path: disabling read_maturation disables this with it; the accounting has no independent switch because it must never diverge from the transform it describes.
- Unsafe override required: No.
- Qualification impact: None.
- Rollback path: revert the commit; no persisted format or API surface changes.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Additional Notes

Headroom Desktop currently ships this arithmetic as a version-pinned sitecustomize shim against 0.37.0 (estimator-scale, with a lock-guarded pending bridge because it cannot reach the handler seam). Once a wheel ships this PR, that shim is deleted - the in-tree form is token-exact and needs no bridge, which is why the fix belongs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

