### PR TITLE
fix(release): use Node 24 for npm packaging and publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "24"
+          node-version: ">=24.16.0 <25"
 
       - name: Sync version to package files
         run: |
@@ -807,7 +807,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "24"
+          node-version: ">=24.16.0 <25"
           registry-url: ${{ env.NPM_REGISTRY_URL }}
 
       # No artifact download required: the publish steps below pack and
@@ -899,7 +899,7 @@ jobs:
       - name: Set up Node.js for GitHub Package Registry
         uses: actions/setup-node@v7
         with:
-          node-version: "24"
+          node-version: ">=24.16.0 <25"
           registry-url: ${{ env.GITHUB_PACKAGES_REGISTRY_URL }}
 
       # No artifact download required: the publish-github-packages flow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Sync version to package files
         run: |
@@ -807,7 +807,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: ${{ env.NPM_REGISTRY_URL }}
 
       # No artifact download required: the publish steps below pack and
@@ -899,7 +899,7 @@ jobs:
       - name: Set up Node.js for GitHub Package Registry
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: ${{ env.GITHUB_PACKAGES_REGISTRY_URL }}
 
       # No artifact download required: the publish-github-packages flow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Sync version to package files
         run: |
@@ -807,7 +807,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: ${{ env.NPM_REGISTRY_URL }}
 
       # No artifact download required: the publish steps below pack and
@@ -899,7 +899,7 @@ jobs:
       - name: Set up Node.js for GitHub Package Registry
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: ${{ env.GITHUB_PACKAGES_REGISTRY_URL }}
 
       # No artifact download required: the publish-github-packages flow


### PR DESCRIPTION
## Description

The release npm jobs must use a runtime compatible with current build dependencies and OpenClaw 2026.9.3, whose Node engine range is `>=24.16.0 <25 || >=26.1.0`. Select `>=24.16.0 <25` for release asset building and both npm publishing jobs. The explicit floor prevents an older cached Node 24 installation from missing OpenClaw's minimum.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Update all three release workflow Node settings to `>=24.16.0 <25`.

## Testing

- [x] Manual testing performed
- [x] Release workflow tests pass

### Test Output

```text
Clean node:24-bookworm container: Node 24.21.0 / npm 11.19.0
npm_config_engine_strict=true
Built and verified npm release assets for 0.39.0
OpenClaw 2026.9.3 (1391f7c)
OpenClaw 2026.9.3 and release plugin import passed
SDK, OpenClaw, OpenCode: npm ci + build + npm pack --dry-run passed on Node 24
pytest --noconftest tests/test_release_workflows.py -q: 50 passed
actionlint -shellcheck= -pyflakes= .github/workflows/release.yml: passed
git diff --check: clean
```

## Real Behavior Proof

- Environment: clean Linux `node:24-bookworm` container, with current main's source (4263da12b) incorporated into this branch.
- Exact command: `npm_config_engine_strict=true node scripts/build_npm_release_assets.mjs 0.39.0 /validation/assets`.
- Observed result: SDK and OpenClaw plugin tarballs built and verified, including release metadata, clean installation, and the plugin import contract. In another clean directory, installed both tarballs together with `openclaw@2026.9.3`, ran its CLI version command, and imported the plugin successfully with engine checks enforced.
- Scope: OpenClaw is an optional peer of the Headroom plugin, so ordinary packaging does not itself prove host compatibility; the separate explicit host installation covers that distinction.
- Not tested: actual registry publication. Hosted PR release dry-runs keep publishing disabled.

## Runtime Rollout Safety

- Rollout-managed features: N/A; release tooling only.
- Rollback path: revert the workflow change.

## Review Readiness

- [x] I have performed a self-review
- [x] Independent review checked all release Node setup sites
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I did **not** edit `CHANGELOG.md`

Hosted release packaging passed at 229f42640e2fad3e16c59362189cd01ad1cea8e4 using Node 24.20.0/npm 11.19.0, including npm artifact verification: https://github.com/headroomlabs-ai/headroom/actions/runs/34487541081/job/102906829879. The full hosted Release dry-run passed, including all five platform wheel builds and seven import checks. General CI passed, including all four test shards, optional-extras/Agno/dashboard tests, workflow validation, and Docker-native installer/compose/wrap/init E2E. Publishing was intentionally skipped. CI run: https://github.com/headroomlabs-ai/headroom/actions/runs/34487540306. Leave this PR unmerged.



