### PR TITLE
fix(proxy): keep non text blocks in place when relocating system sections

### DIFF
--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -917,7 +917,9 @@ def relocate_system_messages_to_top_level(
 
     The relocated content is appended after any existing top-level ``system``
     so wire order (system prompt, then conversation) is preserved and no content
-    is dropped.
+    is dropped. Only text-shaped content moves: non-text blocks (images,
+    documents) stay in a mid-conversation system section at their original
+    position, because top-level `system` accepts text blocks only (issue #3552).
 
     Returns ``(clean_messages, new_system, changed)``. When no system-role
     message is present the inputs pass through unchanged (``changed=False``) so
@@ -979,14 +981,48 @@ def relocate_system_messages_to_top_level(
         return messages, system, False
 
     relocated_blocks: list[Any] = []
+    retained: dict[int, dict[str, Any]] = {}
     for i in sorted(system_indices):
-        relocated_blocks.extend(_system_message_to_blocks(messages[i]))
-
-    clean_messages = [m for i, m in enumerate(messages) if i not in system_indices]
+        message = messages[i]
+        content = message.get("content") if isinstance(message, dict) else None
+        if isinstance(content, list):
+            # Only text-shaped content may move into the top-level ``system``
+            # parameter (text blocks and bare strings). Non-text blocks such as
+            # images or documents stay in place so nothing is dropped and
+            # upstreams that reject non-text system blocks keep working
+            # (issue #3552).
+            hoisted_from_list: list[Any] = []
+            leftovers: list[Any] = []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == _TEXT_BLOCK_TYPE:
+                    hoisted_from_list.append(block)
+                elif isinstance(block, str) and block:
+                    hoisted_from_list.append({"type": _TEXT_BLOCK_TYPE, "text": block})
+                else:
+                    leftovers.append(block)
+            relocated_blocks.extend(hoisted_from_list)
+            if leftovers:
+                retained[i] = {**message, "content": leftovers}
+        else:
+            # String (and other) content converts losslessly to text blocks.
+            relocated_blocks.extend(_system_message_to_blocks(message))
 
     if not relocated_blocks:
+        if retained:
+            # Nothing text-shaped to relocate: the sections stay as they are.
+            return messages, system, False
         # System message(s) carried no content — drop the empty entries only.
+        clean_messages = [m for i, m in enumerate(messages) if i not in system_indices]
         return clean_messages, system, True
+
+    clean_messages = []
+    for i, message in enumerate(messages):
+        if i in system_indices:
+            trimmed = retained.get(i)
+            if trimmed is not None:
+                clean_messages.append(trimmed)
+            continue
+        clean_messages.append(message)
 
     if system is None or system == "" or system == []:
         new_system: Any = relocated_blocks

--- a/tests/test_proxy_handler_helpers.py
+++ b/tests/test_proxy_handler_helpers.py
@@ -404,6 +404,91 @@ def test_relocate_system_messages_moves_valid_shape_for_unsupported_model() -> N
     assert system == [{"type": "text", "text": "mid-turn instruction"}]
 
 
+def test_relocate_system_messages_keeps_image_blocks_out_of_top_level_system() -> None:
+    image_block = {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": "aGk="},
+    }
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "look at this"}]},
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "<system-reminder>image attached</system-reminder>"},
+                image_block,
+            ],
+        },
+        {"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+    ]
+    system = [{"type": "text", "text": "You are Claude Code."}]
+
+    clean, new_system, changed = relocate_system_messages_to_top_level(messages, system, None)
+
+    assert changed is True
+    assert isinstance(new_system, list)
+    assert all(not isinstance(block, dict) or block.get("type") == "text" for block in new_system)
+    retained = [
+        message.get("content")
+        for message in clean
+        if isinstance(message, dict) and message.get("role") == "system"
+    ]
+    assert any(image_block in (content or []) for content in retained)
+
+
+def test_relocate_system_messages_hoists_only_text_from_mixed_sections() -> None:
+    messages = [
+        {"role": "user", "content": "question"},
+        {
+            "role": "system",
+            "content": [
+                "plain string section",
+                {"type": "text", "text": "structured note"},
+                {"type": "image", "source": {"type": "url", "url": "https://x/y.png"}},
+            ],
+        },
+        {"role": "assistant", "content": "ok"},
+    ]
+
+    clean, new_system, changed = relocate_system_messages_to_top_level(messages, None, None)
+
+    assert changed is True
+    assert new_system == [
+        {"type": "text", "text": "plain string section"},
+        {"type": "text", "text": "structured note"},
+    ]
+    retained = [
+        message
+        for message in clean
+        if isinstance(message, dict) and message.get("role") == "system"
+    ]
+    assert retained == [
+        {
+            "role": "system",
+            "content": [{"type": "image", "source": {"type": "url", "url": "https://x/y.png"}}],
+        }
+    ]
+
+
+def test_relocate_system_messages_image_only_sections_pass_through_unchanged() -> None:
+    image_block = {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": "aGk="},
+    }
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "system", "content": [image_block]},
+        {"role": "assistant", "content": "ok"},
+    ]
+    system = "base"
+
+    clean, new_system, changed = relocate_system_messages_to_top_level(messages, system, None)
+
+    assert changed is False
+    assert clean == messages
+    assert new_system == system
+
+
 def test_headroom_bypass_helper_is_transport_neutral() -> None:
     assert _headroom_bypass_enabled({"x-headroom-bypass": "true"}) is True
     assert _headroom_bypass_enabled({"x-headroom-bypass": " TRUE "}) is True


### PR DESCRIPTION
## Description

Closes #3552

when a payload carries a mid conversation system message holding non text blocks, `relocate_system_messages_to_top_level` hoisted the whole thing into the top level `system` parameter, image and document blocks included
the top level `system` parameter only takes text, so anthropic compatible upstreams that type `system` as a string reject the request, the reporter hit `Input should be a valid string` with `loc body system str` on a z.ai style endpoint
the fix keeps the hoist text only: text blocks and bare strings move up, non text blocks stay in a system message at the original position, nothing is dropped and the message order is untouched

### Steps to reproduce
1. run the new tests on untouched main: `python -m pytest -q tests/test_proxy_handler_helpers.py::test_relocate_system_messages_keeps_image_blocks_out_of_top_level_system`
2. Expected (after this fix): text moves to top level `system`, the image block stays in a mid conversation system message
3. Actual (raw output on untouched main 04cdf79a):

```text
FAILED tests/test_proxy_handler_helpers.py::test_relocate_system_messages_keeps_image_blocks_out_of_top_level_system
FAILED tests/test_proxy_handler_helpers.py::test_relocate_system_messages_hoists_only_text_from_mixed_sections
FAILED tests/test_proxy_handler_helpers.py::test_relocate_system_messages_image_only_sections_pass_through_unchanged
========================= 3 failed, 53 passed in 1.95s =========================
```

an image only system section was also needlessly rewritten into a top level system list with an image block in it, which is exactly the shape upstreams choke on

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `headroom/proxy/helpers.py`: the hoist now splits each relocated system section, text blocks and bare strings move to the top level `system` parameter, non text blocks stay behind in a system message at the original spot, sections that hold nothing text shaped pass through unchanged, existing behavior for text only and string content is byte identical
- `tests/test_proxy_handler_helpers.py`: 3 regression tests, image block kept out of top level system, mixed section hoists text only and retains the image, image only section passes through unchanged

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality

### Test Output

```text
python -m pytest -q tests/test_proxy_handler_helpers.py
56 passed in 1.93s

without the fix (git restore --source main -- headroom/proxy/helpers.py):
3 failed, 53 passed
(the 3 new tests fail, every pre existing test still passes)

ruff check .
All checks passed!

ruff format --check .
1577 files already formatted

mypy headroom
Success: no issues found in 532 source files
```

## Real Behavior Proof

- Environment: linux, python 3.12.3, headroom main 04cdf79a plus the fix (4f15cc02) in a venv, no live provider call involved
- Exact command / steps: the pytest commands in the test output block, plus a restore dance, restoring main `helpers.py` turns the 3 new tests red, restoring the fix turns them green, so the tests fail without the change and pass with it
- Observed result: after the fix the top level `system` list only ever contains text blocks and the image block survives in a mid conversation system message, which is the wire shape upstreams typing `system` as a string accept
- Not tested: a live call against a z.ai or similar endpoint, i verified the wire shape at the helper level, the reporter's exact upstream config is not available to me

## Runtime Rollout Safety

- Rollout-managed feature(s): none
- Minimum rollout channel: n/a
- Stable/default behavior changed: yes, mid conversation system sections with non text blocks keep those blocks in place instead of moving them into the top level `system` parameter, text only and string content payloads are byte identical, that is the fix
- Kill switch / disable path: none needed, revert the commit
- Unsafe override required: no
- Qualification impact: none
- Rollback path: revert the one commit, nothing else to unwind

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review
