### PR TITLE
fix(transforms): scope ContentRouter per-request state to the request (#3549)

### DIFF
--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -44,7 +44,7 @@ import re
 import sys
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field, replace
 from enum import Enum
@@ -1706,6 +1706,29 @@ class ContentRouterConfig:
     search_group_by_file: bool = False
 
 
+@dataclass(frozen=True)
+class CompressionRequestContext:
+    """Immutable per-request state for one ``ContentRouter.apply`` call.
+
+    A ``ContentRouter`` is long-lived and shared: the proxy builds one per provider
+    pipeline and runs ``apply`` on a thread pool, so a request-scoped value stored on
+    the instance can be overwritten mid-``apply`` by a concurrent request (#3549).
+    Building this once per request and passing it down keeps that state owned by the
+    request instead of the router.
+    """
+
+    tool_names: Mapping[str, str] = field(default_factory=dict)
+    tool_call_args: Mapping[str, str] = field(default_factory=dict)
+    tool_call_commands: Mapping[str, str] = field(default_factory=dict)
+    protected_tool_ids: frozenset[str] = frozenset()
+    protected_message_indices: frozenset[int] = frozenset()
+
+
+# Stand-in for helpers reached without going through ``apply``: no tool metadata,
+# no read protection.
+_EMPTY_REQUEST_CONTEXT = CompressionRequestContext()
+
+
 class ContentRouter(Transform):
     """Intelligent router that selects optimal compression strategy.
 
@@ -1850,11 +1873,6 @@ class ContentRouter(Transform):
         # different strategies for the same block, share one provider
         # invocation. See `_lossless_provider_result`.
         self._lossless_provider_memo: dict[tuple[int, int, int], tuple[str, str] | None] = {}
-
-        # tool_call_id → compact args text, populated by _build_tool_name_map.
-        self._tool_call_args: dict[str, str] = {}
-        # tool_call_id → raw shell command (bash-search fold), same population.
-        self._tool_call_commands: dict[str, str] = {}
 
         # Phase 0 (#1171): cap the input size handed to kompress (ModernBERT
         # ONNX). Its inference scales O(tokens) and runs synchronously on the
@@ -4529,16 +4547,14 @@ class ContentRouter(Transform):
 
     # Transform interface
 
-    def _build_tool_name_map(self, messages: list[dict[str, Any]]) -> dict[str, str]:
-        """Build mapping from tool_call_id to tool_name.
+    def _scan_tool_calls(
+        self, messages: list[dict[str, Any]]
+    ) -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
+        """Collect tool-call metadata in one scan: names, compact args, shell commands.
 
-        Scans assistant messages to find tool calls and extract their names.
-        Supports both OpenAI and Anthropic message formats. Also populates
-        ``self._tool_call_args`` (id → compact args text) in the same scan, so
-        the relevance split can score a tool output against the *precise* ask
-        that triggered it (grep pattern, read path, …), not just the user
-        prompt. Read-only after build → safe to read from the parallel
-        compression pass.
+        Supports both OpenAI and Anthropic message formats. Returns the values
+        instead of storing them on the router, so a concurrent request cannot
+        overwrite them mid-``apply`` (#3549).
         """
         mapping: dict[str, str] = {}
         args_map: dict[str, str] = {}
@@ -4592,9 +4608,69 @@ class ContentRouter(Transform):
                             if command:
                                 commands_map[tc_id] = command
 
-        self._tool_call_args = args_map
-        self._tool_call_commands = commands_map
-        return mapping
+        return mapping, args_map, commands_map
+
+    def _build_tool_name_map(self, messages: list[dict[str, Any]]) -> dict[str, str]:
+        """Build mapping from tool_call_id to tool_name."""
+        return self._scan_tool_calls(messages)[0]
+
+    def _build_request_context(self, messages: list[dict[str, Any]]) -> CompressionRequestContext:
+        """Build the per-request state ``apply`` needs, owned by the caller (#3549)."""
+        tool_names, tool_call_args, tool_call_commands = self._scan_tool_calls(messages)
+
+        protected_tool_ids: frozenset[str] = frozenset()
+        protected_message_indices: frozenset[int] = frozenset()
+        if read_protection_enabled():
+            # Read protection (HEADROOM_PROTECT_READS=1): for bash-family agents the
+            # exclude-by-tool-NAME set never catches file reads (they are `bash`
+            # tool calls whose COMMAND is a cat/sed/head/...). Mark those tool_use_ids
+            # so their output is never LOSSY-compressed (the agent needs exact bytes
+            # to edit; lossy reads caused re-reads/turn-inflation + resolve loss on
+            # SWE-bench). Type-specific by design: grep/test/ls output stays
+            # compressible, so the cache-mode delta still compresses whenever the
+            # newest turn is NOT a read.
+            #
+            # Use tool_call_commands (the parsed shell command), NOT tool_call_args
+            # (a compact free-text blob that, for OpenAI-style JSON-string args, is
+            # the raw ``{"command": ...}`` JSON — on which _is_read_command always
+            # returns False, silently disabling read protection for OpenAI-native
+            # harnesses). tool_call_commands is extracted via
+            # _tool_call_command_text, correct for both wire shapes.
+            protected_tool_ids = frozenset(
+                tid for tid in tool_names if _is_read_command(tool_call_commands.get(tid, ""))
+            )
+
+            # Read protection — TEXT-BASED shape (shape-agnostic twin of the above).
+            # Text-based agents (GPT-5.4/Codex/Cursor backticks) have no tool_use
+            # blocks: the command is in the PRECEDING assistant message's fenced
+            # block and the observation is a plain user string with no id to match.
+            # Detect the producing command by walking back to that assistant turn and
+            # mark the observation's message index so it is passed verbatim — so
+            # cat/sed/head code reads are protected on ANY model/harness, not just
+            # those that emit tool-call/tool_result blocks.
+            indices: set[int] = set()
+            for _idx, _m in enumerate(messages):
+                if _m.get("role") != "user":
+                    continue
+                _cmd = ""
+                for _j in range(_idx - 1, -1, -1):
+                    _rj = messages[_j].get("role")
+                    if _rj == "assistant":
+                        _cmd = _fenced_shell_command(messages[_j].get("content"))
+                        break
+                    if _rj == "user":
+                        break
+                if _cmd and _is_read_command(_cmd):
+                    indices.add(_idx)
+            protected_message_indices = frozenset(indices)
+
+        return CompressionRequestContext(
+            tool_names=tool_names,
+            tool_call_args=tool_call_args,
+            tool_call_commands=tool_call_commands,
+            protected_tool_ids=protected_tool_ids,
+            protected_message_indices=protected_message_indices,
+        )
 
     def _net_cost_allows(
         self,
@@ -4854,8 +4930,9 @@ class ContentRouter(Transform):
         context = kwargs.get("context", "")
         hook_biases: dict[int, float] = kwargs.get("biases") or {}
 
-        # Build tool name map for exclusion checking
-        tool_name_map = self._build_tool_name_map(messages)
+        # Per-request tool-call/read-protection state, owned by this call (#3549).
+        request_context = self._build_request_context(messages)
+        tool_name_map = request_context.tool_names
 
         # Compute excluded tool IDs based on config
         exclude_tools = (
@@ -4892,50 +4969,8 @@ class ContentRouter(Transform):
             if is_tool_excluded(name, ("headroom_retrieve",))
         }
 
-        # Read protection (HEADROOM_PROTECT_READS=1): for bash-family agents the
-        # exclude-by-tool-NAME set above never catches file reads (they are `bash`
-        # tool calls whose COMMAND is a cat/sed/head/...). Mark those tool_use_ids so
-        # their output is never LOSSY-compressed (the agent needs exact bytes to edit;
-        # lossy reads caused re-reads/turn-inflation + resolve loss on SWE-bench).
-        # Type-specific by design: grep/test/ls output stays compressible, so the
-        # cache-mode delta still compresses whenever the newest turn is NOT a read.
-        self._protect_read_tool_ids = set()
-        if read_protection_enabled():
-            # Use _tool_call_commands (the parsed shell command), NOT
-            # _tool_call_args (a compact free-text blob that, for OpenAI-style
-            # JSON-string args, is the raw ``{"command": ...}`` JSON — on which
-            # _is_read_command always returns False, silently disabling read
-            # protection for OpenAI-native harnesses). _tool_call_commands is
-            # extracted via _tool_call_command_text, correct for both wire shapes.
-            self._protect_read_tool_ids = {
-                tid
-                for tid in tool_name_map
-                if _is_read_command(self._tool_call_commands.get(tid, ""))
-            }
-
-        # Read protection — TEXT-BASED shape (shape-agnostic twin of the above).
-        # Text-based agents (GPT-5.4/Codex/Cursor backticks) have no tool_use
-        # blocks: the command is in the PRECEDING assistant message's fenced
-        # block and the observation is a plain user string with no id to match.
-        # Detect the producing command by walking back to that assistant turn and
-        # mark the observation's message index so it is passed verbatim — so
-        # cat/sed/head code reads are protected on ANY model/harness, not just
-        # those that emit tool-call/tool_result blocks.
-        self._protect_read_msg_indices: set[int] = set()
-        if read_protection_enabled():
-            for _idx, _m in enumerate(messages):
-                if _m.get("role") != "user":
-                    continue
-                _cmd = ""
-                for _j in range(_idx - 1, -1, -1):
-                    _rj = messages[_j].get("role")
-                    if _rj == "assistant":
-                        _cmd = _fenced_shell_command(messages[_j].get("content"))
-                        break
-                    if _rj == "user":
-                        break
-                if _cmd and _is_read_command(_cmd):
-                    self._protect_read_msg_indices.add(_idx)
+        # Read-protection sets are built with the rest of the request context
+        # (see _build_request_context) so a concurrent request cannot overwrite them.
 
         # --- Adaptive parameters based on context pressure ---
         num_messages = len(messages)
@@ -5165,6 +5200,7 @@ class ContentRouter(Transform):
                     skip_system=skip_system,
                     compress_assistant_text_blocks=compress_assistant_text_blocks,
                     prefix_replay_guaranteed=prefix_replay_guaranteed,
+                    request_context=request_context,
                 )
                 result_slots[i] = transformed_message
                 route_counts["content_blocks"] += 1
@@ -5240,7 +5276,9 @@ class ContentRouter(Transform):
                 # Bash-search lossless pre-empt: a read-only search (grep/rg/git
                 # grep) run via a shell tool yields byte-losslessly foldable
                 # output. Fold it instead of the lossy strategy path.
-                bash_folded = self._bash_search_fold(tool_name, tool_call_id, content)
+                bash_folded = self._bash_search_fold(
+                    tool_name, tool_call_id, content, request_context
+                )
                 if bash_folded is not None:
                     result_slots[i] = {**message, "content": bash_folded}
                     transforms_applied.append("router:bash:lossless_search")
@@ -5263,8 +5301,9 @@ class ContentRouter(Transform):
             # in the block path; this covers STRING-content observations.)
             if role in ("user", "tool", "function"):
                 _tcid = message.get("tool_call_id") or message.get("tool_use_id") or ""
-                _is_read_obs = _tcid in getattr(self, "_protect_read_tool_ids", ()) or i in getattr(
-                    self, "_protect_read_msg_indices", ()
+                _is_read_obs = (
+                    _tcid in request_context.protected_tool_ids
+                    or i in request_context.protected_message_indices
                 )
                 if _is_read_obs and _read_output_should_be_protected(content):
                     _exp = self._experimental_compress_read(content, context)
@@ -5838,7 +5877,13 @@ class ContentRouter(Transform):
         minified = json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
         return minified if len(minified) < len(content) else None
 
-    def _bash_search_fold(self, tool_name: str, tool_id: str, content: Any) -> str | None:
+    def _bash_search_fold(
+        self,
+        tool_name: str,
+        tool_id: str,
+        content: Any,
+        request_context: CompressionRequestContext,
+    ) -> str | None:
         """Byte-lossless fold for a read-only search run through a shell tool.
 
         ``bash`` is not excluded, so its output normally takes the lossy strategy
@@ -5856,7 +5901,7 @@ class ContentRouter(Transform):
             return None
         if tool_name.lower() not in self.config.bash_tool_names:
             return None
-        command = self._tool_call_commands.get(tool_id, "")
+        command = request_context.tool_call_commands.get(tool_id, "")
         if not command or not _bash_command_is_search(command, self.config.bash_search_commands):
             return None
         try:
@@ -6055,8 +6100,13 @@ class ContentRouter(Transform):
         skip_system: bool = True,
         compress_assistant_text_blocks: bool = False,
         prefix_replay_guaranteed: bool = False,
+        request_context: CompressionRequestContext | None = None,
     ) -> dict[str, Any]:
         """Process content blocks (Anthropic format) for compression.
+
+        ``request_context`` carries this request's tool-call metadata and
+        read-protection sets (#3549). ``None`` (a direct caller that never went
+        through ``apply``) means no read protection and no bash-search fold.
 
         Cache-safety contract:
           1. Any block carrying `cache_control` is the client's explicit
@@ -6120,6 +6170,7 @@ class ContentRouter(Transform):
         Returns:
             Transformed message with compressed content blocks.
         """
+        request_context = request_context or _EMPTY_REQUEST_CONTEXT
         new_blocks = []
         any_compressed = False
         role = message.get("role", "")
@@ -6189,9 +6240,9 @@ class ContentRouter(Transform):
                 # log/lockfile/text) is not byte-patched, so it falls through to its
                 # content-specific compressor. Cross-turn dedup still runs later, so
                 # re-reads of the same file are losslessly de-duplicated either way.
-                if tool_use_id in getattr(
-                    self, "_protect_read_tool_ids", ()
-                ) and _read_output_should_be_protected(_tr_text):
+                if tool_use_id in request_context.protected_tool_ids and (
+                    _read_output_should_be_protected(_tr_text)
+                ):
                     _exp = self._experimental_compress_read(_tr_text, context or "")
                     if _exp is not None:
                         new_blocks.append({**block, "content": _exp})
@@ -6262,7 +6313,7 @@ class ContentRouter(Transform):
                 # signal. Gated so default behavior is byte-identical.
                 block_context = context
                 if self.config.relevance_split and tool_use_id:
-                    call_args = self._tool_call_args.get(tool_use_id, "")
+                    call_args = request_context.tool_call_args.get(tool_use_id, "")
                     if call_args:
                         block_context = build_relevance_query(context, tool_name, call_args)
 
@@ -6292,7 +6343,9 @@ class ContentRouter(Transform):
                 # Bash-search lossless pre-empt (twin of the string-form path):
                 # fold read-only search output (grep/rg/git grep) byte-losslessly
                 # instead of taking the lossy strategy path.
-                bash_folded = self._bash_search_fold(tool_name, tool_use_id, tool_text)
+                bash_folded = self._bash_search_fold(
+                    tool_name, tool_use_id, tool_text, request_context
+                )
                 if bash_folded is not None:
                     new_blocks.append(
                         {

--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -6088,7 +6088,7 @@ class ContentRouter(Transform):
         transforms_applied: list[str],
         excluded_tool_ids: set[str],
         ccr_retrieve_tool_ids: set[str],
-        tool_name_map: dict[str, str] | None = None,
+        tool_name_map: Mapping[str, str] | None = None,
         route_counts: dict[str, int] | None = None,
         compressed_details: list[str] | None = None,
         min_ratio: float = 0.85,

--- a/tests/test_content_router_request_context_isolation.py
+++ b/tests/test_content_router_request_context_isolation.py
@@ -1,0 +1,210 @@
+"""Regression test (#3549): request-scoped router state must not cross requests.
+
+A single ``ContentRouter`` is shared by every request in a proxy process
+(``proxy/server.py`` builds one instance per provider pipeline and runs compression
+on a ``ThreadPoolExecutor``), so any per-request value kept on the instance is
+writable by a concurrent request.
+
+The concrete harm pinned down here is read protection: Request B overwrites the
+tool-call/read-protection state Request A built, so A's ``cat src/a.py`` observation
+is no longer recognized as a file read and is handed to lossy compression -- exactly
+the bytes the agent needs for a line-precise edit.
+
+The interleaving is forced with events rather than run as a probabilistic stress
+test, so the failure is deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+
+from headroom.transforms import content_router as content_router_module
+from headroom.transforms.content_router import (
+    CompressionStrategy,
+    ContentRouter,
+    ContentRouterConfig,
+    ContentType,
+    RouterCompressionResult,
+    RoutingDecision,
+)
+from headroom.transforms.read_lifecycle import ReadLifecycleConfig
+
+_REQUEST_A = "request-A"
+
+_TOKEN_COUNT = 4800
+_LOSSY_SENTINEL = "LOSSY <<ccr:deadbeef>>"
+
+
+class _StubTokenizer:
+    def count_text(self, text: str) -> int:
+        return len(str(text).split())
+
+
+_FILE_BYTES = "def f():\n" + "    x = 1\n" * 400
+
+
+def _tool_call(call_id: str, command: str) -> dict:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": "bash", "arguments": json.dumps({"command": command})},
+    }
+
+
+def _request_a() -> list[dict]:
+    """Request A: a ``cat`` of a source file whose bytes must stay verbatim."""
+    return [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("call_A", "cat src/a.py")]},
+        {"role": "tool", "tool_call_id": "call_A", "content": _FILE_BYTES},
+    ]
+
+
+def _request_b() -> list[dict]:
+    """Request B: an unrelated ``echo`` whose state must never reach Request A."""
+    return [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("call_B", "echo ok")]},
+        {"role": "tool", "tool_call_id": "call_B", "content": "ok\n" * 400},
+    ]
+
+
+class _LossyRouter(ContentRouter):
+    """Router whose ``compress()`` is observably lossy for anything that reaches it.
+
+    Read protection short-circuits *before* ``compress()``, so a protected read stays
+    byte-identical while an unprotected observation is replaced by ``_LOSSY_SENTINEL``.
+
+    The sentinel and ``routing_log`` are not decoration: ``apply()`` discards a result
+    that carries no CCR retrieval marker (#1307, unrecoverable loss) and one whose
+    ratio does not clear ``min_ratio`` (derived from ``routing_log``, so an empty log
+    reads as ratio 1.0). Without both, the replacement never lands and this test would
+    pass vacuously on the unpatched router.
+    """
+
+    def compress(self, content: str, **_kwargs):
+        return RouterCompressionResult(
+            compressed=_LOSSY_SENTINEL,
+            original=content,
+            strategy_used=CompressionStrategy.KOMPRESS,
+            routing_log=[
+                RoutingDecision(
+                    content_type=ContentType.PLAIN_TEXT,
+                    strategy=CompressionStrategy.KOMPRESS,
+                    original_tokens=_TOKEN_COUNT,
+                    compressed_tokens=10,
+                )
+            ],
+        )
+
+
+def _new_router() -> _LossyRouter:
+    return _LossyRouter(
+        ContentRouterConfig(
+            skip_user_messages=False,
+            read_lifecycle=ReadLifecycleConfig(enabled=False),
+        )
+    )
+
+
+def _apply(router: ContentRouter, messages: list[dict]):
+    return router.apply(
+        [dict(m) for m in messages],
+        _StubTokenizer(),
+        frozen_message_count=0,
+        context="",
+        compress_user_messages=True,
+        protect_recent=0,
+        min_tokens_to_compress=25,
+    )
+
+
+class _OnceGate:
+    """Lets one designated thread pause at a chosen point, exactly once."""
+
+    def __init__(self) -> None:
+        self.reached = threading.Event()
+        self.release = threading.Event()
+        self._fired = False
+        self._lock = threading.Lock()
+
+    def pause(self) -> None:
+        with self._lock:
+            if self._fired:
+                return
+            self._fired = True
+        self.reached.set()
+        assert self.release.wait(timeout=30), "gate was never released"
+
+
+@pytest.fixture(autouse=True)
+def _enable_read_protection(monkeypatch):
+    monkeypatch.setenv("HEADROOM_PROTECT_READS", "1")
+    monkeypatch.delenv("HEADROOM_EXPERIMENTAL_READ_KEEP_RATIO", raising=False)
+    yield
+
+
+def test_lossy_stub_is_effective_for_a_non_read_observation():
+    """Guard against a vacuous suite: an unprotected observation is really replaced.
+
+    Without this, a change to the accept gates could silently turn the regression
+    test below into one that passes on every router, fixed or not.
+    """
+    out = _apply(_new_router(), _request_b())
+    assert out.messages[3]["content"] == _LOSSY_SENTINEL
+
+
+def test_read_protection_holds_without_concurrency():
+    """Control: Request A alone keeps its source read byte-identical."""
+    out = _apply(_new_router(), _request_a())
+    assert out.messages[3]["content"] == _FILE_BYTES
+    assert "router:read_protected" in out.transforms_applied
+
+
+def test_request_a_read_protection_survives_concurrent_request_b(monkeypatch):
+    """The regression: B's request state must not disarm A's read protection.
+
+    ``read_protection_enabled`` is consulted inside ``apply()`` after the router has
+    built its per-request tool/read state and before that state is consumed, so
+    pausing there reproduces the interleaving from the issue without any timing luck.
+    """
+    router = _new_router()
+    gate = _OnceGate()
+    real_enabled = content_router_module.read_protection_enabled
+
+    def gated_enabled() -> bool:
+        if threading.current_thread().name == _REQUEST_A:
+            gate.pause()
+        return real_enabled()
+
+    monkeypatch.setattr(content_router_module, "read_protection_enabled", gated_enabled)
+
+    result: dict = {}
+
+    def run_a() -> None:
+        try:
+            result["a"] = _apply(router, _request_a())
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the main thread
+            result["error"] = exc
+
+    thread = threading.Thread(target=run_a, name=_REQUEST_A, daemon=True)
+    thread.start()
+
+    assert gate.reached.wait(timeout=30), "request A never built its state"
+    _apply(router, _request_b())
+    gate.release.set()
+    thread.join(timeout=30)
+    assert not thread.is_alive(), "request A did not finish"
+
+    if "error" in result:
+        raise result["error"]
+
+    assert result["a"].messages[3]["content"] == _FILE_BYTES, (
+        "request B overwrote request A's read-protection state: A's `cat src/a.py` "
+        "result was handed to lossy compression"
+    )

--- a/tests/test_observed_wire_shapes.py
+++ b/tests/test_observed_wire_shapes.py
@@ -466,8 +466,9 @@ def test_text_based_read_protection_shape_agnostic(monkeypatch=None):
         min_tokens_to_compress=25,
     )
     # the observation AFTER the cat (index 3) must be read-protected; the grep one (5) must not
-    assert 3 in r._protect_read_msg_indices, r._protect_read_msg_indices
-    assert 5 not in r._protect_read_msg_indices, r._protect_read_msg_indices
+    ctx = r._build_request_context([dict(m) for m in msgs])
+    assert 3 in ctx.protected_message_indices, ctx.protected_message_indices
+    assert 5 not in ctx.protected_message_indices, ctx.protected_message_indices
 
 
 def test_bugB_read_detection_across_tool_call_wire_shapes():
@@ -581,8 +582,7 @@ def test_read_protection_role_agnostic_openai_role_tool():
         protect_recent=0,
         min_tokens_to_compress=25,
     )
-    assert "c_read" in r._protect_read_tool_ids, (
-        "read cmd must be identified from OpenAI tool_calls"
-    )
+    ctx = r._build_request_context([dict(m) for m in msgs])
+    assert "c_read" in ctx.protected_tool_ids, "read cmd must be identified from OpenAI tool_calls"
     # the role:tool READ observation is protected verbatim (was the bug: unprotected)
     assert out.messages[3]["content"] == code, "role:tool code read must be protected verbatim"


### PR DESCRIPTION
## Description

A `ContentRouter` is long-lived and shared. `headroom/proxy/server.py` builds one instance per provider pipeline and every request runs `apply()` on it, from the request-path `ThreadPoolExecutor` — and, nested inside that, from a second pool for the parallel compression pass.

`apply()` stored two pieces of per-request state on `self`:

- `self._tool_call_args` / `self._tool_call_commands`, written by `_build_tool_name_map()`
- `self._protect_read_tool_ids` / `self._protect_read_msg_indices`, the read-protection sets derived from them

A concurrent request could therefore overwrite them mid-`apply`. The harmful case is read protection: with `HEADROOM_PROTECT_READS=1`, if Request B's scan landed between A's scan and A's read-protection classification, A's `cat src/a.py` observation was no longer recognized as a file read and was handed to lossy compression — destroying exactly the bytes the agent needs for a line-precise edit.

Closes #3549

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add a frozen `CompressionRequestContext` holding the per-request tool-call maps and read-protection sets.
- Split the old `_build_tool_name_map()` into `_scan_tool_calls()` (returns the three maps instead of storing them on `self`) and `_build_request_context()` (the scan plus read-protection classification). `_build_tool_name_map()` is kept as a thin wrapper over the scan, so its existing caller is unaffected.
- `apply()` builds one context per request and threads it through the string path (`_bash_search_fold`, the read-observation branch) and the content-block path (`_process_content_blocks`).
- Delete the `self._tool_call_args` / `self._tool_call_commands` instance fields and the inline `self._protect_read_*` writes in `apply()`.
- Widen `_process_content_blocks`'s `tool_name_map` parameter to `Mapping[str, str] | None` — the block path only reads it, so no per-request dict copy is needed.
- Add `tests/test_content_router_request_context_isolation.py`, a deterministic regression test. Repoint three white-box assertions in `tests/test_observed_wire_shapes.py` that read the removed private attributes at the new per-request builder, preserving their original semantics.

`self._runtime_*` (target ratio, force/skip kompress, model, policy) is deliberately **not** moved in this PR — see Additional Notes.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

New regression test, unpatched router (RED):

```text
$ git checkout -- headroom/transforms/content_router.py
$ uv run pytest tests/test_content_router_request_context_isolation.py -p no:randomly -q
tests\test_content_router_request_context_isolation.py ..F               [100%]

E   AssertionError: request B overwrote request A's read-protection state:
    A's `cat src/a.py` result was handed to lossy compression
E   assert 'LOSSY <<ccr:deadbeef>>' == 'def f():\n  ...\n    x = 1\n'
========================= 1 failed, 2 passed in 0.54s =========================
```

Same test, patched router (GREEN) — only the source file changed:

```text
$ uv run pytest tests/test_content_router_request_context_isolation.py -p no:randomly -q
============================== 3 passed in 0.42s ==============================
```

Existing suite:

```text
$ uv run pytest tests/test_observed_wire_shapes.py \
      tests/test_content_router_request_context_isolation.py -p no:randomly -q
22 passed

$ uv run pytest tests/test_content_router_*.py tests/test_transforms_content_router.py \
      tests/test_observed_wire_shapes.py tests/test_compression_batches.py \
      tests/test_compression_units.py tests/test_compression_determinism.py \
      tests/test_compression_cache.py tests/test_compression_safety_rails.py \
      tests/test_code_compressor_thread_safety.py tests/test_compression_store.py \
      tests/test_compression_observability.py -p no:randomly -q
286 passed, 8 skipped

$ uv run ruff check <changed files>      -> All checks passed!
$ uv run ruff format --check <changed files> -> 3 files already formatted
$ uv run mypy headroom/transforms/content_router.py -> Success: no issues found
```

The 8 skips are pre-existing in `test_code_compressor_thread_safety.py` (native/Rust-gated), not introduced here.

## Real Behavior Proof

- Environment: Windows 10 Pro N (10.0.19045), Python 3.13.8, pytest 9.0.3, `uv sync --extra dev` (native `headroom._core` built), base `origin/main` @ `04cdf79a`.

- Exact command / steps: Run the RED and GREEN pytest commands shown below, then the focused pytest, ruff, and mypy commands in the Test Output section.\n
```text
git checkout -- headroom/transforms/content_router.py      # unpatched
uv run pytest tests/test_content_router_request_context_isolation.py -p no:randomly -q

cp content_router_fixed.py headroom/transforms/content_router.py   # patched
uv run pytest tests/test_content_router_request_context_isolation.py -p no:randomly -q
```

- Observed result: unpatched → `1 failed, 2 passed`, with Request A's `cat src/a.py` bytes replaced by the lossy sentinel. Patched → `3 passed`, A's bytes byte-identical. Instrumentation on the unpatched router shows the shared map being overwritten inside A's `apply()` (`commands before B: {'call_A': 'cat src/a.py'}` → `commands after B: {'call_B': 'echo ok'}`), A's `_protect_read_tool_ids` ending up empty, `router:read_protected` absent from `transforms_applied`, and `compress()` being called on A's file bytes.

- Not tested: not run through a live proxy process with real concurrent HTTP traffic — the interleaving is forced with `threading.Event` synchronization rather than reproduced from a loaded server. No provider calls; no Modal. The Rust/native compression path is unchanged by this patch but was not separately exercised. `_runtime_*` request state is untouched here and still carries the same class of hazard (follow-up, see below). Full `tests/` run in progress at time of opening; results will be posted as a comment.

## Runtime Rollout Safety

- Rollout-managed feature(s): none. No feature flag gates this change.
- Minimum rollout channel: n/a — pure bug fix, no new behavior.
- Stable/default behavior changed: No. Single-request behavior is identical: the same maps are computed from the same messages and the same classification runs. The only intended difference is under concurrency, where a request now reads its own state. `HEADROOM_PROTECT_READS` semantics are unchanged.
- Kill switch / disable path: existing `HEADROOM_PROTECT_READS=0` disables read protection entirely, as before.
- Unsafe override required: No.
- Qualification impact: none.
- Rollback path: revert the commit (single self-contained module change plus tests).

## Review Readiness

- [ ] I have performed a self-review
- [ ] This PR is ready for human review

<!-- Intentionally left unchecked: opened as a draft. -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Additional Notes

**Scope: why `self._runtime_*` is not in this PR.** `apply()` also stores `_runtime_target_ratio`, `_runtime_force_kompress`, `_runtime_skip_kompress`, `_runtime_kompress_model` and `_runtime_compression_policy` on `self` and comments them "Store runtime options on self for access by `_route_and_compress_block`". They are the same class of hazard, but they are *mutated from outside the router*: `headroom/transforms/compression_units.py` and `compression_batches.py` save and restore them around their own calls into the router. Moving them changes a cross-module contract and is a materially larger change than this one, so it is left as a follow-up to keep this PR to one logical change.

**Why a context object rather than a `contextvar`.** The parallel compression pass runs on a nested `concurrent.futures.ThreadPoolExecutor`. `asyncio.run_in_executor` copies context, but a bare `ThreadPoolExecutor.submit()` does not — a contextvar would silently lose read protection in exactly the pass this issue is about. Passing the context explicitly keeps it correct without serializing anything, so compression stays parallel (no lock).

**Test-adaptation note.** Three assertions in `tests/test_observed_wire_shapes.py` read the private attributes this patch removes. They now call `_build_request_context()` and assert on its fields; their original assertion values and intent (which message index / tool id is classified as a read) are unchanged, and both tests still assert the public verbatim-output outcome.

