### PR TITLE
fix(litellm): compress anthropic messages route in HeadroomCallback

### DIFF
--- a/headroom/integrations/litellm_callback.py
+++ b/headroom/integrations/litellm_callback.py
@@ -9,7 +9,8 @@
     # Cloud mode (managed CCR, TOIN, analytics via Headroom Cloud):
     litellm.callbacks = [HeadroomCallback(api_key="hdr_xxx")]
 
-Works with LiteLLM's completion(), acompletion(), and proxy modes.
+Works with LiteLLM's completion(), acompletion(), the Anthropic Messages
+proxy routes (/v1/messages), and proxy modes.
 Cloud mode requires httpx: pip install httpx
 """
 
@@ -122,7 +123,16 @@ class HeadroomCallback(_CustomLogger):
         if data is None:
             return None
 
-        if call_type not in ("completion", "acompletion"):
+        # LiteLLM's proxy maps the Anthropic Messages API routes to their own
+        # call types (CallTypes.anthropic_messages for /v1/messages and
+        # /anthropic/v1/messages, plus the async twin), and the payload still
+        # carries "messages" in Anthropic format, which compress() handles.
+        if call_type not in (
+            "completion",
+            "acompletion",
+            "anthropic_messages",
+            "aanthropic_messages",
+        ):
             return data
 
         messages = data.get("messages", [])

--- a/tests/test_litellm_callback.py
+++ b/tests/test_litellm_callback.py
@@ -68,3 +68,95 @@ class TestHeadroomCallbackCustomLoggerInheritance:
     def test_total_tokens_saved_property(self) -> None:
         cb = HeadroomCallback()
         assert cb.total_tokens_saved == 0
+
+
+class TestAnthropicMessagesRouteCompression:
+    """LiteLLM's proxy maps /v1/messages to the "anthropic_messages" call
+    type (and its async twin), so compression must fire there too (#3503)."""
+
+    @staticmethod
+    def _anthropic_payload() -> dict:
+        import json
+
+        big = json.dumps(
+            [
+                {"id": i, "status": "active", "name": f"item_{i}", "value": i * 17}
+                for i in range(200)
+            ]
+        )
+        return {
+            "model": "claude-sonnet-4-5",
+            "system": "You are helpful.",
+            "messages": [
+                {"role": "user", "content": "What are the top items?"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "list_items",
+                            "input": {},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": big,
+                        }
+                    ],
+                },
+            ],
+        }
+
+    @staticmethod
+    def _run(call_type: str, data: dict):
+        import asyncio
+
+        cb = HeadroomCallback()
+        out = asyncio.run(
+            cb.async_pre_call_hook(user_api_key_dict={}, cache=None, data=data, call_type=call_type)
+        )
+        return cb, out
+
+    def test_anthropic_messages_route_compresses(self) -> None:
+        cb, out = self._run("anthropic_messages", self._anthropic_payload())
+        assert cb.total_tokens_saved > 0
+        assert out["messages"][2]["content"][0]["type"] == "tool_result"
+
+    def test_aanthropic_messages_route_compresses(self) -> None:
+        cb, out = self._run("aanthropic_messages", self._anthropic_payload())
+        assert cb.total_tokens_saved > 0
+        assert out["messages"][2]["content"][0]["type"] == "tool_result"
+
+    def test_completion_route_still_compresses(self) -> None:
+        big = self._anthropic_payload()["messages"][2]["content"][0]["content"]
+        payload = {
+            "model": "gpt-4o",
+            "messages": [
+                {"role": "user", "content": "What are the top items?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "list_items", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "content": big, "tool_call_id": "call_1"},
+            ],
+        }
+        cb, _ = self._run("completion", payload)
+        assert cb.total_tokens_saved > 0
+
+    def test_non_chat_routes_still_skip(self) -> None:
+        data = self._anthropic_payload()
+        _, out = self._run("embeddings", data)
+        assert out["messages"] == data["messages"]


### PR DESCRIPTION
## Description

Closes #3503

LiteLLM's proxy maps /v1/messages and /anthropic/v1/messages to the `anthropic_messages` call type (`aanthropic_messages` for the async path), but `HeadroomCallback.async_pre_call_hook` only accepted `completion` and `acompletion`, so every request through the Anthropic Messages route exited at the call-type gate and no compression ran at all
the payload on that route still carries `messages` in Anthropic format and `compress()` already handles that shape, so the gate now accepts the two anthropic call types next to the existing two

### Steps to reproduce
1. build a `HeadroomCallback()` and call `async_pre_call_hook(user_api_key_dict={}, cache=None, data=<anthropic payload with a 200-row JSON tool_result block>, call_type="anthropic_messages")`
2. Expected: the tool_result content gets compressed and `total_tokens_saved` grows
3. Actual (raw output on untouched main e67b3c8a):

```text
=== control: OpenAI-format completion route ===
call_type='completion': tokens_saved=3387 messages_modified=True
=== lane: /v1/messages route (reporter's case) ===
call_type='anthropic_messages': tokens_saved=0 messages_modified=False
=== lane: async variant ===
call_type='aanthropic_messages': tokens_saved=0 messages_modified=False
```

after the fix the same probe saves tokens on both anthropic call types and the completion control still fires

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `headroom/integrations/litellm_callback.py`: the pre-call gate now also accepts `anthropic_messages` and `aanthropic_messages`, with a comment naming where LiteLLM defines those call types (`CallTypes.anthropic_messages` in litellm/types/utils.py, route table for /v1/messages)
- `tests/test_litellm_callback.py`: regression tests for both call types (tokens saved + tool_result block structure preserved), a completion-route control, and a guard that non-chat routes still skip

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
python -m pytest -q tests/test_litellm_callback.py tests/test_integrations/test_litellm_callback.py tests/test_compress_api.py
32 passed, 5 skipped in 2.23s

without the fix (git checkout main -- headroom/integrations/litellm_callback.py):
2 failed, 9 passed in 2.22s
(the two new anthropic_messages tests fail, the completion control and the skip guard pass)

ruff check .
All checks passed!

ruff format --check .
1567 files already formatted

mypy headroom
Success: no issues found in 530 source files
```

## Real Behavior Proof

- Environment: Linux, Python 3.12, headroom main at e67b3c8a in a venv
- Exact command / steps: the probe above, then the pytest triple before and after the fix, with the fix file checked out from main to show the tests fail without it
- Observed result: `anthropic_messages` and `aanthropic_messages` saved 0 tokens and left messages untouched before the fix, the same payload compresses after it, the completion control saves tokens in both runs, `embeddings` still skips
- Not tested: a live LiteLLM proxy with an Anthropic-format client end to end, the unit tests stand in for how the proxy passes the call type

## Runtime Rollout Safety

- Rollout-managed feature(s): none
- Minimum rollout channel: n/a
- Stable/default behavior changed: yes, the callback now compresses on the Anthropic Messages routes, that is the fix
- Kill switch / disable path: none needed, revert the commit or drop the callback from litellm.callbacks
- Unsafe override required: no
- Qualification impact: none
- Rollback path: revert the one commit, nothing else to unwind

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
