### PR TITLE
fix(learn): count each tool call once per tool_call_id when detecting loops

### DIFF
--- a/headroom/learn/fixtures.py
+++ b/headroom/learn/fixtures.py
@@ -21,11 +21,17 @@ def _tc(
     command: str,
     output: str,
     *,
+    session_id: str,
     msg_index: int,
     is_error: bool = False,
     error_category: ErrorCategory = ErrorCategory.UNKNOWN,
 ) -> ToolCall:
-    """Build a ToolCall, keying input on the field the tool's summary reads."""
+    """Build a ToolCall, keying input on the field the tool's summary reads.
+
+    ``tool_call_id`` is scoped by session: ``detect_loops`` counts a call once
+    per id, so an id unique only within a session would make two sessions
+    running the same loop look like one session replayed twice.
+    """
     if name.lower() in ("bash", "shell"):
         input_data = {"command": command}
     elif name.lower() in ("read",):
@@ -36,7 +42,7 @@ def _tc(
         input_data = {"command": command}
     return ToolCall(
         name=name,
-        tool_call_id=f"tc_{msg_index}",
+        tool_call_id=f"{session_id}_tc_{msg_index}",
         input_data=input_data,
         output=output,
         is_error=is_error,
@@ -67,7 +73,7 @@ def refetch_loop_session(
         # Same base command; only the output-limit varies — the loop signature.
         command = f"grep -rn 'TimeoutError' logs/ | head -{limit}"
         output = "logs/app.log:" + ("x" * (bytes_per_call - 20)) + "\n(truncated)"
-        calls.append(_tc("Bash", command, output, msg_index=i * 2))
+        calls.append(_tc("Bash", command, output, session_id=session_id, msg_index=i * 2))
         limit += 50  # agent asks for more next time — still truncated
     return SessionData(session_id=session_id, tool_calls=calls)
 
@@ -85,6 +91,7 @@ def error_loop_session(
                 "Bash",
                 "python3 run_tests.py",
                 "python3: command not found",
+                session_id=session_id,
                 msg_index=i * 2,
                 is_error=True,
                 error_category=ErrorCategory.COMMAND_NOT_FOUND,
@@ -102,10 +109,11 @@ def one_off_error_session(session_id: str = "one-off") -> SessionData:
                 "Read",
                 "/etc/missing.conf",
                 "Error: file not found",
+                session_id=session_id,
                 msg_index=0,
                 is_error=True,
                 error_category=ErrorCategory.FILE_NOT_FOUND,
             ),
-            _tc("Bash", "ls -la", "total 8\ndrwxr-xr-x", msg_index=1),
+            _tc("Bash", "ls -la", "total 8\ndrwxr-xr-x", session_id=session_id, msg_index=1),
         ],
     )

--- a/headroom/learn/loops.py
+++ b/headroom/learn/loops.py
@@ -106,6 +106,24 @@ def _tokens(tc: ToolCall) -> int:
     return nbytes // _BYTES_PER_TOKEN
 
 
+def _without_replays(calls: list[ToolCall], seen: set[str]) -> list[ToolCall]:
+    """Drop calls whose ``tool_call_id`` is already in ``seen``, recording the rest.
+
+    ``seen`` is mutated, so the caller chooses the scope a replay is judged
+    against: a fresh set collapses a transcript's own repeated turns, while a
+    set carried across sessions suppresses a resume's replay of earlier ones.
+    An id-less call is always kept — nothing identifies it as a replay.
+    """
+    kept: list[ToolCall] = []
+    for call in calls:
+        if call.tool_call_id:
+            if call.tool_call_id in seen:
+                continue
+            seen.add(call.tool_call_id)
+        kept.append(call)
+    return kept
+
+
 def detect_loops(
     sessions: list[SessionData],
     *,
@@ -128,6 +146,16 @@ def detect_loops(
     unique across sessions, not just within one, or two unrelated sessions look
     like one replayed twice. Scanners that synthesize ids scope them by session
     (see ``GeminiPlugin`` and ``OpenCodePlugin``).
+
+    Dedup runs *before* the threshold, twice over. A session is screened on its
+    distinct calls, because the question the threshold asks — did this
+    conversation repeat itself? — is not answered by one call written into the
+    transcript three times. Only then are its calls merged, deduped again
+    against the calls already collected for that signature so a resume that
+    replays an earlier session adds only what is new. Screening the raw group
+    instead would let three sessions that each merely replayed one call
+    contribute one real call apiece and clear the bar together, reporting a loop
+    no conversation ran.
     """
     groups: dict[str, list[ToolCall]] = {}
     seen_ids: dict[str, set[str]] = {}
@@ -138,24 +166,18 @@ def detect_loops(
         # Merge each session's qualifying groups into the global view keyed by
         # signature so cross-session recurrence of the SAME loop accumulates.
         for sig, calls in per_session.items():
-            if len(calls) < min_occurrences:
+            distinct = _without_replays(calls, set())
+            if len(distinct) < min_occurrences:
                 continue
             bucket = groups.setdefault(sig, [])
-            ids = seen_ids.setdefault(sig, set())
-            for call in calls:
-                if call.tool_call_id:
-                    if call.tool_call_id in ids:
-                        continue
-                    ids.add(call.tool_call_id)
-                bucket.append(call)
+            bucket.extend(_without_replays(distinct, seen_ids.setdefault(sig, set())))
 
     loops: list[LoopPattern] = []
     for sig, calls in groups.items():
+        # No post-merge threshold re-check: every group here was seeded by a
+        # session that cleared the bar on its own distinct calls, and merging
+        # only ever adds.
         count = len(calls)
-        if count < min_occurrences:
-            # The group cleared the bar before dedup and no longer does: its
-            # extra repetitions were replays of one call, not a loop.
-            continue
         is_error_loop = sum(1 for c in calls if c.is_error) >= (count / 2)
         if is_error_loop:
             # Every repetition of a failing call is waste — including the first,

--- a/headroom/learn/loops.py
+++ b/headroom/learn/loops.py
@@ -117,8 +117,20 @@ def detect_loops(
     a within-conversation phenomenon; the same command in two unrelated
     sessions is not a loop). Groups meeting ``min_occurrences`` become
     ``LoopPattern`` results, sorted by measured wasted tokens descending.
+
+    A call is counted once per ``tool_call_id``. A resumed conversation can be
+    written as a fresh transcript that replays earlier turns, which presents the
+    same provider-assigned call to the scanner more than once; without this the
+    replayed turns would inflate the loop. Calls carrying no id are always
+    counted, since nothing identifies them as replays.
+
+    This makes ``tool_call_id`` uniqueness a scanner contract: an id must be
+    unique across sessions, not just within one, or two unrelated sessions look
+    like one replayed twice. Scanners that synthesize ids scope them by session
+    (see ``GeminiPlugin`` and ``OpenCodePlugin``).
     """
     groups: dict[str, list[ToolCall]] = {}
+    seen_ids: dict[str, set[str]] = {}
     for session in sessions:
         per_session: dict[str, list[ToolCall]] = {}
         for tc in session.tool_calls:
@@ -126,12 +138,24 @@ def detect_loops(
         # Merge each session's qualifying groups into the global view keyed by
         # signature so cross-session recurrence of the SAME loop accumulates.
         for sig, calls in per_session.items():
-            if len(calls) >= min_occurrences:
-                groups.setdefault(sig, []).extend(calls)
+            if len(calls) < min_occurrences:
+                continue
+            bucket = groups.setdefault(sig, [])
+            ids = seen_ids.setdefault(sig, set())
+            for call in calls:
+                if call.tool_call_id:
+                    if call.tool_call_id in ids:
+                        continue
+                    ids.add(call.tool_call_id)
+                bucket.append(call)
 
     loops: list[LoopPattern] = []
     for sig, calls in groups.items():
         count = len(calls)
+        if count < min_occurrences:
+            # The group cleared the bar before dedup and no longer does: its
+            # extra repetitions were replays of one call, not a loop.
+            continue
         is_error_loop = sum(1 for c in calls if c.is_error) >= (count / 2)
         if is_error_loop:
             # Every repetition of a failing call is waste — including the first,

--- a/tests/test_learn/test_loop_weighting.py
+++ b/tests/test_learn/test_loop_weighting.py
@@ -383,3 +383,41 @@ class TestFixturesSatisfyTheDedupContract:
         tuesday = {c.tool_call_id for c in refetch_loop_session("session-tuesday").tool_calls}
 
         assert monday.isdisjoint(tuesday)
+
+
+class TestSubThresholdSessionsDoNotCombine:
+    """A session that only looped in replays must not contribute at all.
+
+    ``min_occurrences`` is screened against the *pre-dedup* per-session group, so
+    a session whose repetitions are all replays of one call still qualifies and
+    hands its single real call to the global view. Three such sessions then clear
+    the bar together, reporting a loop no conversation actually ran.
+    """
+
+    def _replay_padded_session(self, session_id: str, call_id: str) -> SessionData:
+        # One real Read, written into this transcript three times.
+        return SessionData(
+            session_id=session_id,
+            tool_calls=[
+                _call("Read", call_id, {"file_path": "/repo/design.md"}, msg_index=i)
+                for i in range(3)
+            ],
+        )
+
+    def test_each_session_alone_is_not_a_loop(self):
+        sessions = [
+            self._replay_padded_session("s1", "toolu_s1"),
+            self._replay_padded_session("s2", "toolu_s2"),
+            self._replay_padded_session("s3", "toolu_s3"),
+        ]
+
+        assert [detect_loops([s]) for s in sessions] == [[], [], []]
+
+    def test_sub_threshold_sessions_do_not_combine_into_a_loop(self):
+        sessions = [
+            self._replay_padded_session("s1", "toolu_s1"),
+            self._replay_padded_session("s2", "toolu_s2"),
+            self._replay_padded_session("s3", "toolu_s3"),
+        ]
+
+        assert detect_loops(sessions) == []

--- a/tests/test_learn/test_loop_weighting.py
+++ b/tests/test_learn/test_loop_weighting.py
@@ -16,6 +16,8 @@ surfaced, were ranked no higher than a one-off rule. These tests pin:
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from headroom.learn.analyzer import SessionAnalyzer, _build_digest
 from headroom.learn.fixtures import (
     error_loop_session,
@@ -31,6 +33,8 @@ from headroom.learn.models import (
     ProjectInfo,
     Recommendation,
     RecommendationTarget,
+    SessionData,
+    ToolCall,
 )
 
 
@@ -195,3 +199,187 @@ class TestAnalyzeEndToEnd:
         # After weighting, the loop guardrail ranks first despite the LLM's order.
         assert result.recommendations[0].is_loop_guardrail is True
         assert "loop" in result.recommendations[0].section.lower()
+
+
+# =============================================================================
+# signature identity (regressions)
+# =============================================================================
+
+
+def _call(name: str, tool_call_id: str, input_data: dict, *, msg_index: int) -> ToolCall:
+    """A successful tool call with a fixed 40 KB output."""
+    output = "x" * 40_000
+    return ToolCall(
+        name=name,
+        tool_call_id=tool_call_id,
+        input_data=input_data,
+        output=output,
+        is_error=False,
+        msg_index=msg_index,
+        output_bytes=len(output),
+    )
+
+
+def _mixed_calls() -> list[ToolCall]:
+    return [
+        _call("Read", "call_r0", {"file_path": "/repo/a.py"}, msg_index=0),
+        _call("Read", "call_r1", {"file_path": "/repo/a.py"}, msg_index=1),
+        _call("Read", "call_r2", {"file_path": "/repo/a.py"}, msg_index=2),
+        _call("Bash", "call_b0", {"command": "rg alpha /repo"}, msg_index=3),
+        _call("Bash", "call_b1", {"command": "rg alpha /repo"}, msg_index=4),
+        _call("Bash", "call_b2", {"command": "rg alpha /repo"}, msg_index=5),
+        _call("Grep", "call_g0", {"pattern": "beta"}, msg_index=6),
+    ]
+
+
+class TestReplayedTranscriptsDoNotDoubleCount:
+    """A resume that replays prior history must not recount the same calls.
+
+    ``detect_loops`` accumulates a signature across sessions so a recurring loop
+    adds up. Providers whose resume writes a *new* transcript replaying earlier
+    turns therefore present the same tool call more than once; identity comes
+    from ``tool_call_id``, which the provider assigns.
+    """
+
+    def _reads(self) -> list[ToolCall]:
+        return [
+            _call("Read", f"call_r{i}", {"file_path": "/repo/docs/design.md"}, msg_index=i)
+            for i in range(3)
+        ]
+
+    def test_replayed_calls_counted_once(self):
+        reads = self._reads()
+        single = detect_loops([SessionData(session_id="rollout-1", tool_calls=list(reads))])
+        replayed = detect_loops(
+            [
+                SessionData(session_id="rollout-1", tool_calls=list(reads)),
+                SessionData(session_id="rollout-2-resume", tool_calls=list(reads)),
+            ]
+        )
+        assert replayed[0].count == single[0].count
+        assert replayed[0].wasted_tokens == single[0].wasted_tokens
+
+    def test_new_calls_in_a_resume_still_accumulate(self):
+        # Dedup must not swallow genuinely new repetitions in the resumed run.
+        reads = self._reads()
+        extra = [
+            _call("Read", f"call_r{i}", {"file_path": "/repo/docs/design.md"}, msg_index=i)
+            for i in range(3, 6)
+        ]
+        replayed = detect_loops(
+            [
+                SessionData(session_id="rollout-1", tool_calls=list(reads)),
+                SessionData(session_id="rollout-2-resume", tool_calls=list(reads) + extra),
+            ]
+        )
+        assert replayed[0].count == 6
+
+    def test_calls_without_ids_are_not_deduped(self):
+        # An id-less scanner must keep counting repetitions rather than collapse.
+        calls = [
+            _call("Read", "", {"file_path": "/repo/docs/design.md"}, msg_index=i) for i in range(3)
+        ]
+        loops = detect_loops(
+            [
+                SessionData(session_id="a", tool_calls=list(calls)),
+                SessionData(session_id="b", tool_calls=list(calls)),
+            ]
+        )
+        assert loops[0].count == 6
+
+    @pytest.mark.parametrize("replays", [1, 2, 3, 5])
+    def test_replaying_a_transcript_never_changes_the_count(self, replays):
+        calls = _mixed_calls()
+        sessions = [
+            SessionData(session_id=f"rollout-{i}", tool_calls=list(calls)) for i in range(replays)
+        ]
+
+        once = detect_loops([SessionData(session_id="rollout-0", tool_calls=list(calls))])
+        many = detect_loops(sessions)
+
+        assert sorted(lp.count for lp in many) == sorted(lp.count for lp in once)
+
+
+class TestDedupRespectsTheOccurrenceThreshold:
+    """Dedup must not leave behind loops that no longer meet the bar.
+
+    ``detect_loops`` screens a group against ``min_occurrences`` before removing
+    replayed calls, so a group can clear the bar only *because* of duplicates and
+    still be reported once they are gone. Real transcripts do repeat a
+    ``tool_use_id`` within one file, so this is reachable from the default
+    Claude Code path.
+    """
+
+    def test_a_group_that_only_duplicates_is_not_a_loop(self):
+        # One call, written into the transcript three times.
+        calls = [
+            _call("Read", "toolu_SAME", {"file_path": "/repo/design.md"}, msg_index=i)
+            for i in range(3)
+        ]
+
+        assert detect_loops([SessionData(session_id="s", tool_calls=calls)]) == []
+
+    def test_partial_dedup_still_has_to_clear_the_bar(self):
+        # Three calls, two distinct — below DEFAULT_MIN_OCCURRENCES once deduped.
+        calls = [
+            _call("Read", "toolu_A", {"file_path": "/repo/design.md"}, msg_index=0),
+            _call("Read", "toolu_A", {"file_path": "/repo/design.md"}, msg_index=1),
+            _call("Read", "toolu_B", {"file_path": "/repo/design.md"}, msg_index=2),
+        ]
+
+        assert detect_loops([SessionData(session_id="s", tool_calls=calls)]) == []
+
+    def test_a_real_loop_padded_with_duplicates_is_still_reported(self):
+        # Dedup must subtract the replays without dropping the genuine loop.
+        distinct = [
+            _call("Read", f"toolu_{i}", {"file_path": "/repo/design.md"}, msg_index=i)
+            for i in range(3)
+        ]
+        padded = distinct + [
+            _call("Read", "toolu_0", {"file_path": "/repo/design.md"}, msg_index=9)
+        ]
+
+        loops = detect_loops([SessionData(session_id="s", tool_calls=padded)])
+
+        assert [lp.count for lp in loops] == [3]
+
+    def test_no_loop_is_reported_with_zero_measured_waste(self):
+        """A zero-waste loop is the tell that a group survived on duplicates.
+
+        ``format_loops_for_digest`` bills every entry to the LLM as HIGHEST
+        PRIORITY, and ``SessionAnalyzer.analyze`` treats a non-empty loop list as
+        reason enough to call the model, so a zero-waste entry buys an LLM round
+        trip for a session with nothing to report.
+        """
+        calls = [
+            _call("Read", "toolu_SAME", {"file_path": "/repo/design.md"}, msg_index=i)
+            for i in range(4)
+        ]
+
+        loops = detect_loops([SessionData(session_id="s", tool_calls=calls)])
+
+        assert [lp for lp in loops if lp.wasted_tokens == 0] == []
+
+
+class TestFixturesSatisfyTheDedupContract:
+    """Dedup keys on ``tool_call_id``, so the shipped fixtures must scope theirs.
+
+    ``detect_loops`` accumulates a signature across sessions. An id that is only
+    unique *within* a session makes two unrelated sessions look like one replayed
+    twice, silently halving a real loop.
+    """
+
+    def test_the_same_loop_in_two_sessions_accumulates(self):
+        monday = refetch_loop_session("session-monday")
+        tuesday = refetch_loop_session("session-tuesday")
+
+        one = detect_loops([monday])
+        both = detect_loops([monday, tuesday])
+
+        assert both[0].count == one[0].count * 2
+
+    def test_fixture_ids_are_unique_across_sessions(self):
+        monday = {c.tool_call_id for c in refetch_loop_session("session-monday").tool_calls}
+        tuesday = {c.tool_call_id for c in refetch_loop_session("session-tuesday").tool_calls}
+
+        assert monday.isdisjoint(tuesday)


### PR DESCRIPTION
## Description

`headroom learn` counts the same tool call once per transcript file it appears in.
`detect_loops()` merges each session's qualifying groups into a global view keyed by
signature and never dedups by `tool_call_id`:

```python
for sig, calls in per_session.items():
    if len(calls) >= min_occurrences:
        groups.setdefault(sig, []).extend(calls)   # <- no id dedup
```

When a provider resumes a conversation by writing a **new** transcript that replays prior
history, every replayed call is scanned again and counted again. Three reads become six and
the measured waste rises with them, though nothing about the agent's behavior changed —
only the number of files on disk describing it. `ToolCall.tool_call_id` already carries the
provider-assigned id and is already parsed by every scanner, so the information needed to
tell a replay from a repetition is present and unused.

The inflated counts propagate: `detect_loops()` sorts by `wasted_tokens`, and
`apply_loop_weighting()` scales by that same measured waste, so a loop that is merely
replayed can outrank one that is real.

This is one of two PRs splitting #3440. The grouping-key truncation originally filed with it
is a different mechanism — that one merges *distinct* calls because the key is lossy, this
one over-counts calls that are correctly grouped and genuinely identical — and it ships
separately against #3440. The two are independent and either can land first. They conflict
textually in `detect_loops` — this PR rewrites the merge loop's body, that one renames its
variable — so whichever lands second needs a ~6-line rebase. Happy to do it either way round.

Closes #3452

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/learn/loops.py`: `detect_loops()` counts a call once per `tool_call_id` when
  merging per-session groups into the global view. Calls carrying **no** id are always
  counted — nothing identifies them as replays, and inventing an identity for them would
  drop real repetitions.
- `headroom/learn/loops.py`: `min_occurrences` is re-checked **after** dedup. The existing
  check runs on the per-session group, so a group whose repetitions are entirely replays of
  one call clears the bar on replay count alone. Deduping without the re-check would convert
  a double-counted loop into a sub-threshold phantom rather than removing it — the two
  changes are not separable, which is why they are in one commit.
- `headroom/learn/loops.py`: the docstring now states that `tool_call_id` must be unique
  *across* sessions, not merely within one. This is a new constraint on every current and
  future scanner: where a plugin synthesizes ids, two unrelated sessions running the same
  loop would otherwise look like one session replayed twice — the same defect in the
  opposite direction. I checked the existing plugins rather than assume it; both that
  synthesize ids already scope them by session (`gemini.py:280`, `opencode.py:250`), so no
  scanner needed changing. The docstring records the requirement they already satisfy.
- `headroom/learn/fixtures.py`: `_tc()` took `msg_index` only and built `tool_call_id` as
  `f"tc_{msg_index}"` — unique within a session, colliding across them. Under the new dedup
  that made two fixture sessions running the same loop dedup into one, so the helper now
  takes `session_id` and scopes the id. This is the cross-session contract above, applied to
  the one place in-tree that was violating it; two tests pin that the fixtures satisfy it.
- `tests/test_learn/test_loop_weighting.py`: 10 new tests, 13 cases with parametrization.
  I ran them against `upstream/main` rather than assume the split: **9 fail there and pass
  here**. The rest pin the boundaries the fix must not cross — a resume that *continues* a
  loop still accumulates, calls with no id stay counted, and the fixture contract holds.

No public API, CLI flag, config key or digest format changes.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest -q tests/test_learn/
260 passed, 4 skipped

$ pytest -q tests/test_learn/test_loop_weighting.py
26 passed          # 13 pre-existing + 13 added by this PR

$ ruff check .
All checks passed!

$ ruff format --check headroom/learn/ tests/test_learn/
30 files already formatted

$ mypy headroom
Found 1 error in 1 file (checked 530 source files)
# The one error is pre-existing and in a file this PR does not touch:
# headroom/integrations/langchain/chat_model.py:394 [truthy-function]
# Zero errors in headroom/learn/loops.py.

$ pytest -q tests/test_learn/ \
    --cov=headroom.learn.loops --cov=headroom.learn.fixtures --cov-report=term-missing
Name                         Stmts   Miss Branch BrPart  Cover   Missing
headroom/learn/fixtures.py      27      3     10      1    84%   39-42
headroom/learn/loops.py         92      0     40      1    99%   243->235
# The 4 uncovered fixtures.py lines are an unrelated branch that predates this PR.
# Every statement in loops.py is covered.

$ pytest -q          # full suite, this branch
21 failed, 11912 passed, 583 skipped, 6044 warnings in 666.10s (0:11:06)

$ pytest -q          # same suite, unpatched upstream/main @ e67b3c8a
21 failed, 11899 passed, 583 skipped, 6044 warnings in 651.63s (0:10:51)
```

**The 21 failures are pre-existing and identical on both sides.** I ran the entire suite on
this branch and on `upstream/main` @ `e67b3c8a`, and diffed the sorted `FAILED` lists:
empty diff. The only difference between the two runs is the passing count — `11912` here
versus `11899` on the base — which is exactly the 13 test cases this PR adds. No
existing test changes outcome.

The pre-existing failures are `test_integrations/langchain` (7 — wants a live local
Ollama), `test_proxy_health` (4), `test_cli/test_wrap_copilot` (3),
`test_mcp_registry/test_claude_registrar` (2), `test_install/test_providers` (2),
`test_cli/test_wrap_bridge` (1), `test_cli/test_unwrap_claude` (1) and
`test_scripts/test_repro_codex_replay_smoke` (1). None touch `headroom/learn/`.
The 4 `test_proxy_health` ones pass when that file is run on its own (`17 passed`) and fail
only in a full-suite run, on the base as well as here, so they look order-dependent —
flagging it in case it is news, but it is not something this PR introduces or fixes.

## Real Behavior Proof

- Environment: Ubuntu 22.04.5 LTS on WSL2 (Linux 6.18.33.2), Python 3.13.11,
  ruff 0.16.3. Branch `134e5172` on `upstream/main` `e67b3c8a` (`headroom 0.38.0-dev`).
  The "before" side is `upstream/main` @ `e67b3c8a` itself. I also ran it against the
  released `headroom-ai 0.36.5` from pipx as a cross-check and got identical output, which
  is expected: `learn/loops.py` is byte-identical between the two. No LLM/provider is
  involved in the code path under test.

- Exact command / steps: two constructed Claude transcripts are written to disk — a main
  session, and a resume that replays it under the original `tool_use_id`s, which is the
  situation this PR is about. They are then scanned through the *real* production path —
  `ClaudeCodePlugin.scan_project()` → `detect_loops()` → `_build_digest()`. The same two
  files are scanned twice, once by each interpreter:

  ```bash
  # before (unpatched upstream/main)
  PYTHONPATH=<main worktree> python run_proof.py data
  # after (this branch)
  PYTHONPATH=<this branch>   python run_proof.py data
  ```

  Ground truth planted in the fixtures: **one** genuine re-fetch loop — the same file read
  5 times with a growing `head -N` limit — which the resume then extends by 2 *new* calls,
  so the true count is **7**, not 5. The resume also replays all 5 originals verbatim. The
  fixtures additionally contain 5 long `rg` commands that diverge only after character 100
  and 5 `apply_patch` calls sharing an 80-character path prefix; those are not loops, and
  their being reported as such is #3440's defect, untouched here.

- Observed result: every count drops to the planted ground truth; full before/after `_build_digest()` output below.

  ```text
  before (upstream/main):  loops detected: 3
    [refetch-loop] Bash:        count=12 wasted=110,011   <- true count is 7
    [refetch-loop] Bash:        count=10 wasted=90,009    <- 5 distinct rg cmds, replayed
    [refetch-loop] apply_patch: count=10 wasted=90,009    <- 5 distinct patches, replayed
                                total wasted ~290,029

  after (this branch):     loops detected: 3
    [refetch-loop] Bash:        count=7  wasted=60,006    <- ground truth
    [refetch-loop] Bash:        count=5  wasted=40,004
    [refetch-loop] apply_patch: count=5  wasted=40,004
                                total wasted ~140,014
  ```

  Every count drops to what the session actually did: the real loop lands exactly on its
  planted ground truth of 7, keeping the 2 genuinely new calls the resume added rather than
  collapsing the whole resume away. The two **phantom** loops are still reported — they are
  distinct calls wrongly merged by the grouping key, which is #3440's fix, not this one —
  but they are no longer also double-counted. With both PRs applied the same scenario
  reports `loops detected: 1, count=7 wasted=60,006`. I am reporting this PR's effect in
  isolation rather than quoting the combined figure.

  `_build_digest()` output is quoted as-is — verbatim what the LLM step would receive.

- **Aggregate check against real history.** The constructed transcripts prove the mechanism;
  to confirm replays actually occur on disk, I ran the real `ClaudeCodePlugin` over my own
  187 Claude Code transcripts — 166 sessions, 19,188 tool calls. Counts only, no paths,
  commands or session content, for the reason given under Not tested.

  **3 of the 187 files repeat a `tool_use_id` they already contain; the worst repeats one id
  375 times.** So this is not hypothetical: resume transcripts on the default Claude Code
  path do replay history under the original ids, and every replayed call is currently a
  counted repetition. It is a minority of files, which is the honest framing — but the
  inflation within an affected file is large, and those are exactly the long sessions where
  loop detection is meant to help.

  Caveat on the summary table: my aggregate A/B was run with both this change and #3440's
  applied together (749 loops / 5,691,304 wasted tokens on `main`, versus 547 / 3,446,209
  with both), so I am not attributing that delta to this PR alone. Happy to re-run the
  A/B against this branch in isolation if the split number is wanted for review.

- **Performance.** This PR makes no performance claim. It adds one `set` membership test per
  call and one `set` per signature inside `detect_loops`; the hot loops — signature
  construction, the pagination and integer regexes — are untouched. Memory is bounded by the
  number of *qualifying* calls, which already bounds the `groups` list those calls are
  appended to alongside. `learn` is an offline command that reads history files, not a proxy
  transform, so it is not on the `<50ms` P99 path either way.

- Not tested: the LLM step itself, any quoted output from my own history, and non-Claude resume transcripts — each detailed below.
  - The LLM step itself. `headroom learn` has no flag that halts before the model call, so
    the proof drives scanner → `detect_loops` → `_build_digest` directly. That is the whole
    production path minus the model, and `_build_digest` output is the model's literal input.
  - Any *quoted* output from my own history. The before/after transcript above is
    constructed, deliberately: loop signatures embed absolute repo paths and full shell
    commands, and I am not willing to publish mine. The code path exercised is production
    code; only the input files are synthetic. Real history is used in the aggregate check
    above, but only as counts — no signature, path, command or session content.
  - Real resume transcripts from the non-Claude scanners (`codex`, `gemini`, `grok`,
    `opencode`). The change is in provider-agnostic `learn/loops.py` so they share it, and I
    read each plugin's id handling to check the cross-session contract, but I have no
    `codex`/`gemini`/`grok`/`opencode` history on this machine to scan and did not build
    per-provider fixtures. Whether each of those CLIs writes resume transcripts that replay
    prior ids is unverified — if it does, this fixes it there too; if it assigns fresh ids
    per file, this is a no-op there rather than a regression.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. `learn` loop detection is not behind a rollout
  channel or feature flag.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: yes, and intentionally — loop `count` and
  `wasted_tokens` drop to per-call truth, and a group that only cleared `min_occurrences`
  via replays is no longer reported at all. This is the fix. No public API, CLI flag, config
  key, or digest format changes.
- **New constraint on plugins:** `tool_call_id` must now be unique across sessions, not just
  within one. Both in-tree scanners that synthesize ids already satisfy this; the docstring
  records it so future plugins do too.
- Kill switch / disable path: none added. Reverting the single commit fully restores
  prior behavior.
- Unsafe override required: no.
- Qualification impact: `learn` runs will report smaller, more accurate loop counts, so
  the generated guardrail text changes. Nothing persisted by earlier runs is read back or
  migrated, so old and new outputs do not need to agree.
- Rollback path: `git revert` of one commit. No schema, cache, or on-disk state is
  touched.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A, see Additional Notes
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my
      Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — terminal output is included above.

## Additional Notes

- **Documentation:** no user-facing surface changed (no new flag, config, or output format),
  and `docs/failure-learning` does not document the counting rule, so there is nothing to
  update. The one durable statement worth recording — cross-session id uniqueness — is a
  constraint on plugin authors rather than users, so I put it in the `detect_loops`
  docstring where a plugin author will actually hit it. Happy to add it to contributor docs
  as well if you would rather it lived there.

- **The ordering is the subtle part, called out for review.** Dedup and the
  `min_occurrences` re-check have to happen in that order and both have to happen. Dedup
  alone leaves groups that cleared the threshold only because of replays — they survive as
  sub-threshold "loops" with a real signature and attributed waste, which is arguably worse
  than the inflation it fixed, since the loop is then entirely fictional rather than merely
  exaggerated. Re-checking alone does nothing. Two of the new tests pin this specific
  interaction rather than either half of it.

- **Why calls with no id stay counted.** Dedup keys on a value the scanner may not have.
  Treating a missing id as "same as the last missing id" would collapse every id-less call
  in a group into one; treating each as unique is what the current code already does. So the
  no-id path is deliberately unchanged, and a transcript that carries no ids gets exactly
  today's behavior — the fix is opt-in on the data, not on a flag. `codex`, `grok` and
  `claude` read ids from the transcript and fall back to `""` when absent, so they degrade
  to today's behavior per call rather than per file. A test pins this.

- **The fixtures change is a contract fix, not test-fitting.** `headroom/learn/fixtures.py`
  is shipped library code, not a test file, and its `_tc()` helper was generating ids unique
  only within a session. That was harmless while nothing deduped and wrong the moment
  something did. I changed the generator to satisfy the contract rather than weaken the
  dedup to tolerate it, and added two tests asserting the fixtures hold the property — so if
  the helper regresses, that fails directly rather than surfacing as a confusing loop-count
  change somewhere downstream.

- **Scope, stated plainly.** This fixes over-counting from replayed transcripts. It does not
  make loop *grouping* correct — distinct calls can still merge into one reported loop
  through the truncated grouping key (#3440), and `Grep`/`Glob` identity still drops `path`
  (#3453). Those are separate mechanisms with separate fixes; this PR deliberately leaves
  both exactly as found, which is why the two phantom loops above survive in the "after"
  column.

- **`mypy headroom`** reports 1 pre-existing error in `integrations/langchain/chat_model.py`,
  untouched by this PR. I left it alone rather than mix an unrelated fix into this change.

