### PR TITLE
fix(ccr): make batch processing import optional so core compression works without httpx

### DIFF
--- a/headroom/ccr/__init__.py
+++ b/headroom/ccr/__init__.py
@@ -21,12 +21,27 @@ Batch API Support:
 - Works with all providers: Anthropic, OpenAI, Google
 """
 
-from .batch_processor import (
-    BatchResultProcessor,
-    BatchResultProcessorConfig,
-    ProcessedBatchResult,
-    process_batch_results,
-)
+# Batch processing is optional: it imports httpx to make continuation API
+# calls, but httpx is only declared under the [proxy]/[mcp]/[dev] extras, not
+# the base install. SmartCrusher (core compression) reaches CCR_TOOL_NAME
+# below through this package's __init__, so a hard import here breaks core
+# compression for anyone who installed plain `headroom-ai`.
+try:
+    from .batch_processor import (
+        BatchResultProcessor,
+        BatchResultProcessorConfig,
+        ProcessedBatchResult,
+        process_batch_results,
+    )
+
+    BATCH_PROCESSING_AVAILABLE = True
+except ImportError:
+    BatchResultProcessor = None  # type: ignore
+    BatchResultProcessorConfig = None  # type: ignore
+    ProcessedBatchResult = None  # type: ignore
+    process_batch_results = None  # type: ignore
+    BATCH_PROCESSING_AVAILABLE = False
+
 from .batch_store import (
     BatchContext,
     BatchContextStore,
@@ -109,6 +124,7 @@ __all__ = [
     "get_batch_context_store",
     "process_batch_results",
     "reset_batch_context_store",
+    "BATCH_PROCESSING_AVAILABLE",
     # MCP server
     "HeadroomMCPServer",
     "create_ccr_mcp_server",

--- a/tests/test_ccr_optional_httpx.py
+++ b/tests/test_ccr_optional_httpx.py
@@ -1,0 +1,68 @@
+"""Core compression must not require httpx.
+
+httpx is only declared under the [proxy]/[mcp]/[dev] extras, not the base
+`headroom-ai` install. Before this fix, headroom.ccr unconditionally
+imported batch_processor (which imports httpx at module level), and
+SmartCrusher — documented as core, lightweight compression — reaches
+CCR_TOOL_NAME through headroom.ccr's __init__, so a plain `pip install
+headroom-ai` with no extras broke SmartCrusher/compress() entirely with an
+uncaught ImportError.
+
+Each check runs in a fresh subprocess with httpx import blocked at the
+meta-path level, rather than monkeypatching this process's sys.modules:
+mutating already-imported headroom modules in place corrupts identity-keyed
+state (e.g. transform registries) for every test that runs afterwards in
+the same session.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_BLOCK_HTTPX = """
+import sys
+
+class _BlockHttpx:
+    def find_spec(self, name, path, target=None):
+        if name == "httpx" or name.startswith("httpx."):
+            raise ImportError("No module named 'httpx' (blocked for this test)")
+        return None
+
+sys.meta_path.insert(0, _BlockHttpx())
+"""
+
+
+def _run_with_httpx_blocked(import_line: str) -> subprocess.CompletedProcess[str]:
+    script = _BLOCK_HTTPX + "\n" + import_line
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_ccr_package_imports_without_httpx() -> None:
+    result = _run_with_httpx_blocked(
+        "import headroom.ccr as m\n"
+        "assert m.BATCH_PROCESSING_AVAILABLE is False, m.BATCH_PROCESSING_AVAILABLE\n"
+        "assert m.BatchResultProcessor is None\n"
+        "assert m.CCR_TOOL_NAME\n"
+        "print('OK')\n"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_smart_crusher_imports_without_httpx() -> None:
+    # Regression check: this raised ModuleNotFoundError: No module named
+    # 'httpx' before the ccr/__init__.py fix, even on a plain
+    # `pip install headroom-ai` with no extras.
+    result = _run_with_httpx_blocked(
+        "import headroom.transforms.smart_crusher as m\n"
+        "assert m.SmartCrusher is not None\n"
+        "print('OK')\n"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout


### PR DESCRIPTION
## Description

`headroom.ccr`'s `__init__.py` unconditionally imports `batch_processor`, which imports `httpx` at module level. `httpx` is only declared under the `[proxy]`/`[mcp]`/`[dev]` extras — not the base install.

`headroom.transforms.smart_crusher` (SmartCrusher, listed in this file's own module docstring as "Core: lightweight compression") reaches `CCR_TOOL_NAME` via `from ..ccr.tool_injection import CCR_TOOL_NAME`, which runs `headroom/ccr/__init__.py` first. So a plain `pip install headroom-ai` with no extras raises `ModuleNotFoundError: No module named 'httpx'` the first time `compress()` routes JSON content to SmartCrusher — and because `compress()`'s router swallows the error rather than raising, the user-visible symptom isn't a crash, it's silent: `tokens_saved` comes back `0` with no indication SmartCrusher never ran.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `headroom/ccr/__init__.py`: guard the `batch_processor` import with `try`/`except ImportError`, mirroring the existing `MCP_SERVER_AVAILABLE` pattern already used for the optional `mcp_server` import in this same file. Adds a `BATCH_PROCESSING_AVAILABLE` flag; `BatchResultProcessor` and friends become `None` when `httpx` is absent. Batch processing (which genuinely needs `httpx` for continuation API calls) stays unavailable without it — only the accidental coupling to core compression is removed.
- `tests/test_ccr_optional_httpx.py`: new regression test.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom/ccr/__init__.py`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ uv run ruff check headroom/ccr/__init__.py tests/test_ccr_optional_httpx.py
All checks passed!
$ uv run ruff format --check headroom/ccr/__init__.py tests/test_ccr_optional_httpx.py
2 files already formatted
$ uv run mypy headroom/ccr/__init__.py
Success: no issues found in 1 source file
$ uv run pytest tests/test_ccr_optional_httpx.py -v
tests/test_ccr_optional_httpx.py::test_ccr_package_imports_without_httpx PASSED
tests/test_ccr_optional_httpx.py::test_smart_crusher_imports_without_httpx PASSED
2 passed in 0.62s
$ uv run pytest tests/ -q
11913 passed, 592 skipped, 6047 warnings in 1000.23s (0:16:40)
```

New test confirmed to fail before the fix (`git stash` on just `headroom/ccr/__init__.py`, rerun):

```text
ImportError: No module named 'httpx'
  File ".../headroom/ccr/__init__.py", line 24, in <module>
    from .batch_processor import (
  File ".../headroom/ccr/batch_processor.py", line 28, in <module>
    import httpx
2 failed in 0.55s
```

The new test blocks `httpx` at the meta-path level in a **subprocess**, rather than monkeypatching `sys.modules` in-process. An earlier in-process version passed in isolation but corrupted identity-keyed state for 5 unrelated tests later in the same session (`test_ccr_response_handler_extra.py`, `test_proxy_handlers_batch.py::test_gemini_native_ccr_uses_real_retrieval_result_shape[*]`) — confirmed by re-running those 5 standalone against unpatched `main`, where they passed. Subprocess isolation avoids that entirely; the full suite (11913 passed) confirms no side effects from either the fix or the test.

## Real Behavior Proof

- **Environment:** macOS (Apple Silicon), Python 3.14 (repro venvs) / 3.13 (dev venv via `uv sync --extra dev`), two throwaway venvs — one with unpatched `pip install headroom-ai` (no extras), one with this branch installed editable (`pip install -e . --no-deps`) into an identical base-only venv. `pip show httpx` confirmed "Package(s) not found: httpx" in both.
- **Exact command / steps:** Same script in both venvs — build a 200-item JSON payload as a tool-result message, call `headroom.compress(messages, config=CompressConfig(protect_recent=1, min_tokens_to_compress=10))`, print `tokens_before`/`tokens_after`/`tokens_saved`/`compression_ratio`/`transforms_applied`.
- **Observed result:**
  - Before (unpatched, `pip install headroom-ai`): `tokens_before=6653 tokens_after=6653 tokens_saved=0 ratio=0.0000`, `transforms_applied=['router:protected:user_message', 'router:protected:user_message']` — SmartCrusher never ran, no error surfaced.
  - After (this branch, same base-only env): `tokens_before=6653 tokens_after=4466 tokens_saved=2187 ratio=0.3287`, `transforms_applied=[..., 'router:smart_crusher:0.75']`.
- **Not tested:** Windows/Linux (macOS only). The `[proxy]`/`[mcp]` extras' actual batch-processing behavior when `httpx` *is* installed — unchanged by this PR and covered by existing `test_ccr_batch_processor.py`, which still passes.

## Runtime Rollout Safety

- Rollout-managed feature(s): N/A — plain import-guard fix, no feature flag.
- Minimum rollout channel: N/A
- Stable/default behavior changed: Only for installs missing `httpx` (base `pip install headroom-ai`): SmartCrusher now works instead of silently no-op'ing. No change for `[proxy]`/`[mcp]`/`[dev]` installs, which already had `httpx`.
- Kill switch / disable path: N/A
- Unsafe override required: No
- Qualification impact: None
- Rollback path: Revert the single commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title

## Additional Notes

No docs change: I couldn't find existing docs claiming SmartCrusher works on a base-only install, so there's nothing describing the broken behavior to correct. Happy to add a note if maintainers know where that should live.
