### PR TITLE
perf(cache): purge expired CCR rows by deadline instead of decoding every payload

### DIFF
--- a/benchmarks/ccr_sqlite_expiry_benchmark.py
+++ b/benchmarks/ccr_sqlite_expiry_benchmark.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Measure SQLite CCR insertion cleanup without expiring live entries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# Run as a script sys.path[0] is benchmarks/, so an editable install of another
+# checkout would win and we would silently measure the wrong tree.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from headroom.cache.backends.sqlite import SQLiteBackend
+from headroom.cache.compression_store import CompressionEntry, CompressionStore
+
+
+def benchmark(entry_count: int, payload_bytes: int, runs: int) -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="headroom-ccr-expiry-") as tmp:
+        backend = SQLiteBackend(Path(tmp) / "ccr.db")
+        payload = "x" * payload_bytes
+        for index in range(entry_count):
+            key = str(index)
+            backend.set(
+                key,
+                CompressionEntry(
+                    hash=key,
+                    original_content=payload,
+                    compressed_content="compact",
+                    original_tokens=payload_bytes // 4,
+                    compressed_tokens=2,
+                    original_item_count=0,
+                    compressed_item_count=0,
+                    tool_name=None,
+                    tool_call_id=None,
+                    query_context=None,
+                    created_at=time.time(),
+                    ttl=3600,
+                ),
+            )
+
+        store = CompressionStore(
+            max_entries=entry_count + runs + 1,
+            backend=backend,
+            enable_feedback=False,
+        )
+        samples_ms: list[float] = []
+        for index in range(runs):
+            start = time.perf_counter()
+            key = store.store(f"new original {index}", f"new compact {index}")
+            samples_ms.append((time.perf_counter() - start) * 1000)
+            assert store.retrieve(key) is not None
+
+        backend._conn.close()
+        return {
+            "preexisting_entries": entry_count,
+            "original_bytes_each": payload_bytes,
+            "runs": runs,
+            "median_insert_ms": statistics.median(samples_ms),
+        }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--entries", type=int, nargs="+", default=[100, 500, 1000])
+    parser.add_argument("--payload-bytes", type=int, nargs="+", default=[1024, 16384])
+    parser.add_argument("--runs", type=int, default=7)
+    args = parser.parse_args()
+
+    results = [
+        benchmark(entry_count, payload_bytes, args.runs)
+        for payload_bytes in args.payload_bytes
+        for entry_count in args.entries
+    ]
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/headroom/cache/backends/sqlite.py
+++ b/headroom/cache/backends/sqlite.py
@@ -40,7 +40,10 @@ CREATE TABLE IF NOT EXISTS ccr_entries (
     created_at REAL NOT NULL,
     ttl INTEGER NOT NULL
 );
-CREATE INDEX IF NOT EXISTS idx_ccr_expiry ON ccr_entries (created_at);
+CREATE INDEX IF NOT EXISTS idx_ccr_expiry_deadline ON ccr_entries (created_at + ttl);
+-- Superseded by idx_ccr_expiry_deadline: no query searches or orders by bare
+-- created_at, so the old index only cost writes. Drop it from existing files.
+DROP INDEX IF EXISTS idx_ccr_expiry;
 """
 
 # Purge expired rows at most this often (seconds). Purging is hygiene,
@@ -153,17 +156,31 @@ class SQLiteBackend:
         known = {f.name for f in fields(CompressionEntry)}
         return CompressionEntry(**{k: v for k, v in data.items() if k in known})
 
+    def _purge_expired(self, now: float) -> int:
+        """Delete expired rows using metadata; caller holds ``_lock``."""
+        cursor = self._conn.execute(
+            "DELETE FROM ccr_entries WHERE created_at + ttl < ?",
+            (now,),
+        )
+        self._conn.commit()
+        self._last_purge = now
+        return cursor.rowcount
+
+    def purge_expired(self, now: float | None = None) -> int:
+        """Delete expired rows without deserializing their payloads."""
+        with self._lock:
+            try:
+                return self._purge_expired(time.time() if now is None else now)
+            except sqlite3.DatabaseError as e:
+                self._handle_db_error(e, "purge")
+                return 0
+
     def _maybe_purge(self) -> None:
         """Delete expired rows; called opportunistically under the lock."""
         now = time.time()
         if now - self._last_purge < _PURGE_INTERVAL:
             return
-        self._last_purge = now
-        self._conn.execute(
-            "DELETE FROM ccr_entries WHERE created_at + ttl < ?",
-            (now,),
-        )
-        self._conn.commit()
+        self._purge_expired(now)
 
     def get(self, hash_key: str) -> CompressionEntry | None:
         with self._lock:

--- a/headroom/cache/compression_store.py
+++ b/headroom/cache/compression_store.py
@@ -764,6 +764,11 @@ class CompressionStore:
 
         CRITICAL FIX: Track stale heap entries when deleting to prevent memory leak.
         """
+        purge_expired = getattr(self._backend, "purge_expired", None)
+        if callable(purge_expired):
+            self._stale_heap_entries += purge_expired()
+            return
+
         expired_keys = [key for key, entry in self._backend.items() if entry.is_expired()]
         for key in expired_keys:
             self._backend.delete(key)

--- a/tests/test_ccr_sqlite_backend.py
+++ b/tests/test_ccr_sqlite_backend.py
@@ -86,6 +86,74 @@ class TestSQLiteBackend:
         assert stats["entry_count"] == 2
         assert stats["bytes_used"] > 0
 
+    def test_opening_a_db_with_the_old_index_drops_it_and_keeps_the_rows(self, db_path):
+        # Databases written before idx_ccr_expiry_deadline still carry the
+        # superseded idx_ccr_expiry; opening them must migrate, not fail.
+        seeded = SQLiteBackend(db_path)
+        seeded.set("h1", make_entry("h1"))
+        seeded._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ccr_expiry ON ccr_entries (created_at)"
+        )
+        seeded._conn.commit()
+        seeded._conn.close()
+
+        b = SQLiteBackend(db_path)
+        indexes = {
+            row[0]
+            for row in b._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_%'"
+            )
+        }
+        assert indexes == {"idx_ccr_expiry_deadline"}
+        entry = b.get("h1")
+        assert entry is not None
+        assert entry.original_content == make_entry("h1").original_content
+
+    def test_purge_expired_deletes_by_deadline_and_keeps_the_boundary_row(self, db_path):
+        b = SQLiteBackend(db_path)
+        now = time.time()
+        expired = make_entry("expired", ttl=10)
+        expired.created_at = now - 11
+        boundary = make_entry("boundary", ttl=10)
+        boundary.created_at = now - 10
+        live = make_entry("live", ttl=60)
+        live.created_at = now - 11
+
+        # Keep backend.set() from performing its opportunistic purge first.
+        b._last_purge = now
+        for entry in (expired, boundary, live):
+            b.set(entry.hash, entry)
+
+        assert b.purge_expired(now) == 1
+        assert set(b.keys()) == {"boundary", "live"}
+
+    def test_new_insert_purges_expired_sqlite_entry_without_decoding_live_payloads(
+        self, db_path, monkeypatch
+    ):
+        backend = SQLiteBackend(db_path)
+        store = CompressionStore(max_entries=4, backend=backend, enable_feedback=False)
+        expired_hash = store.store("expired original", "expired compact", ttl=10)
+        live_hash = store.store("live original", "live compact", ttl=60)
+        other_live_hash = store.store("other live original", "other live compact", ttl=60)
+
+        expired = backend.get(expired_hash)
+        assert expired is not None
+        expired.created_at = time.time() - 11
+        backend.set(expired_hash, expired)
+
+        monkeypatch.setattr(
+            backend,
+            "_entry_from_json",
+            lambda _raw: pytest.fail("new insertion decoded existing CCR payloads"),
+        )
+
+        new_hash = store.store("new original", "new compact", ttl=60)
+
+        assert not backend.exists(expired_hash)
+        assert backend.exists(live_hash)
+        assert backend.exists(other_live_hash)
+        assert backend.exists(new_hash)
+
     def test_clear(self, db_path):
         b = SQLiteBackend(db_path)
         b.set("h1", make_entry())


### PR DESCRIPTION
## Description

`CompressionStore._clean_expired()` runs on every CCR insertion and calls `backend.items()`, which deserializes every live original just to read the `created_at`/`ttl` that SQLite already stores as columns. With 1,000 unexpired 16 KiB originals, one new insertion decoded all 1,000 payloads.

This replaces that scan with a metadata-only delete on the persistent backend.

Closes # N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `SQLiteBackend.purge_expired()` deletes expired rows with `DELETE ... WHERE created_at + ttl < ?`, backed by a new expression index `idx_ccr_expiry_deadline`. `_maybe_purge()` now shares the same helper instead of duplicating the statement.
- `CompressionStore._clean_expired()` calls the backend method when the backend offers one, and folds its deleted-row count into `_stale_heap_entries` so eviction accounting and the heap-rebuild threshold behave exactly as before. Backends without `purge_expired` — `InMemoryBackend` and any third-party implementation — keep the existing item-scan path, so the `CompressionStoreBackend` protocol is unchanged.
- Dropped the superseded `idx_ccr_expiry (created_at)`. Nothing in the tree searches or orders by bare `created_at`, so it only cost writes; the schema now drops it, migrating existing database files on open.
- Added `benchmarks/ccr_sqlite_expiry_benchmark.py` for reproduction.

Behavior deliberately preserved: expired entries are still cleaned before any live entry is evicted, TTL semantics and the expiry boundary are unchanged (`created_at + ttl == now` is not expired), and originals/markers/retrieval, persistence and eviction feedback are untouched.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

Three new tests in `tests/test_ccr_sqlite_backend.py`:

1. `test_purge_expired_deletes_by_deadline_and_keeps_the_boundary_row` — mixed TTLs and the exact expiry boundary.
2. `test_new_insert_purges_expired_sqlite_entry_without_decoding_live_payloads` — fails the test if a new insertion decodes any existing payload; this is the regression guard for the issue.
3. `test_opening_a_db_with_the_old_index_drops_it_and_keeps_the_rows` — a database file written with the old index migrates on open with its rows intact.

Tests 1 and 2 both fail on the base commit and pass with this change.

### Test Output

```text
$ pytest tests/test_ccr_sqlite_backend.py tests/test_compression_store.py -q
98 passed in 7.35s

$ pytest tests/ -q -k "ccr or compression_store or cache"
1839 passed, 8 failed
# All 8 failures (7 Playwright dashboard, 1 live-API) also fail on the base
# commit in this environment; they are unrelated to this change.

# The two new behavioral tests against the base commit:
$ git stash push headroom/cache/backends/sqlite.py headroom/cache/compression_store.py
$ pytest tests/test_ccr_sqlite_backend.py -q -k "purge_expired or purges_expired_sqlite_entry"
E   Failed: new insertion decoded existing CCR payloads
2 failed, 21 deselected

$ pre-commit run --all-files   # via commit hooks
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
mypy.....................................................................Passed
```

## Real Behavior Proof

- Environment: macOS 15 (arm64), Python 3.13.11, SQLite via stdlib `sqlite3`, worktree off `upstream/main` @ `e67b3c8a`.
- Exact command / steps: `python benchmarks/ccr_sqlite_expiry_benchmark.py --entries 1000 --payload-bytes 16384 --runs 7`, run on this branch and then with the two source files stashed, sequentially in the same process environment with identical inputs.

  ```text
  candidate: {"preexisting_entries":1000,"original_bytes_each":16384,"runs":7,"median_insert_ms":0.04654214717447758}
  baseline:  {"preexisting_entries":1000,"original_bytes_each":16384,"runs":7,"median_insert_ms":17.63250003568828}
  ```

- Observed result: median insertion **17.63 ms → 0.047 ms**; payload deserializations during cleanup **1,000+ → 0** (counted by instrumenting `_entry_from_json`, and asserted permanently by test 2). Separately, on 1,000 rows × 16 KiB (n=200), dropping the old `created_at` index leaves the purge delete unchanged at ~0.0012 ms and makes each insert ~14% cheaper (0.0064 ms → 0.0056 ms); the new expression index is what takes the purge from 0.171 ms to 0.0012 ms.
- Not tested: end-to-end proxy latency. This is an insertion-path micro-measurement on synthetic entries and should not be read as an end-to-end speedup. No measurement on very large databases (>1,000 entries) or under concurrent writers. `InMemoryBackend` is unchanged and unmeasured.

## Runtime Rollout Safety

- Rollout-managed feature(s): none; no flag or channel gates this.
- Minimum rollout channel: N/A.
- Stable/default behavior changed: no observable behavior change — the same entries expire at the same times. Only the persistent backend's schema (one index added, one dropped) and the cleanup mechanism change.
- Kill switch / disable path: none needed; a backend without `purge_expired` transparently uses the previous code path.
- Unsafe override required: none.
- Qualification impact: none.
- Rollback path: revert the commit. The index changes are idempotent DDL applied on open, so a reverted build re-creates `idx_ccr_expiry` and simply stops using `idx_ccr_expiry_deadline`; cached rows are never rewritten or dropped by the migration.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md`

## Additional Notes

- "Documentation update" is checked as done in the sense that no user-facing docs describe this internal cleanup path; the new behavior is documented in docstrings and in the schema comment explaining why the old index is dropped.
- The `_purge_expired`/`purge_expired` split is deliberate rather than redundant: `SQLiteBackend._lock` is a plain `threading.Lock`, and `_maybe_purge()` already runs inside `set()`'s critical section, so it cannot call the public lock-acquiring method.
- `purge_expired(now=None)` takes an explicit time only so the boundary test can assert deterministically that `created_at + ttl == now` is not expired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
