### PR TITLE
feat(init): support the Antigravity CLI (headroom init -g agy)

### DIFF
--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -55,13 +55,14 @@ _GLOBAL_PROFILE = "init-user"
 _CLAUDE_HOOK_MARKER = "headroom-init-claude"
 _COPILOT_HOOK_MARKER = "headroom-init-copilot"
 _CODEX_HOOK_MARKER = "headroom-init-codex"
+_AGY_HOOK_MARKER = "headroom-init-agy"
 _CODEX_PROVIDER_MARKER_START = "# --- Headroom init provider ---"
 _CODEX_PROVIDER_MARKER_END = "# --- end Headroom init provider ---"
 _CODEX_FEATURE_MARKER_START = "# --- Headroom init features ---"
 _CODEX_FEATURE_MARKER_END = "# --- end Headroom init features ---"
-_SUPPORTED_TARGETS = ("claude", "copilot", "codex", "openclaw")
+_SUPPORTED_TARGETS = ("claude", "copilot", "codex", "openclaw", "agy")
 _LOCAL_TARGETS = {"claude", "codex"}
-_GLOBAL_TARGETS = {"claude", "copilot", "codex", "openclaw"}
+_GLOBAL_TARGETS = {"claude", "copilot", "codex", "openclaw", "agy"}
 _STARTUP_READY_TIMEOUT_SECONDS = 15
 _TOML_TABLE_HEADER_RE = re.compile(r"^[ \t]*(?:\[\[[^\]\r\n]+\]\]|\[[^\]\r\n]+\])[ \t]*(?:#.*)?$")
 _TOML_FEATURES_NAME_RE = r"(?:features|\"features\"|'features')"
@@ -131,6 +132,10 @@ def _copilot_config_path() -> Path:
 
 def _codex_hooks_path(global_scope: bool) -> Path:
     return (Path.home() if global_scope else Path.cwd()) / ".codex" / "hooks.json"
+
+
+def _agy_hooks_path() -> Path:
+    return Path.home() / ".gemini" / "config" / "hooks.json"
 
 
 def _claude_scope_path(global_scope: bool) -> Path:
@@ -248,6 +253,23 @@ def _ensure_copilot_hooks(path: Path, profile: str) -> None:
         retained.append({"type": "command", "command": command, "cwd": ".", "timeout": 15})
         hooks[event] = retained
     payload["hooks"] = hooks
+    _write_json(path, payload)
+
+
+def _ensure_agy_hooks(path: Path, profile: str) -> None:
+    """Register the Headroom keep-alive hook in Antigravity's hooks.json.
+
+    Antigravity keys hooks.json by hook name, so Headroom owns exactly one
+    entry and rewriting it in place is the whole update. Only PreInvocation
+    is installed: PreToolUse handlers must answer with a permission decision
+    and Headroom has no opinion on tool calls.
+    """
+    logger.debug("ensure agy hooks: %s (profile=%s)", path, profile)
+    payload = _json_file(path)
+    command = f"{_hook_command('--profile', profile)} --marker {_AGY_HOOK_MARKER}"
+    payload[_AGY_HOOK_MARKER] = {
+        "PreInvocation": [{"type": "command", "command": command, "timeout": 15}]
+    }
     _write_json(path, payload)
 
 
@@ -649,6 +671,12 @@ def _resolve_copilot_env(port: int, backend: str) -> dict[str, str]:
     }
 
 
+def _resolve_agy_env(port: int) -> dict[str, str]:
+    # The Antigravity CLI sends every Cloud Code Assist call to CLOUD_CODE_URL
+    # when it is set, which is what puts its traffic through Headroom.
+    return {"CLOUD_CODE_URL": f"http://127.0.0.1:{port}"}
+
+
 def _marketplace_source() -> str:
     override = os.environ.get("HEADROOM_MARKETPLACE_SOURCE")
     if override:
@@ -884,6 +912,24 @@ def _init_openclaw(*, global_scope: bool, port: int) -> None:
         raise SystemExit(result.returncode)
 
 
+def _init_agy(*, global_scope: bool, profile: str, port: int) -> None:
+    if not global_scope:
+        raise click.ClickException(
+            "Antigravity durable init currently requires -g (current-user scope)."
+        )
+    _ensure_agy_hooks(_agy_hooks_path(), profile)
+    _apply_user_env(_resolve_agy_env(port))
+    # agy runs its eligibility check against CLOUD_CODE_URL at startup, before
+    # the first model call and therefore before any hook can start the proxy:
+    # a proxy that is down makes `agy` refuse to boot. Start it here so the
+    # next launch works, and let the PreInvocation hook revive it later.
+    _ensure_profile_running(profile)
+    click.echo("Configured Antigravity CLI (user scope).")
+    click.echo(
+        "Open a new shell (CLOUD_CODE_URL is exported from your shell profile), then run agy."
+    )
+
+
 def _run_init_targets(
     *,
     targets: list[str],
@@ -923,6 +969,8 @@ def _run_init_targets(
             _init_codex(global_scope=global_scope, profile=profile, port=port)
         elif target == "openclaw":
             _init_openclaw(global_scope=global_scope, port=port)
+        elif target == "agy":
+            _init_agy(global_scope=global_scope, profile=profile, port=port)
 
     # Register the headroom MCP server with every targeted agent that has
     # a registrar implemented. Wave 1 covers Claude Code; subsequent waves
@@ -1084,6 +1132,21 @@ def init_openclaw(ctx: click.Context) -> None:
     """Install the durable OpenClaw Headroom plugin."""
     _run_init_targets(
         targets=["openclaw"],
+        global_scope=bool(_ctx_value(ctx, "global_scope")),
+        port=int(_ctx_value(ctx, "port") or 8787),
+        backend=str(_ctx_value(ctx, "backend") or "anthropic"),
+        anyllm_provider=_ctx_value(ctx, "anyllm_provider"),
+        region=_ctx_value(ctx, "region"),
+        memory=bool(_ctx_value(ctx, "memory")),
+    )
+
+
+@init.command("agy")
+@click.pass_context
+def init_agy(ctx: click.Context) -> None:
+    """Install Antigravity CLI durable hooks and provider routing."""
+    _run_init_targets(
+        targets=["agy"],
         global_scope=bool(_ctx_value(ctx, "global_scope")),
         port=int(_ctx_value(ctx, "port") or 8787),
         backend=str(_ctx_value(ctx, "backend") or "anthropic"),

--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -26,7 +26,12 @@ except ModuleNotFoundError:  # Python < 3.11
 import click
 
 from headroom.install.models import ConfigScope, InstallPreset, RuntimeKind, SupervisorKind
-from headroom.install.paths import claude_settings_path, codex_config_path, validate_profile_name
+from headroom.install.paths import (
+    claude_settings_path,
+    codex_config_path,
+    unix_user_env_targets,
+    validate_profile_name,
+)
 from headroom.install.planner import build_manifest
 from headroom.install.providers import _apply_unix_env_scope, _apply_windows_env_scope
 from headroom.install.runtime import (
@@ -912,21 +917,36 @@ def _init_openclaw(*, global_scope: bool, port: int) -> None:
         raise SystemExit(result.returncode)
 
 
+def _ensure_agy_launcher(profile: str) -> None:
+    """Start the proxy before Antigravity's startup eligibility request."""
+    start = "# --- Headroom init agy launcher ---"
+    end = "# --- end Headroom init agy launcher ---"
+    command = _command_string(
+        [*resolve_headroom_command(), "init", "launch-agy", "--profile", profile, "--"]
+    )
+    block = f'{start}\nagy() {{\n  {command} "$@"\n}}\n{end}'
+    for path in unix_user_env_targets():
+        content = path.read_text(encoding="utf-8") if path.exists() else ""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(_replace_marker_block(content, start, end, block), encoding="utf-8")
+
+
 def _init_agy(*, global_scope: bool, profile: str, port: int) -> None:
     if not global_scope:
         raise click.ClickException(
             "Antigravity durable init currently requires -g (current-user scope)."
         )
+    if os.name == "nt":
+        raise click.ClickException("Antigravity durable init currently requires a POSIX shell.")
     _ensure_agy_hooks(_agy_hooks_path(), profile)
     _apply_user_env(_resolve_agy_env(port))
-    # agy runs its eligibility check against CLOUD_CODE_URL at startup, before
-    # the first model call and therefore before any hook can start the proxy:
-    # a proxy that is down makes `agy` refuse to boot. Start it here so the
-    # next launch works, and let the PreInvocation hook revive it later.
+    _ensure_agy_launcher(profile)
+    # Warm the proxy now; the shell launcher also ensures readiness on every
+    # subsequent launch, before loadCodeAssist can run (unlike PreInvocation).
     _ensure_profile_running(profile)
     click.echo("Configured Antigravity CLI (user scope).")
     click.echo(
-        "Open a new shell (CLOUD_CODE_URL is exported from your shell profile), then run agy."
+        "Open a new bash/zsh shell, then run agy (the shell launcher ensures the proxy is ready)."
     )
 
 
@@ -1154,6 +1174,32 @@ def init_agy(ctx: click.Context) -> None:
         region=_ctx_value(ctx, "region"),
         memory=bool(_ctx_value(ctx, "memory")),
     )
+
+
+@init.command("launch-agy", hidden=True)
+@click.option("--profile", required=True)
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def init_launch_agy(profile: str, args: tuple[str, ...]) -> None:
+    """Launch Antigravity only after its configured proxy is ready."""
+    binary = shutil.which("agy")
+    if not binary:
+        raise click.ClickException("'agy' not found in PATH. Install Antigravity CLI first.")
+    try:
+        manifest = load_manifest(validate_profile_name(profile))
+    except ManifestError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if manifest is None:
+        raise click.ClickException(f"Missing profile '{profile}'. Run headroom init -g agy.")
+    _ensure_profile_running(profile)
+    if not wait_ready(manifest, timeout_seconds=_STARTUP_READY_TIMEOUT_SECONDS):
+        raise click.ClickException(
+            f"Headroom proxy for '{profile}' is not ready; agy was not started."
+        )
+    env = {**os.environ, **_resolve_agy_env(manifest.port)}
+    try:
+        os.execvpe(binary, [binary, *args], env)
+    except OSError as exc:
+        raise click.ClickException(f"Could not launch agy: {exc}") from exc
 
 
 @init.group("hook", hidden=True)

--- a/tests/test_cli/test_init_agy_live.py
+++ b/tests/test_cli/test_init_agy_live.py
@@ -1,0 +1,80 @@
+"""Opt-in real Antigravity recovery proof; requires an authenticated agy on PATH.
+
+Run: HEADROOM_TEST_AGY_LIVE=1 .venv/bin/python -m pytest \
+    tests/test_cli/test_init_agy_live.py -q -s
+
+Uses temporary Headroom state and shell configuration, preserving user dotfiles.
+This tests a stopped proxy and fresh shells, not an actual OS reboot.
+"""
+
+import importlib
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import urllib.request
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.mark.skipif(
+    os.environ.get("HEADROOM_TEST_AGY_LIVE") != "1", reason="requires live Antigravity OAuth"
+)
+def test_agy_recovers_stopped_proxy_in_fresh_shell(monkeypatch, tmp_path):
+    from headroom.install.runtime import stop_runtime, wait_ready
+    from headroom.install.state import load_manifest
+
+    init_cli = importlib.import_module("headroom.cli.init")
+    assert shutil.which("agy"), "Install and authenticate agy first"
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    monkeypatch.setenv("HEADROOM_WORKSPACE_DIR", str(tmp_path / "workspace"))
+    monkeypatch.setenv("HEADROOM_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv(
+        "PATH", str(os.path.dirname(sys.executable)) + os.pathsep + os.environ["PATH"]
+    )
+    shell_profile = tmp_path / ".profile"
+    monkeypatch.setattr(init_cli, "unix_user_env_targets", lambda: [shell_profile])
+    monkeypatch.setattr("headroom.install.providers.unix_user_env_targets", lambda: [shell_profile])
+    monkeypatch.setattr(init_cli, "_agy_hooks_path", lambda: tmp_path / "hooks.json")
+
+    def launch(shell):
+        result = subprocess.run(
+            [shell, "-c", '. "$1"; agy -p "Reply with exactly: pong"', shell, str(shell_profile)],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        print(f"fresh {shell}: exit={result.returncode}, response={result.stdout.strip()!r}")
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip().lower() == "pong"
+
+    try:
+        result = CliRunner().invoke(init_cli.init, ["-g", "--port", str(port), "agy"])
+        assert result.exit_code == 0, result.output
+        manifest = load_manifest("init-user")
+        assert manifest is not None
+        assert wait_ready(manifest, timeout_seconds=15)
+        print(f"init completed; proxy ready on port {port}")
+        launch("bash")
+        stop_runtime(manifest)
+        assert not wait_ready(manifest, timeout_seconds=1)
+        print("proxy stopped; health unavailable")
+        launch("zsh" if shutil.which("zsh") else "bash")
+        assert wait_ready(manifest, timeout_seconds=1)
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/stats", timeout=5) as response:
+            import json
+
+            stats = json.load(response)
+        agents = [
+            agent for agent in stats["agent_usage"]["agents"] if agent["agent"] == "antigravity"
+        ]
+        assert agents and agents[0]["requests"] >= 2, agents
+        print(f"recovered proxy attribution: {agents}")
+    finally:
+        manifest = load_manifest("init-user")
+        if manifest is not None:
+            stop_runtime(manifest)

--- a/tests/test_cli/test_init_cli.py
+++ b/tests/test_cli/test_init_cli.py
@@ -316,11 +316,17 @@ def test_detect_init_targets_respects_scope(monkeypatch) -> None:
     monkeypatch.setattr(
         init_cli.shutil,
         "which",
-        lambda name: name if name in {"claude", "copilot", "codex", "openclaw"} else None,
+        lambda name: name if name in {"claude", "copilot", "codex", "openclaw", "agy"} else None,
     )
 
     assert init_cli.detect_init_targets(False) == ["claude", "codex"]
-    assert init_cli.detect_init_targets(True) == ["claude", "copilot", "codex", "openclaw"]
+    assert init_cli.detect_init_targets(True) == [
+        "claude",
+        "copilot",
+        "codex",
+        "openclaw",
+        "agy",
+    ]
 
 
 def test_marketplace_source_prefers_env_override(monkeypatch) -> None:
@@ -1554,3 +1560,70 @@ def test_init_codex_strip_removes_openai_base_url(monkeypatch, tmp_path: Path) -
         f"_strip_codex_init_block must remove orphaned openai_base_url:\n{orphan_stripped}"
     )
     assert 'model = "gpt-4o"' in orphan_stripped
+
+
+def test_init_agy_requires_global(monkeypatch) -> None:
+    init_cli, fake_main = _load_init_module(monkeypatch)
+    runner = CliRunner()
+    monkeypatch.setattr(init_cli, "_ensure_runtime_manifest", lambda **kwargs: "init-local-test")
+
+    result = runner.invoke(fake_main, ["init", "agy"])
+
+    assert result.exit_code != 0
+    assert "requires -g" in result.output
+
+
+def test_init_agy_global_writes_hooks_and_env(monkeypatch, tmp_path: Path) -> None:
+    init_cli, _ = _load_init_module(monkeypatch)
+    captured_env: dict[str, str] = {}
+    ensured: list[str] = []
+    hooks_path = tmp_path / "hooks.json"
+    monkeypatch.setattr(init_cli, "_agy_hooks_path", lambda: hooks_path)
+    monkeypatch.setattr(init_cli, "_apply_user_env", lambda values: captured_env.update(values))
+    monkeypatch.setattr(
+        init_cli, "_ensure_profile_running", lambda profile: ensured.append(profile)
+    )
+
+    init_cli._init_agy(global_scope=True, profile="init-user", port=9007)
+
+    payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+    entries = payload["headroom-init-agy"]["PreInvocation"]
+    assert len(entries) == 1
+    assert "--profile init-user" in entries[0]["command"]
+    assert entries[0]["command"].endswith("--marker headroom-init-agy")
+    assert captured_env == {"CLOUD_CODE_URL": "http://127.0.0.1:9007"}
+    # agy checks eligibility before any hook can run, so init starts the proxy.
+    assert ensured == ["init-user"]
+
+
+def test_ensure_agy_hooks_preserves_user_hooks(monkeypatch, tmp_path: Path) -> None:
+    """Antigravity keys hooks.json by hook name: only Headroom's key may change."""
+
+    init_cli, _ = _load_init_module(monkeypatch)
+    hooks_path = tmp_path / "hooks.json"
+    hooks_path.write_text(
+        json.dumps(
+            {
+                "my-linter": {"PostToolUse": [{"matcher": "*", "hooks": [{"command": "lint.sh"}]}]},
+                "headroom-init-agy": {
+                    "PreInvocation": [{"type": "command", "command": "stale --profile old"}]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(init_cli, "_hook_command", lambda *parts: "headroom init hook ensure")
+
+    init_cli._ensure_agy_hooks(hooks_path, "init-user")
+
+    payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+    assert payload["my-linter"]["PostToolUse"][0]["hooks"][0]["command"] == "lint.sh"
+    assert payload["headroom-init-agy"] == {
+        "PreInvocation": [
+            {
+                "type": "command",
+                "command": "headroom init hook ensure --marker headroom-init-agy",
+                "timeout": 15,
+            }
+        ]
+    }

--- a/tests/test_cli/test_init_cli.py
+++ b/tests/test_cli/test_init_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import os
+import subprocess
 import sys
 import types
 from contextlib import contextmanager
@@ -1573,12 +1574,14 @@ def test_init_agy_requires_global(monkeypatch) -> None:
     assert "requires -g" in result.output
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX shell integration")
 def test_init_agy_global_writes_hooks_and_env(monkeypatch, tmp_path: Path) -> None:
     init_cli, _ = _load_init_module(monkeypatch)
     captured_env: dict[str, str] = {}
     ensured: list[str] = []
     hooks_path = tmp_path / "hooks.json"
     monkeypatch.setattr(init_cli, "_agy_hooks_path", lambda: hooks_path)
+    monkeypatch.setattr(init_cli, "unix_user_env_targets", lambda: [tmp_path / ".profile"])
     monkeypatch.setattr(init_cli, "_apply_user_env", lambda values: captured_env.update(values))
     monkeypatch.setattr(
         init_cli, "_ensure_profile_running", lambda profile: ensured.append(profile)
@@ -1627,3 +1630,67 @@ def test_ensure_agy_hooks_preserves_user_hooks(monkeypatch, tmp_path: Path) -> N
             }
         ]
     }
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX shell launcher")
+def test_agy_launcher_preserves_arguments_exit_status_and_user_config(monkeypatch, tmp_path):
+    init_cli, _ = _load_init_module(monkeypatch)
+    shell_profile = tmp_path / ".profile"
+    shell_profile.write_text("export USER_SETTING=kept\n")
+    launcher = tmp_path / "headroom with spaces"
+    launcher.write_text('#!/bin/sh\nprintf \'%s\\n\' "$USER_SETTING" "$@"\nexit 23\n')
+    launcher.chmod(0o755)
+    monkeypatch.setattr(init_cli, "unix_user_env_targets", lambda: [shell_profile])
+    monkeypatch.setattr(init_cli, "resolve_headroom_command", lambda: [str(launcher)])
+    init_cli._ensure_agy_launcher("init-user")
+    init_cli._ensure_agy_launcher("init-user")
+
+    result = subprocess.run(
+        ["sh", "-c", '. "$1"; agy -p "hello world" --model test', "sh", str(shell_profile)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 23
+    assert result.stdout.splitlines() == [
+        "kept",
+        "init",
+        "launch-agy",
+        "--profile",
+        "init-user",
+        "--",
+        "-p",
+        "hello world",
+        "--model",
+        "test",
+    ]
+    assert shell_profile.read_text().count("agy()") == 1
+
+
+@pytest.mark.parametrize("ready", [False, True])
+def test_agy_launch_requires_ready_proxy_before_executing_client(monkeypatch, ready):
+    init_cli, fake_main = _load_init_module(monkeypatch)
+    manifest = SimpleNamespace(port=9007)
+    events = []
+    monkeypatch.setattr(init_cli, "load_manifest", lambda profile: manifest)
+    monkeypatch.setattr(init_cli.shutil, "which", lambda name: "/bin/agy")
+    monkeypatch.setattr(
+        init_cli, "_ensure_profile_running", lambda profile: events.append("ensure")
+    )
+
+    def wait(manifest, **kwargs):
+        events.append("ready")
+        return ready
+
+    def execute(binary, args, env):
+        events.append("execute")
+        assert args == ["/bin/agy", "-p", "hello world"]
+        assert env["CLOUD_CODE_URL"] == "http://127.0.0.1:9007"
+
+    monkeypatch.setattr(init_cli, "wait_ready", wait)
+    monkeypatch.setattr(init_cli.os, "execvpe", execute)
+    result = CliRunner().invoke(
+        fake_main, ["init", "launch-agy", "--profile", "init-user", "--", "-p", "hello world"]
+    )
+    assert result.exit_code == (0 if ready else 1), result.output
+    assert events == (["ensure", "ready", "execute"] if ready else ["ensure", "ready"])


### PR DESCRIPTION
## Description

Adds `headroom init -g agy` for Antigravity CLI in Bash/Zsh. Init configures Cloud Code Assist routing and installs a shell launcher that starts or recovers the Headroom proxy and verifies readiness **before** executing agy. This handles agy's startup `loadCodeAssist` eligibility request, which runs before `PreInvocation`.

Closes #3427

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add `agy` as a user-scope init target and export `CLOUD_CODE_URL` using the existing managed shell environment block. Project scope is rejected.
- Install a managed `agy()` function in `.bashrc`, `.zshrc`, and `.profile`. It invokes `headroom init launch-agy --profile <profile> -- <args>` using the resolved Headroom command. Re-running init replaces the managed block and preserves surrounding shell configuration.
- The launcher reuses `_ensure_profile_running`, verifies proxy readiness, then executes the original agy binary with the profile's URL. Startup failure produces a clear error without executing agy; arguments and the client's exit status are preserved.
- Install one named `headroom-init-agy` `PreInvocation` entry in `~/.gemini/config/hooks.json`, preserving unrelated hooks. This hook is for in-session recovery, **not** startup recovery. No `PreToolUse` permission hook is installed.
- Warm the proxy during init. No new supervisor or dependency is required.
- Reject Windows init explicitly until a suitable launcher is implemented.
- Add unit coverage and an opt-in real-client recovery test in `tests/test_cli/test_init_agy_live.py`.

Scope: normal `agy` invocations in configured Bash/Zsh shells use the launcher. Absolute-path execution, `command agy`, and subprocesses that bypass shell functions also bypass recovery. Those callers can explicitly use `headroom init launch-agy --profile init-user -- <agy args>`.

## Testing

- [x] Unit tests pass (`pytest`, CLI suite)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (repository pre-commit mypy hook)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ .venv/bin/python -m pytest tests/test_cli -q
743 passed, 2 skipped in 1384.65s

$ .venv/bin/python -m pytest tests/test_cli/test_init_cli.py tests/test_cli/test_init_agy_live.py -q
79 passed, 1 skipped in 1.08s

$ .venv/bin/ruff check .
All checks passed!

$ .venv/bin/ruff format --check headroom/cli/init.py tests/test_cli/test_init_cli.py tests/test_cli/test_init_agy_live.py
3 files already formatted

$ .venv/bin/mypy headroom/cli/init.py --follow-imports=silent
Success: no issues found in 1 source file
```

The live test is skipped by default and was run separately with `HEADROOM_TEST_AGY_LIVE=1`. Initial sandboxed CLI tests could not bind local sockets; the CLI suite passed when rerun with local socket access. In addition to the focused type check above, the repository's pre-commit mypy hook (`mypy headroom --ignore-missing-imports`) passed, as did the version synchronization, merge-conflict, Ruff, formatting, and commitlint hooks.

The full pre-push `make ci-precheck` also passed: Rust formatting, Clippy, workspace tests, native extension build/import, the selected Python suite (175 passed, 4 skipped; one tokenizer-approximation warning), and commitlint. On this machine the Rust Kompress tests required `ORT_DYLIB_PATH` pointing to the installed ONNX Runtime 1.26.0 library; the initial unconfigured run hung and was stopped, then the complete hook passed with that environment setting. No hooks were bypassed.

## Real Behavior Proof

- **Environment:** macOS arm64, Python 3.13.14, editable Headroom source installation with dev/proxy extras, Antigravity CLI 1.1.27 with existing Google OAuth authentication. Traffic used the Gemini Cloud Code Assist route; recovered stats reported `gemini-3.1-flash-lite` and `gemini-3.7-flash-high`.
- **Exact command / steps:**

  ```sh
  HEADROOM_TEST_AGY_LIVE=1 .venv/bin/python -m pytest tests/test_cli/test_init_agy_live.py -q -s
  ```

  The test runs init against temporary Headroom state and generated shell configuration, confirms readiness, launches real agy in a fresh Bash process, stops its own proxy, verifies health is unavailable, and launches real agy from a fresh Zsh process. It does **not** rerun init or manually start the proxy between the stop and second launch. It checks agent attribution at `/stats` → `.agent_usage.agents` and stops its own proxy in `finally`. Existing agy authentication is reused; user dotfiles are preserved by the test.

- **Observed result:**

  ```text
  init completed; proxy ready on port 57851
  fresh bash: exit=0, response='pong'
  proxy stopped; health unavailable
  fresh zsh: exit=0, response='pong'
  recovered proxy attribution: antigravity, requests=2, providers={'gemini': 2}
  1 passed in 45.19s
  ```

  Before the fix, a real agy invocation against a stopped proxy failed with `Eligibility check failed ... /v1internal:loadCodeAssist ... connect: connection refused`. After installing the patched integration into the real user shell configuration, `zsh -ic 'agy -p "Reply with exactly: pong"'` also returned `pong`, exit 0. The non-TTY shell emitted existing `zle` option warnings.

- **Not tested:** physical OS reboot (a stopped proxy plus fresh shell was tested), Linux, Windows, enterprise/ADC authentication, API-key routing, `headroom wrap agy`, or whole-project pytest. Windows and project-scope init are explicitly unsupported. The agy MCP registrar remains unimplemented.

## Runtime Rollout Safety

- **Rollout-managed feature(s):** none; explicit init target / existing target auto-detection.
- **Minimum rollout channel:** n/a; no channel gate.
- **Stable/default behavior changed:** user-scope auto-detection now includes agy when on PATH. Existing agents retain their integration paths. On Windows, selecting/detecting agy fails with the explicit POSIX-shell requirement.
- **Kill switch / disable path:** remove the managed `Headroom init agy launcher` block from shell startup files, remove the `headroom-init-agy` hook entry, and remove/unset `CLOUD_CODE_URL`. In a current shell, also run `unset -f agy` and `unset CLOUD_CODE_URL`. Select other targets explicitly to avoid auto-installing agy.
- **Unsafe override required:** none for the feature or real-client test.
- **Qualification impact:** the feature covers configured Bash/Zsh entrypoints; invoking the original binary directly bypasses recovery. No claims are made for untested platforms or auth modes.
- **Rollback path:** revert the PR and remove the agy-specific configuration described above, or restore pre-install backups while preserving subsequent user edits. Retain shared runtime profiles used by other agents.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented the startup-order constraint
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective
- [x] The CLI unit suite and opt-in live test pass locally
- [x] I did not edit `CHANGELOG.md`

## Additional Notes

The README's agent table describes `headroom wrap`, which this PR does not extend. The live test's module docstring includes reproduction instructions. The implementation keeps startup recovery in the launcher rather than claiming that `PreInvocation` can recover a proxy before eligibility checking.
