### PR TITLE
fix(proxy): give each non-default port its own proxy log file

### DIFF
--- a/e2e/wrap/Dockerfile
+++ b/e2e/wrap/Dockerfile
@@ -84,6 +84,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
+# npm 10.9.8 crashes in Arborist's peer-set resolver when installing the local
+# OpenClaw plugin (Cannot read properties of null, reading 'edgesOut'). Pin the
+# tested npm version so both wrap-e2e callers use the same working installer.
+RUN npm install -g --no-fund --no-audit npm@11.16.0
+
 WORKDIR /workspace
 
 # Bring in the prebuilt manylinux wheel from stage 1.

--- a/headroom/cli/wrap.py
+++ b/headroom/cli/wrap.py
@@ -611,13 +611,18 @@ def _find_available_port(start_port: int, max_attempts: int = 100) -> int:
     raise RuntimeError(f"No available port found in range {start_port}-{end_port - 1}")
 
 
-def _get_log_path() -> Path:
-    """Get path for proxy log file."""
+def _get_log_path(port: int | None = None) -> Path:
+    """Get path for proxy log file.
+
+    Delegates the filename to `paths.proxy_log_path` so this stays in sync
+    with what the proxy subprocess (started with `--port port`) actually
+    writes to — see `_setup_file_logging` in `headroom.proxy.helpers`.
+    """
     from headroom import paths as _paths
 
-    log_dir = _paths.log_dir()
-    log_dir.mkdir(parents=True, exist_ok=True)
-    return log_dir / "proxy.log"
+    log_path = _paths.proxy_log_path(port=port)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    return log_path
 
 
 def _get_proxy_stdio_log_path() -> Path:
@@ -695,7 +700,7 @@ def _start_proxy(
         cmd.extend(["--vertex-api-url", vertex_api_url])
 
     timeout_seconds = _resolve_wrap_proxy_timeout_seconds()
-    log_path = _get_log_path()
+    log_path = _get_log_path(port)
     stdio_log_path = _get_proxy_stdio_log_path()
     stdio_log_file = open(stdio_log_path, "a", encoding="utf-8")  # noqa: SIM115
 

--- a/headroom/paths.py
+++ b/headroom/paths.py
@@ -74,6 +74,9 @@ _SYNC_STATE_FILE = "sync_state.json"
 _BRIDGE_STATE_FILE = "bridge_state.json"
 _LOGS_DIR = "logs"
 _PROXY_LOG_FILE = "proxy.log"
+# Mirrors `ProxyConfig.port`'s default (headroom/proxy/models.py). Kept as a
+# plain literal here to avoid this low-level module importing proxy code.
+_DEFAULT_PROXY_PORT = 8787
 _DEBUG_400_DIR = "debug_400"
 _CODEX_WIRE_DEBUG_DIR = "codex_wire"
 _BIN_DIR = "bin"
@@ -300,9 +303,22 @@ def log_dir() -> Path:
     return workspace_dir() / _LOGS_DIR
 
 
-def proxy_log_path() -> Path:
-    """Return the path for the proxy log file."""
+def proxy_log_path(*, port: int | None = None) -> Path:
+    """Return the path for the proxy log file.
 
+    Every proxy process shares one workspace by default (e.g. sibling
+    `install apply` profiles on different ports), so without per-port
+    scoping they all open the same file and rotate it out from under each
+    other. Passing the running proxy's `port` gives it a distinct file
+    (`proxy.<port>.log`); the default port keeps the original unsuffixed
+    name so existing tooling that reads it directly is unaffected.
+
+    Args:
+        port: The port the proxy is (or will be) listening on. Omit, or
+            pass the default port, to get the original shared filename.
+    """
+    if port is not None and port != _DEFAULT_PROXY_PORT:
+        return log_dir() / f"proxy.{port}.log"
     return log_dir() / _PROXY_LOG_FILE
 
 

--- a/headroom/perf/analyzer.py
+++ b/headroom/perf/analyzer.py
@@ -26,6 +26,13 @@ log = logging.getLogger(__name__)
 LOG_DIR = _paths.log_dir()
 DEFAULT_SLOW_OPTIMIZATION_MS = 500.0
 
+# The default port's log keeps its legacy unsuffixed name (proxy.log,
+# proxy.log.1, ...); every other port gets proxy.<port>.log[.N] — see
+# paths.proxy_log_path(). Both patterns are globbed so a workspace shared by
+# multiple `install apply` profiles (issue #3421) still has every profile's
+# log aggregated here, not just the default port's.
+_PROXY_LOG_GLOB_PATTERNS = ("proxy.log*", "proxy.[0-9]*.log*")
+
 # Matches: 2026-03-07 13:38:31,009 - headroom.proxy - INFO - [hr_...] PERF model=... ...
 _PERF_RE = re.compile(
     r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d+) .* \[(?P<rid>[^\]]+)\] PERF (?P<kv>.+)$"
@@ -313,7 +320,8 @@ def parse_log_files(last_n_hours: float = 168.0) -> PerfReport:
         if report.newest_kept_ts is None or ts_str > report.newest_kept_ts:
             report.newest_kept_ts = ts_str
 
-    # Collect log files: proxy.log, proxy.log.1, proxy.log.2, ...
+    # Collect log files: proxy.log, proxy.log.1, proxy.log.2, ... plus every
+    # non-default port's proxy.<port>.log[.N] (see _PROXY_LOG_GLOB_PATTERNS).
     #
     # A rotated file last written before the cutoff cannot contain a record
     # inside the window, so skip it without opening it. Without this the cost
@@ -328,7 +336,10 @@ def parse_log_files(last_n_hours: float = 168.0) -> PerfReport:
     # are stat'd once and the value reused for the sort.
     cutoff_epoch = cutoff.timestamp() if cutoff is not None else None
     dated_files: list[tuple[float, Path]] = []
-    for path in log_dir.glob("proxy.log*"):
+    matched_paths: set[Path] = set()
+    for pattern in _PROXY_LOG_GLOB_PATTERNS:
+        matched_paths.update(log_dir.glob(pattern))
+    for path in matched_paths:
         try:
             mtime = path.stat().st_mtime
         except OSError:

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -1561,19 +1561,20 @@ def _headroom_log_dir() -> Path:
     return _paths.log_dir()
 
 
-def _setup_file_logging() -> None:
+def _setup_file_logging(port: int | None = None) -> None:
     """Add a RotatingFileHandler to the headroom root logger.
 
-    Writes to ~/.headroom/logs/proxy.log with automatic rotation:
+    Writes to ~/.headroom/logs/proxy.log (or, for a non-default `port`,
+    the per-port `proxy.<port>.log` — see `paths.proxy_log_path`) with
+    automatic rotation:
     - Rotates at 10 MB
     - Keeps 5 backups (~50 MB max)
     """
     from logging.handlers import RotatingFileHandler
 
     try:
-        log_dir = _headroom_log_dir()
-        log_dir.mkdir(parents=True, exist_ok=True)
-        log_path = log_dir / "proxy.log"
+        log_path = _paths.proxy_log_path(port=port)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
         handler = RotatingFileHandler(
             log_path,
             maxBytes=10 * 1024 * 1024,  # 10 MB

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -2737,13 +2737,16 @@ def create_app(config: ProxyConfig | None = None) -> FastAPI:
 
     from contextlib import asynccontextmanager
 
+    config = config or ProxyConfig()
+
     # Always-on file logging to ~/.headroom/logs/ for `headroom perf` analysis.
     # Installed here (not at module import) so importing headroom.proxy.server
     # in tests or library contexts does not silently attach a RotatingFileHandler
-    # to the user's live proxy.log.
-    _setup_file_logging()
-
-    config = config or ProxyConfig()
+    # to the user's live proxy.log. Scoped to `config.port` so sibling proxy
+    # instances on other ports (e.g. multiple `install apply` profiles sharing
+    # one workspace) don't share and rotate the same file out from under each
+    # other (#3421).
+    _setup_file_logging(config.port)
 
     # Defensive re-apply of file-backed settings for embedded/non-CLI callers
     # that construct the app without going through the `headroom` CLI entrypoint

--- a/tests/test_agent_savings.py
+++ b/tests/test_agent_savings.py
@@ -321,7 +321,7 @@ def test_start_proxy_does_not_inject_agent_savings_by_default(monkeypatch, tmp_p
     monkeypatch.setattr(wrap_module.subprocess, "Popen", popen)
     monkeypatch.setattr(wrap_module.time, "sleep", lambda seconds: None)
     monkeypatch.setattr(wrap_module, "_check_proxy", lambda port: True)
-    monkeypatch.setattr(wrap_module, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_module, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
 
     wrap_module._start_proxy(8787, agent_type="codex")
 
@@ -346,7 +346,7 @@ def test_start_proxy_injects_explicit_agent_savings_profile(monkeypatch, tmp_pat
     monkeypatch.setattr(wrap_module.subprocess, "Popen", popen)
     monkeypatch.setattr(wrap_module.time, "sleep", lambda seconds: None)
     monkeypatch.setattr(wrap_module, "_check_proxy", lambda port: True)
-    monkeypatch.setattr(wrap_module, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_module, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
 
     wrap_module._start_proxy(8787, agent_type="codex")
 

--- a/tests/test_cli/test_wrap_claude_vertex_proxy_env.py
+++ b/tests/test_cli/test_wrap_claude_vertex_proxy_env.py
@@ -434,7 +434,7 @@ def test_start_proxy_sets_vertex_target_env_for_proxy_subprocess(
     fake_proc = _FakeProxyProcess()
     captured: dict[str, Any] = {}
 
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
     monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
 
@@ -467,7 +467,7 @@ def test_start_proxy_clears_inherited_vertex_target_env(
     captured: dict[str, Any] = {}
 
     monkeypatch.setenv("VERTEX_TARGET_API_URL", "http://127.0.0.1:8787")
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
     monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
 
@@ -497,7 +497,7 @@ def test_start_proxy_sets_pythonsafepath_to_avoid_cwd_shadow(
     fake_proc = _FakeProxyProcess()
     captured: dict[str, Any] = {}
 
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
     monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
 

--- a/tests/test_cli/test_wrap_codex.py
+++ b/tests/test_cli/test_wrap_codex.py
@@ -1403,7 +1403,7 @@ def test_start_proxy_uses_separate_session_for_signal_isolation(
         popen_kwargs.update(kwargs)
         return FakeProc()
 
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda port: True)
     monkeypatch.setattr(wrap_mod.subprocess, "Popen", fake_popen)
 
@@ -1441,7 +1441,7 @@ def test_start_proxy_does_not_apply_agent_90_defaults(
         popen_kwargs.update(kwargs)
         return FakeProc()
 
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda port: True)
     monkeypatch.setattr(wrap_mod.subprocess, "Popen", fake_popen)
 
@@ -1473,7 +1473,7 @@ def test_start_proxy_preserves_explicit_savings_overrides(
 
     monkeypatch.setenv("HEADROOM_TARGET_RATIO", "0.20")
     monkeypatch.setenv("HEADROOM_MAX_ITEMS", "12")
-    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_mod, "_check_proxy", lambda port: True)
     monkeypatch.setattr(wrap_mod.subprocess, "Popen", fake_popen)
 

--- a/tests/test_cli/test_wrap_proxy_detach.py
+++ b/tests/test_cli/test_wrap_proxy_detach.py
@@ -44,7 +44,7 @@ def _capture_popen_kwargs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> di
     monkeypatch.setattr(wrap_cli.subprocess, "Popen", _fake_popen)
     monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: True)
     monkeypatch.setattr(wrap_cli.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_cli, "_resolve_wrap_proxy_timeout_seconds", lambda: 1)
 
     wrap_cli._start_proxy(8787)
@@ -98,7 +98,7 @@ def test_start_proxy_retries_without_breakaway_when_job_forbids_it(
     monkeypatch.setattr(wrap_cli.subprocess, "Popen", _flaky_popen)
     monkeypatch.setattr(wrap_cli, "_check_proxy", lambda port: True)
     monkeypatch.setattr(wrap_cli.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_cli, "_resolve_wrap_proxy_timeout_seconds", lambda: 1)
 
     wrap_cli._start_proxy(8787)
@@ -137,7 +137,7 @@ def test_start_proxy_closes_log_when_both_spawns_fail(
 
     monkeypatch.setattr(wrap_cli.subprocess, "Popen", _always_fails)
     monkeypatch.setattr(wrap_cli.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda: tmp_path / "proxy.log")
+    monkeypatch.setattr(wrap_cli, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
     monkeypatch.setattr(wrap_cli, "_resolve_wrap_proxy_timeout_seconds", lambda: 1)
 
     with pytest.raises(OSError):

--- a/tests/test_cli_perf_format.py
+++ b/tests/test_cli_perf_format.py
@@ -296,6 +296,61 @@ def test_unwindowed_parse_still_reads_every_rotated_log(monkeypatch, tmp_path):
     assert report.log_files_read == 2
 
 
+def test_parse_log_files_includes_non_default_port_logs(monkeypatch, tmp_path):
+    """`headroom perf` (and `/stats` throughput) must aggregate every
+    profile's log, not just the default port's.
+
+    Regression test for https://github.com/headroomlabs-ai/headroom/pull/3444
+    review feedback: giving each non-default port its own
+    `proxy.<port>.log` (issue #3421) silently dropped that data from
+    `parse_log_files`, which only globbed `proxy.log*`.
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    now = datetime.now()
+    _write_log(log_dir / "proxy.log", _perf_line(now - timedelta(minutes=5), "default"), now)
+    _write_log(
+        log_dir / "proxy.8791.log",
+        _perf_line(now - timedelta(minutes=5), "openrouter"),
+        now,
+    )
+    _write_log(
+        log_dir / "proxy.8791.log.1",
+        _perf_line(now - timedelta(days=3), "openrouter-rotated"),
+        now - timedelta(days=3),
+    )
+    monkeypatch.setattr(analyzer, "LOG_DIR", log_dir)
+
+    report = analyzer.parse_log_files(last_n_hours=0)
+
+    assert {r.client for r in report.perf_records} == {
+        "default",
+        "openrouter",
+        "openrouter-rotated",
+    }
+    assert report.log_files_read == 3
+
+
+def test_parse_log_files_windowed_still_skips_stale_non_default_port_logs(monkeypatch, tmp_path):
+    """The mtime-based windowing optimization must also cover per-port logs."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    now = datetime.now()
+    _write_log(
+        log_dir / "proxy.8791.log.1",
+        _perf_line(now - timedelta(days=3), "stale"),
+        now - timedelta(days=3),
+    )
+    _write_log(log_dir / "proxy.8791.log", _perf_line(now - timedelta(minutes=5), "live"), now)
+    monkeypatch.setattr(analyzer, "LOG_DIR", log_dir)
+
+    report = analyzer.parse_log_files(last_n_hours=1.0)
+
+    assert [r.client for r in report.perf_records] == ["live"]
+    assert report.log_files_read == 1
+    assert report.log_files_skipped == 1
+
+
 def test_perf_csv_by_model(runner, monkeypatch):
     _patch_report(monkeypatch, _sample_report())
     result = runner.invoke(main, ["perf", "--format", "csv"])

--- a/tests/test_cli_proxy_env.py
+++ b/tests/test_cli_proxy_env.py
@@ -65,7 +65,7 @@ class TestCLIWrapProxyTimeout:
 
         monkeypatch.delenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, raising=False)
         monkeypatch.setattr(wrap_mod, "_ml_wrap_extras_detected", lambda: False)
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda seconds: sleeps.append(seconds))
         monkeypatch.setattr(wrap_mod.subprocess, "Popen", lambda *args, **kwargs: fake_proc)
@@ -82,7 +82,7 @@ class TestCLIWrapProxyTimeout:
 
         monkeypatch.delenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, raising=False)
         monkeypatch.setattr(wrap_mod, "_ml_wrap_extras_detected", lambda: False)
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
 
@@ -115,7 +115,7 @@ class TestCLIWrapProxyTimeout:
         monkeypatch.setenv("GITHUB_COPILOT_API_TOKEN_EXPIRES_AT", "123")
         monkeypatch.delenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, raising=False)
         monkeypatch.setattr(wrap_mod, "_ml_wrap_extras_detected", lambda: False)
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
 
@@ -145,7 +145,7 @@ class TestCLIWrapProxyTimeout:
         logs: list[str] = []
 
         monkeypatch.delenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, raising=False)
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: True)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
         monkeypatch.setattr(wrap_mod, "_ml_wrap_extras_detected", lambda: False)
@@ -171,7 +171,7 @@ class TestCLIWrapProxyTimeout:
         checks = []
 
         monkeypatch.setenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, "4")
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda seconds: sleeps.append(seconds))
         monkeypatch.setattr(wrap_mod.subprocess, "Popen", lambda *args, **kwargs: fake_proc)
 
@@ -196,7 +196,7 @@ class TestCLIWrapProxyTimeout:
         fake_proc.poll = lambda: fake_proc.returncode
 
         monkeypatch.setenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, "2")
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
         monkeypatch.setattr(wrap_mod.subprocess, "Popen", lambda *args, **kwargs: fake_proc)
@@ -216,7 +216,7 @@ class TestCLIWrapProxyTimeout:
         fake_proc = _FakeProxyProcess()
 
         monkeypatch.setenv(wrap_mod._WRAP_PROXY_TIMEOUT_ENV, "2")
-        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda: tmp_path / "proxy.log")
+        monkeypatch.setattr(wrap_mod, "_get_log_path", lambda _port=None: tmp_path / "proxy.log")
         monkeypatch.setattr(wrap_mod, "_check_proxy", lambda _port: False)
         monkeypatch.setattr(wrap_mod.time, "sleep", lambda _seconds: None)
         monkeypatch.setattr(wrap_mod.subprocess, "Popen", lambda *args, **kwargs: fake_proc)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -310,6 +310,30 @@ def test_proxy_log_path_default(fake_home: Path) -> None:
     assert paths.proxy_log_path() == fake_home / ".headroom" / "logs" / "proxy.log"
 
 
+def test_proxy_log_path_default_port_matches_no_port(fake_home: Path) -> None:
+    """Passing the default port explicitly must not change the filename."""
+    assert paths.proxy_log_path(port=8787) == paths.proxy_log_path()
+
+
+def test_proxy_log_path_non_default_port_is_distinct(fake_home: Path) -> None:
+    """Sibling profiles on other ports must not share the default log file.
+
+    Regression test for https://github.com/headroomlabs-ai/headroom/issues/3421:
+    multiple `install apply` profiles in one workspace all opened the same
+    proxy.log and rotated it out from under each other.
+    """
+    default_log = paths.proxy_log_path()
+    other_log = paths.proxy_log_path(port=8791)
+    assert other_log != default_log
+    assert other_log == fake_home / ".headroom" / "logs" / "proxy.8791.log"
+
+
+def test_proxy_log_path_different_ports_are_distinct_from_each_other(
+    fake_home: Path,
+) -> None:
+    assert paths.proxy_log_path(port=8791) != paths.proxy_log_path(port=8792)
+
+
 def test_debug_400_dir_default(fake_home: Path) -> None:
     assert paths.debug_400_dir() == fake_home / ".headroom" / "logs" / "debug_400"
 
@@ -365,6 +389,14 @@ def test_proxy_log_path_follows_workspace_env(
     ws = tmp_path / "state"
     clean_env.setenv(paths.HEADROOM_WORKSPACE_DIR_ENV, str(ws))
     assert paths.proxy_log_path() == ws / "logs" / "proxy.log"
+
+
+def test_proxy_log_path_with_port_follows_workspace_env(
+    fake_home: Path, clean_env: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ws = tmp_path / "state"
+    clean_env.setenv(paths.HEADROOM_WORKSPACE_DIR_ENV, str(ws))
+    assert paths.proxy_log_path(port=8791) == ws / "logs" / "proxy.8791.log"
 
 
 def test_beacon_lock_path_follows_workspace_env(

--- a/tests/test_pr208_changes.py
+++ b/tests/test_pr208_changes.py
@@ -361,13 +361,13 @@ class TestSetupFileLogging:
         """_setup_file_logging should not raise on OSError."""
         from headroom.proxy.helpers import _setup_file_logging
 
-        # Monkey-patch _headroom_log_dir to return a path that will cause OSError
-        def _bad_log_dir():
-            return Path("/nonexistent/deeply/nested/path/that/cannot/exist/___test___")
+        # Monkey-patch proxy_log_path to return a path that will cause OSError
+        def _bad_log_path(*, port: int | None = None) -> Path:
+            return Path("/nonexistent/deeply/nested/path/that/cannot/exist/___test___/proxy.log")
 
         import headroom.proxy.helpers as helpers_mod
 
-        monkeypatch.setattr(helpers_mod, "_headroom_log_dir", _bad_log_dir)
+        monkeypatch.setattr(helpers_mod._paths, "proxy_log_path", _bad_log_path)
         # Should not raise
         _setup_file_logging()
 


### PR DESCRIPTION
## Summary
- Every proxy process attached its own `RotatingFileHandler` to the same shared `~/.headroom/logs/proxy.log`, with no scoping by port. Anyone running multiple persistent `install apply` profiles in one workspace (default/anthropic, openrouter, ollama, gemini, etc., each bound to a different port) ends up with every process rotating the same file out from under the others — banners, per-day counts, CCR lines, and error signatures from all profiles get interleaved, and any "read proxy.log" diagnosis looks at the wrong service.
- `paths.proxy_log_path()` was the one path helper in `paths.py` without port-scoping — its siblings (`proxy_clients_dir`, `beacon_lock_path`, `proxy_start_lock_path`) are all already keyed by port. Extends it with an optional `port` argument: the default port keeps the original unsuffixed `proxy.log` (no behavior change for the common single-instance case, or for existing tooling that reads that fixed path), while any other port gets its own `proxy.<port>.log`.
- Wires `config.port` through `create_app` into `_setup_file_logging` (which now delegates to `proxy_log_path` instead of re-deriving the same path independently), and threads `port` into `headroom wrap`'s subprocess log-path display helper so the path shown to the user always matches where that instance actually writes.

Fixes #3421

Known gap, left for a follow-up: `headroom perf`'s log aggregation (`parse_log_files`) still only globs the default `proxy.log*`, so per-profile perf analysis on non-default ports isn't wired up yet — this PR fixes the file-corruption bug, not full multi-profile `perf` support.

## Release note

Persistent `install apply` profiles on different ports (e.g. multiple backends sharing one workspace) each get their own `logs/proxy.<port>.log` instead of sharing and rotating the default profile's `proxy.log`.

---

Disclosure: investigated and fixed with AI-agent assistance (Claude Code).