### PR TITLE
fix(init): restrict local profile slug to ASCII so non-ASCII directories pass validation

### DIFF
--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -117,8 +117,7 @@ def _local_profile(cwd: Path | None = None) -> str:
     # isalnum() is Unicode-aware and keeps Cyrillic/CJK/etc. letters, but
     # validate_profile_name() only allows ASCII [A-Za-z0-9._-] (#3467).
     slug = "".join(
-        ch if (ch.isascii() and ch.isalnum()) or ch in "-._" else "-"
-        for ch in root.name.lower()
+        ch if (ch.isascii() and ch.isalnum()) or ch in "-._" else "-" for ch in root.name.lower()
     ).strip("-")
     digest = sha1(str(root).encode("utf-8")).hexdigest()[:8]
     return validate_profile_name(f"init-{slug or 'repo'}-{digest}")

--- a/headroom/cli/init.py
+++ b/headroom/cli/init.py
@@ -114,9 +114,12 @@ def _enable_verbose_logging() -> None:
 
 def _local_profile(cwd: Path | None = None) -> str:
     root = (cwd or Path.cwd()).resolve()
-    slug = "".join(ch if ch.isalnum() or ch in "-._" else "-" for ch in root.name.lower()).strip(
-        "-"
-    )
+    # isalnum() is Unicode-aware and keeps Cyrillic/CJK/etc. letters, but
+    # validate_profile_name() only allows ASCII [A-Za-z0-9._-] (#3467).
+    slug = "".join(
+        ch if (ch.isascii() and ch.isalnum()) or ch in "-._" else "-"
+        for ch in root.name.lower()
+    ).strip("-")
     digest = sha1(str(root).encode("utf-8")).hexdigest()[:8]
     return validate_profile_name(f"init-{slug or 'repo'}-{digest}")
 

--- a/tests/test_cli/test_init_cli.py
+++ b/tests/test_cli/test_init_cli.py
@@ -1554,3 +1554,22 @@ def test_init_codex_strip_removes_openai_base_url(monkeypatch, tmp_path: Path) -
         f"_strip_codex_init_block must remove orphaned openai_base_url:\n{orphan_stripped}"
     )
     assert 'model = "gpt-4o"' in orphan_stripped
+
+
+def test_local_profile_ascii_only_for_non_ascii_dir(monkeypatch, tmp_path: Path) -> None:
+    """Non-ASCII working directory names must still yield a valid profile (#3467)."""
+    import re
+
+    init_cli, _ = _load_init_module(monkeypatch)
+
+    non_ascii = tmp_path / "Мастеринг в HW"
+    non_ascii.mkdir(parents=True, exist_ok=True)
+    profile = init_cli._local_profile(cwd=non_ascii)
+    assert re.fullmatch(r"[A-Za-z0-9._-]+", profile), f"non-ASCII slug leaked: {profile!r}"
+    assert "hw" in profile
+
+    all_non_ascii = tmp_path / "日本語テスト"
+    all_non_ascii.mkdir(parents=True, exist_ok=True)
+    fallback = init_cli._local_profile(cwd=all_non_ascii)
+    assert re.fullmatch(r"[A-Za-z0-9._-]+", fallback), f"fallback invalid: {fallback!r}"
+    assert fallback.startswith("init-repo-")


### PR DESCRIPTION
## Description

`headroom init` (and `headroom init hook ensure`) crashes with `Invalid profile name` when the working directory name contains non-ASCII letters (e.g. `C:\tmp\Мастеринг в HW`).

Root cause: `_local_profile()` built its slug with `ch.isalnum()`, which is a Unicode-aware check that keeps Cyrillic/CJK letters, while `validate_profile_name()` (`headroom/install/paths.py`) only accepts `^[A-Za-z0-9._-]+$`. So the slug passed validation input it could never satisfy.

Fixes #3467

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/cli/init.py:115-125` (`_local_profile`): require `(ch.isascii() and ch.isalnum())` when building the directory slug so non-ASCII letters map to `-`, matching the `validate_profile_name` character set. Uniqueness is still preserved by the sha1 digest of the full path; an all-non-ASCII name falls back to `init-repo-<digest>` as before.
- `tests/test_cli/test_init_cli.py:1559-1577` (`test_local_profile_ascii_only_for_non_ascii_dir`): regression test covering a Cyrillic + ASCII directory name and an all-CJK directory name; asserts the result matches `[A-Za-z0-9._-]+` and the fallback prefix.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
# New regression test (after fix)
tests\test_cli\test_init_cli.py .  [100%]
1 passed, 1 warning in 23.27s

# Before fix (fix stashed) — reproduces #3467 exactly:
FAILED tests/test_cli/test_init_cli.py::test_local_profile_ascii_only_for_non_ascii_dir
E   click.exceptions.ClickException: Invalid profile name 'init-мастеринг-в-hw-7ad97e0f'

# Full init CLI suite (after fix)
tests\test_cli\test_init_cli.py ........................................ [ 54%]
..................................                                       [100%]
74 passed, 1 warning in 52.23s

# Lint
uvx ruff check headroom/cli/init.py tests/test_cli/test_init_cli.py
All checks passed!
```

Note: `tests/test_install/test_paths.py` (3 tests) could not be run to completion locally — the run hung past 180s in this environment (base-deps-only `uv sync --no-install-project`; full `uv sync --extra dev` is not installable here because `hnswlib` needs MSVC and the maturin build exceeds the shell timeout). The touched behavior is covered by the 74 init CLI tests above. `mypy` was not run (dev extra not installed).

## Real Behavior Proof

- Environment: Windows 11, Python 3.13.13 (`.venv`), repo at `upstream/main` (`e67b3c8`), base-deps-only venv (`uv sync --no-install-project` + `pytest`).
- Exact command / steps:
  1. `git stash push -- headroom/cli/init.py` (restore pre-fix code), then `.venv\Scripts\python.exe -m pytest tests/test_cli/test_init_cli.py::test_local_profile_ascii_only_for_non_ascii_dir -q` → reproduces the reported `ClickException: Invalid profile name 'init-мастеринг-в-hw-7ad97e0f'`.
  2. `git stash pop` (re-apply fix), re-run the same test plus the full `tests/test_cli/test_init_cli.py` suite → all green (see Test Output).
- Observed result: before the fix, a Cyrillic directory name produces an invalid profile and `headroom init hook ensure` aborts; after the fix, `_local_profile()` returns an ASCII-only profile (e.g. `init-<ascii-slug>-<digest>`, `init-repo-<digest>` fallback) and validation passes.
- Not tested: end-to-end `headroom init` against a live agent binary on a non-ASCII path (no `claude`/`codex` binaries in this environment); non-Windows OS paths (logic is OS-independent, but only exercised on win32 here).

## Runtime Rollout Safety

- Rollout-managed feature(s): none
- Minimum rollout channel: N/A
- Stable/default behavior changed: ASCII-only directory names produce byte-identical slugs as before; only names containing non-ASCII characters change (previously they crashed, now they slug to `-`).
- Kill switch / disable path: N/A (workaround remains `--profile <ascii-name>`)
- Unsafe override required: no
- Qualification impact: none
- Rollback path: revert this one-line predicate

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A

## Additional Notes

- One-line predicate change plus regression test; no dependency or config changes.
- `mypy` and the full `uv sync --extra dev` suite could not run in this Windows environment (see Testing note); CI will cover the rest.
