### PR TITLE
chore(ci): pin npm for OpenClaw wrap installs

### DIFF
--- a/e2e/wrap/Dockerfile
+++ b/e2e/wrap/Dockerfile
@@ -84,6 +84,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
+# npm 10.9.8 crashes in Arborist's peer-set resolver when installing the local
+# OpenClaw plugin (Cannot read properties of null, reading 'edgesOut'). Pin the
+# tested npm version so both wrap-e2e callers use the same working installer.
+RUN npm install -g --no-fund --no-audit npm@11.16.0
+
 WORKDIR /workspace
 
 # Bring in the prebuilt manylinux wheel from stage 1.


### PR DESCRIPTION
## Description

The Docker wrap test image inherits npm 10.9.8 from NodeSource's Node 22 package. Installing the local OpenClaw plugin crashes in Arborist's peer-set resolver with `Cannot read properties of null (reading 'edgesOut')`, before the plugin can build. This fails both Wrap E2E and CI's Docker-native wrap step, including on upstream main.

Pin npm 11.16.0 in that test image. The same dependency-resolution fixture installs successfully with this version under Node 22.23.2. Runtime application code and dependency manifests are unchanged.

## Type of Change

- [x] Bug fix (CI tooling)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- Install npm 11.16.0 after NodeSource installs Node 22 in `e2e/wrap/Dockerfile`.
- Both affected jobs build this Dockerfile, so one pin covers both callers.

## Testing

- [x] Reproduced npm 10.9.8 failure with the OpenClaw manifest and local SDK tarball
- [x] Identical fixture installs under npm 11.16.0 / Node 22.23.2
- [x] Installed esbuild executable runs
- [x] `git diff --check`
- [x] Full Docker wrap and Docker-native end-to-end runs passed in GitHub CI

### Test Output

```text
npm exec --yes --package npm@10.9.8 -- npm install --ignore-scripts --no-audit --no-fund
Cannot read properties of null (reading 'edgesOut')

npm exec --yes --package node@22 --package npm@11.16.0 -- npm install --no-audit --no-fund
added 89 packages in 8s

node --version  # from the npm exec Node 22 environment
v22.23.2
node_modules/.bin/esbuild --version
0.28.2
```

## Real Behavior Proof

- Environment: isolated macOS package-install fixtures; Node 22.23.2 and npm 11.16.0 for the passing case.
- Exact steps: copy the repository OpenClaw package manifest, replace its SDK dependency with an npm-packed local SDK tarball as the e2e harness does, install with each npm version.
- Observed: npm 10.9.8 crashes in `loadPeerSet`; npm 11.16.0 resolves and installs the tree. The installed esbuild binary works.
- Not tested locally: complete Linux Docker image build, plugin compilation, and gateway wrap flow; these remain CI gates. The resolver fixture tarball contains the SDK package metadata, not compiled SDK output.
- Upstream main failure: https://github.com/headroomlabs-ai/headroom/actions/runs/34009244325

## Runtime Rollout Safety

- Rollout-managed features: none; e2e test image only.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: npm installer version in the test image.
- Kill switch / disable path: revert the pin.
- Unsafe override required: none; no peer-dependency bypass or test skip added.
- Qualification impact: both Docker wrap test callers must complete successfully.
- Rollback path: revert this Dockerfile change.

## Review Readiness

- [x] Self-review completed
- [x] Full Docker qualification completed
- [ ] Final human approval

## Checklist

- [x] Change is limited to CI tooling
- [x] No manual CHANGELOG.md changes
- [x] No merge or auto-merge performed

## Current GitHub Validation

At `34e4abcf4`, all current checks completed with no failures. Both affected jobs passed: [Docker-native E2E](https://github.com/headroomlabs-ai/headroom/actions/runs/34074172033/job/101597002855) and [Wrap E2E](https://github.com/headroomlabs-ai/headroom/actions/runs/34074172062/job/101596978161). Docker init, macOS/Windows wrappers, and CodeQL also passed. Runtime lint/unit jobs were skipped by the path filter for this Dockerfile-only change. Final human review is still required.
