### PR TITLE
fix(tabular): keep each table's schema when a document holds several

### DIFF
--- a/headroom/transforms/tabular_ingest.py
+++ b/headroom/transforms/tabular_ingest.py
@@ -7,6 +7,11 @@ array of records and routes it through the existing, battle-tested
 `SmartCrusher`, which already does lossless ``csv-schema`` compaction first and
 lossy row-drop with reversible ``<<ccr:HASH>>`` markers as a fallback.
 
+A document may hold several tables with prose between them. Each table
+carries its own header row, so they are parsed and rendered separately and
+the text around them is carried through — folding them together filed the
+later header rows as data and dropped the prose entirely.
+
 No new compression algorithm and no new CCR plumbing live here — only the
 text→records bridge.
 """
@@ -24,6 +29,9 @@ from .content_detector import ContentType, detect_content_type
 # Mirrors content_detector's separator-cell pattern (e.g. ``| --- | :--: |``).
 _MD_SEP_CELL = re.compile(r"^:?-{2,}:?$")
 
+# A parsed table: its header row, then its data rows.
+Table = tuple[list[str], list[list[str]]]
+
 
 # ─── Public dataclasses (mirror SearchCompressor / LogCompressor surface) ────
 
@@ -39,6 +47,17 @@ class TabularCompressorConfig:
     min_savings_chars: int = 1
 
 
+@dataclass(frozen=True)
+class Segment:
+    """One piece of a parsed document: a table, or the text around it.
+
+    Exactly one of ``table`` / ``text`` is set.
+    """
+
+    table: Table | None = None
+    text: str | None = None
+
+
 @dataclass
 class TabularCompressionResult:
     """Result of tabular-text compression."""
@@ -50,6 +69,8 @@ class TabularCompressionResult:
     rows: int
     columns: int
     strategy: str = "tabular"
+    # Number of distinct tables found. > 1 means each kept its own schema.
+    tables: int = 1
 
     @property
     def compression_ratio(self) -> float:
@@ -71,6 +92,75 @@ def parse_csv(content: str, delimiter: str = ",") -> tuple[list[str], list[list[
     return headers, parsed[1:]
 
 
+def split_csv_blocks(content: str, delimiter: str = ",") -> list[list[list[str]]]:
+    """Split delimited text into blocks at blank-line boundaries.
+
+    Goes through the csv reader rather than splitting raw lines so a blank
+    line inside a quoted field stays part of its cell.
+    """
+    blocks: list[list[list[str]]] = []
+    current: list[list[str]] = []
+    for row in csv.reader(io.StringIO(content), delimiter=delimiter):
+        if any(cell.strip() for cell in row):
+            current.append(row)
+        elif current:
+            blocks.append(current)
+            current = []
+    if current:
+        blocks.append(current)
+    return blocks
+
+
+def parse_csv_tables(content: str, delimiter: str = ",") -> list[Table] | None:
+    """Parse delimited text into one table per blank-line-separated block.
+
+    Returns ``None`` if any block is unusable — a header with no rows under
+    it, or ragged rows that can't be zipped under the headers without
+    shifting values into the wrong column (#1652) — so the caller passes the
+    text through verbatim rather than emitting something the original never
+    said.
+
+    Tables run together with no blank line between them are indistinguishable
+    from one table that happens to contain a row of column names, so they
+    stay a single table.
+    """
+    tables: list[Table] = []
+    for block in split_csv_blocks(content, delimiter):
+        if len(block) < 2:
+            return None
+        headers = [h.strip() for h in block[0]]
+        rows = block[1:]
+        width = len(headers)
+        if not width or any(len(row) != width for row in rows):
+            return None
+        tables.append((headers, rows))
+    return tables or None
+
+
+def parse_tabular_segments(
+    content: str,
+    fmt: str,
+    delimiter: str = ",",
+) -> list[Segment] | None:
+    """Ordered segments for a tabular document, whatever its format.
+
+    Markdown can carry prose between its tables; the delimited and
+    fixed-width formats carry tables only.
+    """
+    if fmt == "markdown":
+        return parse_markdown_segments(content) or None
+    if fmt == "fixed_width":
+        headers, rows = parse_fixed_width(content)
+        width = len(headers)
+        if not headers or not rows or any(len(row) != width for row in rows):
+            return None
+        return [Segment(table=(headers, rows))]
+    tables = parse_csv_tables(content, delimiter)
+    if tables is None:
+        return None
+    return [Segment(table=table) for table in tables]
+
+
 def parse_markdown_table(content: str) -> tuple[list[str], list[list[str]]]:
     """Parse a markdown table, dropping the ``|---|`` separator row."""
 
@@ -87,6 +177,51 @@ def parse_markdown_table(content: str) -> tuple[list[str], list[list[str]]]:
     headers = split_row(lines[0])
     rows = [split_row(ln) for ln in lines[1:] if not is_separator(ln)]
     return headers, rows
+
+
+def split_markdown_segments(content: str) -> list[tuple[str, str]]:
+    """Split markdown into ordered ``("table" | "text", block)`` segments.
+
+    ``parse_markdown_table`` keeps every line holding a pipe and discards
+    the rest, so a document with several tables collapsed into one — the
+    later header rows landing as data — and the headings between them
+    vanished. Splitting on pipe/non-pipe runs first keeps each table whole
+    and keeps the prose around them.
+    """
+    segments: list[tuple[str, str]] = []
+    buf: list[str] = []
+    kind: str | None = None
+
+    for line in content.split("\n"):
+        line_kind = "table" if "|" in line and line.strip() else "text"
+        if kind is not None and line_kind != kind:
+            segments.append((kind, "\n".join(buf)))
+            buf = []
+        kind = line_kind
+        buf.append(line)
+    if kind is not None and buf:
+        segments.append((kind, "\n".join(buf)))
+
+    return [(k, block) for k, block in segments if block.strip()]
+
+
+def parse_markdown_segments(content: str) -> list[Segment]:
+    """Parse markdown into ordered text blocks and well-formed tables.
+
+    A pipe run that does not parse into a rectangular table — a lone pipe
+    inside a sentence, or ragged rows that would shift values under the
+    wrong column (#1652) — stays a text block rather than being guessed at.
+    """
+    parsed: list[Segment] = []
+    for kind, block in split_markdown_segments(content):
+        if kind == "table":
+            headers, rows = parse_markdown_table(block)
+            width = len(headers)
+            if headers and rows and all(len(row) == width for row in rows):
+                parsed.append(Segment(table=(headers, rows)))
+                continue
+        parsed.append(Segment(text=block))
+    return parsed
 
 
 def parse_fixed_width(content: str) -> tuple[list[str], list[list[str]]]:
@@ -144,6 +279,32 @@ def parse_tabular(
     return headers, rows, fmt
 
 
+def segments_to_document(segments: list[Segment]) -> dict[str, object]:
+    """Build an ordered JSON document from parsed markdown segments.
+
+    Each table becomes a record array keyed by its first column, so
+    SmartCrusher's walker renders it as its own CSV+schema block. Text
+    blocks keep their place under ``_text{n}`` keys so nothing between
+    the tables is lost. Insertion order is the document's order.
+    """
+    document: dict[str, object] = {}
+    text_n = 0
+    for segment in segments:
+        if segment.table is None:
+            text_n += 1
+            document[f"_text{text_n}"] = segment.text
+            continue
+        headers, rows = segment.table
+        key = headers[0].strip() or "table"
+        if key in document:
+            n = 2
+            while f"{key}_{n}" in document:
+                n += 1
+            key = f"{key}_{n}"
+        document[key] = to_records(headers, rows)
+    return document
+
+
 # ─── Compressor (text → records → SmartCrusher) ──────────────────────────────
 
 
@@ -163,18 +324,28 @@ class TabularCompressor:
         context: str = "",
         bias: float = 1.0,
     ) -> TabularCompressionResult:
-        parsed = parse_tabular(content)
-        if parsed is None:
-            return TabularCompressionResult(
-                compressed=content,
-                original=content,
-                was_modified=False,
-                fmt="unknown",
-                rows=0,
-                columns=0,
-            )
+        detection = detect_content_type(content)
+        if detection.content_type is not ContentType.TABULAR:
+            return self._passthrough(content, "unknown", 0, 0, 0)
 
-        headers, rows, fmt = parsed
+        fmt = detection.metadata.get("format", "csv")
+        delimiter = detection.metadata.get("delimiter", ",")
+        segments = parse_tabular_segments(content, fmt, delimiter)
+        if segments is None:
+            return self._passthrough(content, "unknown", 0, 0, 0)
+
+        tables = [seg.table for seg in segments if seg.table is not None]
+        has_text = any(seg.table is None for seg in segments)
+        if not tables:
+            return self._passthrough(content, "unknown", 0, 0, 0)
+
+        # More than one table, or prose to preserve, needs the document
+        # walker: one schema per table instead of one schema for all.
+        if len(tables) > 1 or has_text:
+            return self._compress_document(content, segments, fmt, tables)
+
+        headers, rows = tables[0]
+
         records = to_records(headers, rows)
         json_str = json.dumps(records, ensure_ascii=False)
 
@@ -193,14 +364,7 @@ class TabularCompressor:
         # source, so only adopt the result when it genuinely saves bytes.
         savings = len(content) - len(result.compressed)
         if not result.was_modified or savings < self.config.min_savings_chars:
-            return TabularCompressionResult(
-                compressed=content,
-                original=content,
-                was_modified=False,
-                fmt=fmt,
-                rows=len(rows),
-                columns=len(headers),
-            )
+            return self._passthrough(content, fmt, len(rows), len(headers), 1)
 
         return TabularCompressionResult(
             compressed=result.compressed,
@@ -212,14 +376,73 @@ class TabularCompressor:
             strategy=result.strategy or "tabular",
         )
 
+    def _compress_document(
+        self,
+        content: str,
+        segments: list[Segment],
+        fmt: str,
+        tables: list[Table],
+    ) -> TabularCompressionResult:
+        """Render a multi-table / prose-bearing document losslessly."""
+        total_rows = sum(len(rows) for _, rows in tables)
+        widest = max(len(headers) for headers, _ in tables)
+
+        from .smart_crusher import SmartCrusher
+
+        crusher = SmartCrusher(
+            with_compaction=True,
+            compaction_format=self.config.compaction_format,
+        )
+        document = segments_to_document(segments)
+        compressed = crusher.compact_document_json(json.dumps(document, ensure_ascii=False))
+
+        savings = len(content) - len(compressed)
+        if savings < self.config.min_savings_chars:
+            return self._passthrough(content, fmt, total_rows, widest, len(tables))
+
+        return TabularCompressionResult(
+            compressed=compressed,
+            original=content,
+            was_modified=True,
+            fmt=fmt,
+            rows=total_rows,
+            columns=widest,
+            tables=len(tables),
+        )
+
+    @staticmethod
+    def _passthrough(
+        content: str,
+        fmt: str,
+        rows: int,
+        columns: int,
+        tables: int,
+    ) -> TabularCompressionResult:
+        return TabularCompressionResult(
+            compressed=content,
+            original=content,
+            was_modified=False,
+            fmt=fmt,
+            rows=rows,
+            columns=columns,
+            tables=tables,
+        )
+
 
 __all__ = [
+    "Segment",
     "TabularCompressor",
     "TabularCompressorConfig",
     "TabularCompressionResult",
     "parse_csv",
     "parse_markdown_table",
     "parse_fixed_width",
+    "parse_csv_tables",
+    "parse_markdown_segments",
     "parse_tabular",
+    "parse_tabular_segments",
+    "segments_to_document",
+    "split_csv_blocks",
+    "split_markdown_segments",
     "to_records",
 ]

--- a/tests/test_transforms_tabular.py
+++ b/tests/test_transforms_tabular.py
@@ -26,12 +26,18 @@ from headroom.transforms.content_router import (
     ContentRouterConfig,
 )
 from headroom.transforms.tabular_ingest import (
+    Segment,
     TabularCompressionResult,
     TabularCompressor,
     parse_csv,
+    parse_csv_tables,
     parse_fixed_width,
+    parse_markdown_segments,
     parse_markdown_table,
     parse_tabular,
+    segments_to_document,
+    split_csv_blocks,
+    split_markdown_segments,
     to_records,
 )
 
@@ -376,3 +382,145 @@ def test_load_spreadsheet_missing_file(tmp_path) -> None:
 
     with pytest.raises(FileNotFoundError):
         load_spreadsheet(tmp_path / "nope.xlsx")
+
+
+# Multi-table markdown -------------------------------------------------------
+
+
+def _multi_table_doc(rows: int = 30) -> str:
+    """Two headed tables with prose between them, big enough to compress."""
+    team = "\n".join(f"| Person {i} | Role number {i} |" for i in range(rows))
+    voice = "\n".join(f"| Audience {i} | Tone descriptor {i} |" for i in range(rows))
+    return (
+        "## Team\n\n| Name | Role |\n| --- | --- |\n" + team + "\n\n"
+        "## Voice\n\n| Audience | Tone |\n| --- | --- |\n" + voice + "\n"
+    )
+
+
+def test_split_markdown_segments_separates_tables_from_prose() -> None:
+    kinds = [kind for kind, _ in split_markdown_segments(_multi_table_doc(2))]
+    assert kinds == ["text", "table", "text", "table"]
+
+
+def test_parse_markdown_segments_keeps_each_header_row() -> None:
+    segments = parse_markdown_segments(_multi_table_doc(2))
+    tables = [seg.table for seg in segments if seg.table is not None]
+    assert [headers for headers, _ in tables] == [["Name", "Role"], ["Audience", "Tone"]]
+    # The second table's header must not appear as a row of the first.
+    assert ["Audience", "Tone"] not in tables[0][1]
+
+
+def test_parse_markdown_segments_demotes_ragged_block_to_text() -> None:
+    # A pipe inside prose is not a table; keep it verbatim rather than guess.
+    segments = parse_markdown_segments("a sentence with a | pipe in it")
+    assert segments == [Segment(text="a sentence with a | pipe in it")]
+
+
+def test_compress_gives_each_table_its_own_schema() -> None:
+    result = TabularCompressor().compress(_multi_table_doc())
+    assert result.was_modified
+    assert result.tables == 2
+    # One schema per table, and no header row smuggled in as data.
+    assert result.compressed.count("[30]{") == 2
+    assert "Audience,Tone" not in result.compressed
+
+
+def test_compress_preserves_prose_between_tables() -> None:
+    result = TabularCompressor().compress(_multi_table_doc())
+    assert "## Team" in result.compressed
+    assert "## Voice" in result.compressed
+
+
+def test_compress_multi_table_keeps_every_cell() -> None:
+    doc = _multi_table_doc()
+    result = TabularCompressor().compress(doc)
+    cells = [
+        cell.strip()
+        for line in doc.split("\n")
+        if "|" in line and "---" not in line
+        for cell in line.strip().strip("|").split("|")
+    ]
+    missing = [c for c in cells if c and c not in result.compressed]
+    assert missing == []
+
+
+def test_segments_to_document_disambiguates_repeated_first_column() -> None:
+    table = (["Name", "Role"], [["Ann", "COO"]])
+    document = segments_to_document([Segment(table=table), Segment(table=table)])
+    assert list(document) == ["Name", "Name_2"]
+
+
+def test_compress_single_table_without_prose_is_unchanged_path() -> None:
+    # A lone table with no surrounding text keeps the original record-array
+    # path, so existing single-table output stays byte-identical.
+    result = TabularCompressor().compress(_verbose_markdown(40))
+    assert result.was_modified
+    assert result.tables == 1
+    assert not result.compressed.startswith("{")
+
+
+# Multi-table CSV ------------------------------------------------------------
+
+
+def _multi_table_csv(rows: int = 40) -> str:
+    team = "\n".join(f"Person{i},Role number {i}" for i in range(rows))
+    voice = "\n".join(f"Audience{i},Tone descriptor {i}" for i in range(rows))
+    return "Name,Role\n" + team + "\n\nAudience,Tone\n" + voice
+
+
+def test_split_csv_blocks_breaks_on_blank_lines() -> None:
+    blocks = split_csv_blocks("a,b\n1,2\n\nc,d\n3,4")
+    assert blocks == [[["a", "b"], ["1", "2"]], [["c", "d"], ["3", "4"]]]
+
+
+def test_split_csv_blocks_keeps_blank_line_inside_quoted_field() -> None:
+    # A blank line within a quoted cell is part of the value, not a boundary.
+    blocks = split_csv_blocks('a,b\n1,"line one\n\nline two"')
+    assert len(blocks) == 1
+    assert blocks[0][1][1] == "line one\n\nline two"
+
+
+def test_parse_csv_tables_splits_each_block() -> None:
+    tables = parse_csv_tables(_multi_table_csv(2))
+    assert tables is not None
+    assert [headers for headers, _ in tables] == [["Name", "Role"], ["Audience", "Tone"]]
+
+
+def test_parse_csv_tables_rejects_header_only_block() -> None:
+    # Dropping a header with no rows would lose content; pass through instead.
+    assert parse_csv_tables("a,b\n1,2\n\nc,d") is None
+
+
+def test_parse_csv_tables_rejects_ragged_block() -> None:
+    assert parse_csv_tables("a,b\n1,2\n\nc,d\n3,4,5") is None
+
+
+def test_compress_csv_gives_each_table_its_own_schema() -> None:
+    result = TabularCompressor().compress(_multi_table_csv())
+    if result.was_modified:
+        assert result.tables == 2
+        assert "\nAudience,Tone\n" not in result.compressed
+    else:
+        # Already-compact CSV may not beat its own source; passthrough is
+        # correct, but it must still have seen two tables, not one merged one.
+        assert result.tables == 2
+
+
+@pytest.mark.parametrize("tables", [1, 2, 3])
+@pytest.mark.parametrize("rows", [3, 60])
+def test_compress_never_drops_a_cell(tables: int, rows: int) -> None:
+    blocks = []
+    for t in range(tables):
+        body = "\n".join(f"| v{t}_{i}_x | v{t}_{i}_y |" for i in range(rows))
+        blocks.append(f"## Section {t}\n\n| H{t}a | H{t}b |\n| --- | --- |\n{body}")
+    doc = "\n\n".join(blocks)
+
+    result = TabularCompressor().compress(doc)
+    cells = [
+        cell.strip()
+        for line in doc.split("\n")
+        if "|" in line and "---" not in line
+        for cell in line.strip().strip("|").split("|")
+    ]
+    assert [c for c in cells if c and c not in result.compressed] == []
+    assert all(f"## Section {t}" in result.compressed for t in range(tables))


### PR DESCRIPTION
## The bug

A document holding more than one table collapses into a single table, and the
text between the tables is dropped.

`parse_markdown_table` keeps every line containing a `|` and discards the rest,
and `parse_csv` treats only the first row as headers. So the second and later
header rows are filed as **data**, and every row beneath them is relabelled
under the first table's columns.

A three-table brief compressed to this — note `Audience,Tone` and `Type,Format`
sitting in the roster as though they were people, under a schema claiming all
25 rows are `{Name, Role}`:

```
[25]{Name:string,Role:string}
Beth Prine,COO
...
Audience,Tone
Patients,"Warm, simple, reassuring"
...
Type,Format
Email,Subject + 3 short paragraphs + CTA
```

It round-trips through a CSV parser cleanly and every value survives, so
nothing downstream notices — but the schema is wrong, and a model reading it
back will state that Audience is a member of staff.

## Reproduction

```python
from headroom.transforms.tabular_ingest import TabularCompressor

t1 = "\n".join(f"| Person {i} | Role number {i} |" for i in range(30))
t2 = "\n".join(f"| Audience {i} | Tone descriptor {i} |" for i in range(30))
doc = ("## Team\n\n| Name | Role |\n| --- | --- |\n" + t1 +
       "\n\n## Voice\n\n| Audience | Tone |\n| --- | --- |\n" + t2)

r = TabularCompressor().compress(doc)
assert "Audience,Tone" not in r.compressed   # fails on main
assert "## Voice" in r.compressed            # fails on main
```

Both assertions fail before this change and pass after.

The loss only shows above the `min_savings_chars` threshold: at small sizes the
result is rejected and passed through, so the corruption appears exactly when
the compressor is doing its job.

## The change

Markdown is split into ordered table/text segments, and delimited text into
blank-line-separated blocks, so each table keeps its own header and renders as
its own CSV+schema block while the prose around it is carried through.

Anything ambiguous passes through verbatim rather than being guessed at,
following the #1652 invariant that a compressed table must never state facts
the original didn't:

- a pipe run that isn't a clean rectangle (a `|` inside a sentence)
- a header row with no rows under it
- a ragged block

CSV block splitting goes through the `csv` reader rather than splitting raw
lines, so a blank line inside a quoted field stays part of its cell.

Single-table documents with no surrounding prose keep the original
record-array path, so their output is byte-identical.

### Known limitation

CSV tables run together with **no** blank line between them are
indistinguishable from one table that happens to contain a row of column
names, so they stay merged. There's no signal to separate them; this is noted
in `parse_csv_tables`.

## Tests

`tests/test_transforms_tabular.py`: 39 → 59. New coverage for segment
splitting, quoted-field blank lines, header-only and ragged block rejection,
per-table schemas for both markdown and CSV, and a parametrized property test
asserting no cell or heading is ever dropped across table counts and sizes.

## Verified on

- macOS 15 (Darwin 25.6.0), Python 3.13.15, headroom-ai 0.37.0
- 59 passing in `test_transforms_tabular.py`; 134 across `test_compress_api`,
  `test_compression_decision`, `test_builtin_compressor_adapters`,
  `test_compression_batches`
- `ruff check`, `ruff format`, and `mypy --disallow-untyped-defs
  --warn-return-any` clean on the changed module
- Beyond unit tests: ran the patched module in the installed uv tool venv and
  confirmed the real `TabularCompressor` output through a fresh interpreter —
  two schema blocks, headings preserved, no header-row leak

## Not tested

- **The full suite.** The Rust `headroom._core` extension isn't built in my
  checkout, so I ran against a prebuilt `_core.abi3.so` with the checkout ahead
  of it on `PYTHONPATH`. In that hybrid setup `tests/test_compress_passthrough.py`
  fails 5 tests **on unmodified `main` as well** — baseline noise from my
  environment, not this change. Worth a maintainer confirming under real CI.
- The proxy/server path end-to-end; I exercised `TabularCompressor` directly.
- Multi-table **fixed-width** input, which `detect_content_type` classifies as
  `PLAIN_TEXT` and so never reaches this code. Left as a single table.
- Any platform other than macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)