### PR TITLE
fix(learn): show both ends of CLI output on a parse failure

### DIFF
--- a/headroom/learn/analyzer.py
+++ b/headroom/learn/analyzer.py
@@ -602,6 +602,28 @@ def _strip_fenced_json(raw: str) -> dict:
     return result
 
 
+def _output_snippet(text: str, limit: int = _MAX_SNIPPET_LEN) -> str:
+    """Bounded excerpt of CLI output showing BOTH ends.
+
+    A head-only excerpt cannot diagnose the failure it is attached to. When a
+    model's JSON answer does not parse, the head is valid-looking JSON in every
+    case: what tells a payload truncated mid-value from one with trailing prose
+    after the closing fence is the END of it. Same reasoning as
+    :func:`_failure_detail` tailing stdout -- CLI backends put the interesting
+    part last -- except a parse failure needs the head too, because that is
+    where a wrapper (a fence, a preamble) shows up.
+
+    Returns *text* unchanged when it already fits, so short output -- the common
+    case -- reads exactly as before.
+    """
+    if len(text) <= limit:
+        return text
+    head = limit // 2
+    tail = limit - head
+    omitted = len(text) - limit
+    return f"{text[:head]}\n...[{omitted} chars omitted]...\n{text[-tail:]}"
+
+
 def _failure_detail(
     stderr: str | None, stdout: str | None, *, result_text: str | None = None
 ) -> str:
@@ -725,10 +747,10 @@ def _call_cli_llm(
     try:
         return _strip_fenced_json(result.stdout)
     except json.JSONDecodeError as exc:
-        stdout_snippet = (result.stdout or "")[:_MAX_SNIPPET_LEN]
+        stdout_snippet = _output_snippet(result.stdout or "")
         raise RuntimeError(
             f"`{' '.join(cmd)}` returned unparseable output. "
-            f"First {_MAX_SNIPPET_LEN} chars:\n{stdout_snippet}"
+            f"Head and tail of the output:\n{stdout_snippet}"
         ) from exc
 
 
@@ -894,19 +916,19 @@ def _call_claude_cli_streaming(
         logger.debug("CLI stderr (exit 0): %s", stderr_blob[:_MAX_SNIPPET_LEN])
 
     if final_result is None:
-        stdout_snippet = "".join(stdout_lines)[:_MAX_SNIPPET_LEN]
+        stdout_snippet = _output_snippet("".join(stdout_lines))
         raise RuntimeError(
             f"`{' '.join(cmd)}` did not emit a final `result` event. "
-            f"First {_MAX_SNIPPET_LEN} chars of stdout:\n{stdout_snippet}"
+            f"Head and tail of stdout:\n{stdout_snippet}"
         )
 
     try:
         return _strip_fenced_json(final_result)
     except json.JSONDecodeError as exc:
-        snippet = final_result[:_MAX_SNIPPET_LEN]
+        snippet = _output_snippet(final_result)
         raise RuntimeError(
             f"`{' '.join(cmd)}` returned unparseable output. "
-            f"First {_MAX_SNIPPET_LEN} chars:\n{snippet}"
+            f"Head and tail of the output:\n{snippet}"
         ) from exc
 
 

--- a/tests/test_learn/test_analyzer.py
+++ b/tests/test_learn/test_analyzer.py
@@ -15,6 +15,7 @@ from headroom.learn.analyzer import (
     _call_cli_llm,
     _call_llm,
     _detect_default_model,
+    _output_snippet,
     _parse_llm_response,
     _resolve_timeout_secs,
     _strip_fenced_json,
@@ -970,6 +971,31 @@ class TestCallCliLlm:
         ):
             with pytest.raises(RuntimeError, match="unparseable output"):
                 _call_cli_llm("test digest", "claude-cli")
+
+    def test_claude_cli_unparseable_result_shows_both_ends(self):
+        # A head-only excerpt of a long answer is valid-looking JSON in every
+        # case; the reason it did not parse -- truncated mid-value, or prose
+        # after the closing fence -- is only visible at the end.
+        payload = '```json\n{"context_file_rules": [' + '{"section": "x"}, ' * 400 + "]}\n```"
+        payload += "\n\nLet me know if you want this in another shape!"
+        with patch(
+            "headroom.learn.analyzer.subprocess.Popen",
+            _fake_claude_popen(stdout_lines=[_result_event(payload)]),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                _call_cli_llm("test digest", "claude-cli")
+        message = str(exc_info.value)
+        assert "unparseable output" in message
+        assert "```json" in message, "head is missing"
+        assert "another shape" in message, "tail is missing"
+        assert "chars omitted" in message
+        # Still bounded: the excerpt cannot grow with the payload.
+        assert len(message) < len(payload)
+
+    def test_output_snippet_leaves_short_output_alone(self):
+        assert _output_snippet("short") == "short"
+        edge = "x" * 2000
+        assert _output_snippet(edge) == edge
 
     def test_claude_cli_not_installed_raises(self):
         popen = MagicMock(side_effect=FileNotFoundError("No such file or directory: 'claude'"))


### PR DESCRIPTION
## Description

`_call_cli_llm` and `_call_claude_cli_streaming` attach a HEAD-only excerpt of
the CLI's output to their parse failures ("returned unparseable output. First
2000 chars:", "did not emit a final `result` event"). For those two failures
specifically, the head is the one part that is never diagnostic: a model's JSON
answer that does not parse looks like valid JSON for its first 2000 chars in
every case. What separates a payload truncated mid-value from one with prose
after the closing fence is the END of it, and that is exactly what gets cut.

This is not hypothetical. Downstream (the Headroom desktop app) these
RuntimeErrors are reported with the CLI's stderr attached, and a real report
arrived with 2000 characters of well-formed ```json ... and no way to tell which
of the two shapes it was, so the defect could not be acted on at all.

`_failure_detail` already makes this argument for the non-zero-exit path ("stdout
is tailed rather than headed because CLI backends emit the error last"). This
extends the same reasoning to the parse failures, which need both ends: the head
is where a wrapper (fence, preamble) shows up, the tail is where the break is.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `_output_snippet(text, limit=_MAX_SNIPPET_LEN)`: returns short output
  unchanged, otherwise `head + "...[N chars omitted]..." + tail`, still bounded
  by the same `_MAX_SNIPPET_LEN` budget.
- Used it at the three sites that excerpt CLI OUTPUT for a parse failure: the
  non-streaming unparseable stdout, the missing final `result` event, and the
  unparseable `result` text.
- Reworded those messages from "First 2000 chars:" to "Head and tail of the
  output:". Deliberately no counts in the marker line: downstream groups these
  errors by that line, so a length in it would open a new group per failure.
- Left the stderr excerpts and `_failure_detail` alone.

## Testing

- [x] Unit tests pass (`pytest`)

### Test Output

```text
uv run --frozen --extra dev pytest tests/test_learn/ -q
260 passed, 4 skipped in 11.02s
```

## Real Behavior Proof

- Environment: macOS 15, Python 3.12, uv --frozen, headroom main @ 4e1f7769
- Exact command / steps: Added `test_claude_cli_unparseable_result_shows_both_ends`, which feeds `_call_cli_llm` a claude-cli `result` event carrying a ~7 KB fenced JSON payload followed by trailing prose (the shape that cannot be diagnosed today), then ran `uv run --frozen --extra dev pytest tests/test_learn/test_analyzer.py -q`.
- Observed result: 97 passed. The RuntimeError now contains both the opening ```json fence and the trailing "another shape" prose, plus a "chars omitted" marker, and stays shorter than the payload. Before the change the same assertion on the tail fails, since the message stopped at 2000 chars.
- Not tested: A live `claude -p` run against a real API failure; the CLI is mocked, as in the surrounding tests.

## Runtime Rollout Safety

- Rollout-managed feature(s): None.
- Minimum rollout channel: Stable.
- Stable/default behavior changed: No. Only the text of three error messages; short output is byte-identical to before.
- Kill switch / disable path: Not applicable; no flag, no new dependency, no I/O.
- Unsafe override required: No.
- Qualification impact: None. `headroom learn` success paths are untouched.
- Rollback path: Revert this commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
