### PR TITLE
fix(compression): protect Bash before the tree-sitter guard, not after

### DIFF
--- a/headroom/transforms/code_compressor.py
+++ b/headroom/transforms/code_compressor.py
@@ -1364,6 +1364,30 @@ class CodeAwareCompressor(Transform):
                 syntax_valid=True,
             )
 
+        # Bash control-flow is recognized and parsed for validation, but is not
+        # rewritten yet.  Its grammar uses anonymous delimiters (`then`, `fi`,
+        # `do`, `done`, `esac`) that a generic AST reassembler cannot safely
+        # preserve.  Returning the validated source keeps shell scripts
+        # byte-for-byte intact instead of sending them to lossy Kompress.
+        if detected_lang == CodeLanguage.BASH:
+            # Validate only when a parser exists.  Without tree-sitter there is
+            # nothing to validate against, and the source is returned unchanged
+            # either way — report it as valid rather than as broken, matching
+            # the tree-sitter-unavailable return below.
+            syntax_valid = (
+                self._verify_syntax(code, detected_lang) if _check_tree_sitter_available() else True
+            )
+            return CodeCompressionResult(
+                compressed=code,
+                original=code,
+                original_tokens=original_tokens,
+                compressed_tokens=original_tokens,
+                compression_ratio=1.0,
+                language=detected_lang,
+                language_confidence=confidence,
+                syntax_valid=syntax_valid,
+            )
+
         # Check if tree-sitter is available
         if not _check_tree_sitter_available():
             logger.warning("tree-sitter not available. Install with: pip install headroom-ai[code]")
@@ -1394,24 +1418,6 @@ class CodeAwareCompressor(Transform):
                 language=detected_lang,
                 language_confidence=confidence,
                 syntax_valid=True,
-            )
-
-        # Bash control-flow is recognized and parsed for validation, but is not
-        # rewritten yet.  Its grammar uses anonymous delimiters (`then`, `fi`,
-        # `do`, `done`, `esac`) that a generic AST reassembler cannot safely
-        # preserve.  Returning the validated source keeps shell scripts
-        # byte-for-byte intact instead of sending them to lossy Kompress.
-        if detected_lang == CodeLanguage.BASH:
-            syntax_valid = self._verify_syntax(code, detected_lang)
-            return CodeCompressionResult(
-                compressed=code,
-                original=code,
-                original_tokens=original_tokens,
-                compressed_tokens=original_tokens,
-                compression_ratio=1.0,
-                language=detected_lang,
-                language_confidence=confidence,
-                syntax_valid=syntax_valid,
             )
 
         # Parse and compress


### PR DESCRIPTION
## Description

Follow-up to #3425 (which closed #3423). That PR added a `BASH` early-return so shell scripts are returned byte-for-byte instead of being sent to lossy Kompress — but placed it **after** the `_check_tree_sitter_available()` guard, which itself returns `_fallback_compress()` (Kompress).

So on any install without the optional `[code]` extra the BASH branch was unreachable, and #3423's corruption path stayed fully open. Reproduced on merged `main` with the issue's own snippet:

```
lang: CodeLanguage.UNKNOWN  ratio: 0.96875  LOSSLESS: False
```

The bare `then` is still dropped.

CI installs only `[dev]` (`ci.yml:264`), so tree-sitter is absent there too. That has two further consequences on `main` right now:

- both new tests in `tests/test_code_compressor_bash.py` fail (`detected UNKNOWN, expected BASH`);
- instantiating the compressor reaches `_fallback_compress`, loading the Kompress model and polluting global state, which breaks four `tests/test_proxy_health.py` readyz assertions when they run in the same pytest session (they pass in isolation — this only shows up in a combined run, as CI does).

## Changes Made

- Move the `BASH` early-return above the tree-sitter guard. Bash needs no parser to be returned unchanged.
- Validate only when a parser exists. Without one there is nothing to validate against and the source is returned unmodified either way, so report `syntax_valid=True` rather than `False` — matching the tree-sitter-unavailable return immediately below.

No behaviour change when tree-sitter is installed.

## Testing

Without tree-sitter (the CI configuration), the issue's snippet now returns `BASH`, `ratio=1.0`, byte-identical, with both `then` and both `fi` preserved.

```text
# without tree-sitter
479 passed, 86 skipped
# with tree-sitter installed
546 passed, 19 skipped
# previously on main (same selection, no tree-sitter)
6 failed, 473 passed
```

`ruff check` and `ruff format --check` clean on the touched file (0.16.3).

## Runtime Rollout Safety

- Stable/default behavior changed: Bash is now protected on installs without the `[code]` extra, which is the fix.
- Kill switch: none needed; `fallback_to_kompress=False` already bypasses Kompress.
- Rollback path: revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dnm4hC2dCve6o6iKYaC2LZ