### PR TITLE
fix(tools): key codebase-memory-mcp assets by platform, not upstream naming

### DIFF
--- a/headroom/tools.json
+++ b/headroom/tools.json
@@ -103,27 +103,45 @@
       "version": "v0.8.1",
       "binary": "codebase-memory-mcp",
       "source": "DeusData/codebase-memory-mcp",
-      "_comment": "No Windows build published for v0.8.1.",
+      "_comment": "Upstream names its assets arm64/amd64; the registry keys them by PlatformKey.key(), i.e. aarch64/x86_64.",
       "assets": {
-        "darwin-arm64": {
-          "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-darwin-arm64.tar.gz",
+        "linux-x86_64-gnu": {
+          "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-linux-amd64.tar.gz",
           "member": "codebase-memory-mcp",
-          "sha256": "fbd047509852021b5446a11141bcb0a3d1dcaebf6e5112460960f29f052c1c58"
+          "sha256": "dbd3b92ea870ef240b63059f26bda15015f76ef9978931bebc3a0f9d09470973"
         },
-        "darwin-amd64": {
-          "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-darwin-amd64.tar.gz",
+        "linux-x86_64-musl": {
+          "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-linux-amd64-portable.tar.gz",
           "member": "codebase-memory-mcp",
-          "sha256": "fb62da3016ea12b948351208759b5c083fb1446cf6e78d6db8b7cd28fe86fd54"
+          "sha256": "6ab87a6c05d049dde57700803ca0ab4199fcf25973a0606618af0fcee73f5abd",
+          "_comment": "upstream publishes a separate -portable build of this release; used for musl, where the standard (glibc-linked) linux asset is not expected to run. Not yet run on a musl host."
         },
-        "linux-arm64": {
+        "linux-aarch64-gnu": {
           "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-linux-arm64.tar.gz",
           "member": "codebase-memory-mcp",
           "sha256": "d2f842d1365da5c35d9c5796f57a821c9745267350994346735e1e6e04d46091"
         },
-        "linux-amd64": {
-          "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-linux-amd64.tar.gz",
+        "linux-aarch64-musl": {
+          "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-linux-arm64-portable.tar.gz",
           "member": "codebase-memory-mcp",
-          "sha256": "dbd3b92ea870ef240b63059f26bda15015f76ef9978931bebc3a0f9d09470973"
+          "sha256": "13526acc2a6a0697dff3c763fb443a416589bc10ad8b12015b63d87e515dd72b",
+          "_comment": "upstream publishes a separate -portable build of this release; used for musl, where the standard (glibc-linked) linux asset is not expected to run. Not yet run on a musl host."
+        },
+        "darwin-x86_64": {
+          "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-darwin-amd64.tar.gz",
+          "member": "codebase-memory-mcp",
+          "sha256": "fb62da3016ea12b948351208759b5c083fb1446cf6e78d6db8b7cd28fe86fd54"
+        },
+        "darwin-aarch64": {
+          "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-darwin-arm64.tar.gz",
+          "member": "codebase-memory-mcp",
+          "sha256": "fbd047509852021b5446a11141bcb0a3d1dcaebf6e5112460960f29f052c1c58"
+        },
+        "windows-x86_64": {
+          "url": "https://github.com/DeusData/codebase-memory-mcp/releases/download/v0.8.1/codebase-memory-mcp-windows-amd64.zip",
+          "member": "codebase-memory-mcp.exe",
+          "sha256": "a602ad090ed3f49d86c55472f73f27ad7055222806a82358f2e08513e027f00f",
+          "_comment": "member name follows the difft/scc convention for the windows zip; not yet extracted on a windows host."
         }
       }
     }

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -382,3 +382,55 @@ def test_status_reports_every_registered_tool(monkeypatch):
     assert {"difft", "scc", "ast-grep"} <= names
     for r in rows:
         assert r["state"] in ("on-path", "cached", "missing", "unsupported-platform")
+
+
+# -------- Registry key hygiene ------------------------------------------- #
+
+
+def _all_platform_keys() -> set[str]:
+    """Every key `PlatformKey.key()` can emit — the only keys a lookup can hit."""
+    keys = set()
+    for os_ in ("linux", "darwin", "windows"):
+        for arch in ("x86_64", "aarch64"):
+            libcs = ("gnu", "musl") if os_ == "linux" else ("n/a",)
+            for libc in libcs:
+                keys.add(binaries.PlatformKey(os_, arch, libc).key())
+    return keys
+
+
+def test_every_registry_asset_key_is_reachable():
+    """Guard against assets filed under a key no platform can produce.
+
+    `_asset_for_platform` does a plain dict lookup on `PlatformKey.key()`, so an
+    asset keyed in some upstream project's own naming (`darwin-arm64` rather than
+    `darwin-aarch64`) is dead weight: the tool ships a binary and reports
+    `unsupported-platform` anyway, on every machine.
+    """
+    valid = _all_platform_keys()
+    for tool, entry in binaries._registry()["tools"].items():
+        for key in entry.get("assets", {}):
+            assert key in valid, (
+                f"{tool}: asset key {key!r} is unreachable; expected one of {sorted(valid)}"
+            )
+
+
+def test_asset_lookup_matches_declared_platforms():
+    """For every real platform, a tool resolves iff it declares that platform.
+
+    Builds the PlatformKey from the platform axes rather than by parsing the
+    registry key, so a mis-keyed asset cannot make this pass by round-tripping.
+    """
+    for tool, entry in binaries._registry()["tools"].items():
+        if binaries._is_pypi_tool(tool):
+            continue
+        assets = entry.get("assets", {})
+        for os_ in ("linux", "darwin", "windows"):
+            for arch in ("x86_64", "aarch64"):
+                for libc in ("gnu", "musl") if os_ == "linux" else ("n/a",):
+                    plat = binaries.PlatformKey(os_, arch, libc)
+                    declared = assets.get(plat.key())
+                    if declared is None:
+                        with pytest.raises(binaries.PlatformNotSupported):
+                            binaries._asset_for_platform(tool, plat)
+                    else:
+                        assert binaries._asset_for_platform(tool, plat) is declared


### PR DESCRIPTION
## Description

`_asset_for_platform()` resolves a tool's download with a plain `assets.get(plat.key())`, and `PlatformKey.key()` normalizes arch to `aarch64`/`x86_64`. The `codebase-memory-mcp` entry in `tools.json` was keyed in the upstream project's own naming (`darwin-arm64`, `linux-amd64`, …), so the lookup missed on **every** platform: the tool ships binaries for four platforms and resolved on none, reporting `unsupported-platform` everywhere.

`difft` and `scc` already transliterate upstream names into the registry's scheme (including duplicating one asset across `-gnu`/`-musl` with a `_comment`), so this fixes the data to match that convention rather than adding an alias layer in the lookup.

This went unnoticed because `headroom/graph/installer.py` fetches the same tool over its own code path, building the URL from upstream naming directly — so the graph feature works and only the registry view (`headroom tools doctor`) reports the tool as unavailable.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Refile the four existing `codebase-memory-mcp` assets under the keys `PlatformKey.key()` actually emits. URLs and sha256 pins are unchanged, and all four match the release's published `checksums.txt`.
- Add the assets the entry was missing: `linux-{x86_64,aarch64}-musl` pointing at upstream's `-portable` builds, and `windows-x86_64`. The entry carried `"_comment": "No Windows build published for v0.8.1."`, but v0.8.1 publishes `codebase-memory-mcp-windows-amd64.zip`; that stale comment is replaced.
- Add `test_every_registry_asset_key_is_reachable` — every asset key must be one `PlatformKey.key()` can produce. This is the guard that would have caught the bug.
- Add `test_asset_lookup_matches_declared_platforms` — a tool resolves iff it declares that platform. It builds the `PlatformKey` from the platform axes rather than by parsing the registry key, so a mis-keyed asset cannot make it pass by round-tripping, and it forbids "fixing" a future mis-key with a silent alias fallback instead of correcting the table.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_binaries.py -q
24 passed, 1 warning in 1.84s

$ python -m pytest tests/test_binaries.py tests/test_graph.py tests/test_cli_tools.py \
                   tests/test_bundled_tools_savings.py -q
53 passed, 2 skipped, 1 warning in 2.07s

$ ruff check .
All checks passed!

$ ruff format --check tests/test_binaries.py
1 file already formatted

$ mypy headroom
Success: no issues found in 530 source files
```

Test fails before the fix, passes after — re-introducing the original key in-process:

```text
$ python -c "import tests.test_binaries as t; from headroom import binaries
a = binaries._registry()['tools']['codebase-memory-mcp']['assets']
a['darwin-arm64'] = a.pop('darwin-aarch64')
t.test_every_registry_asset_key_is_reachable()"
AssertionError: codebase-memory-mcp: asset key 'darwin-arm64' is unreachable;
expected one of ['darwin-aarch64', 'darwin-x86_64', 'linux-aarch64-gnu',
'linux-aarch64-musl', 'linux-x86_64-gnu', 'linux-x86_64-musl', 'windows-x86_64']
```

## Real Behavior Proof

- Environment: macOS 26 (Darwin 27.0.0), Apple silicon → `darwin-aarch64`; Python 3.13.13; branch = `upstream/main` + this commit. "Before" numbers come from headroom-ai 0.37.0 installed from PyPI in a separate site-packages, unpatched.

- Exact command / steps: ran `headroom tools doctor` and `binaries.status()` against the unpatched installed 0.37.0, then resolved all seven declared platforms against the patched tree; full transcript below.

  Before (unpatched 0.37.0, imported from outside the checkout):

  ```text
  $ python -c "import headroom.binaries as b; print([r for r in b.status() if r['tool']=='codebase-memory-mcp'])"
  codebase-memory-mcp -> unsupported-platform

  $ headroom tools doctor
  │ codebase-memo… │ unsupported-pl… │ v0.8.1 │ darwin-aarch64 │ - │
  codebase-memory-mcp: no prebuilt binary for darwin-aarch64;
  supported: ['darwin-amd64', 'darwin-arm64', 'linux-amd64', 'linux-arm64']
  ```

  After (patched tree), resolving every platform the registry now declares:

  ```text
  $ python -c "from headroom.binaries import PlatformKey, _asset_for_platform; ..."
  darwin-aarch64       -> codebase-memory-mcp-darwin-arm64.tar.gz
  darwin-x86_64        -> codebase-memory-mcp-darwin-amd64.tar.gz
  linux-x86_64-gnu     -> codebase-memory-mcp-linux-amd64.tar.gz
  linux-x86_64-musl    -> codebase-memory-mcp-linux-amd64-portable.tar.gz
  linux-aarch64-gnu    -> codebase-memory-mcp-linux-arm64.tar.gz
  linux-aarch64-musl   -> codebase-memory-mcp-linux-arm64-portable.tar.gz
  windows-x86_64       -> codebase-memory-mcp-windows-amd64.zip
  ```

- Observed result: the tool resolves on all seven declared platforms instead of none, and no longer reports `unsupported-platform` on this host. On my machine `status()` now reports `cached` — note that the cached binary was already present from an earlier run, so `cached` reflects the existing cache, not a download performed by this patch.

- Not tested: two gaps, detailed below.
  - I did not download the newly added `-portable` or `windows-amd64` archives locally; their pins were taken from the release's published `checksums.txt`. CI's `tools-hash-refresh / verify-pins` has since fetched and re-hashed every pin in this PR and passed, so the URLs and digests are confirmed. What remains unverified is the `member` name *inside* those three archives, which CI does not extract; they follow the existing convention (`codebase-memory-mcp`, `codebase-memory-mcp.exe`). A wrong `member` fails loudly and safely — the pin is verified before extraction and `_extract_member_from_tar/zip` raises `archive did not contain expected member`. Happy to drop those hunks and land only the key fix if you would rather not take them.
  - No musl or Windows host was available. Mapping the `-portable` build to the `-musl` keys is inferred from upstream shipping it as a separate variant; the release notes do not state its linking. This is recorded in a `_comment` on those assets.

## Runtime Rollout Safety

- Rollout-managed feature(s): none — registry data plus tests.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: yes, in the sense that a tool that previously never resolved now resolves. No proxy behavior, compression path, or default is affected.
- Kill switch / disable path: N/A.
- Unsafe override required: no.
- Qualification impact: none.
- Rollback path: revert this commit; the registry returns to its prior state.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

- No linked issue: `CONTRIBUTING.md` routes a bug fix with a repro and a test straight to a PR.
- No other consumer regresses: `headroom/graph/installer.py` fetches this tool over its own path and resolves its pin by URL via `sha256_for_url()`, and no pre-existing URL changes here, so that lookup still resolves (checked on this host).
- Docs checkbox is N/A — the platform key scheme is not user-facing documentation; the reasoning is recorded in a `_comment` on the registry entry instead.
- The two added tests are registry-wide, not specific to this tool, so any future asset added under an upstream naming scheme fails at test time rather than silently on every machine.
