### PR TITLE
fix(proxy): prefer explicit proxy auth header

### DIFF
--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2624,11 +2624,18 @@ def read_proxy_token(headers: Mapping[str, str]) -> str | None:
     expected to be lowercase (Starlette's ``Headers`` is case-insensitive; the
     WebSocket middleware lowercases the raw ASGI pairs itself).
     """
+    raw = headers.get("x-headroom-proxy-token")
+    if raw is not None:
+        return str(raw) or None
+
+    # A provider credential can legitimately occupy Authorization (for example,
+    # an OAuth/subscription client). Prefer the explicit proxy header whenever
+    # it is present so that the upstream credential is not mistaken for the
+    # proxy credential.
     auth = str(headers.get("authorization") or "")
     if auth.lower().startswith("bearer "):
         return auth[7:].strip() or None
-    raw = headers.get("x-headroom-proxy-token")
-    return str(raw) if raw else None
+    return None
 
 
 class WebSocketAuthMiddleware:

--- a/tests/test_proxy_hardening.py
+++ b/tests/test_proxy_hardening.py
@@ -65,6 +65,19 @@ class TestInboundAuthToken:
             resp = c.get("/stats", headers={"X-Headroom-Proxy-Token": "s3cr3t-token"})
             assert resp.status_code != 401
 
+    def test_token_set_accepts_custom_header_with_upstream_oauth(self):
+        """The upstream OAuth bearer must not override the proxy credential."""
+        app = _make_app(proxy_token="s3cr3t-token")
+        with TestClient(app, base_url="http://testserver", client=NONLOOPBACK) as c:
+            resp = c.get(
+                "/stats",
+                headers={
+                    "Authorization": "Bearer oauth-subscription-token",
+                    "X-Headroom-Proxy-Token": "s3cr3t-token",
+                },
+            )
+            assert resp.status_code != 401
+
     def test_token_set_rejects_wrong_token(self):
         app = _make_app(proxy_token="s3cr3t-token")
         with TestClient(app, base_url="http://testserver", client=NONLOOPBACK) as c:
@@ -170,6 +183,24 @@ class TestWebSocketAuthMiddleware:
         mw = WebSocketAuthMiddleware(downstream, proxy_token="s3cr3t-token")
 
         sent = await _drive(mw, _ws_scope(headers=[("x-headroom-proxy-token", "s3cr3t-token")]))
+
+        assert downstream.called is True
+        assert not _closed_with_policy_violation(sent)
+
+    async def test_accepts_custom_header_with_upstream_oauth(self):
+        """The upstream OAuth bearer must not override the proxy credential."""
+        downstream = _SpyApp()
+        mw = WebSocketAuthMiddleware(downstream, proxy_token="s3cr3t-token")
+
+        sent = await _drive(
+            mw,
+            _ws_scope(
+                headers=[
+                    ("authorization", "Bearer oauth-subscription-token"),
+                    ("x-headroom-proxy-token", "s3cr3t-token"),
+                ]
+            ),
+        )
 
         assert downstream.called is True
         assert not _closed_with_policy_violation(sent)


### PR DESCRIPTION
## Description

Closes #3415

Claude Code OAuth/subscription requests carry a provider OAuth bearer in the `Authorization` header while the proxy token is supplied separately through `X-Headroom-Proxy-Token`. The proxy auth gate previously treated `Authorization` as the proxy credential first, so the explicit proxy token was ignored and valid requests were rejected with 401.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (breaking change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Prefer `X-Headroom-Proxy-Token` whenever it is present.
- Fall back to a bearer token in `Authorization` only when the explicit proxy header is absent.
- Add HTTP and WebSocket regression coverage for an OAuth bearer combined with the correct proxy header.

## Testing

- [x] Focused proxy hardening tests pass (`tests/test_proxy_hardening.py`)
- [x] Ruff check passes for changed files
- [x] Python syntax compilation passes for changed files
- [x] New regression tests added
- [ ] Manual testing performed against a live Claude Code OAuth session

### Test Output

```text
30 passed, 2 warnings in 31.04s
5 read_proxy_token precedence checks passed
ruff check headroom/proxy/server.py tests/test_proxy_hardening.py: All checks passed
python -m py_compile headroom/proxy/server.py tests/test_proxy_hardening.py: passed
git diff --check: passed
```

## Real Behavior Proof

- Environment: Windows 10, Python 3.12.14 test environment; proxy token `s3cr3t-token`; simulated non-loopback client.
- Exact command / steps: Ran the HTTP and WebSocket auth tests in `tests/test_proxy_hardening.py`, including requests with `Authorization: Bearer oauth-subscription-token` and `X-Headroom-Proxy-Token: s3cr3t-token`.
- Observed result: Both transports reached the downstream handler and did not return the proxy's 401 rejection when the explicit proxy header matched.
- Not tested: A live Claude Code `/login` session and a deployed non-loopback proxy.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix
- [x] New and existing focused tests pass locally
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

The explicit proxy header remains authoritative even when an upstream provider credential is present in `Authorization`; existing bearer-only proxy authentication remains supported.