### PR TITLE
fix: attach stdin for docker-native MCP stdio

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -194,14 +194,10 @@ function Get-SharedDockerArgs {
 function Add-TtyArgs {
     param($ArgsList)
 
+    # MCP stdio always uses a pipe for stdin. Docker only forwards stdin when
+    # explicitly given -i, regardless of whether the host console is redirected.
+    $ArgsList.Add('-i')
     if (-not [Console]::IsInputRedirected -and -not [Console]::IsOutputRedirected) {
-        $ArgsList.Add('-it')
-        return
-    }
-    if (-not [Console]::IsInputRedirected) {
-        $ArgsList.Add('-i')
-    }
-    if (-not [Console]::IsOutputRedirected) {
         $ArgsList.Add('-t')
     }
 }

--- a/tests/test_install/test_native_installers.py
+++ b/tests/test_install/test_native_installers.py
@@ -647,6 +647,61 @@ def test_powershell_installer_does_not_leak_into_user_path(tmp_path: Path) -> No
             _restore_user_path_entry(before)
 
 
+@pytest.mark.skipif(
+    os.name != "nt" or _powershell_executable() is None,
+    reason="Windows PowerShell coverage runs on Windows hosts only",
+)
+def test_powershell_mcp_wrapper_keeps_stdin_attached_for_redirected_stdio(
+    tmp_path: Path,
+) -> None:
+    """Piped MCP stdio must still pass -i to Docker even when input is redirected."""
+    powershell = _powershell_executable()
+    assert powershell is not None
+
+    home = tmp_path / "home"
+    (home / ".local").mkdir(parents=True)
+    env = _build_env(home, tmp_path)
+    env["HEADROOM_DOCKER_IMAGE"] = "headroom:test-image"
+
+    try:
+        _run(
+            [
+                powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(REPO_ROOT / "scripts" / "install.ps1"),
+            ],
+            env=env,
+            cwd=REPO_ROOT,
+        )
+        wrapper = home / ".local" / "bin" / "headroom.ps1"
+        result = subprocess.run(
+            [
+                powershell,
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(wrapper),
+                "mcp",
+                "serve",
+            ],
+            env=env,
+            input='{"jsonrpc":"2.0","id":1,"method":"initialize"}\n',
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert result.returncode == 0
+        mcp_call = next(call for call in _read_fake_docker_log(env) if call[:2] == ["run", "--rm"])
+        assert "-i" in mcp_call
+        assert "-t" not in mcp_call
+    finally:
+        _cleanup_fake_docker(env)
+
+
 # AST-extract Ensure-PathEntry from install.ps1 and invoke it in isolation under
 # a given HEADROOM_INSTALL_PATH_SCOPE, so the scope allow-list is exercised
 # without running the whole installer. Parsing via the PowerShell AST (not a


### PR DESCRIPTION
## Description

Docker-native PowerShell MCP stdio clients pipe stdin. `Add-TtyArgs` previously omitted Docker's `-i` flag for redirected input, so the container saw EOF before answering `initialize` and MCP clients reported `CONNECTION_CLOSED`.

Closes #3393

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- `Add-TtyArgs` always passes Docker's `-i` flag.
- Pseudo-TTY allocation remains conditional on both host streams being interactive, so `-t` is only added for fully interactive consoles.
- Added a Windows regression that installs the generated PowerShell wrapper, pipes an MCP initialize request, and verifies the fake Docker invocation includes `-i` but not `-t`.

## Testing

- [x] Targeted Windows regression passed (`1 passed, 5 deselected`).
- [x] Ruff check passed for the changed test file.
- [x] Ruff format check passed for the changed test file.
- [x] `git diff --check` passed.
- [x] Full native-installer file: 4 passed, 1 skipped.

### Test Output

```text
python -m pytest tests/test_install/test_native_installers.py -k 'mcp_wrapper_keeps' -q
1 passed, 5 deselected

ruff check tests/test_install/test_native_installers.py
Passed

ruff format --check tests/test_install/test_native_installers.py
Passed

git diff --check
Passed
```

## Real Behavior Proof

- Environment: Windows 10, Windows PowerShell 5.1, Python 3.11.9, repository checkout at the PR head.
- Exact command / steps: install the generated wrapper, pipe an MCP initialize request through it, and use a fake Docker executable that records its exact arguments.
- Observed result: the piped invocation completed successfully; the recorded `docker run --rm` arguments included `-i` and excluded `-t`.
- Not tested: a live pull of the published Headroom image or an end-to-end Claude Code session with Docker Desktop.

## Runtime Rollout Safety

- Rollout-managed feature(s): None.
- Minimum rollout channel: Existing Docker-native wrapper path.
- Stable/default behavior changed: Redirected stdin is now attached to the container; interactive TTY behavior is unchanged.
- Kill switch / disable path: Not applicable.
- Unsafe override required: No.
- Qualification impact: None.
- Rollback path: Revert this commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (not needed for this small change)
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing targeted tests pass locally
- [x] I did **not** edit `CHANGELOG.md`

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The full native-installer file has one unrelated persistent lifecycle test blocked by a pre-existing PowerShell output-encoding failure. The PR's GitHub `docker-wrap-e2e` check later failed while installing the unrelated OpenClaw plugin with npm (`Cannot read properties of null (reading 'edgesOut')`; no code in this PR is involved). The run cannot be rerun with the current token because GitHub requires repository admin rights.