### PR TITLE
fix(langchain): implement get_metrics() on HeadroomChatModel (#3446)

### DIFF
--- a/headroom/integrations/langchain/chat_model.py
+++ b/headroom/integrations/langchain/chat_model.py
@@ -571,6 +571,16 @@ class HeadroomChatModel(BaseChatModel):
             "total_tokens_after": sum(m.tokens_after for m in self._metrics_history),
         }
 
+    def get_metrics(self) -> dict[str, Any]:
+        """Get metrics from the optimization history (see wiki/langchain.md).
+
+        Same aggregate data as get_savings_summary(), with a ``tokens_saved``
+        key so ``llm.get_metrics()['tokens_saved']`` works as documented.
+        """
+        summary = self.get_savings_summary()
+        summary["tokens_saved"] = summary["total_tokens_saved"]
+        return summary
+
 
 class HeadroomCallbackHandler(BaseCallbackHandler):
     """LangChain callback handler for Headroom metrics and observability.

--- a/tests/test_integrations/langchain/test_chat_model.py
+++ b/tests/test_integrations/langchain/test_chat_model.py
@@ -293,6 +293,52 @@ class TestHeadroomChatModel:
         assert summary["total_tokens_saved"] == 70
         assert summary["average_savings_percent"] == 22.5
 
+    def test_get_metrics_empty(self, mock_chat_model):
+        """get_metrics with no history."""
+        from headroom.integrations import HeadroomChatModel
+
+        model = HeadroomChatModel(mock_chat_model)
+        metrics = model.get_metrics()
+
+        assert metrics["tokens_saved"] == 0
+        assert metrics["total_requests"] == 0
+
+    def test_get_metrics_with_data(self, mock_chat_model):
+        """get_metrics returns tokens_saved from tracked optimization history."""
+        from headroom.integrations import HeadroomChatModel
+        from headroom.integrations.langchain import OptimizationMetrics
+
+        model = HeadroomChatModel(mock_chat_model)
+
+        model._metrics_history = [
+            OptimizationMetrics(
+                request_id="1",
+                timestamp=datetime.now(),
+                tokens_before=100,
+                tokens_after=80,
+                tokens_saved=20,
+                savings_percent=20.0,
+                transforms_applied=["smart_crusher"],
+                model="gpt-4o",
+            ),
+            OptimizationMetrics(
+                request_id="2",
+                timestamp=datetime.now(),
+                tokens_before=200,
+                tokens_after=150,
+                tokens_saved=50,
+                savings_percent=25.0,
+                transforms_applied=["cache_aligner"],
+                model="gpt-4o",
+            ),
+        ]
+        model._total_tokens_saved = 70
+
+        metrics = model.get_metrics()
+
+        assert metrics["tokens_saved"] == 70
+        assert metrics["total_requests"] == 2
+
 
 class TestHeadroomCallbackHandler:
     """Tests for HeadroomCallbackHandler."""


### PR DESCRIPTION
## Description

`HeadroomChatModel` (the LangChain integration wrapper) tracks optimization metrics internally in `_metrics_history`/`_total_tokens_saved`, and `wiki/langchain.md` documents reading them back through `llm.get_metrics()['tokens_saved']`. That method was never added to the class, so any usage of the documented pattern raises `AttributeError: 'HeadroomChatModel' object has no attribute 'get_metrics'` (pydantic's `BaseModel.__getattr__` is what surfaces the error). `get_savings_summary()` already existed and aggregates the same tracked data, just without a `tokens_saved` key.

Closes #3446

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Added `get_metrics()` to `HeadroomChatModel` in `headroom/integrations/langchain/chat_model.py`. It reuses `get_savings_summary()`'s dict and adds a `tokens_saved` key aliasing `total_tokens_saved`, so it doesn't duplicate any tracking logic.
- Added `test_get_metrics_empty` and `test_get_metrics_with_data` in `tests/test_integrations/langchain/test_chat_model.py`, mirroring the existing `get_savings_summary` tests.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/test_integrations/langchain/test_chat_model.py -v -m "not real_llm and not live"
...
tests/test_integrations/langchain/test_chat_model.py::TestHeadroomChatModel::test_get_savings_summary_empty PASSED
tests/test_integrations/langchain/test_chat_model.py::TestHeadroomChatModel::test_get_savings_summary_with_data PASSED
tests/test_integrations/langchain/test_chat_model.py::TestHeadroomChatModel::test_get_metrics_empty PASSED
tests/test_integrations/langchain/test_chat_model.py::TestHeadroomChatModel::test_get_metrics_with_data PASSED
...
38 passed, 9 skipped in 6.88s
```

(The 9 skips are the pre-existing Ollama/real-LangChain integration tests, which skip without a local Ollama server — unrelated to this change.)

## Real Behavior Proof

- Environment: Python 3.10.12, fresh venv, `pip install -e ".[langchain]"` (langchain-core 1.x), no network calls.
- Exact command / steps: ran the reproduction from the issue with `FakeChatModel` swapped in for the real HuggingFace endpoint (so it runs offline):
  ```python
  from langchain_core.language_models.fake_chat_models import FakeChatModel
  from headroom.integrations import HeadroomChatModel

  chat_model = FakeChatModel()
  optimized_llm = HeadroomChatModel(chat_model)
  optimized_llm.invoke("Hello!")
  result = optimized_llm.get_metrics()
  print(result["tokens_saved"])
  ```
- Observed result: before the fix this raises `AttributeError: 'HeadroomChatModel' object has no attribute 'get_metrics'`, matching the issue. After the fix the shown command prints `0` and no longer errors. Printing `result` itself returns `{'total_requests': 1, 'total_tokens_saved': 0, 'average_savings_percent': 0.0, 'total_tokens_before': 9, 'total_tokens_after': 9, 'tokens_saved': 0}`.
- Not tested: the original issue's exact HuggingFace/DeepSeek-R1 setup (no HF token available here) — used `FakeChatModel` instead since the bug is in `HeadroomChatModel` itself, not in the wrapped provider.

## Runtime Rollout Safety

- Rollout-managed feature(s): none — this only adds a missing read-only method.
- Minimum rollout channel: n/a
- Stable/default behavior changed: no, purely additive.
- Kill switch / disable path: n/a
- Unsafe override required: no
- Qualification impact: none
- Rollback path: revert the commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

Didn't touch `wiki/langchain.md` — it already documents the intended usage; the code just needed to catch up to it. Didn't run `mypy headroom` locally (not installed in my throwaway venv); ruff check/format are clean.
