### PR TITLE
fix(learn): distinguish Grep and Glob searches by path

### DIFF
--- a/headroom/learn/models.py
+++ b/headroom/learn/models.py
@@ -67,10 +67,10 @@ class ToolCall:
             return cmd[:100] + "..." if len(cmd) > 100 else cmd
         if self.name in ("Read", "read"):
             return str(self.input_data.get("file_path", "?"))
-        if self.name in ("Grep", "grep"):
-            return str(self.input_data.get("pattern", "?"))
-        if self.name in ("Glob", "glob"):
-            return str(self.input_data.get("pattern", "?"))
+        if self.name in ("Grep", "grep", "Glob", "glob"):
+            pattern = self.input_data.get("pattern", "?")
+            path = self.input_data.get("path", "?")
+            return f"{pattern} in {path}"
         if self.name in ("Edit", "edit", "Write", "write"):
             return str(self.input_data.get("file_path", "?"))
         return str(self.input_data)[:80]

--- a/tests/test_learn/test_loop_weighting.py
+++ b/tests/test_learn/test_loop_weighting.py
@@ -16,6 +16,8 @@ surfaced, were ranked no higher than a one-off rule. These tests pin:
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from headroom.learn.analyzer import SessionAnalyzer, _build_digest
 from headroom.learn.fixtures import (
     error_loop_session,
@@ -31,6 +33,8 @@ from headroom.learn.models import (
     ProjectInfo,
     Recommendation,
     RecommendationTarget,
+    SessionData,
+    ToolCall,
 )
 
 
@@ -48,6 +52,46 @@ def _project() -> ProjectInfo:
 
 
 class TestDetectLoops:
+    @pytest.mark.parametrize(
+        ("name", "pattern"),
+        [("Grep", "TimeoutError"), ("Glob", "**/*.py")],
+    )
+    def test_search_signatures_include_path(self, name: str, pattern: str):
+        def call(path: str, index: int):
+            return ToolCall(
+                name=name,
+                tool_call_id=f"{name}-{index}",
+                input_data={"pattern": pattern, "path": path},
+                output="x" * 40000,
+                is_error=False,
+                output_bytes=40000,
+                msg_index=index,
+            )
+
+        distinct_paths = [
+            call("/srv/ingest", 0),
+            call("/srv/billing", 1),
+            call("/srv/web", 2),
+        ]
+        assert len({_canonical_signature(call) for call in distinct_paths}) == 3
+        assert detect_loops([SessionData(session_id=name, tool_calls=distinct_paths)]) == []
+
+        same_path = [call("/srv/ingest", index) for index in range(3)]
+        loop = detect_loops([SessionData(session_id=name, tool_calls=same_path)])[0]
+        assert loop.count == 3
+        assert loop.sample_input == f"{pattern} in /srv/ingest"
+
+    def test_unknown_tool_summary_still_uses_generic_input(self):
+        input_data = {"query": "TimeoutError", "path": "/srv/ingest"}
+        tool_call = ToolCall(
+            name="Search",
+            tool_call_id="search-1",
+            input_data=input_data,
+            output="",
+            is_error=False,
+        )
+        assert tool_call.input_summary == str(input_data)[:80]
+
     def test_refetch_loop_detected_despite_no_errors(self):
         loops = detect_loops([refetch_loop_session(repetitions=5)])
         assert len(loops) == 1


### PR DESCRIPTION
## Description

Fixes #3453.

`headroom learn` grouped native Grep and Glob calls by pattern alone, so the same pattern in different directories appeared as one loop. This includes the search path in the existing summary used for loop signatures and samples, so separate searches remain separate while repeated searches in one directory still form a loop.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Include `path` alongside `pattern` for Grep and Glob input summaries.
- Add regression coverage for separate paths, repeated same-path searches, and the generic summary fallback.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
uv run pytest tests/test_learn/test_loop_weighting.py -q
16 passed in 0.12s

uv run ruff check headroom/learn/models.py tests/test_learn/test_loop_weighting.py
All checks passed!

uv run ruff format --check headroom/learn/models.py tests/test_learn/test_loop_weighting.py
2 files already formatted
```

## Real Behavior Proof

- Environment: macOS on Apple Silicon, Python 3.13.14.
- Exact command / steps: created one `SessionData` session with three native Grep or Glob calls using one pattern and `/srv/ingest`, `/srv/billing`, and `/srv/web`, then ran `detect_loops`.
- Observed result: before, each tool produced one signature and one three-call loop with 20,000 attributed tokens. After, each produces three path-qualified signatures and no loop; three calls with the same path still produce one loop.
- Not tested: full suite and scanning a retained production transcript.

## Runtime Rollout Safety

- Rollout-managed feature(s): None.
- Minimum rollout channel: Standard release.
- Stable/default behavior changed: Grep and Glob searches with the same pattern in different directories no longer merge into one loop.
- Kill switch / disable path: Revert this change.
- Unsafe override required: No.
- Qualification impact: Existing `headroom learn` loop reports become path-specific for native Grep and Glob calls.
- Rollback path: Revert this change; pathless grouping resumes.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A: the summary format is direct)
- [ ] I have made corresponding changes to the documentation (N/A: no public API or documentation change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`: it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)
