### PR TITLE
fix(proxy): preserve CCR retrievals wrapped in Codex exec

### DIFF
--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -2091,10 +2091,26 @@ class OpenAIHandlerMixin:
         for item in items:
             if not isinstance(item, dict):
                 continue
-            if item.get("type") != "function_call":
+            if item.get("type") not in {"function_call", "custom_tool_call"}:
                 continue
             name = item.get("name")
             call_id = item.get("call_id")
+            # Codex code-mode nests MCP calls in JavaScript. Its output belongs
+            # to exec, not the nested retrieval, but has the same verbatim
+            # contract. Conservatively protect the entire matching result.
+            script = item.get("input") or item.get("arguments")
+            if (
+                isinstance(name, str)
+                and name in {"exec", "functions.exec"}
+                and isinstance(script, str)
+                and re.search(
+                    r"\b(?:headroom_retrieve|[A-Za-z0-9_]+__headroom_retrieve)\s*\(",
+                    script,
+                )
+                and isinstance(call_id, str)
+                and call_id
+            ):
+                headroom_retrieve_call_ids.add(call_id)
             if name:
                 # Hermes deferred tools arrive wrapped as `tool_call` with
                 # the real name inside the arguments/input payload.
@@ -2714,7 +2730,11 @@ class OpenAIHandlerMixin:
                 updated_items,
                 self.OPENAI_RESPONSES_OUTPUT_TYPES,
                 tokenizer.count_text,
-                protected_call_ids=verbatim_excluded_call_ids | read_protected_call_ids,
+                protected_call_ids=(
+                    verbatim_excluded_call_ids
+                    | read_protected_call_ids
+                    | headroom_retrieve_call_ids
+                ),
             )
             if dd_folded:
                 modified = True

--- a/tests/test_openai_responses_wrapped_retrieve.py
+++ b/tests/test_openai_responses_wrapped_retrieve.py
@@ -1,0 +1,173 @@
+"""CCR retrievals through Codex code-mode must reach the model verbatim."""
+
+import json
+from types import MethodType, SimpleNamespace
+
+import pytest
+
+from headroom.proxy.handlers.openai import OpenAIHandlerMixin
+from headroom.transforms.content_router import (
+    CompressionStrategy,
+    ContentRouter,
+    RouterCompressionResult,
+)
+
+
+class TokenCounter:
+    def count_text(self, text: str) -> int:
+        return len(text.split())
+
+
+def _handler_with_router(router: ContentRouter) -> OpenAIHandlerMixin:
+    handler = OpenAIHandlerMixin()
+    handler.openai_pipeline = SimpleNamespace(transforms=[router])
+    handler.openai_provider = SimpleNamespace(
+        get_token_counter=lambda _model: TokenCounter(),
+    )
+    return handler
+
+
+def _lossy_router() -> ContentRouter:
+    """Router whose compress() always 'lossy-compresses' any candidate it sees."""
+
+    router = ContentRouter()
+
+    def compress(self, content: str, **_kwargs):
+        return RouterCompressionResult(
+            compressed="kept words",
+            original=content,
+            strategy_used=CompressionStrategy.KOMPRESS,
+        )
+
+    router.compress = MethodType(compress, router)
+    return router
+
+
+def _run(handler: OpenAIHandlerMixin, payload: dict):
+    return handler._compress_openai_responses_live_text_units_with_router(
+        payload,
+        model="gpt-5",
+        request_id="req_read_protection",
+    )
+
+
+@pytest.mark.parametrize(
+    "call_type,name,field",
+    [
+        ("custom_tool_call", "exec", "input"),
+        ("custom_tool_call", "functions.exec", "input"),
+        ("function_call", "functions.exec", "arguments"),
+    ],
+)
+@pytest.mark.parametrize(
+    "original",
+    [
+        "\n".join(
+            f"Instruction {i}: preserve exact whitespace and punctuation." for i in range(90)
+        ),
+        "\n".join(f"def function_{i}():\n    return {i} + 1" for i in range(90)),
+        json.dumps(
+            [{"id": i, "result": "complete", "score": i / 100} for i in range(90)], indent=2
+        ),
+    ],
+    ids=["instructions", "source", "structured"],
+)
+@pytest.mark.parametrize("as_parts", [False, True])
+def test_wrapped_retrieval_stays_verbatim(call_type, name, field, original, as_parts):
+    handler = _handler_with_router(_lossy_router())
+    output = json.dumps(
+        {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "hash": "abc123",
+                            "original_content": original,
+                            "source": "local",
+                        }
+                    ),
+                }
+            ],
+            "isError": False,
+        }
+    )
+    if as_parts:
+        output = [{"type": "output_text", "text": output}]
+    payload = {
+        "model": "gpt-5",
+        "input": [
+            {
+                "type": call_type,
+                "call_id": "retrieve",
+                "name": name,
+                field: (
+                    "const result = await tools.mcp__headroom__headroom_retrieve("
+                    '{hash: "abc123"}); text(result);'
+                ),
+            },
+            {
+                "type": "custom_tool_call_output"
+                if call_type == "custom_tool_call"
+                else "function_call_output",
+                "call_id": "retrieve",
+                "output": output,
+            },
+        ],
+    }
+    forwarded, *_ = _run(handler, payload)
+    assert forwarded["input"][1]["output"] == output
+
+
+def test_ordinary_exec_remains_compressible():
+    handler = _handler_with_router(_lossy_router())
+    payload = {
+        "input": [
+            {
+                "type": "custom_tool_call",
+                "name": "functions.exec",
+                "call_id": "normal",
+                "input": 'text(await tools.exec_command({cmd: "pytest"}));',
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "normal",
+                "output": "test passed successfully\n" * 200,
+            },
+        ]
+    }
+    forwarded, modified, *_ = _run(handler, payload)
+    assert modified
+    assert forwarded["input"][1]["output"] == "kept words"
+
+
+@pytest.mark.parametrize(
+    "name,arguments",
+    [
+        ("headroom_retrieve", '{"hash": "abc123"}'),
+        ("functions.exec", 'text(await tools.mcp__headroom__headroom_retrieve({hash: "abc123"}));'),
+    ],
+)
+def test_retrieval_is_not_replaced_with_cross_turn_pointer(name, arguments):
+    router = _lossy_router()
+    router._cross_turn_dedup_enabled = True
+    handler = _handler_with_router(router)
+    original = "Retrieved original instruction, preserve it verbatim.\n" * 200
+    payload = {"input": []}
+    for call_id in ("first", "second"):
+        payload["input"].extend(
+            [
+                {"type": "function_call", "name": name, "call_id": call_id, "arguments": arguments},
+                {"type": "function_call_output", "call_id": call_id, "output": original},
+            ]
+        )
+    payload["input"].append(
+        {
+            "type": "function_call_output",
+            "call_id": "ordinary",
+            "output": "ordinary test output for compression\n" * 100,
+        }
+    )
+    forwarded, *_ = _run(handler, payload)
+    assert forwarded["input"][1]["output"] == original
+    assert forwarded["input"][3]["output"] == original


### PR DESCRIPTION
## Description

Codex code-mode returns MCP CCR retrievals through an outer `exec` custom tool call. The Responses adapter only recognizes named `function_call` retrievals, so the outer result can be compressed again. Repeated retrievals in mixed batches can also become cross-turn dedup pointers.

Recognize literal `headroom_retrieve(...)` / namespaced MCP invocations in `exec` and `functions.exec`, correlate their outputs by `call_id`, and preserve the entire matching output through routing and deduplication. Ordinary exec output remains compressible. This is the existing locally deployed 0.37.0 repair, submitted upstream.

## Type of Change

- [x] Bug fix

## Testing

- [x] New behavioral regression tests: 18 wrapped payload cases, ordinary exec control, two repeated-retrieval cases.
- [x] Focused tests: `python -m pytest tests/test_openai_responses_wrapped_retrieve.py tests/test_openai_responses_read_protection.py tests/test_openai_responses_compression_units.py -q` — **67 passed**.
- [x] Red/green on current main (`e67b3c8`, native extension built with `uv sync --extra dev --python 3.13`): **19 failed, 18 passed** before handler change; **37 passed** afterward (wrapped + read-protection files).
- [x] Same **19 failed / 18 passed → 37 passed** replay against a freshly downloaded published 0.37.0 wheel in an isolated target directory. Reinstalling the released wheel does not retain this local repair.
- [x] `ruff check .` — all checks passed.
- [x] `ruff format --check .` — 1568 files already formatted.
- [x] Installed pre-commit and commit-msg hooks passed, including `mypy headroom` and commitlint.
- [ ] Full pytest suite green: the initial run encountered network-dependent failures and was stopped. After populating the tokenizer cache, `python -m pytest -q --maxfail=1` stopped at `test_ensure_tools_installs_every_tool` because difftastic was unavailable: **612 passed, 97 skipped, 1 failed**. This binary-install test and the Rust files below are unchanged by the patch.
- [ ] Full pre-push gate green: ran the installed hook; Clippy 1.98 fails `question_mark` on unchanged `crates/headroom-core/src/ccr/backends/in_memory.rs:163`. This machine has Homebrew Rust 1.98, while `rust-toolchain.toml` pins 1.95. Used the hook's documented bypass for this draft; no Rust source changed.

## Real Behavior Proof

Environment: macOS arm64, Python 3.13.13, installed Headroom 0.37.0 with this patch, live Codex configured for `gpt-6-astra` via the local Responses proxy. Current upstream Python/native source was validated separately in an isolated checkout.

Live replay on 2026-09-08:

```javascript
const result = await tools.mcp__headroom__headroom_retrieve({
  hash: "b0f0237f44efca46c672527c"
});
text(result);
```

Also replayed source hash `682f0991295a26d474dcc91d` and structured-result hash `35734066f7e53db8d5fdbaff`. Parsed `original_content` matched independent file reads exactly for **481, 14417, and 16693 characters** respectively. The MCP store is intact.

**Current live limitation:** printing the unmodified result still produced another CCR marker in this Codex session. Printing the parsed instruction string also produced altered prose (for example, `Review repository changes with diff analysis` became `Review repository changes diff analysis`). Small output chunks recovered the original text. Therefore these tests establish the adapter boundary fix, not complete current end-to-end protection. A prior session had successful direct wrapped-retrieval checks, but today's replay does not reproduce that guarantee. The downstream call-correlation/transport path needs investigation before this PR is marked ready. No cause is assumed from the passing unit tests.

Not tested: dynamic JavaScript aliases/property dispatch, deferred `functions.wait`, provider/model quality equivalence, or retention in a future released version. No live installation was upgraded or reconfigured in this replay.

## Runtime Rollout Safety

- No new flag or rollout channel; literal retrieval results are preserved by default.
- Conservative matching may preserve extra output if a matching invocation occurs in a string or comment.
- Ordinary exec output remains eligible for compression.
- Rollback: revert this commit and reload the proxy.

## Review Readiness

- [x] Self-review of patch and focused regressions.
- [ ] Ready for human review: remains draft pending the live transport discrepancy and broader gate qualification.

## Checklist

- [x] Patch and tests follow Ruff formatting; no new dependencies.
- [x] Regression failures observed before applying the fix.
- [x] No `CHANGELOG.md` edit.
