### PR TITLE
fix(cli): restrict init profile slug to ASCII alnum (#3467)

### DIFF
--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -114,9 +114,14 @@ def _enable_verbose_logging() -> None:
 
 def _local_profile(cwd: Path | None = None) -> str:
     root = (cwd or Path.cwd()).resolve()
-    slug = "".join(ch if ch.isalnum() or ch in "-._" else "-" for ch in root.name.lower()).strip(
-        "-"
-    )
+    # str.isalnum() is Unicode-aware and keeps non-ASCII letters (e.g. Cyrillic,
+    # CJK), but validate_profile_name() only accepts [A-Za-z0-9._-]. Restrict to
+    # ASCII alnum here so a non-ASCII directory name doesn't produce a slug that
+    # fails validation downstream (#3467); the sha1 digest keeps the profile
+    # name unique even when the slug collapses to 'repo'.
+    slug = "".join(
+        ch if (ch.isascii() and ch.isalnum()) or ch in "-._" else "-" for ch in root.name.lower()
+    ).strip("-")
     digest = sha1(str(root).encode("utf-8")).hexdigest()[:8]
     return validate_profile_name(f"init-{slug or 'repo'}-{digest}")
 

--- a/tests/test_cli/test_init_cli.py
+++ b/tests/test_cli/test_init_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import os
+import re
 import sys
 import types
 from contextlib import contextmanager
@@ -280,6 +281,48 @@ def test_init_hook_ensure_prefers_local_profile(monkeypatch) -> None:
 
     assert result.exit_code == 0, result.output
     assert ensured == ["init-repo-12345678"]
+
+
+def test_local_profile_strips_non_ascii_letters(monkeypatch, tmp_path: Path) -> None:
+    """Regression test for #3467.
+
+    ``str.isalnum()`` is Unicode-aware and keeps non-ASCII letters (Cyrillic,
+    CJK, etc.), so a working-directory name containing them used to produce a
+    slug that ``validate_profile_name()`` then rejected with "Invalid profile
+    name". The slug must only ever contain characters the validator accepts.
+    """
+    init_cli, _ = _load_init_module(monkeypatch)
+
+    root = tmp_path / "Мастеринг в HW"
+    root.mkdir()
+
+    profile = init_cli._local_profile(cwd=root)
+
+    assert re.fullmatch(r"[A-Za-z0-9._-]+", profile)
+    assert profile.startswith("init-hw-")
+
+
+def test_local_profile_keeps_ascii_slug_unchanged(monkeypatch, tmp_path: Path) -> None:
+    init_cli, _ = _load_init_module(monkeypatch)
+
+    root = tmp_path / "My-Repo_2"
+    root.mkdir()
+
+    profile = init_cli._local_profile(cwd=root)
+
+    assert profile.startswith("init-my-repo_2-")
+
+
+def test_local_profile_falls_back_to_repo_when_slug_is_empty(monkeypatch, tmp_path: Path) -> None:
+    init_cli, _ = _load_init_module(monkeypatch)
+
+    root = tmp_path / "мастеринг"
+    root.mkdir()
+
+    profile = init_cli._local_profile(cwd=root)
+
+    assert profile.startswith("init-repo-")
+    assert re.fullmatch(r"[A-Za-z0-9._-]+", profile)
 
 
 def test_init_openclaw_requires_global(monkeypatch) -> None:


### PR DESCRIPTION
## Description

Fixes `headroom init` (and `headroom init hook ensure`) failing with "Invalid
profile name" when the current working directory's name contains non-ASCII
letters (e.g. Cyrillic, CJK). The profile slug is now restricted to ASCII
alphanumerics so it always passes `validate_profile_name()`'s validation.

Closes #3467 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `_local_profile()` in `headroom/cli/init.py` built its profile-name slug using `str.isalnum()`, which is Unicode-aware and lets non-ASCII letters (Cyrillic, CJK, etc.) through
- `validate_profile_name()` then rejected that slug against its ASCII-only `^[A-Za-z0-9._-]+$` regex, causing `headroom init` and `headroom init hook ensure` to fail with "Invalid profile name" whenever the working directory name contained non-ASCII letters
- Restricted the slug to ASCII alphanumerics (`ch.isascii() and ch.isalnum()`) so it always passes validation
- The sha1-digest uniqueness suffix and the `init-repo-<digest>` fallback for a fully non-ASCII directory name are unchanged

## Testing

<!-- Check what you actually ran, then paste the real command output below. -->

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [] Manual testing performed

### Test Output

```text
PS C:\Users\ishita\headroom> python -m pytest tests\test_cli\test_init_cli.py -q
collected 76 items
tests\test_cli\test_init_cli.py ........................................ [ 52%]
....................................                                     [100%]
======================== 76 passed, 1 warning in 0.59s =========================

PS C:\Users\ishita\headroom> python -m ruff check headroom\cli\init.py tests\test_cli\test_init_cli.py
All checks passed!

PS C:\Users\ishita\headroom> python -m ruff format --check headroom\cli\init.py tests\test_cli\test_init_cli.py
2 files already formatted

PS C:\Users\ishita\headroom> python -m mypy headroom\cli\init.py
Success: no issues found in 1 source file
```


## Real Behavior Proof

- Environment: Windows, Python 3.14.4, pytest 9.1.1
- Exact command / steps: Created a directory named `Мастеринг в HW`, called `_local_profile(cwd=root)` directly on it, then ran the full `tests/test_cli/test_init_cli.py` suite plus `ruff` and `mypy` as shown above.
- Observed result: `_local_profile()` now returns `init-hw-1a918421`, which matches `validate_profile_name`'s `^[A-Za-z0-9._-]+$` regex. Before the fix, the same input raised `click.exceptions.ClickException: Invalid profile name 'init-мастеринг-в-hw-1a918421'`.
- Not tested: Full end-to-end `headroom init` / `headroom init hook ensure` run from an actual non-ASCII-named directory (only the underlying `_local_profile()` function was exercised directly, at unit-test level). Also did not build or test against the compiled Rust extension — an Application Control policy and missing MSVC linker on this machine blocked local builds of it, so only the pure-Python `_local_profile()` code path (which doesn't touch the extension) was verified.
## Runtime Rollout Safety

- Rollout-managed feature(s): N/A
- Minimum rollout channel: N/A
- Stable/default behavior changed: No — only affects directory names containing non-ASCII letters, which previously always errored
- Kill switch / disable path: N/A — pure string-parsing correctness fix, no runtime toggle
- Unsafe override required: N/A
- Qualification impact: None
- Rollback path: Standard git revert; no state or migration involved

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

<!-- Mention any N/A checklist items, tradeoffs, follow-ups, or maintainer context. -->
