### PR TITLE
test(litellm): cover standalone max_completion_tokens forwarding

### DIFF
--- a/headroom/backends/litellm.py
+++ b/headroom/backends/litellm.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 _OPENAI_STANDARD_PARAMS = (
     "max_tokens",
+    "max_completion_tokens",
     "temperature",
     "top_p",
     "stop",

--- a/tests/test_litellm_openai_passthrough.py
+++ b/tests/test_litellm_openai_passthrough.py
@@ -143,3 +143,39 @@ async def test_standard_params_still_forwarded() -> None:
     assert kwargs["top_p"] == 0.9
     assert kwargs["response_format"] == {"type": "json_object"}
     assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+@pytest.mark.asyncio
+async def test_max_completion_tokens_forwarded_as_standard_param() -> None:
+    backend = make_backend()
+    body = request_body(max_completion_tokens=64)
+    body.pop("max_tokens")
+
+    with patch("headroom.backends.litellm.acompletion", new_callable=AsyncMock) as mock_acomp:
+        mock_acomp.return_value = make_response()
+
+        await backend.send_openai_message(body, {})
+
+    kwargs = mock_acomp.await_args.kwargs
+    assert kwargs["max_completion_tokens"] == 64
+    assert "extra_body" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_max_completion_tokens_forwarded_as_standard_param_streaming() -> None:
+    backend = make_backend()
+    body = request_body(max_completion_tokens=64)
+    body.pop("max_tokens")
+    stream = FakeAsyncStream(
+        [SimpleNamespace(model_dump=lambda **kwargs: {"id": "chunk1", "choices": []})]
+    )
+
+    with patch("headroom.backends.litellm.acompletion", new_callable=AsyncMock) as mock_acomp:
+        mock_acomp.return_value = stream
+
+        chunks = [chunk async for chunk in backend.stream_openai_message(body, {})]
+
+    kwargs = mock_acomp.await_args.kwargs
+    assert kwargs["max_completion_tokens"] == 64
+    assert "extra_body" not in kwargs
+    assert chunks[-1] == "data: [DONE]\n\n"


### PR DESCRIPTION
## Description

Current main already forwards `max_completion_tokens` as a standard LiteLLM parameter. After refreshing this branch, the remaining change adds buffered and streaming regression coverage for requests that provide `max_completion_tokens` without `max_tokens`, ensuring the value stays top-level and does not leak into `extra_body`.

Addresses #3554

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add buffered and streaming regression tests that verify the parameter is preserved and not duplicated in `extra_body`.

## Testing

- [x] Unit tests pass (`pytest`)
- [ ] Linting passes (`ruff check .`)
- [ ] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

### Test Output

```text
$ .venv/bin/python -m pytest tests/test_litellm_openai_passthrough.py -q
6 passed in 2.57s

$ .venv/bin/ruff format --check headroom/backends/litellm.py tests/test_litellm_openai_passthrough.py
2 files already formatted

$ .venv/bin/ruff check headroom/backends/litellm.py tests/test_litellm_openai_passthrough.py
All checks passed!
```

## Real Behavior Proof

- Environment: Linux, Python 3.11.16, headroom checkout at commit `77136a57d41bbd720272d5f7d2f8ea1b93278bbe`, LiteLLM 1.88.1.
- Exact command / steps: Ran `LiteLLMBackend.send_openai_message` with a request containing `max_completion_tokens=64` and captured the arguments passed to the LiteLLM completion call.
- Observed result: The backend passed `max_completion_tokens=64` as a top-level LiteLLM argument and did not create `extra_body`.
- Not tested: Live Bedrock or Bifrost calls, and the separate Bedrock prompt-caching gate described in #3554.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` - it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A



## Maintainer refresh (2026-09-16)

Updated from upstream main, retained both the reasoning-parameter and standalone completion-limit regressions, and removed the duplicate tuple entry introduced by combining the two implementations. The net diff is tests only. On macOS/Python 3.13, all 8 passthrough tests pass; focused Ruff lint/format checks pass. Live provider calls were not run.
