### PR TITLE
perf(ccr): bound retrieval history with a deque instead of reslicing

### DIFF
--- a/benchmarks/ccr_retrieval_history_benchmark.py
+++ b/benchmarks/ccr_retrieval_history_benchmark.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Measure CCR retrieval-history maintenance once the event cap is reached.
+
+Past 1,000 events the history has to discard the oldest event on every single
+retrieval. Bounding the container itself makes that O(1); the previous
+append-then-reslice rebuilt a 1,000-pointer list each time.
+
+This times ``_log_retrieval`` directly — the store's public ``retrieve()`` also
+does backend I/O and a feedback drain, which would bury the difference. Read
+the result as "cost of one history append at steady state", not as a proxy for
+end-to-end retrieval latency.
+
+Usage:
+    python benchmarks/ccr_retrieval_history_benchmark.py
+    python benchmarks/ccr_retrieval_history_benchmark.py --events 5000 --runs 7
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# Run as a script, sys.path[0] is benchmarks/, so an editable install of another
+# checkout would win for `import headroom` and this would silently measure the
+# wrong tree.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from headroom.cache.compression_store import CompressionStore  # noqa: E402
+
+
+def _fill_to_cap(store: CompressionStore) -> None:
+    """Bring the history to its cap so every later append must evict."""
+    for i in range(store._max_events):
+        store._log_retrieval(
+            hash_key="h",
+            query=f"warm{i}",
+            items_retrieved=1,
+            total_items=1,
+            tool_name="bench",
+            retrieval_type="full",
+        )
+    store._pending_feedback_events.clear()
+
+
+def measure(events: int) -> float:
+    """Return microseconds per history append at steady state."""
+    store = CompressionStore(enable_feedback=True)
+    _fill_to_cap(store)
+
+    start = time.perf_counter()
+    for i in range(events):
+        store._log_retrieval(
+            hash_key="h",
+            query=f"q{i}",
+            items_retrieved=1,
+            total_items=1,
+            tool_name="bench",
+            retrieval_type="full",
+        )
+    elapsed = time.perf_counter() - start
+
+    # Each run uses a fresh store, so the unbounded feedback queue this also
+    # filled goes away with it.
+    return elapsed / events * 1e6
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--events", type=int, default=20_000)
+    parser.add_argument("--runs", type=int, default=7)
+    args = parser.parse_args()
+
+    store = CompressionStore()
+    print(f"container: {type(store._retrieval_events).__name__}")
+    print(f"cap: {store._max_events} events")
+
+    samples = [measure(args.events) for _ in range(args.runs)]
+
+    print(f"appends per run: {args.events}, runs: {args.runs}")
+    print(f"median: {statistics.median(samples):.3f} us/append")
+    print(f"min: {min(samples):.3f} us, max: {max(samples):.3f} us")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/headroom/cache/compression_store.py
+++ b/headroom/cache/compression_store.py
@@ -38,6 +38,7 @@ import os
 import re
 import threading
 import time
+from collections import deque
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
@@ -250,9 +251,12 @@ class CompressionStore:
         self._default_ttl = default_ttl
         self._enable_feedback = enable_feedback
 
-        # Feedback tracking
-        self._retrieval_events: list[RetrievalEvent] = []
+        # Feedback tracking. maxlen caps the display history, replacing an
+        # append-then-reslice that re-copied 1000 pointers on every retrieval.
         self._max_events = 1000  # Keep last 1000 events
+        self._retrieval_events: deque[RetrievalEvent] = deque(maxlen=self._max_events)
+        # Deliberately NOT bounded: this is a drain-by-swap queue, and every
+        # event in it still owes a feedback notification.
         self._pending_feedback_events: list[RetrievalEvent] = []
 
         # MEDIUM FIX #16: Use a min-heap for O(log n) eviction instead of O(n)
@@ -852,11 +856,8 @@ class CompressionStore:
             tool_signature_hash=tool_signature_hash,
         )
 
+        # maxlen keeps this bounded; no trim needed here.
         self._retrieval_events.append(event)
-
-        # Keep only recent events
-        if len(self._retrieval_events) > self._max_events:
-            self._retrieval_events = self._retrieval_events[-self._max_events :]
 
         # Queue event for feedback processing (will be processed after lock release)
         # This is safe because process_pending_feedback() uses the lock to atomically

--- a/tests/test_compression_store.py
+++ b/tests/test_compression_store.py
@@ -939,6 +939,59 @@ class TestCompressionStoreRetrievalEvents:
         assert len(events) >= 1
         assert events[-1].tool_signature_hash == "sig_123"
 
+    def test_history_past_the_cap_keeps_the_newest_in_order(self, store: CompressionStore):
+        """The cap drops the oldest events and nothing else.
+
+        ``_retrieval_events`` is capped by its container rather than by an
+        append-then-reslice, so this pins what the cap must still mean:
+        exactly ``_max_events`` retained, newest first, oldest discarded.
+        """
+        hash_key = store.store(original="[1]", compressed="[]")
+        overflow = 5
+        total = store._max_events + overflow
+
+        for i in range(total):
+            store.retrieve(hash_key, f"q{i}")
+
+        events = store.get_retrieval_events(limit=total)
+
+        assert len(events) == store._max_events
+        # get_retrieval_events returns newest first.
+        assert [e.query for e in events] == [f"q{i}" for i in reversed(range(overflow, total))]
+
+    @patch("headroom.cache.compression_feedback.get_compression_feedback")
+    @patch("headroom.telemetry.get_telemetry_collector")
+    @patch("headroom.telemetry.toin.get_toin")
+    def test_events_dropped_from_history_still_reach_feedback(
+        self, mock_toin, mock_telemetry, mock_feedback
+    ):
+        """Capping the display history must not cost a feedback notification.
+
+        ``_pending_feedback_events`` is a separate drain-by-swap queue that owes
+        a notification for every event, including the ones the bounded history
+        has already discarded. Bounding it too would silently lose feedback.
+        """
+        mock_feedback.return_value = MagicMock()
+        mock_telemetry.return_value = MagicMock()
+        mock_toin.return_value = MagicMock()
+
+        store = CompressionStore(enable_feedback=True)
+        hash_key = store.store(
+            original="[1]",
+            compressed="[]",
+            tool_signature_hash="sig_123",
+            compression_strategy="top_k",
+        )
+        overflow = 5
+        total = store._max_events + overflow
+
+        for i in range(total):
+            store.retrieve(hash_key, f"q{i}")
+
+        # One notification per retrieval, not one per surviving history entry.
+        assert mock_feedback.return_value.record_retrieval.call_count == total
+        assert len(store.get_retrieval_events(limit=total)) == store._max_events
+
 
 # =============================================================================
 # Edge Cases Tests


### PR DESCRIPTION
## Description

Once the CCR retrieval history reaches its 1,000-event cap, every further retrieval appended to the list and then rebuilt it from a 1,000-element slice, under the store lock. `collections.deque(maxlen=1000)` drops the oldest event as the new one lands, so the trim is deleted rather than moved.

This is a maintenance change that also removes an O(cap) copy. It is **not** an end-to-end speedup, and the measurements below say so: the history append itself gets ~3.9× cheaper, while the full `retrieve()` path is unchanged within noise.

`_pending_feedback_events` deliberately stays an unbounded list. It is a separate drain-by-swap queue that still owes a notification for every event, including ones the capped history has already discarded, so both containers now carry a comment saying which is which.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [x] Code refactoring (no functional changes)

## Changes Made

- `headroom/cache/compression_store.py`: `_retrieval_events` becomes `deque(maxlen=self._max_events)`; the append-then-reslice in `_log_retrieval` is removed. `_max_events` stays as the single readable name for the cap — it is read at construction, by the new tests and by the benchmark, and is never assigned after `__init__`.
- `tests/test_compression_store.py`: two tests — retention and ordering at the cap, and one feedback notification per retrieval past the cap.
- `benchmarks/ccr_retrieval_history_benchmark.py`: standalone script measuring the history append at steady state, following the convention the other benchmarks in that directory use.

Consumer audit before changing anything: the container is only ever hit with `len`, `append`, `clear`, iteration, `list()` and `sys.getsizeof` — all deque-safe. The one slice, `events_copy[-limit:]` in `get_retrieval_events`, operates on the list copy taken under the lock, so deque's lack of slice support is never reached. Repo-wide there is no non-Python consumer, no subclass, no pickling or deepcopy path and no `isinstance(list)` check, and the deleted line was the only assignment to the attribute — so nothing can rebind an unbounded list back onto it. One `threading.Lock` guards every access.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

Both new tests pass before and after this change, deliberately: for a maintenance change, parity is the claim. They exist because the pre-existing `test_retrieval_events_list_bounded` asserts only `len(...) <= 1000`, which cannot tell which end was dropped. Mutation-checked: an unbounded `deque()` fails the length assertion, and a head-trim keeping the oldest 1,000 passes the length check but fails on order.

### Test Output

```text
$ pytest tests/test_compression_store.py tests/test_ccr.py tests/test_ccr_feedback.py \
         tests/test_critical_gaps.py tests/test_critical_fixes.py tests/test_proxy_ccr.py \
         tests/test_ccr_sqlite_backend.py tests/test_ccr_batch_store.py \
         tests/test_memory_tracker_integration.py -q
209 passed, 3 skipped in 16.66s

$ pytest tests/ -q -k "ccr or compression_store or compression_feedback or telemetry \
                       or critical_gaps or critical_fixes or memory_tracker" \
         --ignore=tests/test_integrations
1 failed, 921 passed, 11 skipped in 77.38s
# the one failure is test_ccr_marker_round_trip_live, a live-API test that fails
# identically on the unchanged base

$ python benchmarks/ccr_retrieval_history_benchmark.py
container: deque
cap: 1000 events
appends per run: 20000, runs: 7
median: 0.481 us/append

$ pre-commit run --files headroom/cache/compression_store.py \
      tests/test_compression_store.py benchmarks/ccr_retrieval_history_benchmark.py
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
mypy.....................................................................Passed
```

## Real Behavior Proof

- Environment: macOS 15.6, Python 3.13.11, branch based on `main` @ `e67b3c8a`. Single process, single thread, no contention.
- Exact command / steps: filled a store's history to its cap so every subsequent append must evict, then timed 20,000 `_log_retrieval` calls, 7 runs, median reported. Ran the unchanged tree and this change in both orderings to rule out ordering effects. Separately timed the full public `retrieve()` path, 2,000 calls × 5 runs, also in both orderings.
- Observed result: history append **1.81 to 0.47 us** and, with the order reversed, **1.85 to 0.48 us** per append. Full `retrieve()`: 7.67 vs 7.89 us, and reversed 7.79 vs 7.82 us — unchanged within noise in both directions. Behavior parity checked value by value: `get_stats()["event_count"]`, `get_retrieval_events()` contents/order/length across limits from negative through 1e9, and `clear()` are all identical; `deque.clear()` preserves `maxlen`, so the container stays bounded afterwards.
- Not tested: no multi-threaded or contended measurement, no multi-worker or production workload, and no memory-over-time profile. The benchmark times a private method (`_log_retrieval`) because the public `retrieve()` buries the difference in backend I/O and the feedback drain — that is stated in the benchmark's own docstring. The result is a microbenchmark of one operation and must not be read as a proxy for retrieval latency.

One value does change numerically, and it is not hidden: `get_memory_stats().size_bytes` shifts by a few hundred bytes, because `sys.getsizeof` reports a deque's 64-slot blocks rather than a list's contiguous array (56 to 760 bytes empty; 8,056 to 8,680 at 1,000 entries). It is a shallow size that already excluded the events themselves, `budget_bytes` is `None`, and no test or dashboard compares it against anything.

## Runtime Rollout Safety

- Rollout-managed feature(s): None. CCR retrieval-event history is not rollout-gated.
- Minimum rollout channel: N/A — no rollout-managed feature is touched.
- Stable/default behavior changed: No. The cap, its size, retention order, retrieval results, lock guarantees and feedback delivery are all unchanged; only the container enforcing the cap differs, plus the `size_bytes` gauge noted above.
- Kill switch / disable path: N/A — no flag. Reverting the commit restores the list and its trim.
- Unsafe override required: No.
- Qualification impact: None. No compression decision, retrieval result, CCR marker, TTL or persistence path is touched — this is the in-memory display history only.
- Rollback path: `git revert` of this commit, single step. No schema, data or config migration is involved.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

Not applicable — no user-visible surface changes.

## Additional Notes

- No separate documentation file needed updating; the two comments in `__init__` are the documentation this needs, because the one thing a future reader can get wrong here is bounding `_pending_feedback_events` to match.
- Overlaps nothing in flight: PR #3465 touches this same module, but its entire footprint is inside `_clean_expired`, which never reads the retrieval history, and this change never touches `_stale_heap_entries`.
- Unrelated, left alone, noticed while running the suites: `tests/test_realignment_live_multi_turn.py::test_ccr_marker_round_trip_live` and `tests/test_memory_usage_integration.py::TestProxyMemoryIntegration::test_real_api_calls_memory_tracking` both need live API access and fail on a clean checkout without it.
