### PR TITLE
fix(langchain): compress user context in wrapped chat models

### DIFF
--- a/headroom/integrations/langchain/chat_model.py
+++ b/headroom/integrations/langchain/chat_model.py
@@ -345,6 +345,7 @@ class HeadroomChatModel(BaseChatModel):
             messages=openai_messages,
             model=model_str,
             model_limit=model_limit,
+            compress_user_messages=True,
         )
 
         # Create metrics

--- a/tests/test_integrations/langchain/test_chat_model.py
+++ b/tests/test_integrations/langchain/test_chat_model.py
@@ -229,6 +229,30 @@ class TestHeadroomChatModel:
             assert len(model._metrics_history) == 1
             assert model._metrics_history[0].tokens_saved == 20
 
+    def test_generate_allows_compression_of_user_context(self, mock_chat_model, sample_messages):
+        """The wrapper must allow long HumanMessage context into the router."""
+        from headroom.integrations import HeadroomChatModel
+        from headroom.providers import OpenAIProvider
+
+        model = HeadroomChatModel(mock_chat_model)
+        model._provider = OpenAIProvider()
+        _ = model.pipeline
+
+        with patch.object(model._pipeline, "apply") as mock_apply:
+            mock_result = MagicMock()
+            mock_result.messages = [
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Long context"},
+            ]
+            mock_result.tokens_before = 100
+            mock_result.tokens_after = 80
+            mock_result.transforms_applied = ["kompress"]
+            mock_apply.return_value = mock_result
+
+            model._generate(sample_messages)
+
+        assert mock_apply.call_args.kwargs["compress_user_messages"] is True
+
     def test_metrics_history_limited(self, mock_chat_model, sample_messages):
         """Metrics history is limited to 100 entries."""
         from headroom.integrations import HeadroomChatModel


### PR DESCRIPTION
## What problem does this solve?

LangChain-wrapped chat models leave user-role context uncompressed because the adapter does not enable the existing user-message compression option.

## What changed?

Forward `compress_user_messages=True` through the LangChain adapter so eligible user context reaches the existing compression pipeline. This enables user-message compression by default in the wrapper; existing router eligibility and protection rules still apply.

## Real behavior proof

- Setup: Linux, Python 3.14, langchain-core 1.6.2, local Headroom native extension, and a mocked LangChain chat model.
- Command: `.venv/bin/pytest -q tests/test_integrations/langchain/test_chat_model.py tests/test_integrations/langchain/test_langchain_1x_compat.py tests/test_content_router_user_blocks.py tests/test_transforms/test_content_router.py`
- Result: 112 passed, 9 skipped; the regression assertion verifies that the adapter forwards the compression option.
- Not tested: a live Hugging Face token, endpoint, or downloaded model weights.

## Maintainer validation

At the current head, the four listed suites pass locally: **112 passed, 9 skipped**. Ruff 0.16.3 check and format check pass on both changed files. An actual wrapper/pipeline probe with a 200-row JSON HumanMessage reduced the local token count from 5,358 to 1,971 and preserved the system instruction. A short `Hello!` remained unchanged (18 to 18 tokens including the system message).

Short inputs are not guaranteed savings, and this change does not reduce provider-generated output tokens. Full remote CI has not run; current GitHub checks cover governance.

Closes #3445