### PR TITLE
fix(proxy): keep json_bloat waste signals out of the catch-all lifetime bucket

### DIFF
--- a/headroom/proxy/persistent_metrics.py
+++ b/headroom/proxy/persistent_metrics.py
@@ -16,9 +16,12 @@ MAX_EXPOSED_MODELS = 100
 MAX_LABEL_LENGTH = 128
 
 KNOWN_MISS_REASONS = frozenset({"ttl_expiry", "prefix_change", "unknown"})
+# Names must match ``WasteSignals.to_dict()`` in headroom/config.py — the
+# parser emits ``json_bloat``; an allowlist that says ``json_noise`` silently
+# shoves the largest waste category into the catch-all bucket.
 KNOWN_WASTE_SIGNALS = frozenset(
     {
-        "json_noise",
+        "json_bloat",
         "html_noise",
         "base64",
         "whitespace",
@@ -174,8 +177,12 @@ class PersistentMetricsState:
         raw_cost = _dict_or_empty(source.get("cost"))
         for key in ("input_usd", "compression_savings_usd", "cache_savings_usd"):
             result["cost"][key] = round(_coerce_float(raw_cost.get(key)), 6)
+        # Record-time puts unrecognised names in ``other`` (see
+        # ``record_request``); load-time must do the same, or every restart
+        # relabels the whole ``other`` bucket as ``unknown`` and the two
+        # grow side by side.
         result["waste_signals"] = self._normalize_enum_map(
-            source.get("waste_signals"), KNOWN_WASTE_SIGNALS
+            source.get("waste_signals"), KNOWN_WASTE_SIGNALS, fallback="other"
         )
 
         raw_models = _dict_or_empty(source.get("models"))
@@ -204,12 +211,14 @@ class PersistentMetricsState:
         return result
 
     @staticmethod
-    def _normalize_enum_map(raw: Any, allowed: frozenset[str]) -> dict[str, int]:
+    def _normalize_enum_map(
+        raw: Any, allowed: frozenset[str], *, fallback: str = "unknown"
+    ) -> dict[str, int]:
         result: dict[str, int] = {}
         if not isinstance(raw, dict):
             return result
         for key, value in raw.items():
-            label = key if isinstance(key, str) and key in allowed else "unknown"
+            label = key if isinstance(key, str) and key in allowed | {fallback} else fallback
             result[label] = result.get(label, 0) + _coerce_int(value)
         return result
 

--- a/tests/test_persistent_metrics.py
+++ b/tests/test_persistent_metrics.py
@@ -153,3 +153,48 @@ def test_state_normalizes_invalid_values_and_unknown_dimension_labels() -> None:
     assert snapshot["requests"]["by_stack"] == {"other": 1}
     assert snapshot["by_model"]["other"]["input_tokens"] == 7
     assert snapshot["waste_signals"] == {"other": 9}
+
+
+def test_json_bloat_waste_signal_is_a_named_bucket() -> None:
+    """The parser emits ``json_bloat`` (WasteSignals.to_dict); it must not fall to ``other``."""
+    state = _new_state()
+    state.record_request(
+        provider="anthropic",
+        stack="claude",
+        model="claude-sonnet-5",
+        waste_signals={"json_bloat": 500, "html_noise": 20},
+    )
+
+    snapshot = state.snapshot(persistence={"enabled": True, "healthy": True})
+
+    assert snapshot["waste_signals"] == {"json_bloat": 500, "html_noise": 20}
+
+
+def test_waste_signal_other_bucket_survives_reload() -> None:
+    """Reloading persisted state must keep ``other`` as ``other``, not relabel it ``unknown``.
+
+    Before this fix, unrecognised names went to ``other`` at record time but to
+    ``unknown`` at load time, so every restart moved the whole ``other`` bucket
+    into a new ``unknown`` bucket and the two grew side by side.
+    """
+    state = PersistentMetricsState(
+        {
+            "waste_signals": {"other": 40, "unknown": 60, "html_noise": 5, "bogus": 3},
+        },
+        now=lambda: FIXED_NOW,
+    )
+
+    snapshot = state.snapshot(persistence={"enabled": True, "healthy": True})
+
+    assert snapshot["waste_signals"] == {"other": 103, "html_noise": 5}
+
+
+def test_miss_reasons_still_fall_back_to_unknown_on_reload() -> None:
+    state = PersistentMetricsState(
+        {"prefix_cache": {"misses_by_reason": {"ttl_expiry": 2, "bogus": 1}}},
+        now=lambda: FIXED_NOW,
+    )
+
+    snapshot = state.snapshot(persistence={"enabled": True, "healthy": True})
+
+    assert snapshot["prefix_cache"]["misses_by_reason"] == {"ttl_expiry": 2, "unknown": 1}


### PR DESCRIPTION
## Problem

The dashboard's lifetime "Waste Signals" panel shows large `unknown` and `other` rows and a tiny or missing JSON row, even though bulky JSON in tool outputs is the biggest waste category the parser detects.

Two mismatches in `headroom/proxy/persistent_metrics.py`:

1. `WasteSignals.to_dict()` (`headroom/config.py`) emits the key `json_bloat`, but `KNOWN_WASTE_SIGNALS` lists `json_noise`. Every `json_bloat` count falls to the catch-all bucket.
2. The catch-all has two names. `record_request` files unrecognised names under `other`; `_normalize_enum_map` (used when the persisted state is reloaded) files them under `unknown`, and `other` itself is not an allowed name. So on every proxy restart the entire `other` bucket is relabelled `unknown`, and new traffic starts a fresh `other`. The dashboard then shows both growing side by side.

Observed on 0.37.0 after ~1k requests: `unknown` 638.6k, `other` 209.8k, no JSON row.

## Fix

- Add `json_bloat` to `KNOWN_WASTE_SIGNALS` (with a comment pointing at `WasteSignals.to_dict()` so the two stay in step).
- Give `_normalize_enum_map` a `fallback` argument. Waste signals load with `fallback="other"`, matching record time, and an existing `other` bucket is kept as `other`. Miss reasons keep their `unknown` fallback.

Existing persisted `unknown` waste rows fold into `other` on the next load, so the dashboard stops splitting the same tokens across two labels.

## Tests

- `test_json_bloat_waste_signal_is_a_named_bucket`
- `test_waste_signal_other_bucket_survives_reload`
- `test_miss_reasons_still_fall_back_to_unknown_on_reload`

`uv run pytest tests/test_persistent_metrics*.py` → 11 passed. `ruff check` and `ruff format --check` clean.
