### PR TITLE
fix(telemetry): keep install ID stateless

### DIFF
--- a/headroom/telemetry/session.py
+++ b/headroom/telemetry/session.py
@@ -210,6 +210,11 @@ def install_id() -> str:
     with _identity_lock:
         if _install_id is not None:
             return _install_id
+        from headroom import paths
+
+        if paths.process_is_stateless():
+            _install_id = uuid.uuid4().hex
+            return _install_id
         path = _install_id_path()
         try:
             existing = path.read_text().strip()

--- a/tests/test_stateless_writers.py
+++ b/tests/test_stateless_writers.py
@@ -53,6 +53,18 @@ def test_process_stateless_env(monkeypatch, value, expected):
     assert paths.process_is_stateless() is expected
 
 
+def test_install_id_stays_in_memory_when_stateless(tmp_path, monkeypatch):
+    from headroom.telemetry import session
+
+    workspace = tmp_path / "state"
+    monkeypatch.setenv("HEADROOM_WORKSPACE_DIR", str(workspace))
+    monkeypatch.setattr(session, "_install_id", None)
+    paths.set_process_stateless(True)
+
+    assert len(session.install_id()) == 32
+    assert not workspace.exists()
+
+
 # ---- output-savings recorder ----------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- keep `install_id()` process-local when Headroom is stateless
- prevent disabled telemetry setup from creating `HEADROOM_WORKSPACE_DIR/config/install_id`
- add a regression test for the no-write invariant

## Reproduction

Start a stateless proxy with `HEADROOM_WORKSPACE_DIR` pointing at a missing directory. Creating telemetry resource attributes calls `install_id()` even when telemetry export is disabled, which creates `config/install_id` under that directory.

## Real behavior proof

- Setup: Windows 10, Python 3.13.7, current `main` (`04cdf79a`), `HEADROOM_STATELESS=true`
- Before fix: an mcodex-wrapped Headroom session created `state/config/install_id`; the wrapper rejected the persistent state root on exit.
- After fix:
  - `uv run --frozen --extra dev pytest tests/test_stateless_writers.py -q` → `13 passed`
  - `uv run --frozen ruff check headroom/telemetry/session.py tests/test_stateless_writers.py` → passed
  - `uv run --frozen ruff format --check headroom/telemetry/session.py tests/test_stateless_writers.py` → 2 files already formatted
- Not tested: non-Windows live proxy traffic against an external provider.
