### PR TITLE
fix(transforms): isolate ContentRouter per-request runtime state across concurrent requests

### DIFF
--- a/headroom/transforms/content_router.py
+++ b/headroom/transforms/content_router.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import itertools
 import json
 import logging
 import math
@@ -46,6 +47,7 @@ import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Any
@@ -1706,6 +1708,47 @@ class ContentRouterConfig:
     search_group_by_file: bool = False
 
 
+@dataclass
+class _PerRequestRuntimeState:
+    """Per-``apply()``-call state, isolated across concurrent requests (#3486).
+
+    ``ContentRouter`` is instantiated once at proxy startup and shared, as a
+    single Python object, across every concurrent request — ``apply()`` calls
+    are dispatched onto a real ``ThreadPoolExecutor`` (see
+    ``headroom/proxy/server.py``). Before this fix, ``apply()`` stashed this
+    exact state (compression policy, runtime overrides, tool-call maps) as
+    plain, unsynchronized attributes directly on ``self``, so one request's
+    ``apply()`` call could read a *different, concurrently-running* request's
+    values — a cross-tenant data leak (e.g. a Subscription-mode request
+    incorrectly writing its content into the shared, cross-user TOIN
+    learning pool because a concurrent PAYG request overwrote the policy
+    field mid-flight).
+
+    Every field here previously lived directly on ``ContentRouter`` as
+    ``self._runtime_*`` / ``self._tool_call_*``. They're bundled into one
+    dataclass so ``apply()`` can bind a brand-new, request-exclusive instance
+    of it into a ``ContextVar`` (see ``ContentRouter._runtime_state_var``)
+    instead of mutating shared instance state. ``ContextVar`` values are
+    Context-local per OS thread by default (no propagation across threads
+    unless explicitly copied), which is exactly the isolation two concurrent
+    ``ThreadPoolExecutor`` workers need.
+    """
+
+    compression_policy: Any = None
+    target_ratio: float | None = None
+    force_kompress: bool = False
+    skip_kompress: bool = False
+    kompress_model: str | None = None
+    tool_call_args: dict[str, str] = field(default_factory=dict)
+    tool_call_commands: dict[str, str] = field(default_factory=dict)
+
+
+# Monotonic counter so each ContentRouter instance gets a uniquely named
+# ContextVar (names only matter for repr/debugging; uniqueness avoids any
+# confusion when introspecting multiple router instances in one process).
+_runtime_state_var_ids = itertools.count()
+
+
 class ContentRouter(Transform):
     """Intelligent router that selects optimal compression strategy.
 
@@ -1851,10 +1894,21 @@ class ContentRouter(Transform):
         # invocation. See `_lossless_provider_result`.
         self._lossless_provider_memo: dict[tuple[int, int, int], tuple[str, str] | None] = {}
 
-        # tool_call_id → compact args text, populated by _build_tool_name_map.
-        self._tool_call_args: dict[str, str] = {}
-        # tool_call_id → raw shell command (bash-search fold), same population.
-        self._tool_call_commands: dict[str, str] = {}
+        # #3486: per-request runtime state (compression policy, runtime
+        # overrides, tool-call maps — see `_PerRequestRuntimeState`) lives in
+        # a ContextVar, not on `self`, so concurrent `apply()` calls on this
+        # shared singleton can't observe or clobber each other's values.
+        # `apply()` binds a fresh `_PerRequestRuntimeState()` at the top of
+        # every call. The default below only matters for callers that use
+        # `self._tool_call_args` / `self.compress()` / `_record_to_toin()`
+        # directly, without going through `apply()` — same pre-#3486
+        # behaviour those callers already relied on (a single, instance-
+        # scoped default they can read and mutate).
+        self._default_runtime_state = _PerRequestRuntimeState()
+        self._runtime_state_var: ContextVar[_PerRequestRuntimeState] = ContextVar(
+            f"headroom_content_router_runtime_state_{next(_runtime_state_var_ids)}",
+            default=self._default_runtime_state,
+        )
 
         # Phase 0 (#1171): cap the input size handed to kompress (ModernBERT
         # ONNX). Its inference scales O(tokens) and runs synchronously on the
@@ -1922,12 +1976,11 @@ class ContentRouter(Transform):
         # ``kwargs["compression_policy"]`` at the start of ``apply()``
         # and read by ``_record_to_toin`` to gate TOIN writes when
         # ``policy.toin_read_only`` is true (Subscription mode).
-        # Defaults to ``None`` so direct ``compress()`` callers (e.g.
-        # tests, hand-written pipelines that don't go through the
-        # proxy) keep pre-F2.2 behaviour: TOIN writes are not gated.
-        # Same pattern the existing ``_runtime_target_ratio`` /
-        # ``_runtime_kompress_model`` fields below use.
-        self._runtime_compression_policy: Any = None
+        # Defaults to ``None`` (see ``_PerRequestRuntimeState``) so direct
+        # ``compress()`` callers (e.g. tests, hand-written pipelines that
+        # don't go through the proxy) keep pre-F2.2 behaviour: TOIN writes
+        # are not gated. Now backed by the #3486 ContextVar state — see
+        # the ``_runtime_compression_policy`` property below.
 
         self._cache = CompressionCache()
 
@@ -1971,6 +2024,91 @@ class ContentRouter(Transform):
         # cache. Counting pins isolates the freeze's attributable payoff.
         self._freeze_pin_hits = 0
         self._freeze_pin_chars = 0
+
+    # ── #3486: per-request runtime state accessors ──────────────────────
+    #
+    # These properties proxy every read/write of what used to be plain
+    # ``self._runtime_*`` / ``self._tool_call_*`` instance attributes onto
+    # the ContextVar-backed ``_PerRequestRuntimeState`` for the CURRENT
+    # thread's Context. Existing call sites throughout this file (both
+    # ``self._runtime_compression_policy = ...`` and
+    # ``getattr(self, "_runtime_target_ratio", None)``) work completely
+    # unchanged — the property intercepts attribute access exactly like a
+    # plain instance attribute would, so no other call site needed to
+    # change. ``apply()`` is the only place that binds a *fresh* state
+    # object (at the very top of the method); every other read/write here
+    # just goes through whatever object is ambient for the calling thread.
+    def _get_local_runtime_state(self) -> _PerRequestRuntimeState:
+        """Return the calling thread's per-request state, creating a
+        thread-local copy on first WRITE so direct callers (tests, or any
+        caller of ``compress()`` / ``_build_tool_name_map()`` /
+        ``_record_to_toin()`` that never calls ``apply()``) never mutate
+        the shared default in place — that default is one object shared by
+        every Context that hasn't called ``apply()`` yet, so mutating it
+        directly would leak across threads exactly like the bug this fix
+        removes.
+        """
+        state = self._runtime_state_var.get()
+        if state is self._default_runtime_state:
+            state = _PerRequestRuntimeState()
+            self._runtime_state_var.set(state)
+        return state
+
+    @property
+    def _runtime_compression_policy(self) -> Any:
+        return self._runtime_state_var.get().compression_policy
+
+    @_runtime_compression_policy.setter
+    def _runtime_compression_policy(self, value: Any) -> None:
+        self._get_local_runtime_state().compression_policy = value
+
+    @property
+    def _runtime_target_ratio(self) -> float | None:
+        return self._runtime_state_var.get().target_ratio
+
+    @_runtime_target_ratio.setter
+    def _runtime_target_ratio(self, value: float | None) -> None:
+        self._get_local_runtime_state().target_ratio = value
+
+    @property
+    def _runtime_force_kompress(self) -> bool:
+        return self._runtime_state_var.get().force_kompress
+
+    @_runtime_force_kompress.setter
+    def _runtime_force_kompress(self, value: bool) -> None:
+        self._get_local_runtime_state().force_kompress = value
+
+    @property
+    def _runtime_skip_kompress(self) -> bool:
+        return self._runtime_state_var.get().skip_kompress
+
+    @_runtime_skip_kompress.setter
+    def _runtime_skip_kompress(self, value: bool) -> None:
+        self._get_local_runtime_state().skip_kompress = value
+
+    @property
+    def _runtime_kompress_model(self) -> str | None:
+        return self._runtime_state_var.get().kompress_model
+
+    @_runtime_kompress_model.setter
+    def _runtime_kompress_model(self, value: str | None) -> None:
+        self._get_local_runtime_state().kompress_model = value
+
+    @property
+    def _tool_call_args(self) -> dict[str, str]:
+        return self._runtime_state_var.get().tool_call_args
+
+    @_tool_call_args.setter
+    def _tool_call_args(self, value: dict[str, str]) -> None:
+        self._get_local_runtime_state().tool_call_args = value
+
+    @property
+    def _tool_call_commands(self) -> dict[str, str]:
+        return self._runtime_state_var.get().tool_call_commands
+
+    @_tool_call_commands.setter
+    def _tool_call_commands(self, value: dict[str, str]) -> None:
+        self._get_local_runtime_state().tool_call_commands = value
 
     def _record_freeze_pin(self, content: str, cached_ratio: float) -> None:
         """Count one freeze divergence (thread-safe) and log it.
@@ -4762,6 +4900,21 @@ class ContentRouter(Transform):
         Returns:
             TransformResult with routed and compressed messages.
         """
+        # #3486: bind a brand-new, request-exclusive `_PerRequestRuntimeState`
+        # as this call's ContextVar value BEFORE anything else runs. This
+        # `ContentRouter` is a shared singleton dispatched onto a
+        # ThreadPoolExecutor by the proxy — without this, two concurrent
+        # `apply()` calls on different worker threads would clobber each
+        # other's `_runtime_compression_policy` / `_runtime_target_ratio` /
+        # tool-call maps via plain shared instance attributes. ContextVars
+        # are Context-local per OS thread by default (no cross-thread
+        # propagation), so each worker thread gets its own isolated object
+        # here regardless of what any other concurrently-running `apply()`
+        # call does. No `reset()` is needed: every `apply()` call installs
+        # its own fresh object up front, so the next call on a reused worker
+        # thread simply overwrites the ambient value before reading it.
+        self._runtime_state_var.set(_PerRequestRuntimeState())
+
         # Pre-process: Read lifecycle management (stale/superseded detection)
         if self.config.read_lifecycle.enabled:
             from .read_lifecycle import ReadLifecycleManager

--- a/tests/test_content_router_concurrency.py
+++ b/tests/test_content_router_concurrency.py
@@ -1,0 +1,199 @@
+"""Regression test for issue #3486: ContentRouter per-request state isolation.
+
+``ContentRouter`` is instantiated once at proxy startup and shared across
+all concurrent requests (see ``headroom/proxy/server.py``, which dispatches
+``pipeline.apply()`` calls onto a real ``ThreadPoolExecutor``). ``apply()``
+stores per-call runtime state -- including the F2.2
+``self._runtime_compression_policy`` -- as plain, unsynchronized instance
+attributes (``content_router.py`` around line 4837). A second concurrent
+``apply()`` call can overwrite that attribute before the first call has
+finished reading it, corrupting the first request's view of its own
+compression policy with a *different* request's policy.
+
+This test forces that interleaving deterministically: Thread A starts an
+``apply()`` call under the Subscription policy (``toin_read_only=True`` --
+must NEVER write to the shared TOIN learning pool) and is paused, via a
+patched ``_record_to_toin``, right before it reads
+``self._runtime_compression_policy``. While paused, Thread B runs a
+complete ``apply()`` call under the PAYG policy, which overwrites the
+shared attribute. Thread A is then resumed: on the current (unfixed) code
+it reads Thread B's PAYG policy instead of its own Subscription policy and
+incorrectly writes Subscription-mode content into the shared, cross-user
+TOIN learning pool -- a privacy-relevant cross-tenant leak the F2.2 gate
+exists specifically to prevent.
+
+See ``tests/test_compression_policy_toin_gate.py`` for the (non-concurrent)
+F2.2 gate tests this mirrors, and
+``tests/test_code_compressor_thread_safety.py`` for the
+Event/ThreadPoolExecutor style this follows.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from headroom.proxy.auth_mode import AuthMode
+from headroom.telemetry.toin import TOINConfig, get_toin, reset_toin
+from headroom.transforms.compression_policy import policy_for_mode
+from headroom.transforms.content_router import ContentRouter, ContentRouterConfig
+
+
+@pytest.fixture
+def fresh_toin():
+    """Per-test TOIN instance backed by a tempdir to avoid global drift."""
+    reset_toin()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        storage = str(Path(tmpdir) / "toin.json")
+        toin = get_toin(TOINConfig(storage_path=storage, auto_save_interval=0))
+        yield toin
+        reset_toin()
+
+
+@pytest.fixture
+def tokenizer():
+    from headroom.providers import OpenAIProvider
+    from headroom.tokenizer import Tokenizer
+
+    provider = OpenAIProvider()
+    token_counter = provider.get_token_counter("gpt-4o")
+    return Tokenizer(token_counter, "gpt-4o")
+
+
+class _FakeKompress:
+    """Deterministic stand-in for the ML Kompress stage.
+
+    Truncates to the first 20 words, so the compressed result is always
+    reliably shorter than the (160-item) input regardless of whether the
+    real ML model is installed/ready -- guarantees the
+    ``original_tokens > compressed_tokens`` check in ``_record_to_toin``
+    passes on every run.
+    """
+
+    def is_ready(self) -> bool:
+        return True
+
+    def ensure_background_load(self) -> None:
+        pass
+
+    def compress(self, content: str, **kwargs):
+        compressed = " ".join(content.split()[:20]) + " Retrieve more: hash=deadbeef"
+        return SimpleNamespace(
+            compressed=compressed, compressed_tokens=len(compressed.split())
+        )
+
+
+def _kompress_forcing_tool_message() -> list[dict]:
+    """A tool_result message that reaches ContentRouter's own
+    ``_record_to_toin`` call site via the real ``apply()`` pipeline.
+
+    Mirrors ``test_force_kompress_...`` in
+    ``tests/test_transforms/test_content_router.py``. Confirmed by direct
+    instrumentation that with ``force_kompress=True`` this content lands on
+    the router's own TOIN-recording call (content_router.py:3694) -- NOT
+    the SmartCrusher path, which has its own separate, already-tested gate.
+    """
+    tool_content = " ".join(
+        f'{{"file":"src/module_{i}.py","line":{i},"text":"repeated search payload"}}'
+        for i in range(160)
+    )
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_search_1",
+                    "content": tool_content,
+                }
+            ],
+        }
+    ]
+
+
+def test_concurrent_apply_calls_leak_compression_policy_across_requests(
+    fresh_toin, tokenizer, monkeypatch
+):
+    """#3486: a concurrent PAYG ``apply()`` call must not flip a
+    Subscription request's TOIN write-gate to "write enabled".
+
+    ``ContentRouter`` is a shared singleton (one instance for the whole
+    proxy process); ``apply()`` stashes the per-call ``CompressionPolicy``
+    on ``self._runtime_compression_policy`` with no locking and no
+    per-request scoping. This test proves that a second, unrelated
+    concurrent request corrupts the first request's view of its own
+    policy -- Subscription-mode content ends up written into the
+    cross-user TOIN learning pool, which the F2.2 gate exists specifically
+    to prevent.
+    """
+    router = ContentRouter(ContentRouterConfig(min_section_tokens=10))
+    monkeypatch.setattr(router, "_get_kompress", lambda: _FakeKompress())
+
+    subscription_policy = policy_for_mode(AuthMode.SUBSCRIPTION)
+    payg_policy = policy_for_mode(AuthMode.PAYG)
+
+    thread_a_ready = threading.Event()
+    proceed = threading.Event()
+    thread_a_ident: dict[str, int] = {}
+
+    original_record_to_toin = ContentRouter._record_to_toin
+
+    def patched_record_to_toin(self, *args, **kwargs):
+        if threading.get_ident() == thread_a_ident.get("id"):
+            thread_a_ready.set()
+            # Give Thread B a chance to run its *entire* apply() call and
+            # overwrite self._runtime_compression_policy before Thread A's
+            # _record_to_toin reads it below.
+            if not proceed.wait(timeout=5):
+                raise TimeoutError("Thread B did not signal proceed in time")
+        return original_record_to_toin(self, *args, **kwargs)
+
+    monkeypatch.setattr(ContentRouter, "_record_to_toin", patched_record_to_toin)
+
+    errors: list[BaseException] = []
+
+    def run_thread_a():
+        thread_a_ident["id"] = threading.get_ident()
+        try:
+            router.apply(
+                _kompress_forcing_tool_message(),
+                tokenizer,
+                force_kompress=True,
+                target_ratio=0.10,
+                compress_user_messages=True,
+                min_tokens_to_compress=10,
+                read_protection_window=0,
+                compression_policy=subscription_policy,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    pre = sum(p.total_compressions for p in fresh_toin._patterns.values())
+
+    thread_a = threading.Thread(target=run_thread_a)
+    thread_a.start()
+
+    assert thread_a_ready.wait(timeout=5), "Thread A never reached _record_to_toin"
+
+    # Thread B: a fully independent, concurrent request under PAYG.
+    # Runs to completion while Thread A is paused mid-call.
+    router.apply([], tokenizer, compression_policy=payg_policy)
+
+    proceed.set()
+    thread_a.join(timeout=5)
+    assert not thread_a.is_alive(), "Thread A did not finish"
+    assert not errors, f"Thread A raised: {errors}"
+
+    post = sum(p.total_compressions for p in fresh_toin._patterns.values())
+    assert post == pre, (
+        "Thread A's request used the Subscription policy "
+        "(toin_read_only=True) and must NEVER write to the shared TOIN "
+        "learning pool -- even though an unrelated concurrent PAYG "
+        "request ran in between. A write here means "
+        "self._runtime_compression_policy leaked across concurrent "
+        "requests on the shared ContentRouter singleton (#3486)."
+    )


### PR DESCRIPTION
## Summary

Fixes #3486.

`ContentRouter` is instantiated once at proxy startup and shared, as a single object, across every concurrent request — `apply()` calls are dispatched onto a real `ThreadPoolExecutor` (`headroom/proxy/server.py`). `apply()` stored per-call state (the F2.2 `CompressionPolicy`, `target_ratio`, `force_kompress`/`skip_kompress`, `kompress_model`, and the tool-call-id maps built per request) as plain instance attributes with **no locking and no per-request scoping**. A second, concurrent `apply()` call on a different worker thread could overwrite a first request's values mid-flight.

Concretely this is a cross-tenant data leak: a Subscription-mode request (`toin_read_only=True` — must never write to the shared cross-user TOIN learning pool) could have its `self._runtime_compression_policy` clobbered by a concurrent PAYG request, causing its content to be incorrectly written into the shared pool.

- **Reproduction / regression test** (first commit): forces the race deterministically with a `threading.Event`-paused `apply()` call and a concurrent interloper `apply()` call on the same shared router instance. Fails reliably (5/5 runs) against the current code, asserting `1 == 0` extra TOIN writes.
- **Fix** (second commit): bundles the affected fields into a `_PerRequestRuntimeState` dataclass stored in a per-instance `ContextVar`, bound fresh at the top of every `apply()` call. `ContextVar` values are Context-local per OS thread by default (no cross-thread propagation), so concurrent `apply()` calls on different `ThreadPoolExecutor` workers are now fully isolated. All existing internal read/write call sites (`self._runtime_x = value`, `getattr(self, "_runtime_x", default)`) are unchanged — properties proxy them onto the `ContextVar` transparently, so no other call site in the ~1000-line `apply()` method needed to change. Direct callers that never go through `apply()` (`compress()`, tests calling `_record_to_toin()` directly, etc.) keep their pre-fix behavior via a lazily-created per-thread default.

## Test plan

- [x] New regression test (`tests/test_content_router_concurrency.py`) fails reliably against the pre-fix code (5/5 runs) and passes deterministically against the fix (5/5 runs).
- [x] `tests/test_transforms/test_content_router.py`, `tests/test_compression_policy_toin_gate.py`, `tests/test_code_compressor_thread_safety.py`, `tests/test_hermes_tool_call_unwrap.py`, `tests/test_observed_wire_shapes.py`, and other `ContentRouter`-touching suites pass unchanged.
- [x] `ruff check` and `mypy` clean on the changed file.
- [x] Full suite (`pytest tests/`): 12021 passed, 592 skipped — identical to the pre-fix baseline aside from the new test flipping fail→pass. The 7 failures in `test_proxy_health.py` / `test_read_maturation_handler_nobust.py` are pre-existing full-suite ordering flakes, independently reproduced on the unfixed baseline (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)