### PR TITLE
fix(storage): parse absolute Windows paths from URLs

### DIFF
--- a/headroom/storage/__init__.py
+++ b/headroom/storage/__init__.py
@@ -1,5 +1,7 @@
 """Storage modules for Headroom SDK."""
 
+import os
+
 from .base import Storage
 from .jsonl import JSONLStorage
 from .sqlite import SQLiteStorage
@@ -9,6 +11,21 @@ __all__ = [
     "SQLiteStorage",
     "JSONLStorage",
 ]
+
+
+def _builtin_storage_path(store_url: str, scheme: str) -> str:
+    """Return the filesystem portion of a built-in storage URL."""
+    path = store_url.removeprefix(f"{scheme}://")
+    if (
+        os.name == "nt"
+        and len(path) >= 4
+        and path[0] == "/"
+        and path[1].isalpha()
+        and path[2] == ":"
+        and path[3] in ("/", "\\")
+    ):
+        return path[1:]
+    return path
 
 
 def create_storage(store_url: str) -> Storage:
@@ -29,15 +46,10 @@ def create_storage(store_url: str) -> Storage:
         Storage instance.
     """
     if store_url.startswith("sqlite://"):
-        path = store_url.replace("sqlite://", "")
-        # Handle sqlite:/// (3 slashes for absolute path)
-        if path.startswith("/"):
-            path = path  # Already absolute
+        path = _builtin_storage_path(store_url, "sqlite")
         return SQLiteStorage(path)
     elif store_url.startswith("jsonl://"):
-        path = store_url.replace("jsonl://", "")
-        if path.startswith("/"):
-            path = path
+        path = _builtin_storage_path(store_url, "jsonl")
         return JSONLStorage(path)
     else:
         # Unknown scheme: try entry point headroom.storage_backend[name=scheme]


### PR DESCRIPTION
## Description

Built-in `sqlite://` and `jsonl://` storage URLs containing absolute Windows drive paths were parsed with an extra leading separator, producing invalid paths such as `\C:\Users\...` and `WinError 123`. This change centralizes built-in URL parsing and removes only that URI separator on Windows drive-qualified paths.

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Normalize built-in SQLite and JSONL storage URLs through one helper.
- On Windows only, strip the URI separator slash before a drive-qualified absolute path.
- Preserve POSIX absolute paths and legacy plain-path fallback behavior.

## Testing

- [ ] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
Before:
tests/test_adapter_hooks.py
2 failed with WinError 123

After:
python -m pytest -q tests/test_adapter_hooks.py tests/test_storage_backends.py
37 passed

python -m ruff check headroom/storage/__init__.py
All checks passed!

python -m ruff format --check headroom/storage/__init__.py
1 file already formatted

git diff --check
exit 0
```

## Real Behavior Proof

- Environment: Windows 10; Python 3.13.7; base commit `e67b3c8a29443a60d6b0018fb22f525c5cd7e709`.
- Exact command / steps: run `python -m pytest -q tests/test_adapter_hooks.py tests/test_storage_backends.py` with temporary drive-qualified SQLite and JSONL paths.
- Observed result: both backends initialized successfully and all 37 adapter/storage tests passed.
- Not tested: macOS and network/UNC storage URLs.

## Runtime Rollout Safety

- Rollout-managed feature(s): Built-in SQLite and JSONL storage URL parsing.
- Minimum rollout channel: Stable; no experimental rollout feature is required.
- Stable/default behavior changed: Only malformed Windows drive-qualified URL resolution changes; POSIX and plain-path behavior remain covered.
- Kill switch / disable path: Use a plain storage path or revert this commit.
- Unsafe override required: No.
- Qualification impact: Windows built-in storage URLs now resolve to valid absolute drive paths.
- Rollback path: Revert this PR; it changes parsing only and performs no migration.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

Not applicable; this is a path-parsing fix with command/test evidence above.

## Additional Notes

The existing adapter/storage tests already reproduced the defect, so no new test file was necessary. The unchecked full-suite `pytest`, type-checking, comments, and documentation items are intentionally not claimed; the focused regression, lint, formatting, and diff gates passed.
