### PR TITLE
fix(tokenizers): estimate replayed thinking from text and signature size

### DIFF
--- a/headroom/tokenizers/base.py
+++ b/headroom/tokenizers/base.py
@@ -328,6 +328,16 @@ class BaseTokenizer(ABC):
                         total += frames * 1000
                     else:
                         total += 3200
+                elif part_type == "thinking":
+                    # Anthropic extended thinking replayed by the client. Only
+                    # the thinking text is model input; ``signature`` is an
+                    # opaque server-side verification blob (~1 KB of base64 per
+                    # block) that the provider does not tokenize or bill. The
+                    # JSON catch-all below priced it as text: on a 369-message
+                    # Claude Code session, 99 signatures counted 256K of 414K
+                    # tokens against a provider-reported ~313K, inflating every
+                    # tokens_before-derived figure and the size stratum.
+                    total += self.count_text(part.get("thinking", "") or "")
                 else:
                     # Unknown type - estimate from JSON
                     total += self._count_serialized(part)

--- a/headroom/tokenizers/base.py
+++ b/headroom/tokenizers/base.py
@@ -329,15 +329,22 @@ class BaseTokenizer(ABC):
                     else:
                         total += 3200
                 elif part_type == "thinking":
-                    # Anthropic extended thinking replayed by the client. Only
-                    # the thinking text is model input; ``signature`` is an
-                    # opaque server-side verification blob (~1 KB of base64 per
-                    # block) that the provider does not tokenize or bill. The
-                    # JSON catch-all below priced it as text: on a 369-message
-                    # Claude Code session, 99 signatures counted 256K of 414K
-                    # tokens against a provider-reported ~313K, inflating every
-                    # tokens_before-derived figure and the size stratum.
+                    # Anthropic extended thinking replayed by the client. The
+                    # ``signature`` is the encrypted full reasoning: on the
+                    # keep-all-turns models (Opus 4.5+, Sonnet 4.6+, the 5.x
+                    # line) the server decrypts it into the prompt and bills
+                    # it as input, and under ``display: "omitted"`` (the 5.x
+                    # default) the ``thinking`` text is empty, so text alone
+                    # is not the input. Nor is the base64: the JSON catch-all
+                    # below priced it as prose at ~3 chars/token, and on a
+                    # 369-message Claude Code session 99 signatures counted
+                    # 256K of 414K tokens against ~313K provider-reported.
+                    # Price the text plus the decoded signature bytes at
+                    # ~4 bytes/token (len * 3/4 / 4), which lands that session
+                    # near the provider figure and never prices an omitted
+                    # block at zero.
                     total += self.count_text(part.get("thinking", "") or "")
+                    total += len(part.get("signature") or "") * 3 // 16
                 else:
                     # Unknown type - estimate from JSON
                     total += self._count_serialized(part)

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -730,31 +730,44 @@ class TestLargeToolBlobEstimation:
 
 
 class TestThinkingBlockCounting:
-    """Thinking blocks count their text, never the opaque signature."""
+    """Thinking blocks price their text plus the decoded signature bytes."""
 
-    def test_thinking_signature_is_not_counted_as_text(self):
+    def test_signature_prices_between_zero_and_the_json_catch_all(self):
         counter = EstimatingTokenCounter()
         text = "consider the failing test " * 20
-        with_sig = {
+        block = {"type": "thinking", "thinking": text, "signature": "A" * 4000}
+        signed = {"role": "assistant", "content": [block]}
+        unsigned = {"role": "assistant", "content": [{"type": "thinking", "thinking": text}]}
+        # The signature is encrypted reasoning the server replays as billed
+        # input, so it adds to the text at decoded bytes / 4 (4000 * 3/4 / 4)...
+        delta = counter.count_messages([signed]) - counter.count_messages([unsigned])
+        assert delta == 750
+        # ...which is well under the JSON catch-all's base64-as-prose price.
+        assert delta < counter._count_serialized(block)
+
+    def test_omitted_display_block_is_not_free(self):
+        # display: "omitted" (the 5.x default) returns an empty thinking field
+        # and carries the whole reasoning in the signature.
+        counter = EstimatingTokenCounter()
+        omitted = {
             "role": "assistant",
-            "content": [{"type": "thinking", "thinking": text, "signature": "A" * 4000}],
+            "content": [{"type": "thinking", "thinking": "", "signature": "A" * 4000}],
         }
-        without_sig = {
-            "role": "assistant",
-            "content": [{"type": "thinking", "thinking": text}],
-        }
-        assert counter.count_messages([with_sig]) == counter.count_messages([without_sig])
-        # Sanity: the text itself is still priced (not zeroed with the signature).
         empty = {"role": "assistant", "content": [{"type": "thinking", "thinking": ""}]}
-        assert counter.count_messages([with_sig]) > counter.count_messages([empty])
+        assert counter.count_messages([omitted]) > counter.count_messages([empty])
 
     def test_provider_walker_shares_the_thinking_rule(self):
         from headroom.tokenizers.base import count_content_blocks
 
         counter = EstimatingTokenCounter()
         text = "consider the failing test " * 20
-        with_sig = [{"type": "thinking", "thinking": text, "signature": "A" * 4000}]
-        without_sig = [{"type": "thinking", "thinking": text}]
-        assert count_content_blocks(with_sig, counter.count_text) == count_content_blocks(
-            without_sig, counter.count_text
+        signed = [{"type": "thinking", "thinking": text, "signature": "A" * 4000}]
+        unsigned = [{"type": "thinking", "thinking": text}]
+        assert count_content_blocks(signed, counter.count_text) == counter._count_content_parts(
+            signed
+        )
+        assert (
+            count_content_blocks(signed, counter.count_text)
+            - count_content_blocks(unsigned, counter.count_text)
+            == 750
         )

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -727,3 +727,34 @@ class TestLargeToolBlobEstimation:
             cur = cur["n"]
         cur["leaf"] = "x" * 60_000
         assert EstimatingTokenCounter()._count_serialized(deep) >= 0
+
+
+class TestThinkingBlockCounting:
+    """Thinking blocks count their text, never the opaque signature."""
+
+    def test_thinking_signature_is_not_counted_as_text(self):
+        counter = EstimatingTokenCounter()
+        text = "consider the failing test " * 20
+        with_sig = {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": text, "signature": "A" * 4000}],
+        }
+        without_sig = {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": text}],
+        }
+        assert counter.count_messages([with_sig]) == counter.count_messages([without_sig])
+        # Sanity: the text itself is still priced (not zeroed with the signature).
+        empty = {"role": "assistant", "content": [{"type": "thinking", "thinking": ""}]}
+        assert counter.count_messages([with_sig]) > counter.count_messages([empty])
+
+    def test_provider_walker_shares_the_thinking_rule(self):
+        from headroom.tokenizers.base import count_content_blocks
+
+        counter = EstimatingTokenCounter()
+        text = "consider the failing test " * 20
+        with_sig = [{"type": "thinking", "thinking": text, "signature": "A" * 4000}]
+        without_sig = [{"type": "thinking", "thinking": text}]
+        assert count_content_blocks(with_sig, counter.count_text) == count_content_blocks(
+            without_sig, counter.count_text
+        )


### PR DESCRIPTION
## Description

Estimate replayed Anthropic thinking blocks explicitly instead of pricing their serialized JSON as ordinary text. The shared content walker counts visible thinking text plus `len(signature) * 3 // 16`, an approximation based on decoded signature size. This keeps omitted-display reasoning from counting as free while reducing the old base64-as-prose estimate.

Encrypted reasoning cannot be counted exactly from its opaque signature. This is a local heuristic, informed by the author's traffic sample, not a replacement for provider-reported usage or provider token counting.

## Changes Made

- Add the thinking branch to the shared tokenizer walker.
- Cover signed/unsigned blocks, omitted visible thinking, and provider-walker consistency.

## Testing

Latest reviewer validation on macOS/Python 3.13 at `127a039bd`: `pytest tests/test_tokenizers.py -q` — **55 passed, 14 skipped**. Optional tokenizer dependencies account for the skips. Earlier author validation reported Ruff, formatting, and focused mypy passing.

## Real Behavior Proof

The prior empty-thinking/4,000-character-signature case now adds a 750-token estimate instead of zero. No new live provider calibration was performed during review; accuracy across models, languages, signature formats, and thinking-retention policies remains approximate.

## Runtime Rollout Safety

- Changes local token estimates for replayed thinking; request content is unchanged.
- These estimates feed sizing, compression decisions, and local savings displays.
- No persistent schema migration or experimental opt-in is required.
- Rollback: revert the thinking-count branch and its tests.

## Review Readiness

- [x] The reported omitted-thinking zero-count issue is addressed.
- [x] Focused tests pass.
- [ ] Final human review and merge.
