### PR TITLE
fix(learn): dedup replayed tool calls by tool_call_id in loop detection

### DIFF
--- a/headroom/learn/loops.py
+++ b/headroom/learn/loops.py
@@ -117,8 +117,19 @@ def detect_loops(
     a within-conversation phenomenon; the same command in two unrelated
     sessions is not a loop). Groups meeting ``min_occurrences`` become
     ``LoopPattern`` results, sorted by measured wasted tokens descending.
+
+    Tool calls carrying a non-empty ``tool_call_id`` are deduplicated
+    globally by that id, so a resume transcript that replays prior history
+    does not double-count the same calls. Calls with an empty id are never
+    deduplicated (nothing identifies them as replays). ``min_occurrences``
+    is re-checked after dedup so a group that only cleared the bar via
+    replays is dropped rather than reported. Scanners must therefore keep
+    synthesized ids unique *across* sessions (e.g. scope them by session
+    id); otherwise two unrelated sessions running the same loop would
+    collapse into one.
     """
     groups: dict[str, list[ToolCall]] = {}
+    seen_ids: set[str] = set()
     for session in sessions:
         per_session: dict[str, list[ToolCall]] = {}
         for tc in session.tool_calls:
@@ -127,7 +138,22 @@ def detect_loops(
         # signature so cross-session recurrence of the SAME loop accumulates.
         for sig, calls in per_session.items():
             if len(calls) >= min_occurrences:
-                groups.setdefault(sig, []).extend(calls)
+                unique: list[ToolCall] = []
+                for tc in calls:
+                    tid = (tc.tool_call_id or "").strip()
+                    if not tid:
+                        unique.append(tc)
+                        continue
+                    if tid in seen_ids:
+                        continue
+                    seen_ids.add(tid)
+                    unique.append(tc)
+                if unique:
+                    groups.setdefault(sig, []).extend(unique)
+
+    # Re-check the threshold after dedup: a group that only cleared the bar
+    # via replayed calls must not surface as a sub-threshold phantom loop.
+    groups = {sig: calls for sig, calls in groups.items() if len(calls) >= min_occurrences}
 
     loops: list[LoopPattern] = []
     for sig, calls in groups.items():

--- a/tests/test_learn/test_loop_weighting.py
+++ b/tests/test_learn/test_loop_weighting.py
@@ -31,6 +31,8 @@ from headroom.learn.models import (
     ProjectInfo,
     Recommendation,
     RecommendationTarget,
+    SessionData,
+    ToolCall,
 )
 
 
@@ -85,6 +87,66 @@ class TestDetectLoops:
         assert err.count == ref.count
         # Same count, but error loop counts all N and re-fetch counts N-1.
         assert err.wasted_tokens >= 0 and ref.wasted_tokens >= 0
+
+
+def _read_call(tool_call_id: str, msg_index: int, out_bytes: int = 40000) -> ToolCall:
+    """Build a Read call matching the #3452 repro shape."""
+    return ToolCall(
+        name="Read",
+        tool_call_id=tool_call_id,
+        input_data={"file_path": "/repo/docs/design.md"},
+        output="x" * out_bytes,
+        is_error=False,
+        msg_index=msg_index,
+        output_bytes=out_bytes,
+    )
+
+
+class TestDetectLoopsDedup:
+    """Regression tests for #3452: replayed transcripts must not double-count."""
+
+    def test_replayed_resume_transcript_not_double_counted(self):
+        reads = [_read_call(f"call_r{i}", i) for i in range(3)]
+        one = detect_loops([SessionData(session_id="rollout-1", tool_calls=list(reads))])
+        fork = detect_loops(
+            [
+                SessionData(session_id="rollout-1", tool_calls=list(reads)),
+                SessionData(session_id="rollout-2-resume", tool_calls=list(reads)),
+            ]
+        )
+        assert len(one) == 1
+        assert len(fork) == 1
+        assert fork[0].count == one[0].count == 3
+        assert fork[0].wasted_tokens == one[0].wasted_tokens == 20000
+
+    def test_resume_with_genuinely_new_calls_accumulates(self):
+        base = [_read_call(f"call_r{i}", i) for i in range(3)]
+        resumed = list(base) + [_read_call("call_r3", 3), _read_call("call_r4", 4)]
+        loops = detect_loops(
+            [
+                SessionData(session_id="rollout-1", tool_calls=list(base)),
+                SessionData(session_id="rollout-2-resume", tool_calls=resumed),
+            ]
+        )
+        assert len(loops) == 1
+        assert loops[0].count == 5
+
+    def test_calls_without_ids_stay_counted(self):
+        reads = [_read_call("", i) for i in range(3)]
+        loops = detect_loops(
+            [
+                SessionData(session_id="rollout-1", tool_calls=list(reads)),
+                SessionData(session_id="rollout-2-resume", tool_calls=list(reads)),
+            ]
+        )
+        assert len(loops) == 1
+        assert loops[0].count == 6
+
+    def test_pure_replay_duplicates_dropped_below_threshold(self):
+        # One call duplicated 3x under a single id clears the raw threshold
+        # but is one call after dedup, so no loop may be reported.
+        dupes = [_read_call("call_only", i) for i in range(3)]
+        assert detect_loops([SessionData(session_id="s1", tool_calls=dupes)]) == []
 
 
 # =============================================================================


### PR DESCRIPTION
## Description

`detect_loops()` merged each session's qualifying signature groups into the global view without deduplicating by `tool_call_id`, so a provider resume transcript that replays prior history double-counted every replayed call (3 reads became 6, waste 20,000 became 50,000).

Root cause: `headroom/learn/loops.py` grouped by canonical signature per session and extended the global `groups` dict directly, never consulting `ToolCall.tool_call_id` even though scanners already parse it.

Fixes #3452

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/learn/loops.py:121-129` (docstring): documented the `tool_call_id` dedup contract, the empty-id exception, the post-dedup `min_occurrences` re-check, and the cross-session uniqueness requirement for synthesized scanner ids.
- `headroom/learn/loops.py:132` (`seen_ids: set[str]`): global dedup set across sessions.
- `headroom/learn/loops.py:141-152`: when merging per-session qualifying groups, skip calls whose stripped non-empty `tool_call_id` was already seen; calls with empty ids are never deduped.
- `headroom/learn/loops.py:154-156`: re-check `min_occurrences` after dedup so a group that only cleared the bar via replays is dropped instead of reported as a phantom sub-threshold loop.
- `tests/test_learn/test_loop_weighting.py:92-152` (`_read_call` helper + `TestDetectLoopsDedup` with 4 tests): replayed-resume stays at count 3, resume with 2 genuinely new calls accumulates to 5, empty-id replays stay counted at 6 (deliberately unfixed case), pure-replay single-id triple is dropped below threshold.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Formatting passes (`ruff format --check`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
# Target suite after fix (17/17 green):
tests\test_learn\test_loop_weighting.py .................  [100%]
17 passed, 1 warning in 6.10s

# New regression tests against PRE-FIX code (only headroom/learn/loops.py stashed):
tests\test_learn\test_loop_weighting.py FF.F  [100%]
FAILED test_replayed_resume_transcript_not_double_counted - assert 6 == 3
  (LoopPattern count=6, wasted_tokens=50000, msg_indices=[0, 0, 1, 1, 2, 2])
FAILED test_resume_with_genuinely_new_calls_accumulates - assert 8 == 5
FAILED test_pure_replay_duplicates_dropped_below_threshold - assert [LoopPattern(count=3 ...)] == []
3 failed, 1 passed (test_calls_without_ids_stay_counted passes before and after by design)

# Full tests/test_learn/ after fix:
6 failed, 245 passed, 4 skipped in 33.37s
Failures (all in files NOT touched by this PR):
- tests/test_learn/test_analyzer.py::TestDigestBuilder::test_includes_project_info
- tests/test_learn/test_integration.py::TestIdempotency::test_double_write_replaces_not_appends
- tests/test_learn/test_scanner.py (4x TestDecodeProjectPath Windows-path greedy decoding)
Honest scoping: a clean-tree re-run of those 6 to prove pre-existing status timed out
past 120s in this environment, so pre-existing is inferred from file isolation
(none touch loops.py or loop_weighting.py), not proven here. Leaving to CI.

# Lint / format (after fix):
uvx ruff check headroom/learn/loops.py tests/test_learn/test_loop_weighting.py
All checks passed!
uvx ruff format --check headroom/learn/loops.py tests/test_learn/test_loop_weighting.py
2 files already formatted
```

Note: `mypy` was not run (dev extra not installed in this Windows environment).

## Real Behavior Proof

- Environment: Windows 11, Python 3.13.13, uv 0.11.14, repo at `upstream/main` (`e67b3c8`) + this patch.
- Exact command / steps:
  1. Saved the issue's `repro_dedup.py` verbatim to `%TEMP%\opencode\repro_dedup.py`.
  2. `$env:PYTHONPATH='<repo>'; uv run --no-sync python -u <repro_dedup.py>`
- Observed result (after fix):
```text
headroom 0.38.0-dev
[2] same 3 calls, single transcript vs replayed resume transcript:
    single : count=3 wasted=20,000
    resumed: count=3 wasted=20,000
```
Matches the issue's Expected Behavior row 1 (`count=3`, `wasted=20,000`). The issue reports pre-fix output as `single: count=3 / resumed: count=6, wasted=50,000`; the stashed-code pytest failures above (`assert 6 == 3`, `wasted 50000`) confirm the same pre-fix shape on this checkout.
- Not tested: end-to-end `headroom learn` CLI over real transcript files; scanners that synthesize ids (contract documented in the docstring but no scanner code changed here).

## Runtime Rollout Safety

- Rollout-managed feature(s): none
- Minimum rollout channel: n/a
- Stable/default behavior changed: yes, intentionally — replayed `tool_call_id`s no longer inflate loop counts/waste. Single-session loops with unique ids and all empty-id paths are unchanged (pinned by `test_calls_without_ids_stay_counted` and the 13 pre-existing tests).
- Kill switch / disable path: n/a
- Unsafe override required: no
- Qualification impact: `format_loops_for_digest()` and `apply_loop_weighting()` now receive deduplicated counts, so replayed loops no longer outrank real ones.
- Rollback path: revert this commit

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (docstring updated; no wiki/docs change needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (target suite 17/17; full learn suite has 6 unrelated failures noted honestly above)
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

n/a

## Additional Notes

- Scanner contract (from #3452): dedup by id requires ids unique *across* sessions. Where a scanner synthesizes ids, it must scope them by session id, otherwise two unrelated sessions running the same loop would collapse into one — the same defect in reverse. Stated in the `detect_loops()` docstring; no scanner code changed in this PR.
- One logical change per PR; diff is `headroom/learn/loops.py` (+28/-1) and `tests/test_learn/test_loop_weighting.py` (+62). Not requesting reviews from specific humans.
