### PR TITLE
fix(memory): find cwd in all system prompt locations

### DIFF
--- a/headroom/memory/storage_router.py
+++ b/headroom/memory/storage_router.py
@@ -426,23 +426,23 @@ def extract_system_prompt(body: Mapping[str, Any]) -> str:
 
     Anthropic puts it on the top-level ``system`` field (string or list
     of content blocks); OpenAI/Gemini-style payloads put it as a message
-    with ``role=system``. Returns an empty string when nothing is found
-    rather than raising — the resolver tolerates an empty prompt and
-    will fall through to the configured fallback.
+    with ``role=system``. Some clients send both, so preserve all system
+    text for callers that need to find metadata in either location. Returns
+    an empty string when nothing is found rather than raising — the resolver
+    tolerates an empty prompt and will fall through to the configured fallback.
     """
 
+    parts: list[str] = []
     system_field = body.get("system")
     if isinstance(system_field, str):
-        return system_field
-    if isinstance(system_field, list):
-        parts: list[str] = []
+        if system_field:
+            parts.append(system_field)
+    elif isinstance(system_field, list):
         for block in system_field:
             if isinstance(block, dict):
                 text = block.get("text")
                 if isinstance(text, str):
                     parts.append(text)
-        if parts:
-            return "\n".join(parts)
 
     messages = body.get("messages")
     if isinstance(messages, list):
@@ -453,16 +453,17 @@ def extract_system_prompt(body: Mapping[str, Any]) -> str:
                 continue
             content = msg.get("content")
             if isinstance(content, str):
-                return content
-            if isinstance(content, list):
-                parts = []
+                if content:
+                    parts.append(content)
+            elif isinstance(content, list):
                 for block in content:
                     if isinstance(block, dict):
                         text = block.get("text")
                         if isinstance(text, str):
                             parts.append(text)
-                if parts:
-                    return "\n".join(parts)
+
+        if parts:
+            return "\n".join(parts)
 
         for msg in messages:
             if not isinstance(msg, dict):
@@ -484,5 +485,8 @@ def extract_system_prompt(body: Mapping[str, Any]) -> str:
                     user_text = "\n".join(parts)
             if user_text and any(prefix in user_text for prefix in _CWD_PREFIXES):
                 return user_text
+
+    if parts:
+        return "\n".join(parts)
 
     return ""

--- a/tests/test_memory_storage_router.py
+++ b/tests/test_memory_storage_router.py
@@ -166,6 +166,28 @@ def test_extract_system_prompt_openai_messages() -> None:
     assert extract_system_prompt(body) == "you are helpful"
 
 
+def test_extract_system_prompt_combines_top_level_and_system_messages() -> None:
+    body = {
+        "system": "You are a coding assistant.",
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "# Environment\n - Primary working directory: /Users/foo/code/headroom\n"
+                ),
+            }
+        ],
+    }
+
+    prompt = extract_system_prompt(body)
+    resolved = ProjectResolver().resolve(_ctx(system_prompt=prompt))
+
+    assert prompt.startswith("You are a coding assistant.\n")
+    assert resolved is not None
+    _, display = resolved
+    assert display == "headroom"
+
+
 def test_extract_system_prompt_missing_returns_empty() -> None:
     assert extract_system_prompt({"messages": []}) == ""
 


### PR DESCRIPTION
## Description

Headroom's project resolver currently reads only the top-level `system` field when a client sends both that field and `role=system` messages. Claude Code 2.1.260 places `Primary working directory:` in a later system message, so project memory resolution falls through to the empty-project fallback for those requests.

Closes #3429

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Preserve text from both the top-level `system` field and `role=system` messages.
- Add a regression test for a top-level prompt plus a Claude Code environment message.
- Keep existing provider extraction and user-message fallback behavior unchanged.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
python -m pytest -q tests/test_memory_storage_router.py
29 passed in 0.57s

python -m pytest -q tests/test_memory_storage_router.py tests/test_ccr_context_tracker.py tests/test_memory_injection_mode_policy.py
69 passed in 3.46s

ruff check headroom/memory/storage_router.py tests/test_memory_storage_router.py
All checks passed

ruff format --check headroom/memory/storage_router.py tests/test_memory_storage_router.py
2 files already formatted
```

## Real Behavior Proof

- Environment: Windows, Python 3.13.13; direct invocation of the repository's project resolver. No provider or external service is required for this payload-routing behavior.
- Exact command / steps: Run a payload with `system="You are a coding assistant."` and a later `role=system` message containing `Primary working directory: /tmp/headroom`, then call `extract_system_prompt` and `ProjectResolver.resolve`.
- Observed result: The resolver returned `resolved_display: headroom`, showing that the working directory in the system message is used when the top-level system prompt has no cwd line.
- Not tested: The full repository suite, the native `headroom._core` proxy path, and a live Claude Code/provider request.

## Runtime Rollout Safety

- Rollout-managed feature(s): None; this is existing project-routing logic.
- Minimum rollout channel: N/A; the fix uses the existing default path.
- Stable/default behavior changed: Only requests with both system locations now retain both for metadata extraction; single-source behavior is preserved.
- Kill switch / disable path: Revert this PR; no runtime flag is needed.
- Unsafe override required: No.
- Qualification impact: None; no provider, model, dependency, or service changes.
- Rollback path: Revert commit `f69910f`.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (not needed; the code is self-explanatory)
- [ ] I have made corresponding changes to the documentation (not needed; no public interface changed)
- [x] My changes generate no new warnings in the focused checks
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title

## Screenshots (if applicable)

Not applicable; this is a request-routing fix.

## Additional Notes

This PR is ready for human review. The latest review of f69910f58 approved the change and independently confirmed the 29-test storage-router suite. The available environment lacks the native `headroom._core` module needed to collect `tests/test_proxy_handler_helpers.py`, and `uv run pytest` stalled during environment resolution, so neither is claimed as passing.
