### PR TITLE
fix: preserve Pi evidence and native images during compression

### DIFF
--- a/headroom/agent_savings.py
+++ b/headroom/agent_savings.py
@@ -338,6 +338,8 @@ def proxy_pipeline_kwargs(config: object) -> dict[str, object]:
 
     if getattr(config, "compress_user_messages", False):
         kwargs["compress_user_messages"] = True
+    if os.environ.get("HEADROOM_COMPRESS_USER_MESSAGES") == "0":
+        kwargs["compress_user_messages"] = False
 
     compress_system_messages = getattr(config, "compress_system_messages", None)
     if compress_system_messages is not None:

--- a/headroom/cache/compression_cache.py
+++ b/headroom/cache/compression_cache.py
@@ -15,6 +15,8 @@ import time
 from collections import OrderedDict
 from dataclasses import dataclass
 
+from .compression_store import cached_references_available
+
 logger = logging.getLogger(__name__)
 
 
@@ -153,6 +155,10 @@ class CompressionCache:
         """Retrieve compressed content by hash, refreshing LRU position on hit."""
         with self._lock:
             entry = self._cache.get(hash)
+            if entry is not None and not cached_references_available(entry.compressed):
+                self._total_tokens_saved -= entry.tokens_saved
+                del self._cache[hash]
+                entry = None
             if entry is None:
                 self._misses += 1
                 return None
@@ -317,7 +323,7 @@ class CompressionCache:
                     content = _extract_tool_result_content(msg)
                     if content is not None:
                         h = self.content_hash(content)
-                        if h not in self._cache and h not in self._stable_hashes:
+                        if self.get_compressed(h) is None and h not in self._stable_hashes:
                             break
                     else:
                         # tool_result with non-string content; treat as unstable

--- a/headroom/cache/compression_cache.py
+++ b/headroom/cache/compression_cache.py
@@ -15,6 +15,9 @@ import time
 from collections import OrderedDict
 from dataclasses import dataclass
 
+from headroom.ccr.retrieval_content import is_retrieval_result
+from headroom.config import DEFAULT_VERBATIM_EXCLUDE_TOOLS, is_tool_excluded, unwrap_tool_call_name
+
 from .compression_store import cached_references_available
 
 logger = logging.getLogger(__name__)
@@ -42,6 +45,54 @@ def _is_tool_result_message(msg: dict) -> bool:
     return False
 
 
+def _verbatim_tool_call_ids(messages: list[dict]) -> set[str]:
+    protected = set()
+    for message in messages:
+        calls = message.get("tool_calls")
+        if not isinstance(calls, list):
+            calls = []
+        content = message.get("content")
+        if isinstance(content, list):
+            calls = [
+                *calls,
+                *(
+                    block
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "tool_use"
+                ),
+            ]
+        for call in calls:
+            if not isinstance(call, dict):
+                continue
+            function = call.get("function") or call
+            if not isinstance(function, dict):
+                continue
+            name = function.get("name")
+            if not isinstance(name, str):
+                continue
+            name = unwrap_tool_call_name(name, function.get("arguments", call.get("input")))
+            if isinstance(call.get("id"), str) and is_tool_excluded(
+                name, DEFAULT_VERBATIM_EXCLUDE_TOOLS
+            ):
+                protected.add(call["id"])
+    return protected
+
+
+def _is_verbatim_result(message: dict, protected: set[str]) -> bool:
+    name = message.get("name")
+    if isinstance(name, str) and is_tool_excluded(name, DEFAULT_VERBATIM_EXCLUDE_TOOLS):
+        return True
+    if message.get("tool_call_id") in protected:
+        return True
+    content = message.get("content")
+    return isinstance(content, list) and any(
+        isinstance(block, dict)
+        and block.get("type") == "tool_result"
+        and block.get("tool_use_id") in protected
+        for block in content
+    )
+
+
 def _extract_text_from_blocks(blocks: list) -> str | None:
     """Extract joined text from a list-of-blocks content (e.g. Anthropic list-of-text-blocks).
 
@@ -50,6 +101,8 @@ def _extract_text_from_blocks(blocks: list) -> str | None:
     string.  This helper extracts text from ``type == "text"`` blocks and
     joins them.
     """
+    if any(not isinstance(block, dict) or block.get("type") != "text" for block in blocks):
+        return None
     texts = [b.get("text", "") for b in blocks if isinstance(b, dict) and b.get("type") == "text"]
     return "\n".join(t for t in texts if t != "") or None
 
@@ -346,10 +399,11 @@ class CompressionCache:
         # `_cache` mid-iteration.
         with self._lock:
             result: list[dict] = []
+            protected = _verbatim_tool_call_ids(messages)
             for msg in messages:
-                if _is_tool_result_message(msg):
+                if _is_tool_result_message(msg) and not _is_verbatim_result(msg, protected):
                     content = _extract_tool_result_content(msg)
-                    if content is not None:
+                    if content is not None and not is_retrieval_result(content):
                         h = self.content_hash(content)
                         compressed = self.get_compressed(h)
                         if compressed is not None:

--- a/headroom/cache/compression_store.py
+++ b/headroom/cache/compression_store.py
@@ -1047,6 +1047,26 @@ def _create_default_ccr_backend() -> CompressionStoreBackend | None:
         return None
 
 
+_RECOVERY_REFERENCE = re.compile(
+    r"(?:<<ccr:|Retrieve (?:more|original): hash=|\[[^\]\n]*compressed[^\]\n]*hash=)"
+    r"([a-fA-F0-9]{12,24})(?![a-fA-F0-9])"
+)
+
+
+def cached_references_available(content: str) -> bool:
+    """Reject cached references whose original data is no longer available."""
+    hashes = set(_RECOVERY_REFERENCE.findall(content))
+    if not hashes:
+        return True
+    try:
+        store = get_compression_store()
+        return all(store.get_entry_status(key.lower())["status"] == "available" for key in hashes)
+    except Exception:
+        # A storage failure must preserve evidence, not replay an unusable reference.
+        logger.warning("CCR availability check failed; discard cached compression", exc_info=True)
+        return False
+
+
 def get_compression_store(
     max_entries: int = 1000,
     default_ttl: int | None = None,

--- a/headroom/ccr/retrieval_content.py
+++ b/headroom/ccr/retrieval_content.py
@@ -1,0 +1,34 @@
+"""Recognize original evidence when a delta omits its tool-call history."""
+
+import json
+
+
+def _is_original(value: object) -> bool:
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("hash"), str)
+        and bool(value["hash"])
+        and isinstance(value.get("original_content"), str)
+    )
+
+
+def is_retrieval_result(text: str) -> bool:
+    if "original_content" not in text:
+        return False
+    try:
+        value = json.loads(text)
+    except (ValueError, TypeError):
+        return False
+    if _is_original(value):
+        return True
+    if not isinstance(value, dict) or not isinstance(value.get("content"), list):
+        return False
+    for block in value["content"]:
+        if not isinstance(block, dict) or block.get("type") != "text":
+            continue
+        try:
+            if _is_original(json.loads(block.get("text", ""))):
+                return True
+        except (ValueError, TypeError):
+            continue
+    return False

--- a/headroom/cli/proxy.py
+++ b/headroom/cli/proxy.py
@@ -1321,6 +1321,7 @@ def proxy(
         vertex_api_url=provider_api_overrides.vertex,
         mode=effective_mode,
         optimize=not no_optimize,
+        image_optimize=_get_env_bool("HEADROOM_IMAGE_OPTIMIZE", True),
         cache_enabled=not no_cache,
         rate_limit_enabled=not no_rate_limit,
         rate_limit_requests_per_minute=rpm if rpm is not None else 60,

--- a/headroom/config.py
+++ b/headroom/config.py
@@ -387,12 +387,12 @@ _HERMES_TOOL_CALL_WRAPPER = "tool_call"
 
 
 def unwrap_tool_call_name(name: str, arguments: Any) -> str:
-    """Extract the real tool name from a Hermes deferred ``tool_call`` wrapper.
+    """Extract the real tool name from a Hermes or Pi wrapper.
 
     Non-wrapper names pass through unchanged. Malformed/unparseable wrappers
     fail open and return the wrapper name (caller decides what that means).
     """
-    if name != _HERMES_TOOL_CALL_WRAPPER:
+    if name not in {_HERMES_TOOL_CALL_WRAPPER, "mcp_daemon"}:
         return name
     raw = arguments
     if isinstance(raw, str):
@@ -401,6 +401,13 @@ def unwrap_tool_call_name(name: str, arguments: Any) -> str:
         except (ValueError, TypeError):
             return name
     if isinstance(raw, dict):
+        if name == "mcp_daemon":
+            selector = raw.get("selector")
+            if raw.get("action") == "call" and isinstance(selector, str):
+                parts = selector.split(".")
+                if len(parts) == 2 and all(parts):
+                    return f"mcp__{parts[0]}__{parts[1]}"
+            return name
         inner = raw.get("name")
         if isinstance(inner, str) and inner.strip():
             return inner.strip()

--- a/headroom/config.py
+++ b/headroom/config.py
@@ -392,7 +392,7 @@ def unwrap_tool_call_name(name: str, arguments: Any) -> str:
     Non-wrapper names pass through unchanged. Malformed/unparseable wrappers
     fail open and return the wrapper name (caller decides what that means).
     """
-    if name not in {_HERMES_TOOL_CALL_WRAPPER, "mcp_daemon"}:
+    if name not in (_HERMES_TOOL_CALL_WRAPPER, "mcp_daemon"):
         return name
     raw = arguments
     if isinstance(raw, str):

--- a/headroom/proxy/server.py
+++ b/headroom/proxy/server.py
@@ -873,6 +873,8 @@ class HeadroomProxy(
         # Runs BEFORE the disable_kompress override below so that flag stays
         # authoritative for turning Kompress off.
         _apply_compressor_selection(router_config, config.compressors)
+        if not config.image_optimize:
+            router_config.enable_image_optimizer = False
         # External (non-built-in) `headroom.compressor` selections are ignored by
         # `_apply_compressor_selection` (they have no enable_* flag). Thread them
         # to the router here so it can route matching blocks through them; None

--- a/headroom/transforms/compression_units.py
+++ b/headroom/transforms/compression_units.py
@@ -13,6 +13,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field, replace
 from typing import Protocol
 
+from headroom.ccr.retrieval_content import is_retrieval_result
+
 from .content_router import (
     CompressionStrategy,
     ContentRouter,
@@ -59,6 +61,7 @@ class CompressionUnit:
 UNIT_REASON_CATEGORIES = {
     None: "applied",
     "protected_user_message": "protected_role",
+    "protected_retrieval_result": "protected_role",
     "protected_system_message": "protected_role",
     "protected_assistant_message": "protected_role",
     "immutable": "immutable",
@@ -253,6 +256,8 @@ def compress_unit_with_router(
             kw["reason_category"] = _categorize_reason(reason_val)
         return replace(base, **kw)  # type: ignore[arg-type]
 
+    if is_retrieval_result(unit.text):
+        return _with_reason(reason="protected_retrieval_result")
     if not unit.mutable:
         return _with_reason(reason="immutable")
     if unit.role == "user":

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -50,6 +50,7 @@ from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Any
 
+from ..cache.compression_store import cached_references_available
 from ..config import (
     DEFAULT_BYTE_EXACT_EXCLUDE_TOOLS,
     DEFAULT_EXCLUDE_TOOLS,
@@ -1280,7 +1281,9 @@ class CompressionCache:
             entry = self._results.get(key)
             if entry is not None:
                 compressed, ratio, strategy, created_at = entry
-                if (time.monotonic() - created_at) < self._ttl_seconds:
+                if (
+                    time.monotonic() - created_at
+                ) < self._ttl_seconds and cached_references_available(compressed):
                     self._hits += 1
                     self._total_lookup_ns += time.perf_counter_ns() - t0
                     self._lookup_count += 1

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -50,6 +50,8 @@ from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Any
 
+from headroom.ccr.retrieval_content import is_retrieval_result
+
 from ..cache.compression_store import cached_references_available
 from ..config import (
     DEFAULT_BYTE_EXACT_EXCLUDE_TOOLS,
@@ -2204,6 +2206,12 @@ class ContentRouter(Transform):
         Returns:
             RouterCompressionResult with compressed content and routing metadata.
         """
+        if is_retrieval_result(content):
+            return RouterCompressionResult(
+                compressed=content,
+                original=content,
+                strategy_used=CompressionStrategy.PASSTHROUGH,
+            )
         context = context or ""
         debug_enabled = logger.isEnabledFor(logging.DEBUG)
         request_debug = (
@@ -2585,6 +2593,23 @@ class ContentRouter(Transform):
         compressed = "\n\n".join(compressed_sections)
         if protected:
             compressed = restore_tags(compressed, protected)
+
+        if compressed != content and self.config.ccr_inject_marker and not self.config.lossless:
+            from headroom.cache.compression_store import get_compression_store
+
+            try:
+                store = get_compression_store()
+                key = store.store(content, compressed, compression_strategy="mixed")
+                if store.get_entry_status(key, clean_expired=False).get("status") != "available":
+                    raise ValueError("Mixed-content recovery storage is unavailable")
+            except Exception:
+                logger.warning("Mixed-content recovery storage failed; preserving original")
+                return RouterCompressionResult(
+                    compressed=content,
+                    original=content,
+                    strategy_used=CompressionStrategy.PASSTHROUGH,
+                )
+            compressed += f"\n[Retrieve original: hash={key}]"
 
         return RouterCompressionResult(
             compressed=compressed,

--- a/tests/test_agent_savings.py
+++ b/tests/test_agent_savings.py
@@ -839,3 +839,9 @@ def test_explicit_min_chars_block_env_overrides_the_profile(
         min_tokens_to_crush = 500
 
     assert proxy_pipeline_kwargs(_Config())["min_chars_for_block_compression"] == 120
+
+
+def test_explicit_user_protection_overrides_aggressive_profile(monkeypatch):
+    monkeypatch.setenv("HEADROOM_COMPRESS_USER_MESSAGES", "0")
+    config = ProxyConfig(savings_profile="agent-90", compress_user_messages=False)
+    assert proxy_pipeline_kwargs(config)["compress_user_messages"] is False

--- a/tests/test_ccr_cache_lifetime.py
+++ b/tests/test_ccr_cache_lifetime.py
@@ -1,0 +1,77 @@
+"""Never replay a cached reference after its original expires or disappears."""
+
+from __future__ import annotations
+
+import pytest
+
+from headroom.cache import compression_store
+from headroom.cache.compression_cache import CompressionCache as SessionCache
+from headroom.cache.compression_store import CompressionStore
+from headroom.transforms.content_router import CompressionCache as RouterCache
+
+
+@pytest.mark.parametrize("cache_kind", ["router", "session"])
+@pytest.mark.parametrize("failure", ["expired", "evicted", "backend_error"])
+def test_cached_reference_requires_a_live_original(monkeypatch, cache_kind, failure):
+    store = CompressionStore(max_entries=1, default_ttl=2)
+    monkeypatch.setattr(compression_store, "get_compression_store", lambda: store)
+    key = store.store("Complete original dialogue", "Short dialogue")
+    text = f"[100 lines compressed to 10. Retrieve more: hash={key}]"
+    cache = RouterCache() if cache_kind == "router" else SessionCache()
+    if cache_kind == "router":
+        cache.put(1, text, 0.1, "text")
+
+        def read():
+            return cache.get(1)
+    else:
+        cache.store_compressed("content", text, 100)
+
+        def read():
+            return cache.get_compressed("content")
+
+    assert read() is not None
+    if failure == "expired":
+        timestamp = compression_store.time.time()
+        monkeypatch.setattr(compression_store.time, "time", lambda: timestamp + 3)
+    elif failure == "evicted":
+        store.store("Other original", "Other summary")
+    else:
+
+        def fail(*args, **kwargs):
+            raise OSError("Storage unavailable")
+
+        monkeypatch.setattr(store, "get_entry_status", fail)
+    assert read() is None
+
+
+def test_expired_session_reference_cannot_freeze_raw_evidence(monkeypatch):
+    store = CompressionStore(default_ttl=2)
+    monkeypatch.setattr(compression_store, "get_compression_store", lambda: store)
+    key = store.store("Original evidence", "Summary")
+    cache = SessionCache()
+    message = {"role": "tool", "tool_call_id": "call1", "content": "Original evidence"}
+    cache.store_compressed(cache.content_hash(message["content"]), f"<<ccr:{key},text,1KB>>", 100)
+    timestamp = compression_store.time.time()
+    monkeypatch.setattr(compression_store.time, "time", lambda: timestamp + 3)
+    assert cache.compute_frozen_count([message, {"role": "user", "content": "Continue"}]) == 0
+    assert cache.apply_cached([message]) == [message]
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "<<ccr:{key},text,1KB>>",
+        "[10 items compressed. hash={key}]",
+        "Retrieve original: hash={key}",
+    ],
+)
+def test_all_marker_formats_require_live_originals(monkeypatch, marker):
+    store = CompressionStore(default_ttl=2)
+    monkeypatch.setattr(compression_store, "get_compression_store", lambda: store)
+    key = store.store("Original", "Summary")
+    cache = RouterCache()
+    cache.put(1, marker.format(key=key), 0.1, "text")
+    assert cache.get(1) is not None
+    timestamp = compression_store.time.time()
+    monkeypatch.setattr(compression_store.time, "time", lambda: timestamp + 3)
+    assert cache.get(1) is None

--- a/tests/test_hermes_tool_call_unwrap.py
+++ b/tests/test_hermes_tool_call_unwrap.py
@@ -13,6 +13,10 @@ into `ContentRouter._build_tool_name_map` (OpenAI + Anthropic paths).
 
 from __future__ import annotations
 
+import json
+
+import pytest
+
 from headroom.config import (
     DEFAULT_EXCLUDE_TOOLS,
     is_tool_excluded,
@@ -23,6 +27,34 @@ from headroom.transforms.content_router import ContentRouter, ContentRouterConfi
 # ---------------------------------------------------------------------------
 # Helper unit tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("encoded", [False, True])
+def test_unwrap_mcp_daemon_retrieval(encoded: bool) -> None:
+    arguments = {"action": "call", "selector": "headroom.headroom_retrieve"}
+    name = unwrap_tool_call_name("mcp_daemon", json.dumps(arguments) if encoded else arguments)
+    assert name == "mcp__headroom__headroom_retrieve"
+    assert is_tool_excluded(name, DEFAULT_EXCLUDE_TOOLS)
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        None,
+        "bad json",
+        [],
+        {},
+        {"action": "describe", "selector": "headroom.headroom_retrieve"},
+        {"action": "search", "selector": "headroom.headroom_retrieve"},
+        {"action": "call", "selector": None},
+        {"action": "call", "selector": "headroom"},
+        {"action": "call", "selector": "headroom."},
+        {"action": "call", "selector": ".headroom_retrieve"},
+        {"action": "call", "selector": "headroom.tool.extra"},
+    ],
+)
+def test_unwrap_mcp_daemon_passthrough(arguments: object) -> None:
+    assert unwrap_tool_call_name("mcp_daemon", arguments) == "mcp_daemon"
 
 
 def test_unwrap_passthrough_plain_name() -> None:

--- a/tests/test_mixed_content_recovery.py
+++ b/tests/test_mixed_content_recovery.py
@@ -1,0 +1,36 @@
+import json
+import re
+
+import pytest
+
+from headroom.cache import compression_store
+from headroom.cache.compression_store import CompressionStore
+from headroom.transforms.content_router import ContentRouter
+
+
+@pytest.mark.parametrize("storage_fails", [False, True])
+def test_mixed_json_compression_preserves_full_recovery(monkeypatch, storage_fails):
+    rows = [
+        f"[{i}:00] Speaker: We reviewed the layout and discussed the report. The team needs time to compare the options."
+        for i in range(180)
+    ]
+    rows[17] = (
+        "[17:00] Decision: The launch is NOT approved. Reference ZX-9031. The budget is AUD 137.42, not AUD 173.42."
+    )
+    original = json.dumps({"messages": rows})
+    store = CompressionStore()
+    if storage_fails:
+
+        def fail(*args, **kwargs):
+            raise OSError("Storage unavailable")
+
+        monkeypatch.setattr(store, "store", fail)
+    monkeypatch.setattr(compression_store, "get_compression_store", lambda: store)
+    result = ContentRouter().compress(original)
+    if storage_fails:
+        assert result.compressed == original
+    else:
+        hashes = re.findall(r"Retrieve original: hash=([a-f0-9]+)", result.compressed)
+        assert hashes, "Mixed output has no complete-original recovery reference"
+        assert store.get_stats()["total_retrievals"] == 0
+        assert store.retrieve(hashes[-1]).original_content == original

--- a/tests/test_openai_responses_compression_units.py
+++ b/tests/test_openai_responses_compression_units.py
@@ -587,7 +587,8 @@ def test_openai_responses_adapter_accepts_empty_input_list():
     assert strategy_chain == []
 
 
-def test_openai_responses_adapter_preserves_headroom_retrieve_outputs():
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_openai_responses_adapter_preserves_headroom_retrieve_outputs(wrapped):
     router = ContentRouter()
 
     def compress(self, content: str, **_kwargs):
@@ -606,8 +607,8 @@ def test_openai_responses_adapter_preserves_headroom_retrieve_outputs():
             {
                 "type": "function_call",
                 "call_id": "call_retrieve",
-                "name": "mcp__headroom__headroom_retrieve",
-                "arguments": "{}",
+                "name": "mcp_daemon" if wrapped else "mcp__headroom__headroom_retrieve",
+                "arguments": '{"action":"call","selector":"headroom.headroom_retrieve"}',
             },
             {
                 "type": "function_call_output",

--- a/tests/test_proxy_image_preservation.py
+++ b/tests/test_proxy_image_preservation.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from headroom.cli.main import main
+from headroom.proxy.server import ProxyConfig, create_app
+from headroom.transforms import ContentRouter
+
+
+@pytest.mark.parametrize("selection", [None, {"image", "kompress"}])
+def test_image_disable_preserves_text_compression(selection):
+    app = create_app(
+        ProxyConfig(
+            image_optimize=False,
+            compressors=selection,
+            cache_enabled=False,
+            rate_limit_enabled=False,
+            cost_tracking_enabled=False,
+            log_requests=False,
+        )
+    )
+    router = next(
+        t for t in app.state.proxy.anthropic_pipeline.transforms if isinstance(t, ContentRouter)
+    )
+    assert not router.config.enable_image_optimizer
+    assert router.config.enable_kompress
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_cli_image_policy_reaches_proxy(monkeypatch, enabled):
+    monkeypatch.setenv("HEADROOM_IMAGE_OPTIMIZE", "1" if enabled else "0")
+    monkeypatch.setenv("HEADROOM_MALLOC_TUNING", "0")
+    with patch("headroom.proxy.server.run_server") as run:
+        result = CliRunner().invoke(main, ["proxy", "--no-telemetry"])
+    assert result.exit_code == 0, result.output
+    assert run.call_args.args[0].image_optimize is enabled

--- a/tests/test_retrieval_delta_fidelity.py
+++ b/tests/test_retrieval_delta_fidelity.py
@@ -1,0 +1,44 @@
+import json
+
+import pytest
+
+from headroom.cache.compression_cache import CompressionCache
+from headroom.transforms.compression_units import CompressionUnit, compress_unit_with_router
+from headroom.transforms.content_router import ContentRouter
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_delta_retrieval_stays_exact_without_call_history(wrapped):
+    original = json.dumps(
+        {
+            "messages": [
+                f"[{i}:00] Speaker: We reviewed the layout and discussed the report. The team needs time to compare the options."
+                for i in range(180)
+            ]
+        }
+    )
+    text = json.dumps(
+        {"hash": "abcdef123456", "original_content": original, "retrieval_count": 1}, indent=2
+    )
+    if wrapped:
+        text = json.dumps({"content": [{"type": "text", "text": text}]})
+    router = ContentRouter()
+    assert router.compress(text).compressed == text
+    unit = CompressionUnit(
+        text=text,
+        provider="openai",
+        endpoint="responses",
+        role="tool",
+        item_type="function_call_output",
+        min_bytes=0,
+    )
+
+    class Counter:
+        def count_text(self, s):
+            return len(s)
+
+    assert compress_unit_with_router(unit, router=router, tokenizer=Counter()).compressed == text
+    cache = CompressionCache()
+    cache.store_compressed(cache.content_hash(text), "Stale summary", 1)
+    message = {"role": "tool", "tool_call_id": "delta-no-history", "content": text}
+    assert cache.apply_cached([message]) == [message]

--- a/tests/test_session_cache_fidelity.py
+++ b/tests/test_session_cache_fidelity.py
@@ -1,0 +1,72 @@
+import copy
+
+import pytest
+
+from headroom.cache.compression_cache import CompressionCache
+from headroom.proxy.session_engine import FREEZE_POLICY_CONFIRMED_CLAMP, prepare_turn
+
+
+@pytest.mark.parametrize("provider", ["openai", "anthropic"])
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_recovered_original_bypasses_cached_summary(provider, wrapped):
+    name = "mcp_daemon" if wrapped else "headroom_retrieve"
+    args = (
+        {"action": "call", "selector": "headroom.headroom_retrieve", "args": {"hash": "test"}}
+        if wrapped
+        else {"hash": "test"}
+    )
+    if provider == "openai":
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "recover",
+                        "type": "function",
+                        "function": {"name": name, "arguments": args},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "recover", "content": "Exact original"},
+        ]
+    else:
+        messages = [
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "recover", "name": name, "input": args}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "recover", "content": "Exact original"}
+                ],
+            },
+        ]
+    cache = CompressionCache()
+    cache.store_compressed(cache.content_hash("Exact original"), "Earlier summary", 1)
+    before = copy.deepcopy(messages)
+    result = prepare_turn(cache, messages, policy=FREEZE_POLICY_CONFIRMED_CLAMP)
+    assert result.pipeline_input == before
+    assert messages == before
+
+
+@pytest.mark.parametrize("provider", ["openai", "anthropic"])
+def test_cached_text_does_not_remove_native_images(provider):
+    blocks = [
+        {"type": "text", "text": "Exact original"},
+        {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AA=="}},
+    ]
+    message = (
+        {"role": "tool", "tool_call_id": "read", "content": blocks}
+        if provider == "openai"
+        else {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "read", "content": blocks}],
+        }
+    )
+    cache = CompressionCache()
+    cache.store_compressed(cache.content_hash("Exact original"), "Earlier summary", 1)
+    before = copy.deepcopy(message)
+    result = prepare_turn(cache, [message], policy=FREEZE_POLICY_CONFIRMED_CLAMP)
+    assert result.pipeline_input == [before]
+    assert message == before


### PR DESCRIPTION
Pi can lose evidence when compression removes JSON rows without a recovery reference or replaces a recovered original with cached text. Cached mixed content can also lose native images.

This change preserves recovery results across the Pi MCP wrapper, WebSocket deltas, the content router, and the session cache. Mixed compression stores the complete original and includes its reference. Storage failure preserves the original text. Cached references require available originals.

`HEADROOM_IMAGE_OPTIMIZE=0` disables image optimization in the CLI and content router. Mixed native content bypasses text-only cache replacement.
`HEADROOM_COMPRESS_USER_MESSAGES=0` also overrides the aggressive profile default.

Validation:

- 366 regression tests pass. One optional Anthropic API test skips because `ANTHROPIC_API_KEY` is absent.
- Ruff and `git diff --check` pass.
- An independent review found the cache replacement and image deletion defects. New session preparation tests reproduce and fix both.
- The synthetic Pi test compresses evidence, retrieves its original once, and returns the same required values as the uncompressed baseline.
- All 32 concurrent synthetic compression requests recover exactly. Token savings range from 73.6% to 73.8%.
- Native image bytes remain unchanged in OpenAI and Anthropic payloads.
- The separate Pi MCP suite passes 22 tests, including MP4, MOV, and WebM frame conversion.

The local test command was:

```bash
uv run --no-project --python 3.13 --with pytest --with pytest-asyncio python /tmp/run-headroom-final-tests.py
```

The runner imports this checkout and the installed Headroom 0.37 native wheel. It calls `pytest.main` with the listed files and `-q -ra --import-mode=importlib`.

```text
tests/test_agent_savings.py
tests/test_retrieval_delta_fidelity.py
tests/test_mixed_content_recovery.py
tests/test_mixed_content_sections.py
tests/test_tag_protection_integration.py
tests/test_transforms_content_router.py
tests/test_session_cache_fidelity.py
tests/test_proxy_image_preservation.py
tests/test_ccr_cache_lifetime.py
tests/test_hermes_tool_call_unwrap.py
tests/test_compression_cache.py
tests/test_compression_cache_registry.py
tests/test_cross_turn_cache_safety.py
tests/test_ccr_sqlite_backend.py
tests/test_ccr_row_drop_store_bridge.py
tests/test_ccr_rust_marker_hash_bridge.py
tests/test_ccr_retrieve_history_repair.py
tests/test_ccr_response_handler_openai_responses.py
tests/test_ccr_tool_injection.py
tests/test_ccr_mcp_http.py
tests/test_openai_responses_compression_units.py
tests/test_openai_responses_read_protection.py
tests/test_provider_codex_images.py
tests/test_provider_openai_images.py
tests/test_image_compression_isolation.py
```

The exact-recovery fixture uses 14% more uncached input tokens than bypass because it needs another model call. Payload savings are not total-task savings. These tests do not establish unchanged quality for every lossy result.

The local runtime pins the tested fork revision. Local rollout uses a separate restart command that preserves launchd registration and verifies a new listener. Upstream review and merge remain pending.
