### PR TITLE
fix(proxy): emit native Anthropic buffered SSE

### DIFF
--- a/headroom/proxy/handlers/anthropic.py
+++ b/headroom/proxy/handlers/anthropic.py
@@ -4837,10 +4837,11 @@ class AnthropicHandlerMixin:
 
                             try:
                                 sse_events = self._response_to_sse(resp_json, "anthropic")
-                            except ValueError as sse_err:
+                            except Exception as sse_err:
                                 logger.warning(
                                     f"[{request_id}] CCR: Failed to convert buffered response "
-                                    f"to SSE: {sse_err}"
+                                    f"to SSE: {sse_err}",
+                                    exc_info=True,
                                 )
 
                                 async def _conversion_error_sse():

--- a/headroom/proxy/handlers/streaming.py
+++ b/headroom/proxy/handlers/streaming.py
@@ -651,6 +651,7 @@ class StreamingMixin:
                 "model": response.get("model", "unknown"),
                 "content": [],
                 "stop_reason": None,
+                "stop_sequence": None,
                 "usage": response.get("usage", {}),
             },
         }
@@ -674,12 +675,12 @@ class StreamingMixin:
                     "index": idx,
                     "content_block": {"type": "text", "text": ""},
                 }
-            elif block.get("type") == "tool_use":
+            elif block.get("type") in ("tool_use", "server_tool_use"):
                 block_start = {
                     "type": "content_block_start",
                     "index": idx,
                     "content_block": {
-                        "type": "tool_use",
+                        "type": block["type"],
                         "id": block.get("id", f"toolu_{idx}"),
                         "name": block.get("name", ""),
                         "input": {},
@@ -690,8 +691,6 @@ class StreamingMixin:
                     "type": "thinking",
                     "thinking": "",
                 }
-                if "signature" in block:
-                    content_block["signature"] = block["signature"]
                 block_start = {
                     "type": "content_block_start",
                     "index": idx,
@@ -705,12 +704,6 @@ class StreamingMixin:
                         "type": "redacted_thinking",
                         "data": block.get("data", ""),
                     },
-                }
-            elif block.get("type") == "server_tool_use":
-                block_start = {
-                    "type": "content_block_start",
-                    "index": idx,
-                    "content_block": block,
                 }
             else:
                 block_start = {
@@ -740,13 +733,16 @@ class StreamingMixin:
                     events.append(
                         f"event: content_block_delta\ndata: {json.dumps(citation_delta)}\n\n".encode()
                     )
-            elif block.get("type") == "tool_use" and block.get("input"):
+            elif block.get("type") in ("tool_use", "server_tool_use"):
+                tool_input = block.get("input", {})
+                if not isinstance(tool_input, dict):
+                    raise TypeError(f"Anthropic {block.get('type')} input must be an object")
                 delta = {
                     "type": "content_block_delta",
                     "index": idx,
                     "delta": {
                         "type": "input_json_delta",
-                        "partial_json": json.dumps(block["input"]),
+                        "partial_json": json.dumps(tool_input),
                     },
                 }
                 events.append(f"event: content_block_delta\ndata: {json.dumps(delta)}\n\n".encode())
@@ -778,6 +774,8 @@ class StreamingMixin:
         msg_delta_payload: dict[str, Any] = {}
         if "stop_reason" in response:
             msg_delta_payload["stop_reason"] = response["stop_reason"]
+        if "stop_sequence" in response:
+            msg_delta_payload["stop_sequence"] = response["stop_sequence"]
         if "stop_details" in response:
             msg_delta_payload["stop_details"] = response["stop_details"]
         usage = response.get("usage")

--- a/tests/test_sse_thinking_blocks.py
+++ b/tests/test_sse_thinking_blocks.py
@@ -287,6 +287,13 @@ def test_response_to_sse_preserves_thinking_redacted_and_citations() -> None:
     assert "citations_delta" in sse_text
     assert "redacted_thinking" in sse_text
     assert redacted_blob in sse_text
+    events = _sse_events(sse_text)
+    thinking_start = next(
+        event
+        for event in events
+        if event["type"] == "content_block_start" and event["content_block"]["type"] == "thinking"
+    )
+    assert "signature" not in thinking_start["content_block"]
 
     round_tripped = parser._parse_sse_to_response(sse_text, "anthropic")
     assert round_tripped is not None
@@ -358,7 +365,7 @@ def test_response_to_sse_tolerates_malformed_content_and_usage() -> None:
     assert text_deltas[0]["delta"]["text"] == "hi"
 
 
-def test_response_to_sse_emits_server_tool_use_without_delta() -> None:
+def test_response_to_sse_streams_server_tool_use_input_as_json_delta() -> None:
     parser = _Parser()
     server_tool_use = {
         "type": "server_tool_use",
@@ -383,14 +390,42 @@ def test_response_to_sse_emits_server_tool_use_without_delta() -> None:
 
     block_starts = [ev for ev in events if ev["type"] == "content_block_start"]
     assert block_starts[1]["index"] == 1
-    assert block_starts[1]["content_block"] == server_tool_use
-    assert not any(ev["type"] == "content_block_delta" and ev["index"] == 1 for ev in events)
+    assert block_starts[1]["content_block"] == {
+        "type": "server_tool_use",
+        "id": "srvtoolu_123",
+        "name": "web_search",
+        "input": {},
+    }
+    server_delta = next(
+        ev for ev in events if ev["type"] == "content_block_delta" and ev["index"] == 1
+    )
+    assert server_delta["delta"]["type"] == "input_json_delta"
+    assert json.loads(server_delta["delta"]["partial_json"]) == server_tool_use["input"]
     assert any(
         ev["type"] == "content_block_delta"
         and ev["index"] == 0
         and ev["delta"] == {"type": "text_delta", "text": "Searching."}
         for ev in events
     )
+
+
+def test_response_to_sse_emits_stop_sequence_in_envelope_and_delta() -> None:
+    parser = _Parser()
+    sse_text = b"".join(
+        parser._response_to_sse(
+            {
+                "content": [],
+                "stop_reason": "stop_sequence",
+                "stop_sequence": "END",
+            },
+            "anthropic",
+        )
+    ).decode("utf-8")
+    events = _sse_events(sse_text)
+    message_start = next(ev for ev in events if ev["type"] == "message_start")
+    message_delta = next(ev for ev in events if ev["type"] == "message_delta")
+    assert message_start["message"]["stop_sequence"] is None
+    assert message_delta["delta"]["stop_sequence"] == "END"
 
 
 # Issue #1876: CCR buffered-stream re-synthesis corrupted extended-thinking


### PR DESCRIPTION
## Summary

- omit thinking signatures from content_block_start and emit them only as signature_delta
- stream tool_use and server_tool_use inputs through input_json_delta from an empty input object
- preserve stop_sequence in the message envelope and terminal delta
- catch non-ValueError reconstruction failures so an open stream returns the existing structured 502 SSE error

## Root cause

The buffered CCR path turns an upstream non-stream Message back into SSE. Its hand-built stream differed from Anthropic's contract: thinking signatures appeared in both the start block and a signature delta, server_tool_use started with a fully populated input and emitted no input_json_delta, and stop_sequence was dropped. A TypeError or AttributeError during reconstruction escaped because the call site caught only ValueError, leaving clients with an already-open HTTP 200 stream and no usable message.

This complements the already-merged signed-thinking byte-lock fix in #3124 and buffered Accept fix in #3102.

## Tests

- `python -m pytest tests/test_sse_thinking_blocks.py -q` (16 passed)
- `python -m ruff check headroom/proxy/handlers/streaming.py headroom/proxy/handlers/anthropic.py tests/test_sse_thinking_blocks.py`

Made with [Cursor](https://cursor.com)