### PR TITLE
fix: preserve retrieval results through the Pi MCP wrapper

### DIFF
--- a/headroom/config.py
+++ b/headroom/config.py
@@ -387,12 +387,12 @@ _HERMES_TOOL_CALL_WRAPPER = "tool_call"
 
 
 def unwrap_tool_call_name(name: str, arguments: Any) -> str:
-    """Extract the real tool name from a Hermes deferred ``tool_call`` wrapper.
+    """Extract the real tool name from a Hermes or Pi wrapper.
 
     Non-wrapper names pass through unchanged. Malformed/unparseable wrappers
     fail open and return the wrapper name (caller decides what that means).
     """
-    if name != _HERMES_TOOL_CALL_WRAPPER:
+    if name not in {_HERMES_TOOL_CALL_WRAPPER, "mcp_daemon"}:
         return name
     raw = arguments
     if isinstance(raw, str):
@@ -401,6 +401,13 @@ def unwrap_tool_call_name(name: str, arguments: Any) -> str:
         except (ValueError, TypeError):
             return name
     if isinstance(raw, dict):
+        if name == "mcp_daemon":
+            selector = raw.get("selector")
+            if raw.get("action") == "call" and isinstance(selector, str):
+                parts = selector.split(".")
+                if len(parts) == 2 and all(parts):
+                    return f"mcp__{parts[0]}__{parts[1]}"
+            return name
         inner = raw.get("name")
         if isinstance(inner, str) and inner.strip():
             return inner.strip()

--- a/headroom/config.py
+++ b/headroom/config.py
@@ -392,7 +392,7 @@ def unwrap_tool_call_name(name: str, arguments: Any) -> str:
     Non-wrapper names pass through unchanged. Malformed/unparseable wrappers
     fail open and return the wrapper name (caller decides what that means).
     """
-    if name not in {_HERMES_TOOL_CALL_WRAPPER, "mcp_daemon"}:
+    if name not in (_HERMES_TOOL_CALL_WRAPPER, "mcp_daemon"):
         return name
     raw = arguments
     if isinstance(raw, str):

--- a/tests/test_hermes_tool_call_unwrap.py
+++ b/tests/test_hermes_tool_call_unwrap.py
@@ -13,6 +13,10 @@ into `ContentRouter._build_tool_name_map` (OpenAI + Anthropic paths).
 
 from __future__ import annotations
 
+import json
+
+import pytest
+
 from headroom.config import (
     DEFAULT_EXCLUDE_TOOLS,
     is_tool_excluded,
@@ -23,6 +27,34 @@ from headroom.transforms.content_router import ContentRouter, ContentRouterConfi
 # ---------------------------------------------------------------------------
 # Helper unit tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("encoded", [False, True])
+def test_unwrap_mcp_daemon_retrieval(encoded: bool) -> None:
+    arguments = {"action": "call", "selector": "headroom.headroom_retrieve"}
+    name = unwrap_tool_call_name("mcp_daemon", json.dumps(arguments) if encoded else arguments)
+    assert name == "mcp__headroom__headroom_retrieve"
+    assert is_tool_excluded(name, DEFAULT_EXCLUDE_TOOLS)
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        None,
+        "bad json",
+        [],
+        {},
+        {"action": "describe", "selector": "headroom.headroom_retrieve"},
+        {"action": "search", "selector": "headroom.headroom_retrieve"},
+        {"action": "call", "selector": None},
+        {"action": "call", "selector": "headroom"},
+        {"action": "call", "selector": "headroom."},
+        {"action": "call", "selector": ".headroom_retrieve"},
+        {"action": "call", "selector": "headroom.tool.extra"},
+    ],
+)
+def test_unwrap_mcp_daemon_passthrough(arguments: object) -> None:
+    assert unwrap_tool_call_name("mcp_daemon", arguments) == "mcp_daemon"
 
 
 def test_unwrap_passthrough_plain_name() -> None:

--- a/tests/test_openai_responses_compression_units.py
+++ b/tests/test_openai_responses_compression_units.py
@@ -587,7 +587,8 @@ def test_openai_responses_adapter_accepts_empty_input_list():
     assert strategy_chain == []
 
 
-def test_openai_responses_adapter_preserves_headroom_retrieve_outputs():
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_openai_responses_adapter_preserves_headroom_retrieve_outputs(wrapped):
     router = ContentRouter()
 
     def compress(self, content: str, **_kwargs):
@@ -606,8 +607,8 @@ def test_openai_responses_adapter_preserves_headroom_retrieve_outputs():
             {
                 "type": "function_call",
                 "call_id": "call_retrieve",
-                "name": "mcp__headroom__headroom_retrieve",
-                "arguments": "{}",
+                "name": "mcp_daemon" if wrapped else "mcp__headroom__headroom_retrieve",
+                "arguments": '{"action":"call","selector":"headroom.headroom_retrieve"}',
             },
             {
                 "type": "function_call_output",


### PR DESCRIPTION
## Problem

Pi exposes MCP calls through `mcp_daemon` with an `action` and a `server.tool` selector.
Headroom sees the wrapper name instead of the selected tool.
Retrieval results can therefore enter compression again instead of keeping their original content.

## Change

- Resolve valid `mcp_daemon` calls to the existing canonical MCP name.
- Reuse the existing exclusion and retrieval protection paths.
- Leave search, describe, malformed arguments, and Hermes behavior unchanged.
- Test string and object arguments, invalid selectors, and Responses output preservation.

## Local verification

- `python -m pytest tests/test_hermes_tool_call_unwrap.py tests/test_openai_responses_compression_units.py tests/test_openai_responses_read_protection.py -q`: 74 passed.
- `ruff check headroom/config.py tests/test_hermes_tool_call_unwrap.py tests/test_openai_responses_compression_units.py`: passed.
- `ruff format --check headroom/config.py tests/test_hermes_tool_call_unwrap.py tests/test_openai_responses_compression_units.py`: passed.
- `git diff --check`: passed.
- Independent review found no required changes.

Tests use Python 3.13 and the installed Headroom 0.37 native extension with the current Python source.
A native rebuild did not complete because the machine lacks Rust. This change does not modify native code.
The full suite and live proxy rollout remain unverified.
