### PR TITLE
fix(docker): support OpenCode in native wrapper

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,6 +84,7 @@ require_cmd() {
 
 ensure_host_dirs() {
   mkdir -p \
+    "${HEADROOM_HOST_HOME}/.config" \
     "${HEADROOM_HOST_HOME}/.headroom" \
     "${HEADROOM_HOST_HOME}/.claude" \
     "${HEADROOM_HOST_HOME}/.codex" \
@@ -119,6 +120,7 @@ append_common_container_args() {
   ref+=(-v "${HEADROOM_HOST_HOME}/.claude:${HEADROOM_CONTAINER_HOME}/.claude")
   ref+=(-v "${HEADROOM_HOST_HOME}/.codex:${HEADROOM_CONTAINER_HOME}/.codex")
   ref+=(-v "${HEADROOM_HOST_HOME}/.gemini:${HEADROOM_CONTAINER_HOME}/.gemini")
+  ref+=(-v "${HEADROOM_HOST_HOME}/.config:${HEADROOM_CONTAINER_HOME}/.config")
 
   if command -v id >/dev/null 2>&1; then
     ref+=(--user "$(id -u):$(id -g)")
@@ -616,6 +618,7 @@ Supported commands:
   aider
   cursor
   openclaw
+  opencode
 
 Notes:
   - GitHub Copilot CLI wrapping is not supported by the Docker-native wrapper.
@@ -1471,11 +1474,13 @@ main() {
         proxy_args+=(--region "${region}")
       fi
 
-      local container_name=""
+      # Keep this in the wrapper's global scope so the EXIT trap can still
+      # stop the proxy after main returns.
+      container_name=""
       if [[ "${no_proxy}" -eq 0 ]]; then
         container_name="$(start_proxy_container "${port}" "${proxy_args[@]}")"
       fi
-      trap 'stop_proxy_container "${container_name}"' EXIT INT TERM
+      trap 'stop_proxy_container "${container_name:-}"' EXIT INT TERM
 
       local prep_args=("${known_args[@]}")
       if [[ "${no_proxy}" -eq 0 ]]; then
@@ -1507,6 +1512,15 @@ EOF
           while true; do
             sleep 1
           done
+          ;;
+        opencode)
+          local opencode_config_file="${HEADROOM_HOST_HOME}/.config/opencode/opencode.json"
+          if [[ -f "${opencode_config_file}" ]]; then
+            OPENCODE_CONFIG_CONTENT="$(<"${opencode_config_file}")" \
+              run_host_tool opencode "${host_args[@]}"
+          else
+            run_host_tool opencode "${host_args[@]}"
+          fi
           ;;
       esac
       ;;

--- a/tests/test_install/test_native_installers.py
+++ b/tests/test_install/test_native_installers.py
@@ -210,6 +210,19 @@ def _write_fake_docker_shims(tmp_path: Path) -> Path:
     openclaw_sh.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
     openclaw_sh.chmod(0o755)
 
+    opencode_sh = shim_dir / "opencode"
+    opencode_sh.write_text(
+        "#!/usr/bin/env bash\n"
+        "{\n"
+        "  printf 'CONFIG=%s\\n' \"${OPENCODE_CONFIG_CONTENT-}\"\n"
+        "  printf 'ARGS='\n"
+        "  printf '%q ' \"$@\"\n"
+        "  printf '\\n'\n"
+        '} > "${FAKE_OPENCODE_LOG}"\n',
+        encoding="utf-8",
+    )
+    opencode_sh.chmod(0o755)
+
     openclaw_cmd = shim_dir / "openclaw.cmd"
     openclaw_cmd.write_text("@echo off\r\nexit /b 0\r\n", encoding="utf-8")
 
@@ -552,6 +565,52 @@ def test_bash_native_installer_supports_persistent_docker_lifecycle(tmp_path: Pa
         _run([str(wrapper), "install", "restart", "--profile", "smoke"], env=env)
         _run([str(wrapper), "install", "remove", "--profile", "smoke"], env=env)
         assert not manifest_path.parent.exists()
+    finally:
+        _cleanup_fake_docker(env)
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or shutil.which("bash") is None or not _bash_supports_4_3(),
+    reason="installer requires bash >= 4.3 (macOS system bash is 3.2)",
+)
+def test_bash_native_wrapper_supports_opencode(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".local").mkdir(parents=True)
+    env = _build_env(home, tmp_path)
+    env["HEADROOM_DOCKER_IMAGE"] = "headroom:test-image"
+    env["FAKE_OPENCODE_LOG"] = str(tmp_path / "opencode.log")
+
+    try:
+        _run(["bash", str(REPO_ROOT / "scripts" / "install.sh")], env=env, cwd=REPO_ROOT)
+        wrapper = home / ".local" / "bin" / "headroom"
+
+        config_file = home / ".config" / "opencode" / "opencode.json"
+        config_file.parent.mkdir(parents=True)
+        config_content = (
+            '{"provider":{"headroom":{"options":{"baseURL":"http://127.0.0.1:8787/v1"}}}}'
+        )
+        config_file.write_text(config_content, encoding="utf-8")
+
+        port = _free_port()
+        result = _run(
+            [str(wrapper), "wrap", "opencode", "--port", str(port), "--", "--help"],
+            env=env,
+        )
+        assert result.stderr == ""
+
+        docker_calls = _read_fake_docker_log(env)
+        prepare_call = next(
+            call
+            for call in docker_calls
+            if call[:2] == ["run", "--rm"] and "--prepare-only" in call and "opencode" in call
+        )
+        assert f"{home}/.config:/tmp/headroom-home/.config" in prepare_call
+
+        opencode_output = Path(env["FAKE_OPENCODE_LOG"]).read_text(encoding="utf-8")
+        assert f"CONFIG={config_content}" in opencode_output
+        assert "ARGS=--help" in opencode_output
+        docker_state = json.loads(Path(env["FAKE_DOCKER_STATE"]).read_text(encoding="utf-8"))
+        assert docker_state["containers"] == {}
     finally:
         _cleanup_fake_docker(env)
 


### PR DESCRIPTION
## Description

The Docker-native wrapper accepts `opencode` but cannot complete a normal launch: it does not mount the host config directory, its cleanup trap can expand an out-of-scope variable, and the prepared config is not forwarded to the host process. This fix keeps OpenCode configuration on the shared mount, launches the host binary with the prepared JSON, and preserves proxy cleanup.

Closes #3534

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Create and mount the host `.config` directory for Docker-native OpenCode preparation.
- Launch the host OpenCode binary with the prepared config file content and preserve proxy cleanup after the wrapper exits.
- Add a fake-Docker regression test covering the config mount, host arguments, config handoff, and cleanup.

## Testing

- [x] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [ ] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ .venv-3534/bin/python -m pytest tests/test_install/test_native_installers.py -q
=================== 2 passed, 4 skipped, 1 warning in 9.13s ====================
$ .venv-3534/bin/ruff format --check tests/test_install/test_native_installers.py
1 file already formatted
$ .venv-3534/bin/ruff check tests/test_install/test_native_installers.py
All checks passed!
$ bash -n scripts/install.sh
(exit code 0)
```

## Real Behavior Proof

- Environment: Linux x86_64, Python 3.11.16, Bash 5, checkout commit 2b0b73eaea82c3af5fb3ca37aa47552e2ee7062e
- Exact command / steps: `.venv-3534/bin/python -m pytest tests/test_install/test_native_installers.py -q`; the test generated the installer wrapper with fake Docker and OpenCode shims, then ran `headroom wrap opencode --port <ephemeral-port> -- --help`
- Observed result: The wrapper mounted `.config`, passed the prepared JSON through `OPENCODE_CONFIG_CONTENT`, forwarded `--help` to OpenCode, and removed the fake proxy container on exit.
- Not tested: A real Docker daemon or image, the actual OpenCode binary, live provider traffic, Windows, and macOS runtime behavior.

## Runtime Rollout Safety

- Rollout-managed feature(s): N/A
- Minimum rollout channel: N/A
- Stable/default behavior changed: Docker-native `wrap opencode` now launches OpenCode after preparation.
- Kill switch / disable path: Use `--no-proxy` or the Python-native wrapper.
- Unsafe override required: N/A
- Qualification impact: N/A
- Rollback path: Revert this PR.

## Review Readiness

- [ ] I have performed a self-review
- [ ] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` - it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A