### PR TITLE
fix(kompress): append the CCR marker whenever the saving pays for it

### DIFF
--- a/headroom/transforms/kompress_compressor.py
+++ b/headroom/transforms/kompress_compressor.py
@@ -1294,41 +1294,41 @@ class KompressResult:
         return (self.tokens_saved / self.original_tokens) * 100
 
 
-_marker_encoder: Any = None
+_payload_encoder: Any = None
 
 
-def ccr_marker_cost(marker: str) -> int:
-    """Token cost of a retrieval marker, in the tokens the provider will bill.
+def payload_tokens(text: str) -> int:
+    """Token count of a complete payload, in one consistent unit.
 
-    The marker is 12 words but 36-45 cl100k_base tokens: the 24-hex hash alone
-    is ~16 and the word counts add a token per few digits, so any fixed word
-    allowance is wrong for some hash or some count (a 40-word allowance let a
-    43-token marker ship on a payload of 100 single-token words: 100 -> 102).
-    Price the actual marker text with cl100k_base (a hard dependency) and fall
-    back to one token per character, the most any BPE can produce, if the
-    encoder is unavailable.
+    The unit is cl100k_base (tiktoken, a hard dependency): exact for OpenAI
+    models and an ESTIMATE for every other provider, whose tokenizers differ
+    in detail but not in the shape that matters here (a hex hash is many
+    tokens, a common word is one, a word's tokenization depends on what
+    precedes it). Without an encoder, one token per character, the most any
+    BPE can produce.
 
-    The compressor accounts in words, and the words it drops are the cheap
-    ones, at least one token each. So comparing saved WORDS against marker
-    TOKENS is conservative in the direction that matters: a marker is added
-    only when the dropped words are worth at least its tokens under the
-    tightest possible tokenization, and the reported ``compressed_tokens``
-    (kept words plus marker tokens) errs high, never low.
+    The CCR gate measures the whole original and the whole candidate-plus-
+    marker with this, never a marker-only cost against a word count: the
+    marker is 36-45 tokens for 12 words, the words Kompress drops can be one
+    token each, and the word left at the head of the candidate can tokenize
+    differently from its space-prefixed form in the source. Only a comparison
+    of the two complete texts in one unit establishes that the shipped
+    payload is smaller.
     """
-    global _marker_encoder
-    if _marker_encoder is None:
+    global _payload_encoder
+    if _payload_encoder is None:
         try:
             import tiktoken
 
-            _marker_encoder = tiktoken.get_encoding("cl100k_base")
+            _payload_encoder = tiktoken.get_encoding("cl100k_base")
         except Exception:
-            _marker_encoder = False
-    if _marker_encoder:
+            _payload_encoder = False
+    if _payload_encoder:
         try:
-            return len(_marker_encoder.encode(marker))
+            return len(_payload_encoder.encode(text, disallowed_special=()))
         except Exception:
             pass
-    return len(marker)
+    return len(text)
 
 
 def ccr_retrieval_marker(
@@ -1763,12 +1763,15 @@ class KompressCompressor(Transform):
             compressed = " ".join(compressed_words)
             compressed_count = len(compressed_words)
             cache_key: str | None = None
-            marker_cost = 0
+            original_tokens = n_words
+            compressed_tokens = compressed_count
 
             # CCR marker: anything the lossy pass shrank must stay retrievable,
-            # and the complete marked payload must still be a saving. The
-            # marker is built first and priced (ccr_marker_cost); a result
-            # whose saved words cannot pay for it is passed through.
+            # and the complete marked payload must be smaller than the
+            # original. Both are measured whole, in one unit (payload_tokens);
+            # a candidate that is not is passed through. The accounting then
+            # reports that same measurement, so ``tokens_saved`` describes
+            # the shipped payload rather than a word count.
             if self.config.enable_ccr:
                 ccr_source = ccr_original if ccr_original is not None else content
                 ccr_source_tokens = len(ccr_source.split())
@@ -1777,19 +1780,20 @@ class KompressCompressor(Transform):
                     # Report the source line span so a reader can tell content was
                     # compressed away rather than absent — "items" counts words, which
                     # does not map to lines and reads as evidence of absence (#2586).
-                    marker = ccr_retrieval_marker(n_words, compressed_count, ccr_source, cache_key)
-                    marker_cost = ccr_marker_cost(marker)
-                    if n_words - compressed_count <= marker_cost:
+                    marked = compressed + ccr_retrieval_marker(
+                        n_words, compressed_count, ccr_source, cache_key
+                    )
+                    original_tokens = payload_tokens(content)
+                    compressed_tokens = payload_tokens(marked)
+                    if compressed_tokens >= original_tokens:
                         return self._passthrough(content, n_words)
-                    compressed += marker
+                    compressed = marked
 
-            # The accounting covers the payload as shipped, marker included.
-            compressed_tokens = compressed_count + marker_cost
-            ratio = compressed_tokens / n_words if n_words else 1.0
+            ratio = compressed_tokens / original_tokens if original_tokens else 1.0
             result = KompressResult(
                 compressed=compressed,
                 original=content,
-                original_tokens=n_words,
+                original_tokens=original_tokens,
                 compressed_tokens=compressed_tokens,
                 compression_ratio=ratio,
                 cache_key=cache_key,
@@ -2166,7 +2170,8 @@ class KompressCompressor(Transform):
             compressed = " ".join(compressed_words)
             compressed_count = len(compressed_words)
             cache_key: str | None = None
-            marker_cost = 0
+            original_tokens = n_words
+            compressed_tokens = compressed_count
 
             # Same gate and accounting as the single path.
             if self.config.enable_ccr:
@@ -2179,20 +2184,22 @@ class KompressCompressor(Transform):
                     # Report the source line span so a reader can tell content was
                     # compressed away rather than absent — "items" counts words, which
                     # does not map to lines and reads as evidence of absence (#2586).
-                    marker = ccr_retrieval_marker(n_words, compressed_count, ccr_source, cache_key)
-                    marker_cost = ccr_marker_cost(marker)
-                    if n_words - compressed_count <= marker_cost:
+                    marked = compressed + ccr_retrieval_marker(
+                        n_words, compressed_count, ccr_source, cache_key
+                    )
+                    original_tokens = payload_tokens(content)
+                    compressed_tokens = payload_tokens(marked)
+                    if compressed_tokens >= original_tokens:
                         results[text_idx] = self._passthrough(content, n_words)
                         continue
-                    compressed += marker
+                    compressed = marked
 
-            compressed_tokens = compressed_count + marker_cost
             results[text_idx] = KompressResult(
                 compressed=compressed,
                 original=content,
-                original_tokens=n_words,
+                original_tokens=original_tokens,
                 compressed_tokens=compressed_tokens,
-                compression_ratio=compressed_tokens / n_words if n_words else 1.0,
+                compression_ratio=compressed_tokens / original_tokens if original_tokens else 1.0,
                 cache_key=cache_key,
                 model_used=self.config.model_id,
             )

--- a/headroom/transforms/kompress_compressor.py
+++ b/headroom/transforms/kompress_compressor.py
@@ -1294,14 +1294,19 @@ class KompressResult:
         return (self.tokens_saved / self.original_tokens) * 100
 
 
-# Word cost of the retrieval marker below, measured once so the marker gate can
-# ask "does the saving pay for the marker" without building it first. A marker
-# is appended only when the lossy pass saves MORE than this. The old gate was a
-# flat ratio < 0.8: results that shrank 1-20 percent shipped without a marker
-# and were then discarded by the router's lossy-unrecoverable guard (#1307), so
-# the ML pass ran and saved nothing (measured 218 discards in one day of Claude
-# Code traffic, where the router accepts any shrink).
-CCR_MARKER_WORDS = 13
+# Conservative cost of the retrieval marker below, in the word unit this
+# module accounts in. The marker is 12 words but 36-38 cl100k_base tokens (the
+# 24-hex hash alone is 16), while the words Kompress drops are the cheap ones,
+# at worst ~1 token each. So "saved words > marker words" (13) admitted results
+# whose marked payload was LARGER in tokens than the original: drop 16 of 100
+# words, append the marker, and cl100k goes 196 -> 200. Requiring more than 40
+# saved words covers the marker even when every dropped word was a single
+# token; a result that cannot pay for it is passed through untouched, since
+# under CCR an unmarked lossy result is discarded by the router (#1307) anyway.
+# The old gate was a flat ratio < 0.8: results that shrank 1-20 percent shipped
+# without a marker and were thrown away, so the ML pass ran and saved nothing
+# (218 discards in one day of Claude Code traffic).
+CCR_MARKER_COST_WORDS = 40
 
 
 def ccr_retrieval_marker(
@@ -1735,31 +1740,39 @@ class KompressCompressor(Transform):
             compressed_words = [words[w] for w in sorted(kept_ids) if w < n_words]
             compressed = " ".join(compressed_words)
             compressed_count = len(compressed_words)
-            ratio = compressed_count / n_words if n_words else 1.0
+            cache_key: str | None = None
+            marker_cost = 0
 
-            result = KompressResult(
-                compressed=compressed,
-                original=content,
-                original_tokens=n_words,
-                compressed_tokens=compressed_count,
-                compression_ratio=ratio,
-                model_used=self.config.model_id,
-            )
-
-            # CCR marker: whenever the lossy pass saves more than the marker
-            # costs. Anything it shrank is lossy and must stay retrievable.
-            if self.config.enable_ccr and n_words - compressed_count > CCR_MARKER_WORDS:
+            # CCR marker: anything the lossy pass shrank must stay retrievable,
+            # and the complete marked payload must still be a saving. A result
+            # whose saving cannot pay for the marker is passed through.
+            if self.config.enable_ccr:
+                if n_words - compressed_count <= CCR_MARKER_COST_WORDS:
+                    return self._passthrough(content, n_words)
                 ccr_source = ccr_original if ccr_original is not None else content
                 ccr_source_tokens = len(ccr_source.split())
                 cache_key = self._store_in_ccr(ccr_source, compressed, ccr_source_tokens)
                 if cache_key:
-                    result.cache_key = cache_key
                     # Report the source line span so a reader can tell content was
                     # compressed away rather than absent — "items" counts words, which
                     # does not map to lines and reads as evidence of absence (#2586).
-                    result.compressed += ccr_retrieval_marker(
+                    compressed += ccr_retrieval_marker(
                         n_words, compressed_count, ccr_source, cache_key
                     )
+                    marker_cost = CCR_MARKER_COST_WORDS
+
+            # The accounting covers the payload as shipped, marker included.
+            compressed_tokens = compressed_count + marker_cost
+            ratio = compressed_tokens / n_words if n_words else 1.0
+            result = KompressResult(
+                compressed=compressed,
+                original=content,
+                original_tokens=n_words,
+                compressed_tokens=compressed_tokens,
+                compression_ratio=ratio,
+                cache_key=cache_key,
+                model_used=self.config.model_id,
+            )
 
             if inference_ms >= 1000.0:
                 logger.info(
@@ -2130,33 +2143,38 @@ class KompressCompressor(Transform):
             compressed_words = [words[w] for w in sorted(kept_ids) if w < n_words]
             compressed = " ".join(compressed_words)
             compressed_count = len(compressed_words)
-            comp_ratio = compressed_count / n_words if n_words else 1.0
+            cache_key: str | None = None
+            marker_cost = 0
 
-            result = KompressResult(
-                compressed=compressed,
-                original=content,
-                original_tokens=n_words,
-                compressed_tokens=compressed_count,
-                compression_ratio=comp_ratio,
-                model_used=self.config.model_id,
-            )
-
-            if self.config.enable_ccr and n_words - compressed_count > CCR_MARKER_WORDS:
+            # Same gate and accounting as the single path.
+            if self.config.enable_ccr:
+                if n_words - compressed_count <= CCR_MARKER_COST_WORDS:
+                    results[text_idx] = self._passthrough(content, n_words)
+                    continue
                 ccr_source = ccr_sources[text_idx]
                 if ccr_source is None:
                     ccr_source = content
                 ccr_source_tokens = len(ccr_source.split())
                 cache_key = self._store_in_ccr(ccr_source, compressed, ccr_source_tokens)
                 if cache_key:
-                    result.cache_key = cache_key
                     # Report the source line span so a reader can tell content was
                     # compressed away rather than absent — "items" counts words, which
                     # does not map to lines and reads as evidence of absence (#2586).
-                    result.compressed += ccr_retrieval_marker(
+                    compressed += ccr_retrieval_marker(
                         n_words, compressed_count, ccr_source, cache_key
                     )
+                    marker_cost = CCR_MARKER_COST_WORDS
 
-            results[text_idx] = result
+            compressed_tokens = compressed_count + marker_cost
+            results[text_idx] = KompressResult(
+                compressed=compressed,
+                original=content,
+                original_tokens=n_words,
+                compressed_tokens=compressed_tokens,
+                compression_ratio=compressed_tokens / n_words if n_words else 1.0,
+                cache_key=cache_key,
+                model_used=self.config.model_id,
+            )
 
         # Safety: every slot must be populated.
         final: list[KompressResult] = []

--- a/headroom/transforms/kompress_compressor.py
+++ b/headroom/transforms/kompress_compressor.py
@@ -1300,12 +1300,10 @@ _payload_encoder: Any = None
 def payload_tokens(text: str) -> int:
     """Token count of a complete payload, in one consistent unit.
 
-    The unit is cl100k_base (tiktoken, a hard dependency): exact for OpenAI
-    models and an ESTIMATE for every other provider, whose tokenizers differ
-    in detail but not in the shape that matters here (a hex hash is many
-    tokens, a common word is one, a word's tokenization depends on what
-    precedes it). Without an encoder, one token per character, the most any
-    BPE can produce.
+    The unit is cl100k_base (tiktoken, a hard dependency), used as a fixed
+    estimate. Actual model tokenizers, including those of other OpenAI
+    models, can differ. Without an encoder, the fallback compares character
+    counts; that heuristic is not a bound on provider token counts.
 
     The CCR gate measures the whole original and the whole candidate-plus-
     marker with this, never a marker-only cost against a word count: the

--- a/headroom/transforms/kompress_compressor.py
+++ b/headroom/transforms/kompress_compressor.py
@@ -1294,19 +1294,41 @@ class KompressResult:
         return (self.tokens_saved / self.original_tokens) * 100
 
 
-# Conservative cost of the retrieval marker below, in the word unit this
-# module accounts in. The marker is 12 words but 36-38 cl100k_base tokens (the
-# 24-hex hash alone is 16), while the words Kompress drops are the cheap ones,
-# at worst ~1 token each. So "saved words > marker words" (13) admitted results
-# whose marked payload was LARGER in tokens than the original: drop 16 of 100
-# words, append the marker, and cl100k goes 196 -> 200. Requiring more than 40
-# saved words covers the marker even when every dropped word was a single
-# token; a result that cannot pay for it is passed through untouched, since
-# under CCR an unmarked lossy result is discarded by the router (#1307) anyway.
-# The old gate was a flat ratio < 0.8: results that shrank 1-20 percent shipped
-# without a marker and were thrown away, so the ML pass ran and saved nothing
-# (218 discards in one day of Claude Code traffic).
-CCR_MARKER_COST_WORDS = 40
+_marker_encoder: Any = None
+
+
+def ccr_marker_cost(marker: str) -> int:
+    """Token cost of a retrieval marker, in the tokens the provider will bill.
+
+    The marker is 12 words but 36-45 cl100k_base tokens: the 24-hex hash alone
+    is ~16 and the word counts add a token per few digits, so any fixed word
+    allowance is wrong for some hash or some count (a 40-word allowance let a
+    43-token marker ship on a payload of 100 single-token words: 100 -> 102).
+    Price the actual marker text with cl100k_base (a hard dependency) and fall
+    back to one token per character, the most any BPE can produce, if the
+    encoder is unavailable.
+
+    The compressor accounts in words, and the words it drops are the cheap
+    ones, at least one token each. So comparing saved WORDS against marker
+    TOKENS is conservative in the direction that matters: a marker is added
+    only when the dropped words are worth at least its tokens under the
+    tightest possible tokenization, and the reported ``compressed_tokens``
+    (kept words plus marker tokens) errs high, never low.
+    """
+    global _marker_encoder
+    if _marker_encoder is None:
+        try:
+            import tiktoken
+
+            _marker_encoder = tiktoken.get_encoding("cl100k_base")
+        except Exception:
+            _marker_encoder = False
+    if _marker_encoder:
+        try:
+            return len(_marker_encoder.encode(marker))
+        except Exception:
+            pass
+    return len(marker)
 
 
 def ccr_retrieval_marker(
@@ -1744,11 +1766,10 @@ class KompressCompressor(Transform):
             marker_cost = 0
 
             # CCR marker: anything the lossy pass shrank must stay retrievable,
-            # and the complete marked payload must still be a saving. A result
-            # whose saving cannot pay for the marker is passed through.
+            # and the complete marked payload must still be a saving. The
+            # marker is built first and priced (ccr_marker_cost); a result
+            # whose saved words cannot pay for it is passed through.
             if self.config.enable_ccr:
-                if n_words - compressed_count <= CCR_MARKER_COST_WORDS:
-                    return self._passthrough(content, n_words)
                 ccr_source = ccr_original if ccr_original is not None else content
                 ccr_source_tokens = len(ccr_source.split())
                 cache_key = self._store_in_ccr(ccr_source, compressed, ccr_source_tokens)
@@ -1756,10 +1777,11 @@ class KompressCompressor(Transform):
                     # Report the source line span so a reader can tell content was
                     # compressed away rather than absent — "items" counts words, which
                     # does not map to lines and reads as evidence of absence (#2586).
-                    compressed += ccr_retrieval_marker(
-                        n_words, compressed_count, ccr_source, cache_key
-                    )
-                    marker_cost = CCR_MARKER_COST_WORDS
+                    marker = ccr_retrieval_marker(n_words, compressed_count, ccr_source, cache_key)
+                    marker_cost = ccr_marker_cost(marker)
+                    if n_words - compressed_count <= marker_cost:
+                        return self._passthrough(content, n_words)
+                    compressed += marker
 
             # The accounting covers the payload as shipped, marker included.
             compressed_tokens = compressed_count + marker_cost
@@ -2148,9 +2170,6 @@ class KompressCompressor(Transform):
 
             # Same gate and accounting as the single path.
             if self.config.enable_ccr:
-                if n_words - compressed_count <= CCR_MARKER_COST_WORDS:
-                    results[text_idx] = self._passthrough(content, n_words)
-                    continue
                 ccr_source = ccr_sources[text_idx]
                 if ccr_source is None:
                     ccr_source = content
@@ -2160,10 +2179,12 @@ class KompressCompressor(Transform):
                     # Report the source line span so a reader can tell content was
                     # compressed away rather than absent — "items" counts words, which
                     # does not map to lines and reads as evidence of absence (#2586).
-                    compressed += ccr_retrieval_marker(
-                        n_words, compressed_count, ccr_source, cache_key
-                    )
-                    marker_cost = CCR_MARKER_COST_WORDS
+                    marker = ccr_retrieval_marker(n_words, compressed_count, ccr_source, cache_key)
+                    marker_cost = ccr_marker_cost(marker)
+                    if n_words - compressed_count <= marker_cost:
+                        results[text_idx] = self._passthrough(content, n_words)
+                        continue
+                    compressed += marker
 
             compressed_tokens = compressed_count + marker_cost
             results[text_idx] = KompressResult(

--- a/headroom/transforms/kompress_compressor.py
+++ b/headroom/transforms/kompress_compressor.py
@@ -1294,6 +1294,16 @@ class KompressResult:
         return (self.tokens_saved / self.original_tokens) * 100
 
 
+# Word cost of the retrieval marker below, measured once so the marker gate can
+# ask "does the saving pay for the marker" without building it first. A marker
+# is appended only when the lossy pass saves MORE than this. The old gate was a
+# flat ratio < 0.8: results that shrank 1-20 percent shipped without a marker
+# and were then discarded by the router's lossy-unrecoverable guard (#1307), so
+# the ML pass ran and saved nothing (measured 218 discards in one day of Claude
+# Code traffic, where the router accepts any shrink).
+CCR_MARKER_WORDS = 13
+
+
 def ccr_retrieval_marker(
     n_words: int, compressed_count: int, ccr_source: str, cache_key: str
 ) -> str:
@@ -1736,8 +1746,9 @@ class KompressCompressor(Transform):
                 model_used=self.config.model_id,
             )
 
-            # CCR marker
-            if self.config.enable_ccr and ratio < 0.8:
+            # CCR marker: whenever the lossy pass saves more than the marker
+            # costs. Anything it shrank is lossy and must stay retrievable.
+            if self.config.enable_ccr and n_words - compressed_count > CCR_MARKER_WORDS:
                 ccr_source = ccr_original if ccr_original is not None else content
                 ccr_source_tokens = len(ccr_source.split())
                 cache_key = self._store_in_ccr(ccr_source, compressed, ccr_source_tokens)
@@ -2130,7 +2141,7 @@ class KompressCompressor(Transform):
                 model_used=self.config.model_id,
             )
 
-            if self.config.enable_ccr and comp_ratio < 0.8:
+            if self.config.enable_ccr and n_words - compressed_count > CCR_MARKER_WORDS:
                 ccr_source = ccr_sources[text_idx]
                 if ccr_source is None:
                     ccr_source = content

--- a/headroom/transforms/kompress_remote.py
+++ b/headroom/transforms/kompress_remote.py
@@ -57,7 +57,13 @@ import logging
 
 import httpx
 
-from .kompress_compressor import KompressConfig, KompressResult, store_kompress_in_ccr
+from .kompress_compressor import (
+    CCR_MARKER_COST_WORDS,
+    KompressConfig,
+    KompressResult,
+    ccr_retrieval_marker,
+    store_kompress_in_ccr,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +100,6 @@ _MIN_WORDS = 10
 
 # Accept-any-shrink CCR gate, identical to KompressCompressor.compress: only
 # store + mark when the shrink is worth the retrieval marker's own cost.
-_CCR_RATIO_GATE = 0.8
 
 
 class RemoteKompressCompressor:
@@ -238,7 +243,11 @@ class RemoteKompressCompressor:
         # CCR stays PROXY-LOCAL: endpoint is stateless (enable_ccr=False), so we
         # store the mapping + append the retrieval marker here — same policy and
         # marker format as KompressCompressor.compress.
-        if self.config.enable_ccr and result.compression_ratio < _CCR_RATIO_GATE:
+        if self.config.enable_ccr and compressed != content:
+            # Same gate as KompressCompressor: the marked payload must save
+            # tokens, and a result that cannot pay for the marker passes through.
+            if result.original_tokens - result.compressed_tokens <= CCR_MARKER_COST_WORDS:
+                return self._passthrough(content, n_words)
             # Store the PRE-protection text when the caller supplied it. ``content``
             # may be the tag-protected placeholder intermediate, and storing that
             # makes a later full retrieval hand back {{HEADROOM_TAG_N}} instead of
@@ -256,12 +265,15 @@ class RemoteKompressCompressor:
                 result.cache_key = cache_key
                 # Report the source line span so a reader can tell content was
                 # compressed away rather than absent (#2586).
-                source_lines = ccr_source.count("\n") + 1
-                line_word = "line" if source_lines == 1 else "lines"
-                result.compressed += (
-                    f"\n[{result.original_tokens} words compressed to "
-                    f"{result.compressed_tokens} (from {source_lines} source {line_word})."
-                    f" Retrieve more: hash={cache_key}]"
+                result.compressed += ccr_retrieval_marker(
+                    result.original_tokens, result.compressed_tokens, ccr_source, cache_key
+                )
+                # The accounting covers the payload as shipped, marker included.
+                result.compressed_tokens += CCR_MARKER_COST_WORDS
+                result.compression_ratio = (
+                    result.compressed_tokens / result.original_tokens
+                    if result.original_tokens
+                    else 1.0
                 )
 
         return result

--- a/headroom/transforms/kompress_remote.py
+++ b/headroom/transforms/kompress_remote.py
@@ -58,9 +58,9 @@ import logging
 import httpx
 
 from .kompress_compressor import (
-    CCR_MARKER_COST_WORDS,
     KompressConfig,
     KompressResult,
+    ccr_marker_cost,
     ccr_retrieval_marker,
     store_kompress_in_ccr,
 )
@@ -246,8 +246,6 @@ class RemoteKompressCompressor:
         if self.config.enable_ccr and compressed != content:
             # Same gate as KompressCompressor: the marked payload must save
             # tokens, and a result that cannot pay for the marker passes through.
-            if result.original_tokens - result.compressed_tokens <= CCR_MARKER_COST_WORDS:
-                return self._passthrough(content, n_words)
             # Store the PRE-protection text when the caller supplied it. ``content``
             # may be the tag-protected placeholder intermediate, and storing that
             # makes a later full retrieval hand back {{HEADROOM_TAG_N}} instead of
@@ -262,14 +260,18 @@ class RemoteKompressCompressor:
             )
             cache_key = store_kompress_in_ccr(ccr_source, compressed, ccr_source_tokens)
             if cache_key:
-                result.cache_key = cache_key
                 # Report the source line span so a reader can tell content was
                 # compressed away rather than absent (#2586).
-                result.compressed += ccr_retrieval_marker(
+                marker = ccr_retrieval_marker(
                     result.original_tokens, result.compressed_tokens, ccr_source, cache_key
                 )
+                marker_cost = ccr_marker_cost(marker)
+                if result.original_tokens - result.compressed_tokens <= marker_cost:
+                    return self._passthrough(content, n_words)
+                result.cache_key = cache_key
+                result.compressed += marker
                 # The accounting covers the payload as shipped, marker included.
-                result.compressed_tokens += CCR_MARKER_COST_WORDS
+                result.compressed_tokens += marker_cost
                 result.compression_ratio = (
                     result.compressed_tokens / result.original_tokens
                     if result.original_tokens

--- a/headroom/transforms/kompress_remote.py
+++ b/headroom/transforms/kompress_remote.py
@@ -60,8 +60,8 @@ import httpx
 from .kompress_compressor import (
     KompressConfig,
     KompressResult,
-    ccr_marker_cost,
     ccr_retrieval_marker,
+    payload_tokens,
     store_kompress_in_ccr,
 )
 
@@ -262,20 +262,21 @@ class RemoteKompressCompressor:
             if cache_key:
                 # Report the source line span so a reader can tell content was
                 # compressed away rather than absent (#2586).
-                marker = ccr_retrieval_marker(
+                marked = compressed + ccr_retrieval_marker(
                     result.original_tokens, result.compressed_tokens, ccr_source, cache_key
                 )
-                marker_cost = ccr_marker_cost(marker)
-                if result.original_tokens - result.compressed_tokens <= marker_cost:
+                # Whole original against whole marked candidate, one unit,
+                # and the accounting reports that measurement.
+                original_tokens = payload_tokens(content)
+                compressed_tokens = payload_tokens(marked)
+                if compressed_tokens >= original_tokens:
                     return self._passthrough(content, n_words)
                 result.cache_key = cache_key
-                result.compressed += marker
-                # The accounting covers the payload as shipped, marker included.
-                result.compressed_tokens += marker_cost
+                result.compressed = marked
+                result.original_tokens = original_tokens
+                result.compressed_tokens = compressed_tokens
                 result.compression_ratio = (
-                    result.compressed_tokens / result.original_tokens
-                    if result.original_tokens
-                    else 1.0
+                    compressed_tokens / original_tokens if original_tokens else 1.0
                 )
 
         return result

--- a/tests/test_ccr_tag_placeholder_regression.py
+++ b/tests/test_ccr_tag_placeholder_regression.py
@@ -142,8 +142,9 @@ def test_compress_batch_validates_ccr_originals_length():
 # it keeps the first two words of each chunk so the compression ratio clears the
 # ``< 0.8`` CCR-store threshold.
 
-_RAW = "<system-reminder>CRITICAL: invoke the skill</system-reminder> " + " ".join(["filler"] * 40)
-_PLACEHOLDER = "{{HEADROOM_TAG_0}} " + " ".join(["filler"] * 40)
+# 100 filler words: keeping two saves ~99, well past the marker cost gate.
+_RAW = "<system-reminder>CRITICAL: invoke the skill</system-reminder> " + " ".join(["filler"] * 100)
+_PLACEHOLDER = "{{HEADROOM_TAG_0}} " + " ".join(["filler"] * 100)
 
 
 class _FakeEncoding:

--- a/tests/test_kompress_marker_gate.py
+++ b/tests/test_kompress_marker_gate.py
@@ -11,13 +11,15 @@ marker in its own accounting.
 
 from __future__ import annotations
 
+import hashlib
+
 import pytest
 
 from headroom.transforms import kompress_compressor as kc
 from headroom.transforms.kompress_compressor import (
-    CCR_MARKER_COST_WORDS,
     KompressCompressor,
     KompressConfig,
+    ccr_marker_cost,
     ccr_retrieval_marker,
 )
 
@@ -62,71 +64,78 @@ def _prose(n: int) -> str:
     return " ".join(f"w{chr(97 + i % 26)}{chr(97 + (i // 26) % 26)}" for i in range(n))
 
 
-HASH = "c00eb437e5e5c00eb437e5e5"  # real CCR hash length
+def _real_key(source: str) -> str:
+    """The CCR store's own key: the SHA-256 prefix of the stored source."""
+    return hashlib.sha256(source.encode()).hexdigest()[:24]
 
 
 def _compressor(monkeypatch, **config) -> KompressCompressor:
     compressor = KompressCompressor(KompressConfig(min_input_words=10, **config))
     monkeypatch.setattr(compressor, "_should_batch_single_content", lambda *a, **k: False)
     monkeypatch.setattr(compressor, "_should_use_sequential_fallback", lambda: False)
-    monkeypatch.setattr(compressor, "_store_in_ccr", lambda *a, **k: HASH)
+    monkeypatch.setattr(compressor, "_store_in_ccr", lambda source, *a, **k: _real_key(source))
     return compressor
 
 
-def test_marker_cost_bound_covers_a_real_marker_in_tokens():
+# 100 single-token words: the tightest source there is. Dropping 41 saves 41
+# tokens, and the marker for it (with its real source-derived hash) costs 43.
+SINGLE_TOKEN_SOURCE = " ".join(["alpha"] * 99 + ["nfs"])
+
+
+def test_marker_cost_is_the_real_marker_priced_in_tokens():
     enc = pytest.importorskip("tiktoken").get_encoding("cl100k_base")
-    marker = ccr_retrieval_marker(12345, 9876, "x\n" * 400, HASH)
-    # Every dropped word is at least one token, so a bound in words covers the
-    # marker whenever it exceeds the marker's token count.
-    assert len(enc.encode(marker)) < CCR_MARKER_COST_WORDS
+    marker = ccr_retrieval_marker(100, 59, SINGLE_TOKEN_SOURCE, _real_key(SINGLE_TOKEN_SOURCE))
+    assert _real_key(SINGLE_TOKEN_SOURCE) == "7dbb8f8de9f3e1d7c6f3a6e1"
+    assert ccr_marker_cost(marker) == len(enc.encode(marker)) == 43
+    # Digits and a different hash change the price; it is measured, not fixed.
+    other = ccr_retrieval_marker(123456, 98765, "x\n" * 400, "c00eb437e5e5c00eb437e5e5")
+    assert ccr_marker_cost(other) == len(enc.encode(other))
 
 
-def test_weak_shrink_gets_a_marker_and_reports_it(monkeypatch):
-    # 300 -> 240 words is ratio 0.80: the old `ratio < 0.8` gate shipped this
-    # unmarked and the router threw it away.
-    _install(monkeypatch, drop=60)
-    result = _compressor(monkeypatch).compress(_prose(300))
-    assert result.cache_key == HASH
-    assert f"Retrieve more: hash={HASH}" in result.compressed
-    assert result.compressed_tokens == 240 + CCR_MARKER_COST_WORDS
-    assert result.compression_ratio == (240 + CCR_MARKER_COST_WORDS) / 300
+def test_marker_cost_without_an_encoder_is_one_token_per_character(monkeypatch):
+    monkeypatch.setattr(kc, "_marker_encoder", False)
+    marker = ccr_retrieval_marker(100, 59, SINGLE_TOKEN_SOURCE, _real_key(SINGLE_TOKEN_SOURCE))
+    assert ccr_marker_cost(marker) == len(marker)
 
 
-def test_saving_that_cannot_pay_for_the_marker_passes_through(monkeypatch):
-    # The reviewer's case: drop 16 of 100 words and append a real-length
-    # marker, and cl100k goes 196 -> 200. Under the 13-word gate this shipped
-    # as ratio 0.84.
-    _install(monkeypatch, drop=16)
-    prose = _prose(100)
-    result = _compressor(monkeypatch).compress(prose)
-    assert result.compressed == prose
+def test_single_token_words_that_cannot_pay_for_the_marker_pass_through(monkeypatch):
+    # 100 -> 59 words saves 41 tokens; the marked payload is 102 tokens. Under
+    # the earlier fixed 40-word allowance this shipped at reported ratio 0.99.
+    _install(monkeypatch, drop=41)
+    result = _compressor(monkeypatch).compress(SINGLE_TOKEN_SOURCE)
+    assert result.compressed == SINGLE_TOKEN_SOURCE
     assert result.cache_key is None
-    assert result.compressed_tokens == 100
-    assert result.compression_ratio == 1.0
-    enc = pytest.importorskip("tiktoken").get_encoding("cl100k_base")
-    marked = " ".join(prose.split()[16:]) + ccr_retrieval_marker(100, 84, prose, HASH)
-    assert len(enc.encode(marked)) > len(enc.encode(prose))
+    assert (result.original_tokens, result.compressed_tokens, result.compression_ratio) == (
+        100,
+        100,
+        1.0,
+    )
+    [batched] = _compressor(monkeypatch).compress_batch([SINGLE_TOKEN_SOURCE], batch_size=8)
+    assert batched.compressed == SINGLE_TOKEN_SOURCE and batched.compression_ratio == 1.0
 
 
-def test_batch_path_uses_the_same_gate_and_accounting(monkeypatch):
+def test_marked_result_reports_kept_words_plus_the_measured_marker(monkeypatch):
+    # 300 single-token words, drop 60: 60 saved tokens cover a ~43-token marker.
+    source = " ".join(["alpha"] * 299 + ["nfs"])
     _install(monkeypatch, drop=60)
-    [marked] = _compressor(monkeypatch).compress_batch([_prose(300)], batch_size=8)
-    assert f"Retrieve more: hash={HASH}" in marked.compressed
-    assert marked.compressed_tokens == 240 + CCR_MARKER_COST_WORDS
-    _install(monkeypatch, drop=16)
-    prose = _prose(100)
-    [through] = _compressor(monkeypatch).compress_batch([prose], batch_size=8)
-    assert through.compressed == prose
-    assert through.compression_ratio == 1.0
+    result = _compressor(monkeypatch).compress(source)
+    marker = ccr_retrieval_marker(300, 240, source, _real_key(source))
+    assert result.compressed == " ".join(source.split()[60:]) + marker
+    assert result.cache_key == _real_key(source)
+    assert result.compressed_tokens == 240 + ccr_marker_cost(marker)
+    assert result.compression_ratio == (240 + ccr_marker_cost(marker)) / 300
+    [batched] = _compressor(monkeypatch).compress_batch([source], batch_size=8)
+    assert batched.compressed == result.compressed
+    assert batched.compressed_tokens == result.compressed_tokens
 
 
 def test_no_ccr_mode_ships_unmarked_lossy_unchanged(monkeypatch):
     # Without CCR there is no marker to pay for: the deliberate output is the
     # bare lossy result, on both paths, exactly as before.
-    _install(monkeypatch, drop=16)
+    _install(monkeypatch, drop=41)
     compressor = _compressor(monkeypatch, enable_ccr=False)
-    result = compressor.compress(_prose(100))
-    assert result.compressed_tokens == 84
+    result = compressor.compress(SINGLE_TOKEN_SOURCE)
+    assert result.compressed_tokens == 59
     assert "Retrieve more" not in result.compressed
-    [batched] = compressor.compress_batch([_prose(100)], batch_size=8)
-    assert batched.compressed_tokens == 84
+    [batched] = compressor.compress_batch([SINGLE_TOKEN_SOURCE], batch_size=8)
+    assert batched.compressed_tokens == 59

--- a/tests/test_kompress_marker_gate.py
+++ b/tests/test_kompress_marker_gate.py
@@ -1,0 +1,95 @@
+"""The CCR retrieval marker follows the saving, not a flat ratio.
+
+A lossy Kompress result that shipped without a marker was discarded by the
+router's lossy-unrecoverable guard (#1307), so every pass that shrank a block
+by less than 20 percent ran the model and saved nothing. The gate now asks
+whether the saving pays for the marker.
+"""
+
+from __future__ import annotations
+
+from headroom.transforms import kompress_compressor as kc
+from headroom.transforms.kompress_compressor import (
+    CCR_MARKER_WORDS,
+    KompressCompressor,
+    KompressConfig,
+    ccr_retrieval_marker,
+)
+
+
+class _Enc(dict):
+    def word_ids(self, batch_index=0):
+        return self["_word_ids"][batch_index]
+
+
+class _Tok:
+    def __call__(self, chunk_words, **kw):
+        batch_words = (
+            chunk_words if chunk_words and isinstance(chunk_words[0], list) else [chunk_words]
+        )
+        return _Enc(
+            input_ids=[[0] * len(words) for words in batch_words],
+            attention_mask=[[1] * len(words) for words in batch_words],
+            _word_ids=[list(range(len(words))) for words in batch_words],
+        )
+
+
+class _DropFirst:
+    """Keep every word except the first ``drop`` of each row."""
+
+    def __init__(self, drop: int) -> None:
+        self.drop = drop
+
+    def get_keep_mask(self, input_ids, attention_mask):
+        return [[idx >= self.drop for idx, _ in enumerate(row)] for row in input_ids]
+
+    def get_scores(self, input_ids, attention_mask):
+        return [[0.0 if idx < self.drop else 1.0 for idx, _ in enumerate(row)] for row in input_ids]
+
+
+def _install(monkeypatch, drop: int) -> None:
+    monkeypatch.setattr(kc, "_load_kompress", lambda *a, **k: (_DropFirst(drop), _Tok(), "onnx"))
+    monkeypatch.setattr(kc, "_model_device_type", lambda *a, **k: "cpu")
+
+
+def _prose(n: int) -> str:
+    # Plain lowercase words: nothing the must-keep override would pin.
+    return " ".join(f"w{chr(97 + i % 26)}{chr(97 + (i // 26) % 26)}" for i in range(n))
+
+
+def _compressor(monkeypatch) -> KompressCompressor:
+    compressor = KompressCompressor(KompressConfig(min_input_words=10))
+    monkeypatch.setattr(compressor, "_should_batch_single_content", lambda *a, **k: False)
+    monkeypatch.setattr(compressor, "_should_use_sequential_fallback", lambda: False)
+    monkeypatch.setattr(compressor, "_store_in_ccr", lambda *a, **k: "abc123")
+    return compressor
+
+
+def test_marker_word_cost_constant_matches_the_marker():
+    marker = ccr_retrieval_marker(1000, 900, "x\n" * 5, "c00eb437e5e5c00eb437e5e5")
+    assert len(marker.split()) <= CCR_MARKER_WORDS
+
+
+def test_weak_shrink_still_gets_a_marker(monkeypatch):
+    # 100 -> 80 words is ratio 0.80: the old `ratio < 0.8` gate shipped this
+    # unmarked and the router threw it away.
+    _install(monkeypatch, drop=20)
+    result = _compressor(monkeypatch).compress(_prose(100))
+    assert result.compressed_tokens == 80
+    assert result.cache_key == "abc123"
+    assert "Retrieve more: hash=abc123" in result.compressed
+
+
+def test_saving_smaller_than_the_marker_stays_unmarked(monkeypatch):
+    _install(monkeypatch, drop=5)
+    result = _compressor(monkeypatch).compress(_prose(100))
+    assert result.compressed_tokens == 95
+    assert result.cache_key is None
+    assert "Retrieve more" not in result.compressed
+
+
+def test_batch_path_uses_the_same_gate(monkeypatch):
+    _install(monkeypatch, drop=20)
+    [result] = _compressor(monkeypatch).compress_batch([_prose(100)], batch_size=8)
+    assert result.compressed_tokens == 80
+    assert "Retrieve more: hash=abc123" in result.compressed

--- a/tests/test_kompress_marker_gate.py
+++ b/tests/test_kompress_marker_gate.py
@@ -1,16 +1,21 @@
-"""The CCR retrieval marker follows the saving, not a flat ratio.
+"""The CCR retrieval marker follows the saving, and the saving must cover it.
 
 A lossy Kompress result that shipped without a marker was discarded by the
 router's lossy-unrecoverable guard (#1307), so every pass that shrank a block
 by less than 20 percent ran the model and saved nothing. The gate now asks
-whether the saving pays for the marker.
+whether the saving pays for the marker in tokens, not words: the marker is 12
+words but 36-38 cl100k tokens, and the words Kompress drops can be single
+tokens. A result that cannot pay passes through; a marked result reports the
+marker in its own accounting.
 """
 
 from __future__ import annotations
 
+import pytest
+
 from headroom.transforms import kompress_compressor as kc
 from headroom.transforms.kompress_compressor import (
-    CCR_MARKER_WORDS,
+    CCR_MARKER_COST_WORDS,
     KompressCompressor,
     KompressConfig,
     ccr_retrieval_marker,
@@ -57,39 +62,71 @@ def _prose(n: int) -> str:
     return " ".join(f"w{chr(97 + i % 26)}{chr(97 + (i // 26) % 26)}" for i in range(n))
 
 
-def _compressor(monkeypatch) -> KompressCompressor:
-    compressor = KompressCompressor(KompressConfig(min_input_words=10))
+HASH = "c00eb437e5e5c00eb437e5e5"  # real CCR hash length
+
+
+def _compressor(monkeypatch, **config) -> KompressCompressor:
+    compressor = KompressCompressor(KompressConfig(min_input_words=10, **config))
     monkeypatch.setattr(compressor, "_should_batch_single_content", lambda *a, **k: False)
     monkeypatch.setattr(compressor, "_should_use_sequential_fallback", lambda: False)
-    monkeypatch.setattr(compressor, "_store_in_ccr", lambda *a, **k: "abc123")
+    monkeypatch.setattr(compressor, "_store_in_ccr", lambda *a, **k: HASH)
     return compressor
 
 
-def test_marker_word_cost_constant_matches_the_marker():
-    marker = ccr_retrieval_marker(1000, 900, "x\n" * 5, "c00eb437e5e5c00eb437e5e5")
-    assert len(marker.split()) <= CCR_MARKER_WORDS
+def test_marker_cost_bound_covers_a_real_marker_in_tokens():
+    enc = pytest.importorskip("tiktoken").get_encoding("cl100k_base")
+    marker = ccr_retrieval_marker(12345, 9876, "x\n" * 400, HASH)
+    # Every dropped word is at least one token, so a bound in words covers the
+    # marker whenever it exceeds the marker's token count.
+    assert len(enc.encode(marker)) < CCR_MARKER_COST_WORDS
 
 
-def test_weak_shrink_still_gets_a_marker(monkeypatch):
-    # 100 -> 80 words is ratio 0.80: the old `ratio < 0.8` gate shipped this
+def test_weak_shrink_gets_a_marker_and_reports_it(monkeypatch):
+    # 300 -> 240 words is ratio 0.80: the old `ratio < 0.8` gate shipped this
     # unmarked and the router threw it away.
-    _install(monkeypatch, drop=20)
-    result = _compressor(monkeypatch).compress(_prose(100))
-    assert result.compressed_tokens == 80
-    assert result.cache_key == "abc123"
-    assert "Retrieve more: hash=abc123" in result.compressed
+    _install(monkeypatch, drop=60)
+    result = _compressor(monkeypatch).compress(_prose(300))
+    assert result.cache_key == HASH
+    assert f"Retrieve more: hash={HASH}" in result.compressed
+    assert result.compressed_tokens == 240 + CCR_MARKER_COST_WORDS
+    assert result.compression_ratio == (240 + CCR_MARKER_COST_WORDS) / 300
 
 
-def test_saving_smaller_than_the_marker_stays_unmarked(monkeypatch):
-    _install(monkeypatch, drop=5)
-    result = _compressor(monkeypatch).compress(_prose(100))
-    assert result.compressed_tokens == 95
+def test_saving_that_cannot_pay_for_the_marker_passes_through(monkeypatch):
+    # The reviewer's case: drop 16 of 100 words and append a real-length
+    # marker, and cl100k goes 196 -> 200. Under the 13-word gate this shipped
+    # as ratio 0.84.
+    _install(monkeypatch, drop=16)
+    prose = _prose(100)
+    result = _compressor(monkeypatch).compress(prose)
+    assert result.compressed == prose
     assert result.cache_key is None
+    assert result.compressed_tokens == 100
+    assert result.compression_ratio == 1.0
+    enc = pytest.importorskip("tiktoken").get_encoding("cl100k_base")
+    marked = " ".join(prose.split()[16:]) + ccr_retrieval_marker(100, 84, prose, HASH)
+    assert len(enc.encode(marked)) > len(enc.encode(prose))
+
+
+def test_batch_path_uses_the_same_gate_and_accounting(monkeypatch):
+    _install(monkeypatch, drop=60)
+    [marked] = _compressor(monkeypatch).compress_batch([_prose(300)], batch_size=8)
+    assert f"Retrieve more: hash={HASH}" in marked.compressed
+    assert marked.compressed_tokens == 240 + CCR_MARKER_COST_WORDS
+    _install(monkeypatch, drop=16)
+    prose = _prose(100)
+    [through] = _compressor(monkeypatch).compress_batch([prose], batch_size=8)
+    assert through.compressed == prose
+    assert through.compression_ratio == 1.0
+
+
+def test_no_ccr_mode_ships_unmarked_lossy_unchanged(monkeypatch):
+    # Without CCR there is no marker to pay for: the deliberate output is the
+    # bare lossy result, on both paths, exactly as before.
+    _install(monkeypatch, drop=16)
+    compressor = _compressor(monkeypatch, enable_ccr=False)
+    result = compressor.compress(_prose(100))
+    assert result.compressed_tokens == 84
     assert "Retrieve more" not in result.compressed
-
-
-def test_batch_path_uses_the_same_gate(monkeypatch):
-    _install(monkeypatch, drop=20)
-    [result] = _compressor(monkeypatch).compress_batch([_prose(100)], batch_size=8)
-    assert result.compressed_tokens == 80
-    assert "Retrieve more: hash=abc123" in result.compressed
+    [batched] = compressor.compress_batch([_prose(100)], batch_size=8)
+    assert batched.compressed_tokens == 84

--- a/tests/test_kompress_marker_gate.py
+++ b/tests/test_kompress_marker_gate.py
@@ -1,12 +1,15 @@
-"""The CCR retrieval marker follows the saving, and the saving must cover it.
+"""The CCR retrieval marker follows the saving, and the saving must be real.
 
 A lossy Kompress result that shipped without a marker was discarded by the
 router's lossy-unrecoverable guard (#1307), so every pass that shrank a block
-by less than 20 percent ran the model and saved nothing. The gate now asks
-whether the saving pays for the marker in tokens, not words: the marker is 12
-words but 36-38 cl100k tokens, and the words Kompress drops can be single
-tokens. A result that cannot pay passes through; a marked result reports the
-marker in its own accounting.
+by less than 20 percent ran the model and saved nothing. The gate now compares
+the whole original with the whole candidate-plus-marker in one token unit
+(cl100k_base, an estimate for non-OpenAI providers; one token per character
+without an encoder) and passes the candidate through unless it is smaller. A
+marked result reports that same measurement. Word counts cannot do this: the
+marker is 36-45 tokens for 12 words, dropped words can be one token each, and
+the word left at the head of the candidate can tokenize differently from its
+space-prefixed form in the source.
 """
 
 from __future__ import annotations
@@ -19,8 +22,8 @@ from headroom.transforms import kompress_compressor as kc
 from headroom.transforms.kompress_compressor import (
     KompressCompressor,
     KompressConfig,
-    ccr_marker_cost,
     ccr_retrieval_marker,
+    payload_tokens,
 )
 
 
@@ -80,62 +83,72 @@ def _compressor(monkeypatch, **config) -> KompressCompressor:
 # 100 single-token words: the tightest source there is. Dropping 41 saves 41
 # tokens, and the marker for it (with its real source-derived hash) costs 43.
 SINGLE_TOKEN_SOURCE = " ".join(["alpha"] * 99 + ["nfs"])
+# Dropping 36 leaves "bureaucratic" at the head of the candidate, where it
+# tokenizes differently from " bureaucratic" in the source: 100 -> 103 with
+# the marker, though a marker-only cost against saved words called it 99.
+HEAD_WORD_SOURCE = " ".join(["alpha"] * 36 + ["bureaucratic"] + ["alpha"] * 63)
 
 
-def test_marker_cost_is_the_real_marker_priced_in_tokens():
+def _tok(text: str) -> int:
     enc = pytest.importorskip("tiktoken").get_encoding("cl100k_base")
+    return len(enc.encode(text))
+
+
+def test_payload_tokens_is_cl100k_or_one_per_character(monkeypatch):
     marker = ccr_retrieval_marker(100, 59, SINGLE_TOKEN_SOURCE, _real_key(SINGLE_TOKEN_SOURCE))
     assert _real_key(SINGLE_TOKEN_SOURCE) == "7dbb8f8de9f3e1d7c6f3a6e1"
-    assert ccr_marker_cost(marker) == len(enc.encode(marker)) == 43
-    # Digits and a different hash change the price; it is measured, not fixed.
-    other = ccr_retrieval_marker(123456, 98765, "x\n" * 400, "c00eb437e5e5c00eb437e5e5")
-    assert ccr_marker_cost(other) == len(enc.encode(other))
+    assert payload_tokens(marker) == _tok(marker) == 43
+    assert payload_tokens(SINGLE_TOKEN_SOURCE) == _tok(SINGLE_TOKEN_SOURCE) == 100
+    monkeypatch.setattr(kc, "_payload_encoder", False)
+    assert payload_tokens(marker) == len(marker)
 
 
-def test_marker_cost_without_an_encoder_is_one_token_per_character(monkeypatch):
-    monkeypatch.setattr(kc, "_marker_encoder", False)
-    marker = ccr_retrieval_marker(100, 59, SINGLE_TOKEN_SOURCE, _real_key(SINGLE_TOKEN_SOURCE))
-    assert ccr_marker_cost(marker) == len(marker)
-
-
-def test_single_token_words_that_cannot_pay_for_the_marker_pass_through(monkeypatch):
-    # 100 -> 59 words saves 41 tokens; the marked payload is 102 tokens. Under
-    # the earlier fixed 40-word allowance this shipped at reported ratio 0.99.
-    _install(monkeypatch, drop=41)
-    result = _compressor(monkeypatch).compress(SINGLE_TOKEN_SOURCE)
-    assert result.compressed == SINGLE_TOKEN_SOURCE
+@pytest.mark.parametrize(
+    ("source", "drop"),
+    [(SINGLE_TOKEN_SOURCE, 41), (HEAD_WORD_SOURCE, 36)],
+    ids=["single-token-words", "retokenized-head-word"],
+)
+def test_candidates_that_do_not_shrink_the_whole_payload_pass_through(monkeypatch, source, drop):
+    kept = " ".join(source.split()[drop:])
+    marked = kept + ccr_retrieval_marker(100, 100 - drop, source, _real_key(source))
+    assert _tok(marked) > _tok(source)  # the reviewer's measurement
+    _install(monkeypatch, drop=drop)
+    result = _compressor(monkeypatch).compress(source)
+    assert result.compressed == source
     assert result.cache_key is None
-    assert (result.original_tokens, result.compressed_tokens, result.compression_ratio) == (
-        100,
-        100,
-        1.0,
-    )
-    [batched] = _compressor(monkeypatch).compress_batch([SINGLE_TOKEN_SOURCE], batch_size=8)
-    assert batched.compressed == SINGLE_TOKEN_SOURCE and batched.compression_ratio == 1.0
+    assert result.compression_ratio == 1.0
+    [batched] = _compressor(monkeypatch).compress_batch([source], batch_size=8)
+    assert batched.compressed == source and batched.compression_ratio == 1.0
 
 
-def test_marked_result_reports_kept_words_plus_the_measured_marker(monkeypatch):
-    # 300 single-token words, drop 60: 60 saved tokens cover a ~43-token marker.
+def test_marked_result_reports_the_whole_payload_measurement(monkeypatch):
+    # 300 single-token words, drop 60: 240 kept plus a ~43-token marker is
+    # smaller than 300, and the accounting is that measurement, not words.
     source = " ".join(["alpha"] * 299 + ["nfs"])
     _install(monkeypatch, drop=60)
     result = _compressor(monkeypatch).compress(source)
-    marker = ccr_retrieval_marker(300, 240, source, _real_key(source))
-    assert result.compressed == " ".join(source.split()[60:]) + marker
+    marked = " ".join(source.split()[60:]) + ccr_retrieval_marker(
+        300, 240, source, _real_key(source)
+    )
+    assert result.compressed == marked
     assert result.cache_key == _real_key(source)
-    assert result.compressed_tokens == 240 + ccr_marker_cost(marker)
-    assert result.compression_ratio == (240 + ccr_marker_cost(marker)) / 300
+    assert (result.original_tokens, result.compressed_tokens) == (_tok(source), _tok(marked))
+    assert result.compression_ratio == _tok(marked) / _tok(source)
     [batched] = _compressor(monkeypatch).compress_batch([source], batch_size=8)
     assert batched.compressed == result.compressed
-    assert batched.compressed_tokens == result.compressed_tokens
+    assert (batched.original_tokens, batched.compressed_tokens) == (
+        result.original_tokens,
+        result.compressed_tokens,
+    )
 
 
 def test_no_ccr_mode_ships_unmarked_lossy_unchanged(monkeypatch):
-    # Without CCR there is no marker to pay for: the deliberate output is the
-    # bare lossy result, on both paths, exactly as before.
+    # Without CCR there is no marker and no whole-payload gate: the deliberate
+    # output is the bare lossy result in word counts, on both paths, as before.
     _install(monkeypatch, drop=41)
     compressor = _compressor(monkeypatch, enable_ccr=False)
     result = compressor.compress(SINGLE_TOKEN_SOURCE)
-    assert result.compressed_tokens == 59
+    assert (result.original_tokens, result.compressed_tokens) == (100, 59)
     assert "Retrieve more" not in result.compressed
     [batched] = compressor.compress_batch([SINGLE_TOKEN_SOURCE], batch_size=8)
     assert batched.compressed_tokens == 59

--- a/tests/test_kompress_request_nonblocking.py
+++ b/tests/test_kompress_request_nonblocking.py
@@ -235,7 +235,9 @@ def test_capacity_available_still_compresses(monkeypatch):
         lambda *args, **kwargs: (_FakeModel(), _FakeTokenizer(), "onnx"),
     )
 
-    result = KompressCompressor(KompressConfig(min_input_words=10)).compress(
+    # No CCR: this test is about capacity, and 10 saved words would not pay
+    # for a retrieval marker (CCR_MARKER_COST_WORDS), which is a passthrough.
+    result = KompressCompressor(KompressConfig(min_input_words=10, enable_ccr=False)).compress(
         " ".join(["word"] * 20), allow_download=False
     )
     assert 0 < result.compression_ratio < 1.0

--- a/tests/test_remote_kompress_dropin.py
+++ b/tests/test_remote_kompress_dropin.py
@@ -191,3 +191,33 @@ def test_the_common_path_without_an_override_is_unchanged(monkeypatch) -> None:
     assert stored["original"] == ORIGINAL
     # Still the endpoint's own count when no override was supplied.
     assert stored["tokens"] == 999
+
+
+def test_remote_marker_gate_matches_local_on_single_token_words(monkeypatch) -> None:
+    """Parity with KompressCompressor: 100 single-token words dropping 41 save
+    41 tokens against a 43-token marker (real source-derived hash), so the
+    remote path passes through too; a saving that covers the marker reports
+    kept words plus the measured marker cost."""
+    import hashlib
+
+    from headroom.transforms.kompress_compressor import ccr_marker_cost, ccr_retrieval_marker
+
+    def _store(original, compressed, original_tokens):  # noqa: ANN001
+        return hashlib.sha256(original.encode()).hexdigest()[:24]
+
+    monkeypatch.setattr("headroom.transforms.kompress_remote.store_kompress_in_ccr", _store)
+    source = " ".join(["alpha"] * 99 + ["nfs"])
+    kept = " ".join(source.split()[41:])
+    c = _compressor(monkeypatch, enable_ccr=True, payload={"compressed": kept})
+    result = c.compress(source)
+    assert result.compressed == source
+    assert result.cache_key is None
+    assert result.compression_ratio == 1.0
+
+    big = " ".join(["alpha"] * 299 + ["nfs"])
+    kept = " ".join(big.split()[60:])
+    c = _compressor(monkeypatch, enable_ccr=True, payload={"compressed": kept})
+    result = c.compress(big)
+    marker = ccr_retrieval_marker(300, 240, big, _store(big, kept, 300))
+    assert result.compressed == kept + marker
+    assert result.compressed_tokens == 240 + ccr_marker_cost(marker)

--- a/tests/test_remote_kompress_dropin.py
+++ b/tests/test_remote_kompress_dropin.py
@@ -117,8 +117,9 @@ def _compressor(monkeypatch, *, enable_ccr: bool, payload: dict):
     return c
 
 
-ORIGINAL = "real secret block " * 20
-PLACEHOLDER = "{{HEADROOM_TAG_0}} " * 20
+# 60 words: "short" saves 59, past the marker cost gate (CCR_MARKER_COST_WORDS).
+ORIGINAL = "real secret block " * 60
+PLACEHOLDER = "{{HEADROOM_TAG_0}} " * 60
 
 
 def test_passing_ccr_original_no_longer_raises(monkeypatch) -> None:

--- a/tests/test_remote_kompress_dropin.py
+++ b/tests/test_remote_kompress_dropin.py
@@ -193,31 +193,37 @@ def test_the_common_path_without_an_override_is_unchanged(monkeypatch) -> None:
     assert stored["tokens"] == 999
 
 
-def test_remote_marker_gate_matches_local_on_single_token_words(monkeypatch) -> None:
-    """Parity with KompressCompressor: 100 single-token words dropping 41 save
-    41 tokens against a 43-token marker (real source-derived hash), so the
-    remote path passes through too; a saving that covers the marker reports
-    kept words plus the measured marker cost."""
+def test_remote_marker_gate_measures_the_whole_payload_like_local(monkeypatch) -> None:
+    """Parity with KompressCompressor: the whole original against the whole
+    marked candidate in one token unit. Both boundary sources pass through
+    (41 single-token words saved against a 43-token marker; a head word that
+    retokenizes: 100 -> 103), and a real saving reports that measurement."""
     import hashlib
 
-    from headroom.transforms.kompress_compressor import ccr_marker_cost, ccr_retrieval_marker
+    from headroom.transforms.kompress_compressor import ccr_retrieval_marker, payload_tokens
 
     def _store(original, compressed, original_tokens):  # noqa: ANN001
         return hashlib.sha256(original.encode()).hexdigest()[:24]
 
     monkeypatch.setattr("headroom.transforms.kompress_remote.store_kompress_in_ccr", _store)
-    source = " ".join(["alpha"] * 99 + ["nfs"])
-    kept = " ".join(source.split()[41:])
-    c = _compressor(monkeypatch, enable_ccr=True, payload={"compressed": kept})
-    result = c.compress(source)
-    assert result.compressed == source
-    assert result.cache_key is None
-    assert result.compression_ratio == 1.0
+    for source, drop in (
+        (" ".join(["alpha"] * 99 + ["nfs"]), 41),
+        (" ".join(["alpha"] * 36 + ["bureaucratic"] + ["alpha"] * 63), 36),
+    ):
+        kept = " ".join(source.split()[drop:])
+        c = _compressor(monkeypatch, enable_ccr=True, payload={"compressed": kept})
+        result = c.compress(source)
+        assert result.compressed == source
+        assert result.cache_key is None
+        assert result.compression_ratio == 1.0
 
     big = " ".join(["alpha"] * 299 + ["nfs"])
     kept = " ".join(big.split()[60:])
     c = _compressor(monkeypatch, enable_ccr=True, payload={"compressed": kept})
     result = c.compress(big)
-    marker = ccr_retrieval_marker(300, 240, big, _store(big, kept, 300))
-    assert result.compressed == kept + marker
-    assert result.compressed_tokens == 240 + ccr_marker_cost(marker)
+    marked = kept + ccr_retrieval_marker(300, 240, big, _store(big, kept, 300))
+    assert result.compressed == marked
+    assert (result.original_tokens, result.compressed_tokens) == (
+        payload_tokens(big),
+        payload_tokens(marked),
+    )

--- a/tests/test_transforms/test_kompress_deadline.py
+++ b/tests/test_transforms/test_kompress_deadline.py
@@ -10,6 +10,10 @@ one that leaks.
 
 from __future__ import annotations
 
+import hashlib
+
+import pytest
+
 from headroom.transforms import kompress_compressor as kc
 
 
@@ -32,14 +36,26 @@ def test_compress_bails_at_deadline_keeping_tail_verbatim(monkeypatch):
     assert result.compressed.split() == content.split()
 
 
-def test_compress_partial_run_keeps_processed_head_plus_verbatim_tail(monkeypatch):
-    # The real partial case: chunk 0 processes (gets compressed), chunk 1 trips
-    # the deadline (kept verbatim). Output must be compressed-head + verbatim-tail.
-    # Clock: call1=t_deadline(0); calls 2-4 are chunk-0's check+inference reads
-    # (under budget); call 5+ is chunk-1's check -> trips.
-    # Robust clock: jump past the deadline only AFTER chunk 0 is processed
-    # (tracked via the model mock), so adding perf_counter calls inside the chunk
-    # body -- e.g. sub-stage timing -- can't shift when the deadline trips.
+@pytest.mark.parametrize(
+    ("n_words", "net_saving"),
+    [(200, True), (20, False)],
+    ids=["net-saving", "no-net-saving"],
+)
+def test_compress_partial_run_keeps_processed_head_plus_verbatim_tail(
+    monkeypatch, n_words, net_saving
+):
+    # real partial case: chunk 0 processes (gets compressed), chunk 1 trips the
+    # deadline (kept verbatim). Output must be compressed-head + verbatim-tail.
+    # Clock: call 1 = t_deadline (0); calls 2-4 chunk-0's check + inference
+    # reads (under budget); call 5+ chunk-1's check -> trips.
+    # Robust clock: jump past the deadline only AFTER chunk 0 processed
+    # (tracked via the model mock), so adding perf_counter calls inside the
+    # chunk body -- e.g. sub-stage timing -- can't shift when the deadline trips.
+    #
+    # Two sizes: at 200 words the marked partial result is smaller than the
+    # original and ships; at 20 words (150 -> 300-odd tokens either way, plus a
+    # ~43-token marker) the CCR gate finds no net saving and passes the whole
+    # payload through, which is the other half of the contract.
     state = {"chunks_done": 0}
 
     def fake_clock():
@@ -68,15 +84,27 @@ def test_compress_partial_run_keeps_processed_head_plus_verbatim_tail(monkeypatc
     monkeypatch.setenv("HEADROOM_COMPRESSION_DEADLINE_MS", "20000")
 
     comp = kc.KompressCompressor(kc.KompressConfig(min_input_words=10))
-    comp.config.chunk_words = 10  # 20 words -> 2 chunks
+    comp.config.chunk_words = n_words // 2  # two chunks
     monkeypatch.setattr(comp, "_should_batch_single_content", lambda *a, **k: False)
+    monkeypatch.setattr(
+        comp,
+        "_store_in_ccr",
+        lambda source, *a, **k: hashlib.sha256(source.encode()).hexdigest()[:24],
+    )
 
-    words = [f"w{i}" for i in range(20)]
-    out = comp.compress(" ".join(words)).compressed.split()
+    words = [f"w{i}" for i in range(n_words)]
+    result = comp.compress(" ".join(words))
+    if not net_saving:
+        assert result.compressed == " ".join(words)
+        assert result.compression_ratio == 1.0
+        return
 
-    # chunk 0 processed: first half kept (w0..w4), second half dropped (w5..w9)
-    assert "w0" in out and "w4" in out
-    assert "w5" not in out and "w9" not in out
-    # chunk 1 tripped the deadline -> its words kept verbatim (w10..w19 all present)
-    for i in range(10, 20):
+    out = result.compressed.split()
+    half = n_words // 2
+    assert result.cache_key is not None and "Retrieve more" in result.compressed
+    # chunk 0 processed: its first half kept, its second half dropped
+    assert "w0" in out and f"w{half // 2 - 1}" in out
+    assert f"w{half // 2}" not in out and f"w{half - 1}" not in out
+    # chunk 1 tripped the deadline -> its words kept verbatim (all present)
+    for i in range(half, n_words):
         assert f"w{i}" in out


### PR DESCRIPTION
## Description

Kompress previously added a CCR retrieval marker only below a fixed compression ratio. Smaller reductions could therefore produce lossy output without a retrieval marker, which the router discarded.

The single, batch, and remote paths now compare the complete original payload with the complete candidate plus retrieval marker. A marked candidate ships only when it is smaller under the same `cl100k_base` estimate, and its result accounting uses those measured counts. Otherwise the original passes through. CCR-disabled behavior is unchanged.

This is a fixed tokenizer estimate, not an exact billing count for every OpenAI model or other provider. If the encoder is unavailable, the fallback compares character counts rather than claiming a provider-token bound.

## Type of Change

- [x] Bug fix

## Testing

Latest local validation: 81 tests passed across marker, remote, deadline, compressor, size-gate, and CCR policy/resolution suites. Ruff check and format check pass for the five changed Python files.

## Real Behavior Proof

- Environment: macOS, Python 3.13, deterministic compressor stubs with real source-derived CCR hashes and `cl100k_base` encoding.
- Exact command / steps: Run the marker/remote/deadline suites and related compressor/CCR suites. Re-run the single/batch boundary probe using `" ".join(["alpha"] * 36 + ["bureaucratic"] + ["alpha"] * 63)` with the supplied drop-first-36 model stub.
- Observed result: The formerly expanding candidate (100 original tokens, 103 with marker) now passes through unchanged, reporting 100 to 100 with no retrieval key. Tests also verify that candidates with net savings ship with marker-inclusive accounting, and partial deadline completion preserves the unprocessed tail.
- Not tested: exact billing equivalence for other model tokenizers, live model/provider traffic, or long-term retrieval-rate effects. Current-head CI is pending.

## Runtime Rollout Safety

- Rollout-managed feature(s): None.
- Minimum rollout channel: Stable.
- Stable/default behavior changed: CCR-enabled Kompress uses full-payload net savings rather than a fixed ratio threshold for marker admission. Marker-inclusive successful result counts use the same tokenizer estimate as the gate.
- Kill switch / disable path: `KompressConfig(enable_ccr=False)` disables CCR markers as before.
- Unsafe override required: No.
- Qualification impact: Compression accounting includes the marker on admitted CCR results; provider billing remains an estimate.
- Rollback path: Revert this PR.

## Review Readiness

- [x] Prior marker-accounting findings resolved.
- [x] Focused and related local checks pass.
- [ ] Current-head CI complete.
- Final human review is required.

## Checklist

- [x] Single, batch, remote, and deadline regressions covered.
- [x] No manual CHANGELOG edit.
