### PR TITLE
fix(langchain): add get_metrics alias to HeadroomChatModel

### DIFF
--- a/headroom/integrations/langchain/chat_model.py
+++ b/headroom/integrations/langchain/chat_model.py
@@ -571,6 +571,18 @@ class HeadroomChatModel(BaseChatModel):
             "total_tokens_after": sum(m.tokens_after for m in self._metrics_history),
         }
 
+    def get_metrics(self) -> dict[str, Any]:
+        """Return aggregated optimization metrics.
+
+        Alias for :meth:`get_savings_summary` kept for backwards
+        compatibility with docs/examples calling ``get_metrics()``
+        (see wiki/langchain.md). Includes both ``total_tokens_saved``
+        and a ``tokens_saved`` alias key.
+        """
+        summary = self.get_savings_summary()
+        summary.setdefault("tokens_saved", summary.get("total_tokens_saved", 0))
+        return summary
+
 
 class HeadroomCallbackHandler(BaseCallbackHandler):
     """LangChain callback handler for Headroom metrics and observability.

--- a/tests/test_integrations/langchain/test_chat_model.py
+++ b/tests/test_integrations/langchain/test_chat_model.py
@@ -293,6 +293,43 @@ class TestHeadroomChatModel:
         assert summary["total_tokens_saved"] == 70
         assert summary["average_savings_percent"] == 22.5
 
+    def test_get_metrics_alias_empty(self, mock_chat_model):
+        """Regression test for #3446: get_metrics exists with no history."""
+        from headroom.integrations import HeadroomChatModel
+
+        model = HeadroomChatModel(mock_chat_model)
+        metrics = model.get_metrics()
+
+        assert metrics["total_requests"] == 0
+        assert metrics["tokens_saved"] == 0
+        assert metrics["total_tokens_saved"] == 0
+
+    def test_get_metrics_alias_with_data(self, mock_chat_model):
+        """Regression test for #3446: get_metrics matches savings summary."""
+        from headroom.integrations import HeadroomChatModel
+        from headroom.integrations.langchain import OptimizationMetrics
+
+        model = HeadroomChatModel(mock_chat_model)
+        model._metrics_history = [
+            OptimizationMetrics(
+                request_id="1",
+                timestamp=datetime.now(),
+                tokens_before=100,
+                tokens_after=80,
+                tokens_saved=20,
+                savings_percent=20.0,
+                transforms_applied=["smart_crusher"],
+                model="gpt-4o",
+            ),
+        ]
+        model._total_tokens_saved = 20
+
+        metrics = model.get_metrics()
+
+        assert metrics["total_requests"] == 1
+        assert metrics["total_tokens_saved"] == 20
+        assert metrics["tokens_saved"] == 20
+
 
 class TestHeadroomCallbackHandler:
     """Tests for HeadroomCallbackHandler."""


### PR DESCRIPTION
## Description

`HeadroomChatModel` documented `llm.get_metrics()['tokens_saved']` (wiki/langchain.md:345) but only implemented `get_savings_summary()`, so any caller following the docs hit `AttributeError: 'HeadroomChatModel' object has no attribute 'get_metrics'` via Pydantic `BaseModel.__getattr__`.

Fixes #3446

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Added `HeadroomChatModel.get_metrics()` as a backwards-compatible alias for `get_savings_summary()`, including a `tokens_saved` alias key for the documented `['tokens_saved']` access pattern (`headroom/integrations/langchain/chat_model.py:574-585`).
- Added regression tests `test_get_metrics_alias_empty` and `test_get_metrics_alias_with_data` (`tests/test_integrations/langchain/test_chat_model.py:296-330`).

## Testing

- [x] Focused local tests pass: 38 passed, 9 skipped in `tests/test_integrations/langchain/test_chat_model.py` (maintainer validation, Python 3.13.14).
- [x] Ruff 0.16.3 check and format check pass on both changed files (maintainer validation).
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Maintainer validation

Ran the actual LangChain test file against this PR head using the existing native extension: **38 passed, 9 skipped**. Ruff 0.16.3 check and format check passed on both changed files. GitHub currently has successful governance checks; full CI has not run. The original author environment notes below describe the earlier validation limitations.

### Original author test output

```text
# Syntax check (both touched files compile):
uv run --no-sync python -u -m py_compile headroom/integrations/langchain/chat_model.py
uv run --no-sync python -u -m py_compile tests/test_integrations/langchain/test_chat_model.py
# (no output = OK)

# AST + logic verification (real method extracted from the edited file):
has_get_metrics: True
has_get_savings_summary: True
logic_with_data: {'total_requests': 2, 'total_tokens_saved': 70, 'average_savings_percent': 22.5, 'tokens_saved': 70}
logic_empty: {'total_requests': 0, 'total_tokens_saved': 0, 'average_savings_percent': 0, 'tokens_saved': 0}
VERIFY_OK

# Full langchain suite CANNOT run in this env (pre-existing, honest):
# pytest tests/test_integrations/langchain/test_chat_model.py fails at import
# with ModuleNotFoundError: No module named 'headroom._core' (Rust maturin
# extension not built here). The pre-existing test_get_savings_summary_empty
# fails identically on unmodified code, so this is environmental, not caused
# by this PR. Leaving to CI.
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.13.13, uv 0.11.14, repo at `main` + this patch; `headroom._core` Rust extension NOT built locally.
- Exact command / steps: ran the AST extraction + fake-`self` logic check above against the real edited file (no mocks of the method itself); confirmed `get_metrics()` delegates to `get_savings_summary()` and exposes both `total_tokens_saved` and `tokens_saved`.
- Observed result: `tokens_saved == total_tokens_saved` in both empty and with-data cases; `has_get_metrics: True`.
- Not tested: live `ChatHuggingFace`/`ChatOpenAI` invoke path from the issue repro (needs model credentials + built `_core`); full `pytest` langchain file (blocked by missing `_core`, see above). Live provider invocation remains untested.

## Runtime Rollout Safety

- Rollout-managed feature(s): none
- Minimum rollout channel: n/a
- Stable/default behavior changed: no — additive method only; `get_savings_summary()` untouched
- Kill switch / disable path: n/a
- Unsafe override required: no
- Qualification impact: none
- Rollback path: revert this commit

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (docs already promise `get_metrics`; no doc change needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (blocked by missing `headroom._core`; see Test Output — honest)
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

n/a

## Additional Notes

Root cause: `HeadroomChatModel` (`headroom/integrations/langchain/chat_model.py:119`) exposed `total_tokens_saved` (line 240), `metrics_history` (line 245), and `get_savings_summary()` (line 556), but never `get_metrics()` — while `wiki/langchain.md:345` tells agent builders to call `llm.get_metrics()['tokens_saved']`. One-line-class fix, no behavior change to existing APIs. Not requesting reviews from specific humans.
