### PR TITLE
feat(transforms): first-class Elixir support in CodeAwareCompressor

### DIFF
--- a/docs/content/docs/code-compression.mdx
+++ b/docs/content/docs/code-compression.mdx
@@ -18,7 +18,23 @@ Naive truncation breaks code. Cutting a function in half leaves invalid syntax t
 | Tier | Languages | Support Level |
 |---|---|---|
 | Tier 1 | Python, JavaScript, TypeScript | Full AST analysis |
-| Tier 2 | Go, Rust, Java, C, C++, C#, PHP | Function body compression |
+| Tier 2 | Go, Rust, Java, C, C++, C#, PHP, Elixir | Function body compression |
+
+### Elixir
+
+Elixir has no dedicated definition nodes -- `def`, `defmodule` and `alias` are
+macros, so every one of them parses as a generic `call`. Headroom dispatches on
+the macro name instead of the node type, which means:
+
+- `defmodule`, `defprotocol`, `defimpl` and ExUnit `describe` blocks are
+  containers: their members compress individually.
+- `def`, `defp`, `defmacro`, `defguard`, `defdelegate`, and ExUnit
+  `test`/`setup` bodies are compressed; heads (including `when` guards) are kept.
+- `alias`, `import`, `require`, `use` are treated as imports and preserved.
+- `defstruct`, `defexception`, and Ecto `schema`/`embedded_schema` blocks are
+  preserved verbatim -- they declare the module's shape, not its behaviour.
+- One-line `def foo(x), do: expr` clauses have no block to compress and pass
+  through unchanged, as do `~H`/`~s` heredoc sigils, which are single statements.
 
 ## What Gets Preserved vs Compressed
 

--- a/docs/content/docs/limitations.mdx
+++ b/docs/content/docs/limitations.mdx
@@ -55,7 +55,7 @@ Headroom is designed to compress LLM context without losing accuracy. This page 
 
 ## Code Compression
 
-Headroom includes an AST-aware CodeCompressor (tree-sitter, 11 languages: Python, JavaScript, TypeScript, Go, Rust, Java, C, C++, Perl, C#, PHP) but it is gated behind safety protections that prevent it from firing in most real-world scenarios. This is intentional.
+Headroom includes an AST-aware CodeCompressor (tree-sitter, 12 languages: Python, JavaScript, TypeScript, Go, Rust, Java, C, C++, Perl, C#, PHP, Elixir) but it is gated behind safety protections that prevent it from firing in most real-world scenarios. This is intentional.
 
 **Why code mostly passes through:**
 

--- a/headroom/transforms/code_compressor.py
+++ b/headroom/transforms/code_compressor.py
@@ -650,6 +650,13 @@ _LANG_CONFIGS: dict[CodeLanguage, LangConfig] = {
         uses_colon_after_signature=False,
         detection_hints=("defmodule ", "defp ", "@moduledoc", "|>", " do\n"),
         call_node_type="call",
+        # The three target sets below partition the 15 definition macros the
+        # grammar itself recognises — `queries/highlights.scm` in
+        # elixir-lang/tree-sitter-elixir, `#any-of? @keyword "def" ...`. The
+        # function set is that file's own function-definition subset verbatim;
+        # the rest are split by whether the macro owns a member list
+        # (container) or declares shape (verbatim). Re-check against upstream
+        # when the pinned grammar version moves.
         call_function_targets=frozenset(
             {
                 "def",
@@ -677,7 +684,17 @@ _LANG_CONFIGS: dict[CodeLanguage, LangConfig] = {
         # Structure declarations, kept verbatim: they are the module's shape,
         # not its behaviour, and `schema`/`embedded_schema` field lists are
         # exactly what a reader of compressed Ecto code needs.
-        call_type_targets=frozenset({"defstruct", "defexception", "schema", "embedded_schema"}),
+        call_type_targets=frozenset(
+            {
+                "defstruct",
+                "defexception",
+                # Declares which generated functions may be replaced; carries no
+                # body of its own.
+                "defoverridable",
+                "schema",
+                "embedded_schema",
+            }
+        ),
         # Anything at the top level that is not itself a definition is opaque:
         # emitted verbatim, never recursed into. Elixir wraps declarations in
         # ordinary macros (`for encoder <- [...] do defimpl ... end end`), and

--- a/headroom/transforms/code_compressor.py
+++ b/headroom/transforms/code_compressor.py
@@ -16,7 +16,8 @@ Supported Languages (Tier 1):
 - Python, JavaScript, TypeScript
 
 Supported Languages (Tier 2):
-- Go, Rust, Java, C, C++
+- Go, Rust, Java, C, C++, C#, PHP
+- Elixir (macro-call dispatch; see LangConfig.call_node_type)
 - Bash (validated and preserved losslessly)
 
 Compression Strategy:
@@ -274,7 +275,8 @@ def _get_parser(language: str) -> Any:
         except Exception as e:
             raise ValueError(
                 f"Language '{language}' is not supported by tree-sitter. "
-                f"Supported: python, javascript, typescript, go, rust, java, c, cpp, csharp, php, bash. "
+                f"Supported: python, javascript, typescript, go, rust, java, c, cpp, "
+                f"csharp, php, elixir, bash. "
                 f"Error: {e}"
             ) from e
 
@@ -331,6 +333,7 @@ class CodeLanguage(Enum):
     PERL = "perl"
     CSHARP = "csharp"
     PHP = "php"
+    ELIXIR = "elixir"
     BASH = "bash"
     SHELL = "bash"  # Alias: tree-sitter-language-pack exposes the Bash grammar.
     UNKNOWN = "unknown"
@@ -361,6 +364,9 @@ _LANGUAGE_ALIASES: dict[str, CodeLanguage] = {
     "php5": CodeLanguage.PHP,
     "php7": CodeLanguage.PHP,
     "php8": CodeLanguage.PHP,
+    "ex": CodeLanguage.ELIXIR,
+    "exs": CodeLanguage.ELIXIR,
+    "iex": CodeLanguage.ELIXIR,
     "shell": CodeLanguage.BASH,
     "sh": CodeLanguage.BASH,
     "zsh": CodeLanguage.BASH,
@@ -401,6 +407,15 @@ class DocstringMode(Enum):
 # =========================================================================
 
 
+# Dispatch sentinels for macro-call languages (see LangConfig below). They
+# stand in for grammar node types that Elixir does not have, so they must not
+# collide with any real tree-sitter node type.
+_CALL_ROLE_FUNCTION = "__call_function__"
+_CALL_ROLE_CLASS = "__call_class__"
+_CALL_ROLE_IMPORT = "__call_import__"
+_CALL_ROLE_TYPE = "__call_type__"
+
+
 @dataclass(frozen=True)
 class LangConfig:
     """Data-driven configuration for a programming language.
@@ -436,6 +451,28 @@ class LangConfig:
     # descendants individually while the top-level pass re-emits the whole
     # wrapper verbatim, duplicating content. Prefer the false negative.
     opaque_node_types: frozenset[str] | None = None
+
+    # --- Macro-call languages (Elixir) -----------------------------------
+    #
+    # Elixir has no `function_definition` node: `def`, `defp`, `defmodule` and
+    # `alias` are macros, so every one of them parses as a generic `call` whose
+    # first child is the macro's `identifier`. Dispatching on `node.type` alone
+    # would either match nothing or match every function call in the file.
+    # When `call_node_type` is set, `_effective_type` resolves such a node to
+    # one of the `_CALL_ROLE_*` sentinels by looking up that identifier in the
+    # target sets below; the sentinels are what the language's
+    # `function_nodes`/`class_nodes`/`import_nodes`/`type_nodes` contain, so
+    # every existing dispatch site keeps working unchanged.
+    call_node_type: str | None = None
+    call_function_targets: frozenset[str] = frozenset()
+    call_class_targets: frozenset[str] = frozenset()
+    call_import_targets: frozenset[str] = frozenset()
+    call_type_targets: frozenset[str] = frozenset()
+
+    # Block delimiters for languages whose signature and body share a line.
+    # Brace languages use `{`/`}`; Elixir uses the `do`/`end` keywords.
+    body_open_token: str = "{"
+    body_close_token: str = "}"
 
 
 _LANG_CONFIGS: dict[CodeLanguage, LangConfig] = {
@@ -595,6 +632,65 @@ _LANG_CONFIGS: dict[CodeLanguage, LangConfig] = {
         package_node="namespace_definition",
         detection_hints=("<?php", "function ", "namespace ", "->", "$this"),
         class_body_node_types=frozenset({"declaration_list"}),
+    ),
+    CodeLanguage.ELIXIR: LangConfig(
+        # Every entry below is a `_CALL_ROLE_*` sentinel, not a grammar node
+        # type: tree-sitter-elixir emits `call` for `def`, `defmodule`,
+        # `alias` and friends alike, so dispatch runs on the macro name via
+        # `call_*_targets` (see LangConfig).
+        import_nodes=frozenset({_CALL_ROLE_IMPORT}),
+        function_nodes=frozenset({_CALL_ROLE_FUNCTION}),
+        class_nodes=frozenset({_CALL_ROLE_CLASS}),
+        type_nodes=frozenset({_CALL_ROLE_TYPE}),
+        body_node_types=frozenset({"do_block"}),
+        decorator_node=None,
+        comment_prefix="#",
+        # `def foo(x) do` opens its body on the signature line, like a K&R
+        # brace — the same same-line branch handles both.
+        uses_colon_after_signature=False,
+        detection_hints=("defmodule ", "defp ", "@moduledoc", "|>", " do\n"),
+        call_node_type="call",
+        call_function_targets=frozenset(
+            {
+                "def",
+                "defp",
+                "defmacro",
+                "defmacrop",
+                "defguard",
+                "defguardp",
+                "defdelegate",
+                "defn",
+                "defnp",
+                # ExUnit block macros: not definitions, but they wrap a `do`
+                # block of statements that compresses the same way and
+                # dominates test files.
+                "test",
+                "setup",
+                "setup_all",
+            }
+        ),
+        # `describe` groups `test` blocks the way a class groups methods, so it
+        # takes the class path: its children compress individually instead of
+        # the whole group being truncated at the first test.
+        call_class_targets=frozenset({"defmodule", "defprotocol", "defimpl", "describe"}),
+        call_import_targets=frozenset({"import", "alias", "require", "use"}),
+        # Structure declarations, kept verbatim: they are the module's shape,
+        # not its behaviour, and `schema`/`embedded_schema` field lists are
+        # exactly what a reader of compressed Ecto code needs.
+        call_type_targets=frozenset({"defstruct", "defexception", "schema", "embedded_schema"}),
+        # Anything at the top level that is not itself a definition is opaque:
+        # emitted verbatim, never recursed into. Elixir wraps declarations in
+        # ordinary macros (`for encoder <- [...] do defimpl ... end end`), and
+        # capturing the inner `defimpl` while the uncaptured wrapper is
+        # re-emitted verbatim duplicates the whole file (observed at 1.9x input
+        # on ecto/lib/ecto/json.ex). Definition roles are dispatched before
+        # this check, so `defmodule`/`def`/`alias` are unaffected; declarations
+        # nested inside a wrapper stay verbatim, which is the false negative we
+        # want. Module bodies do not take this path — `_compress_class_ast`
+        # walks them directly.
+        opaque_node_types=frozenset({"call", "binary_operator", "unary_operator"}),
+        body_open_token="do",
+        body_close_token="end",
     ),
     CodeLanguage.BASH: LangConfig(
         # Shell control-flow nodes are opaque: their `then`/`fi`, `do`/`done`,
@@ -838,6 +934,21 @@ _LANGUAGE_PREFILTER: dict[CodeLanguage, list[re.Pattern[str]]] = {
             re.MULTILINE,
         ),
         re.compile(r"\$this->|->\w+\s*\(", re.MULTILINE),
+    ],
+    CodeLanguage.ELIXIR: [
+        # `def` alone is shared with Python; only the Elixir-only definition
+        # macros are matched so Python source cannot score here.
+        re.compile(
+            r"^\s*def(module|p|macro|macrop|guard|guardp|delegate|struct|exception"
+            r"|impl|protocol|n|np)\b",
+            re.MULTILINE,
+        ),
+        re.compile(
+            r"^\s*@(moduledoc|doc|spec|type|typep|opaque|behaviour|impl|callback)\b",
+            re.MULTILINE,
+        ),
+        re.compile(r"\|>\s*\w", re.MULTILINE),
+        re.compile(r"^\s*(alias|require|use)\s+[A-Z][\w.]*", re.MULTILINE),
     ],
     CodeLanguage.BASH: [
         re.compile(r"^\s*#!.*\b(?:bash|sh|zsh)\b", re.MULTILINE),
@@ -1099,8 +1210,8 @@ class CodeAwareCompressor(Transform):
         function_calls: dict[str, set[str]] = {}
 
         def collect_definitions(node: Any, parent_name: str = "") -> None:
-            if node.type in all_definition_types:
-                short_name = _get_definition_name(node)
+            if _effective_type(node, lang_config) in all_definition_types:
+                short_name = _get_definition_name(node, lang_config)
                 if short_name:
                     qualified = f"{parent_name}.{short_name}" if parent_name else short_name
                     definitions[qualified] = node
@@ -1111,8 +1222,8 @@ class CodeAwareCompressor(Transform):
             # Also check for decorated definitions
             if lang_config.decorator_node and node.type == lang_config.decorator_node:
                 for child in node.children:
-                    if child.type in all_definition_types:
-                        short_name = _get_definition_name(child)
+                    if _effective_type(child, lang_config) in all_definition_types:
+                        short_name = _get_definition_name(child, lang_config)
                         if short_name:
                             qualified = f"{parent_name}.{short_name}" if parent_name else short_name
                             definitions[qualified] = child
@@ -1640,7 +1751,7 @@ class CodeAwareCompressor(Transform):
             return candidate_validator(node, compressed)
 
         def visit(node: Any) -> None:
-            node_type = node.type
+            node_type = _effective_type(node, lang_config)
 
             # Package declarations (Go, Java)
             if lang_config.package_node and node_type == lang_config.package_node:
@@ -1663,9 +1774,10 @@ class CodeAwareCompressor(Transform):
                 # Check if this export wraps a function or class
                 has_func_or_class = False
                 for child in node.children:
+                    child_type = _effective_type(child, lang_config)
                     if (
-                        child.type in lang_config.function_nodes
-                        or child.type in lang_config.class_nodes
+                        child_type in lang_config.function_nodes
+                        or child_type in lang_config.class_nodes
                     ):
                         has_func_or_class = True
                         compressed = self._compress_function_ast(
@@ -1773,7 +1885,7 @@ class CodeAwareCompressor(Transform):
             # declarations, so appending them as trailing top-level code would
             # produce invalid output (and fall back to no compression).
             if lang_config.opaque_node_types and node_type in lang_config.opaque_node_types:
-                child_types = [child.type for child in node.named_children]
+                child_types = [_effective_type(child, lang_config) for child in node.named_children]
                 has_import = any(t in lang_config.import_nodes for t in child_types)
                 has_declaration = any(
                     t in lang_config.class_nodes
@@ -1846,7 +1958,7 @@ class CodeAwareCompressor(Transform):
         node_lines = _get_node_lines(node, code_lines)
         node_text = "\n".join(node_lines)
 
-        func_name = _get_definition_name(node)
+        func_name = _get_definition_name(node, lang_config)
         body_limit = _get_body_limit(func_name, body_limits, self.config.max_body_lines)
 
         # Small enough to keep as-is
@@ -1900,14 +2012,14 @@ class CodeAwareCompressor(Transform):
             if _brace_in_signature:
                 # Opening brace already in signature line — just find closing
                 pass
-            elif body_lines and body_lines[0].strip().endswith("{"):
+            elif body_lines and body_lines[0].strip().endswith(lang_config.body_open_token):
                 # Matches both a bare `{` line and a multi-line signature's
                 # closing line (e.g. Go's `) error {`), where the brace
                 # shares a line with the closing paren/return type rather
                 # than starting one of its own.
                 opening_brace_line = body_lines[0]
                 body_lines = body_lines[1:]
-            if body_lines and body_lines[-1].strip().endswith("}"):
+            if body_lines and body_lines[-1].strip().endswith(lang_config.body_close_token):
                 closing_brace_line = body_lines[-1]
                 body_lines = body_lines[:-1]
 
@@ -2143,6 +2255,8 @@ class CodeAwareCompressor(Transform):
             if not child.is_named:
                 continue
 
+            child_type = _effective_type(child, lang_config)
+
             # Use line-based extraction for children too
             child_start = child.start_point[0]
             child_end = child.end_point[0]
@@ -2151,14 +2265,14 @@ class CodeAwareCompressor(Transform):
             child_text = "\n".join(code_lines[child_start : child_end + 1])
 
             # Methods/functions inside the class — compress individually
-            if child.type in lang_config.function_nodes:
+            if child_type in lang_config.function_nodes:
                 compressed = self._compress_function_ast(
                     child, code, language, lang_config, body_limits, analysis
                 )
                 body_parts.append(compressed)
                 processed_ranges.append((child.start_byte, child.end_byte))
             # Decorated methods
-            elif lang_config.decorator_node and child.type == lang_config.decorator_node:
+            elif lang_config.decorator_node and child_type == lang_config.decorator_node:
                 decorator_lines = []
                 method_compressed = None
                 for deco_child in child.children:
@@ -2178,8 +2292,8 @@ class CodeAwareCompressor(Transform):
                     body_parts.append(child_text)
                 processed_ranges.append((child.start_byte, child.end_byte))
             # Nested classes / containers (e.g. nested namespaces) — recurse
-            elif child.type in lang_config.class_nodes or (
-                lang_config.container_node_types and child.type in lang_config.container_node_types
+            elif child_type in lang_config.class_nodes or (
+                lang_config.container_node_types and child_type in lang_config.container_node_types
             ):
                 compressed = self._compress_class_ast(
                     child, code, language, lang_config, body_limits, analysis
@@ -2575,12 +2689,89 @@ def _get_same_line_trailing_semicolon(node: Any) -> Any | None:
     return None
 
 
-def _get_definition_name(node: Any) -> str | None:
+def _node_identifier_text(node: Any) -> str:
+    """Decode an AST node's source text (tree-sitter returns bytes)."""
+    text = node.text
+    return text.decode("utf-8") if isinstance(text, bytes) else str(text)
+
+
+def _effective_type(node: Any, lang_config: LangConfig) -> str:
+    """Node type to dispatch on, resolving macro calls to role sentinels.
+
+    Identity for every grammar that names its definitions (`function_item`,
+    `class_declaration`, ...). For Elixir, where `def`/`defmodule`/`alias` all
+    parse as `call`, the macro's target identifier selects a `_CALL_ROLE_*`
+    sentinel instead. A call whose target is not a bare identifier — `dot`, as
+    in `Repo.all(query)` — is never a definition and keeps its own type, so
+    ordinary remote calls fall through untouched.
+    """
+    if lang_config.call_node_type is None or node.type != lang_config.call_node_type:
+        return node.type
+    if not node.child_count:
+        return node.type
+    target = node.children[0]
+    if target.type != "identifier":
+        return node.type
+    name = _node_identifier_text(target)
+    if name in lang_config.call_function_targets:
+        return _CALL_ROLE_FUNCTION
+    if name in lang_config.call_class_targets:
+        return _CALL_ROLE_CLASS
+    if name in lang_config.call_import_targets:
+        return _CALL_ROLE_IMPORT
+    if name in lang_config.call_type_targets:
+        return _CALL_ROLE_TYPE
+    return node.type
+
+
+# Depth cap for the leftmost-head walk below: real Elixir heads are two or
+# three levels deep (`when` guard -> call -> identifier); anything deeper is
+# a shape we do not model, and returning None there costs only the per-symbol
+# body budget, never correctness.
+_CALL_HEAD_MAX_DEPTH = 8
+
+
+def _get_call_definition_name(node: Any) -> str | None:
+    """Name defined by a macro call, e.g. Elixir `def foo(a) when ... do`.
+
+    The call's own target identifier is the macro (`def`), not the name being
+    defined; the name is the head of its first argument. That head may be a
+    bare identifier (`def foo do`), a nested call (`def foo(a)`), the left side
+    of a `when` guard (`def foo(a) when is_map(a)`), or a module alias
+    (`defmodule MyApp.Accounts`), so walk leftmost until one of those lands.
+    """
+    args = None
+    for child in node.children:
+        if child.type == "arguments":
+            args = child
+            break
+    if args is None or not args.named_child_count:
+        return None
+
+    current: Any | None = args.named_children[0]
+    for _ in range(_CALL_HEAD_MAX_DEPTH):
+        if current is None:
+            return None
+        if current.type in ("identifier", "alias"):
+            return _node_identifier_text(current)
+        if current.type in ("call", "binary_operator", "unary_operator", "dot"):
+            current = current.named_children[0] if current.named_child_count else None
+            continue
+        return None
+    return None
+
+
+def _get_definition_name(node: Any, lang_config: LangConfig | None = None) -> str | None:
     """Extract the name identifier from a definition AST node."""
+    if (
+        lang_config is not None
+        and lang_config.call_node_type is not None
+        and node.type == lang_config.call_node_type
+    ):
+        return _get_call_definition_name(node)
     for child in node.children:
         if child.type in ("identifier", "name", "type_identifier", "property_identifier"):
-            text = child.text
-            return text.decode("utf-8") if isinstance(text, bytes) else str(text)
+            return _node_identifier_text(child)
     return None
 
 

--- a/headroom/transforms/code_compressor.py
+++ b/headroom/transforms/code_compressor.py
@@ -2724,10 +2724,8 @@ def _effective_type(node: Any, lang_config: LangConfig) -> str:
     """
     if lang_config.call_node_type is None or node.type != lang_config.call_node_type:
         return node.type
-    if not node.child_count:
-        return node.type
-    target = node.children[0]
-    if target.type != "identifier":
+    target = node.children[0] if node.child_count else None
+    if target is None or target.type != "identifier":
         return node.type
     name = _node_identifier_text(target)
     if name in lang_config.call_function_targets:

--- a/headroom/transforms/code_compressor.py
+++ b/headroom/transforms/code_compressor.py
@@ -634,10 +634,10 @@ _LANG_CONFIGS: dict[CodeLanguage, LangConfig] = {
         class_body_node_types=frozenset({"declaration_list"}),
     ),
     CodeLanguage.ELIXIR: LangConfig(
-        # Every entry below is a `_CALL_ROLE_*` sentinel, not a grammar node
-        # type: tree-sitter-elixir emits `call` for `def`, `defmodule`,
-        # `alias` and friends alike, so dispatch runs on the macro name via
-        # `call_*_targets` (see LangConfig).
+        # Every entry below is a `_CALL_ROLE_*` sentinel rather than a real
+        # grammar node type. tree-sitter-elixir emits `call` for `def`,
+        # `defmodule`, `alias` and friends alike, so dispatch runs on the macro
+        # name via `call_*_targets` (see LangConfig).
         import_nodes=frozenset({_CALL_ROLE_IMPORT}),
         function_nodes=frozenset({_CALL_ROLE_FUNCTION}),
         class_nodes=frozenset({_CALL_ROLE_CLASS}),
@@ -2722,11 +2722,12 @@ def _effective_type(node: Any, lang_config: LangConfig) -> str:
     in `Repo.all(query)` — is never a definition and keeps its own type, so
     ordinary remote calls fall through untouched.
     """
-    if lang_config.call_node_type is None or node.type != lang_config.call_node_type:
-        return node.type
+    node_type: str = node.type
+    if lang_config.call_node_type is None or node_type != lang_config.call_node_type:
+        return node_type
     target = node.children[0] if node.child_count else None
     if target is None or target.type != "identifier":
-        return node.type
+        return node_type
     name = _node_identifier_text(target)
     if name in lang_config.call_function_targets:
         return _CALL_ROLE_FUNCTION
@@ -2736,7 +2737,7 @@ def _effective_type(node: Any, lang_config: LangConfig) -> str:
         return _CALL_ROLE_IMPORT
     if name in lang_config.call_type_targets:
         return _CALL_ROLE_TYPE
-    return node.type
+    return node_type
 
 
 # Depth cap for the leftmost-head walk below: real Elixir heads are two or

--- a/headroom/transforms/content_detector.py
+++ b/headroom/transforms/content_detector.py
@@ -111,6 +111,17 @@ _CODE_PATTERNS = {
         ),
         re.compile(r"^.*\b(get|set|init);"),  # auto-property accessors
     ],
+    "elixir": [
+        # Elixir-only definition macros: bare `def` is shared with Python, so
+        # it is deliberately not matched here.
+        re.compile(
+            r"^\s*def(module|p|macro|macrop|guard|guardp|delegate|struct|exception"
+            r"|impl|protocol|n|np)\b"
+        ),
+        re.compile(r"^\s*@(moduledoc|doc|spec|type|typep|opaque|behaviour|impl|callback)\b"),
+        re.compile(r"\|>\s*\w"),  # pipe operator
+        re.compile(r"^\s*(alias|require|use)\s+[A-Z][\w.]*"),
+    ],
     "php": [
         re.compile(r"<\?php\b"),
         re.compile(r"^\s*namespace\s+[\w\\]+\s*;"),

--- a/headroom/transforms/content_detector.py
+++ b/headroom/transforms/content_detector.py
@@ -804,6 +804,16 @@ def _try_detect_code(content: str) -> DetectionResult | None:
     if not language_scores:
         return None
 
+    # Disambiguation: Elixir's `def foo(...)` heads also match the Python
+    # pattern, so a module with more public functions than attributes would be
+    # tagged `python` and handed to a parser that cannot read it — the file
+    # then fails validation and compresses by nothing. The Elixir patterns are
+    # deliberately exclusive (`defmodule`, `defp`, `@moduledoc`, `|>` have no
+    # Python spelling), so two of them settle the language; the Python score is
+    # folded in rather than dropped because those are Elixir `def` lines.
+    if language_scores.get("elixir", 0) >= 2 and "python" in language_scores:
+        language_scores["elixir"] += language_scores.pop("python")
+
     # Find best matching language
     best_lang = max(language_scores, key=lambda k: language_scores[k])
     best_score = language_scores[best_lang]

--- a/tests/test_transforms/test_code_compressor.py
+++ b/tests/test_transforms/test_code_compressor.py
@@ -2210,3 +2210,364 @@ class TestPhpSupport:
         code = "<?php\nclass Broken {\n    public function oops( {\n"
         result = self._compressor().compress(code, language="php")
         assert result.compressed == code
+
+
+@pytest.mark.skipif(not TREE_SITTER_INSTALLED, reason="tree-sitter grammar pack not installed")
+class TestElixirSupport:
+    """Elixir (``elixir`` grammar) support.
+
+    Elixir has no dedicated definition nodes: ``def``, ``defmodule``, ``alias``
+    and friends are macros, so tree-sitter-elixir emits a generic ``call`` for
+    all of them. These tests pin the macro-name dispatch (``_effective_type``),
+    the ``do``/``end`` block delimiters, and the false negatives that keep
+    output valid — one-line ``, do:`` clauses, ``defstruct``/``schema``
+    declarations, and malformed input.
+    """
+
+    def _compressor(self, **overrides):
+        kwargs = {
+            "min_tokens_for_compression": 1,
+            "max_body_lines": 1,
+            "enable_ccr": False,
+        }
+        kwargs.update(overrides)
+        return CodeAwareCompressor(CodeCompressorConfig(**kwargs))
+
+    def test_defmodule_compresses_bodies_and_keeps_structure(self):
+        """A `call` whose target is `defmodule` must route through class
+        compression: header, aliases and signatures verbatim, bodies elided,
+        module emitted exactly once and still closed by its `end`."""
+        code = textwrap.dedent("""\
+            defmodule MyApp.Billing do
+              @moduledoc "Billing."
+              alias MyApp.Repo
+
+              def charge(user, amount) do
+                invoice = Repo.get_by!(Invoice, user_id: user.id)
+                total = amount + invoice.balance
+                fee = round(total * 0.029) + 30
+                net = total - fee
+                Repo.update(invoice, %{balance: net})
+              end
+            end
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert result.language == CodeLanguage.ELIXIR
+        assert result.syntax_valid is True
+        assert result.compression_ratio < 1.0
+        assert "defmodule MyApp.Billing do" in result.compressed
+        assert '@moduledoc "Billing."' in result.compressed
+        assert "alias MyApp.Repo" in result.compressed
+        assert "def charge(user, amount) do" in result.compressed
+        assert "lines omitted" in result.compressed
+        assert "net = total - fee" not in result.compressed
+        assert result.compressed.count("defmodule MyApp.Billing") == 1
+        assert result.compressed.rstrip().endswith("end")
+
+    def test_private_function_with_guard_keeps_full_signature(self):
+        """`when` guards are part of the head; the whole clause line must
+        survive so the compressed clause still matches the same inputs."""
+        code = textwrap.dedent("""\
+            defmodule MyApp.Norm do
+              defp normalize(attrs) when is_map(attrs) do
+                pairs = Map.to_list(attrs)
+                keyed = Enum.map(pairs, fn {k, v} -> {to_string(k), v} end)
+                Map.new(keyed)
+              end
+            end
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert result.syntax_valid is True
+        assert "defp normalize(attrs) when is_map(attrs) do" in result.compressed
+        assert "lines omitted" in result.compressed
+
+    def test_module_attributes_are_preserved(self):
+        """`@spec`/`@type`/`@doc`/`@impl` are Elixir's type annotations and
+        docs; they parse as `unary_operator` siblings of the definition and
+        must be kept verbatim rather than swept into a compressed body."""
+        code = textwrap.dedent("""\
+            defmodule MyApp.Accounts do
+              @type result :: {:ok, map()} | {:error, term()}
+
+              @doc "Lists active users."
+              @spec list_active_users(map()) :: [map()]
+              @impl true
+              def list_active_users(params) do
+                base = build_query(params)
+                filtered = apply_filters(base, params)
+                ordered = apply_order(filtered, params)
+                Repo.all(ordered)
+              end
+            end
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert result.syntax_valid is True
+        assert "@type result :: {:ok, map()} | {:error, term()}" in result.compressed
+        assert '@doc "Lists active users."' in result.compressed
+        assert "@spec list_active_users(map()) :: [map()]" in result.compressed
+        assert "@impl true" in result.compressed
+
+    def test_single_line_do_clause_is_preserved_verbatim(self):
+        """`def area(s), do: expr` has no `do_block`; there is no body to
+        compress, so the clause must come through byte-identical."""
+        code = textwrap.dedent("""\
+            defmodule MyApp.Shape do
+              def area(%{kind: :rect} = s), do: s.width * s.height
+              def area(_), do: {:error, :unknown}
+
+              def perimeter(s) do
+                w = s.width
+                h = s.height
+                two = 2
+                two * (w + h)
+              end
+            end
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert result.syntax_valid is True
+        assert "def area(%{kind: :rect} = s), do: s.width * s.height" in result.compressed
+        assert "def area(_), do: {:error, :unknown}" in result.compressed
+        assert "lines omitted" in result.compressed
+
+    def test_defstruct_and_schema_blocks_are_preserved_verbatim(self):
+        """`defstruct` and Ecto `schema` declare the module's shape. They are
+        routed to type_nodes, not compressed: eliding field lists would hide
+        exactly what a reader of compressed Ecto code needs."""
+        code = textwrap.dedent("""\
+            defmodule MyApp.User do
+              use Ecto.Schema
+
+              defstruct [:id, :email, active: true]
+
+              schema "users" do
+                field :email, :string
+                field :active, :boolean, default: true
+                field :role, :string
+                timestamps()
+              end
+
+              def changeset(user, attrs) do
+                casted = cast(user, attrs, [:email, :active, :role])
+                required = validate_required(casted, [:email])
+                unique = unique_constraint(required, :email)
+                unique
+              end
+            end
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert result.syntax_valid is True
+        assert "defstruct [:id, :email, active: true]" in result.compressed
+        assert "field :email, :string" in result.compressed
+        assert "timestamps()" in result.compressed
+        # the behaviour, not the shape, is what gets elided
+        assert "lines omitted" in result.compressed
+
+    def test_nested_defmodule_compresses_without_duplication(self):
+        """A nested `defmodule` must recurse through class compression exactly
+        once — the Elixir analogue of the C# block-namespace re-dump trap."""
+        code = textwrap.dedent("""\
+            defmodule MyApp.Outer do
+              defmodule Inner do
+                def hello do
+                  a = 1
+                  b = 2
+                  c = 3
+                  a + b + c
+                end
+              end
+            end
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert result.syntax_valid is True
+        assert result.compression_ratio < 1.0
+        assert result.compressed.count("defmodule Inner") == 1
+        assert result.compressed.count("def hello") == 1
+        assert "lines omitted" in result.compressed
+
+    def test_exunit_blocks_compress(self):
+        """`describe`/`test` are block macros, not definitions, but they own
+        the bulk of a test file's lines and compress the same way."""
+        code = textwrap.dedent("""\
+            defmodule MyApp.AccountsTest do
+              use MyApp.DataCase, async: true
+
+              describe "list_users/1" do
+                test "returns active users" do
+                  a = insert(:user, active: true)
+                  b = insert(:user, active: false)
+                  result = Accounts.list_users()
+                  assert a.id in Enum.map(result, & &1.id)
+                  refute b.id in Enum.map(result, & &1.id)
+                end
+              end
+            end
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert result.syntax_valid is True
+        assert result.compression_ratio < 1.0
+        assert "use MyApp.DataCase, async: true" in result.compressed
+        assert 'describe "list_users/1" do' in result.compressed
+        assert "lines omitted" in result.compressed
+
+    def test_heredoc_sigil_body_stays_intact(self):
+        """A `~H` template is a single statement; keeping it whole is what
+        makes the output still parse."""
+        code = textwrap.dedent("""\
+            defmodule MyAppWeb.UserLive do
+              use MyAppWeb, :live_view
+
+              def render(assigns) do
+                ~H\"\"\"
+                <div class="p-4">
+                  <h1>{@title}</h1>
+                </div>
+                \"\"\"
+              end
+            end
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert result.syntax_valid is True
+        assert "<h1>{@title}</h1>" in result.compressed
+
+    def test_remote_call_is_not_treated_as_a_definition(self):
+        """`Repo.all(query)` is a `call` whose target is a `dot`, not an
+        identifier. Dispatching it as a definition would rewrite ordinary
+        code; it must stay top-level and verbatim."""
+        code = textwrap.dedent("""\
+            alias MyApp.Repo
+
+            emails = Repo.all(query)
+
+            Enum.each(emails, fn email ->
+              IO.puts(email)
+            end)
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert result.syntax_valid is True
+        assert "emails = Repo.all(query)" in result.compressed
+        assert "IO.puts(email)" in result.compressed
+        assert "lines omitted" not in result.compressed
+
+    def test_malformed_elixir_passes_through_unchanged(self):
+        code = "defmodule Broken do\n  def oops do\n    x = \n  end\n"
+        result = self._compressor(fallback_to_kompress=False).compress(code, language="elixir")
+        assert result.compressed == code
+
+    def test_language_detection_and_aliases(self):
+        code = textwrap.dedent("""\
+            defmodule MyApp.Accounts do
+              @moduledoc "Accounts."
+              alias MyApp.Repo
+
+              def list_users do
+                MyApp.User
+                |> Repo.all()
+              end
+            end
+            """)
+        lang, confidence = detect_language(code)
+        assert lang == CodeLanguage.ELIXIR
+        assert confidence > 0.0
+        assert coerce_language("ex") == CodeLanguage.ELIXIR
+        assert coerce_language("exs") == CodeLanguage.ELIXIR
+        assert coerce_language("elixir") == CodeLanguage.ELIXIR
+
+    def test_python_source_is_not_detected_as_elixir(self):
+        """The Elixir pre-filter deliberately omits bare `def` so that Python,
+        which shares it, cannot score on the Elixir patterns."""
+        code = textwrap.dedent("""\
+            import os
+            from typing import List
+
+
+            def process(items: List[str]) -> List[str]:
+                out = []
+                for item in items:
+                    out.append(item.strip())
+                return out
+            """)
+        assert detect_language(code)[0] == CodeLanguage.PYTHON
+
+    def test_definition_names_come_from_the_macro_argument(self):
+        """The call's own identifier is the macro (`def`), not the name being
+        defined. Symbol analysis must key on `charge`/`audit`, not on `def`,
+        or every function in the file shares one body budget."""
+        code = textwrap.dedent("""\
+            defmodule MyApp.Billing do
+              def charge(user, amount) do
+                a = amount + 1
+                b = a + 2
+                c = b + 3
+                c
+              end
+
+              defp audit(user) do
+                x = user.id
+                y = x + 1
+                z = y + 2
+                z
+              end
+            end
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert "charge" in result.symbol_scores
+        assert "audit" in result.symbol_scores
+        assert "def" not in result.symbol_scores
+        assert "defp" not in result.symbol_scores
+
+    def test_effective_type_resolves_macro_calls(self):
+        """Unit-level pin on the dispatch helper itself."""
+        parser = cc._get_parser("elixir")
+        config = cc._LANG_CONFIGS[CodeLanguage.ELIXIR]
+        source = (
+            b"defmodule A do\n"
+            b"  alias B\n"
+            b"  defstruct [:x]\n"
+            b"  def go(v), do: v\n"
+            b"  Enum.map([], & &1)\n"
+            b"end\n"
+        )
+        root = parser.parse(source).root_node
+        module = root.children[0]
+        assert cc._effective_type(module, config) == cc._CALL_ROLE_CLASS
+
+        body = next(c for c in module.children if c.type == "do_block")
+        roles = [cc._effective_type(c, config) for c in body.named_children]
+        assert cc._CALL_ROLE_IMPORT in roles
+        assert cc._CALL_ROLE_TYPE in roles
+        assert cc._CALL_ROLE_FUNCTION in roles
+        # `Enum.map/2` is an ordinary remote call, never a definition.
+        assert roles.count("call") == 1
+
+    def test_declarations_inside_a_macro_wrapper_are_not_duplicated(self):
+        """Elixir wraps declarations in ordinary macros. Capturing the inner
+        `defimpl` while the uncaptured `for`/`if` wrapper is re-emitted verbatim
+        duplicated the whole file (1.9x input on ecto/lib/ecto/json.ex). The
+        wrapper is opaque: emitted once, never recursed into."""
+        code = textwrap.dedent("""\
+            for encoder <- [Jason.Encoder, JSON.Encoder] do
+              if Code.ensure_loaded?(encoder) do
+                defimpl encoder, for: Ecto.Association.NotLoaded do
+                  def encode(%{__owner__: owner}, _) do
+                    raise "cannot encode association from #{inspect(owner)}"
+                  end
+                end
+              end
+            end
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert result.syntax_valid is True
+        assert result.compressed.count("defimpl encoder") == 1
+        assert result.compressed.count("def encode(") == 1
+        assert result.compression_ratio <= 1.0

--- a/tests/test_transforms/test_code_compressor.py
+++ b/tests/test_transforms/test_code_compressor.py
@@ -2549,6 +2549,59 @@ class TestElixirSupport:
         # `Enum.map/2` is an ordinary remote call, never a definition.
         assert roles.count("call") == 1
 
+    def test_definition_macro_roles_match_the_grammars_own_list(self):
+        """The role table is the grammar's classification, not a guess: the
+        function role is `queries/highlights.scm`'s function-definition subset
+        verbatim, and every one of the 15 definition macros that file lists is
+        assigned a role. Pins the table so a grammar bump surfaces here."""
+        config = cc._LANG_CONFIGS[CodeLanguage.ELIXIR]
+        upstream_function_definitions = {
+            "def",
+            "defdelegate",
+            "defguard",
+            "defguardp",
+            "defmacro",
+            "defmacrop",
+            "defn",
+            "defnp",
+            "defp",
+        }
+        # ExUnit block macros are ours, not the grammar's; strip them to compare.
+        exunit_blocks = {"test", "setup", "setup_all"}
+        assert config.call_function_targets - exunit_blocks == upstream_function_definitions
+
+        upstream_definition_keywords = upstream_function_definitions | {
+            "defexception",
+            "defimpl",
+            "defmodule",
+            "defoverridable",
+            "defprotocol",
+            "defstruct",
+        }
+        assigned = (
+            config.call_function_targets | config.call_class_targets | config.call_type_targets
+        )
+        assert upstream_definition_keywords <= assigned
+
+    def test_defoverridable_declaration_is_preserved(self):
+        code = textwrap.dedent("""\
+            defmodule MyApp.Base do
+              def handle(x) do
+                a = x + 1
+                b = a + 2
+                c = b + 3
+                c
+              end
+
+              defoverridable handle: 1
+            end
+            """)
+        result = self._compressor().compress(code, language="elixir")
+
+        assert result.syntax_valid is True
+        assert "defoverridable handle: 1" in result.compressed
+        assert "lines omitted" in result.compressed
+
     def test_declarations_inside_a_macro_wrapper_are_not_duplicated(self):
         """Elixir wraps declarations in ordinary macros. Capturing the inner
         `defimpl` while the uncaptured `for`/`if` wrapper is re-emitted verbatim

--- a/tests/test_transforms/test_code_compressor.py
+++ b/tests/test_transforms/test_code_compressor.py
@@ -2525,6 +2525,29 @@ class TestElixirSupport:
         assert "def" not in result.symbol_scores
         assert "defp" not in result.symbol_scores
 
+    def test_block_macro_without_arguments_has_no_name(self):
+        """`setup do` is a definition-role call with no `arguments` child at
+        all. The name lookup must return None (falling back to the default body
+        budget) rather than raising."""
+        parser = cc._get_parser("elixir")
+        config = cc._LANG_CONFIGS[CodeLanguage.ELIXIR]
+        node = parser.parse(b"setup do\n  :ok\nend\n").root_node.children[0]
+
+        assert cc._effective_type(node, config) == cc._CALL_ROLE_FUNCTION
+        assert [c.type for c in node.children] == ["identifier", "do_block"]
+        assert cc._get_call_definition_name(node) is None
+
+    def test_definition_name_walk_is_depth_capped(self):
+        """The leftmost-head walk stops after `_CALL_HEAD_MAX_DEPTH` levels.
+        Real heads are two or three deep; a pathological operator chain must
+        give up and return None instead of walking an arbitrary tree."""
+        parser = cc._get_parser("elixir")
+        source = b"def " + b"!" * (cc._CALL_HEAD_MAX_DEPTH + 2) + b"x do\n  1\nend\n"
+        node = parser.parse(source).root_node.children[0]
+
+        assert node.type == "call"
+        assert cc._get_call_definition_name(node) is None
+
     def test_effective_type_resolves_macro_calls(self):
         """Unit-level pin on the dispatch helper itself."""
         parser = cc._get_parser("elixir")

--- a/tests/test_transforms_content_detection.py
+++ b/tests/test_transforms_content_detection.py
@@ -261,6 +261,50 @@ def test_code_detection_identifies_language_and_thresholds() -> None:
     assert _try_detect_code("\n\n") is None
 
 
+def test_code_detection_routes_elixir_away_from_python() -> None:
+    """Elixir `def foo(...)` heads match the Python pattern too. A module with
+    more public functions than attributes used to be tagged `python` and handed
+    to a parser that cannot read it, so it compressed by nothing. Two
+    Elixir-exclusive markers settle the language and the Python score, which is
+    really those Elixir `def` lines, is folded in."""
+    elixir_code = "\n".join(
+        [
+            "defmodule MyApp.Accounts do",
+            '  @moduledoc "Accounts."',
+            "  alias MyApp.Repo",
+            "",
+            "  def list_users(params) do",
+            "    Repo.all(User)",
+            "  end",
+            "",
+            "  def get_user!(id) do",
+            "    Repo.get!(User, id)",
+            "  end",
+            "end",
+        ]
+    )
+    result = _try_detect_code(elixir_code)
+    assert result is not None
+    assert result.content_type is ContentType.SOURCE_CODE
+    assert result.metadata["language"] == "elixir"
+    assert detect_content_type(elixir_code).content_type is ContentType.SOURCE_CODE
+
+    # A single stray marker must not steal Python's files.
+    python_code = "\n".join(
+        [
+            "import os",
+            "from pathlib import Path",
+            "",
+            "def main():",
+            "    defn = 1",
+            "    return defn",
+            "def other():",
+            "    return 2",
+        ]
+    )
+    assert _try_detect_code(python_code).metadata["language"] == "python"
+
+
 def test_detect_content_type_respects_priority_order() -> None:
     diff_like_search = "\n".join(
         [


### PR DESCRIPTION
## Description

Elixir has no dedicated definition nodes: `def`, `defmodule` and `alias` are
macros, so tree-sitter-elixir emits a generic `call` for all of them.
Dispatching on `node.type` would either match nothing or match every function
call in the file — which is why the data-driven `LangConfig` could not express
Elixir as-is.

`LangConfig` gains `call_node_type` plus per-role target sets. `_effective_type`
resolves such a node to a `_CALL_ROLE_*` sentinel from the macro's target
identifier, and those sentinels are what Elixir's
`function_nodes`/`class_nodes`/`import_nodes`/`type_nodes` contain — so every
existing dispatch site keeps working unchanged and **no other language's
behavior moves**. The same-line body delimiters are generalised
(`body_open_token`/`body_close_token`) so `do`/`end` reuses the existing K&R
brace branch, and `_get_definition_name` reads the defined name from the macro's
first argument instead of the macro identifier.

**No new dependencies** — the `elixir` grammar ships inside the already-pinned
`tree-sitter-language-pack==0.13.0`.

Without this, Elixir source is scored as `python` by `_try_detect_code` (Elixir
`def foo(...)` matches Python's pattern), handed to a parser that cannot read
it, and compressed by **0%**.

Closes #3495

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `CodeLanguage.ELIXIR` + full `_LANG_CONFIGS` entry; `ex`/`exs`/`iex` aliases;
  `_LANGUAGE_PREFILTER` and `content_detector` patterns chosen to be
  Elixir-exclusive (bare `def` deliberately **not** matched, so Python cannot
  score on them).
- New `LangConfig` fields, in the pattern of #1334's `class_body_node_types` and
  #1926's `container_node_types`: `call_node_type` + `call_function_targets` /
  `call_class_targets` / `call_import_targets` / `call_type_targets`, and
  `body_open_token` / `body_close_token`.
- Role table taken from the grammar's own classification —
  `queries/highlights.scm` in `elixir-lang/tree-sitter-elixir`. The function
  role is that file's function-definition subset verbatim (9/9), and a test pins
  it so a grammar bump surfaces drift.
- `defmodule`/`defprotocol`/`defimpl` and ExUnit `describe` are containers whose
  members compress individually; `def`/`defp`/`defmacro`/`defguard`/
  `defdelegate` and `test`/`setup` bodies compress with heads (including `when`
  guards) preserved; `alias`/`import`/`require`/`use` are imports;
  `defstruct`/`defexception`/`defoverridable` and Ecto `schema`/`embedded_schema`
  stay verbatim.
- Non-definition top-level nodes are opaque. Elixir wraps declarations in
  ordinary macros; capturing an inner `defimpl` while the uncaptured `for`/`if`
  wrapper was re-emitted verbatim duplicated the whole file — observed at **1.9x
  input** on `ecto/lib/ecto/json.ex`, now a fail-before test.
- **Behavior change to call out:** `_try_detect_code` no longer scores Elixir as
  `python`. Two Elixir-exclusive markers settle the language, and Python's score
  is folded in rather than dropped because those matches *are* Elixir `def`
  lines.
- **From @JerrettDavis's review:** the container-head reconstruction now goes
  through `LangConfig.body_open_token` instead of a hard-coded `{`. Detail under
  *Real Behavior Proof → Observed result*.
- Docs: `code-compression.mdx` gains Elixir + an Elixir section;
  `limitations.mdx` language count 11 → 12.
- `TestElixirSupport` (23 tests) + an Elixir/Python routing test in
  `test_transforms_content_detection.py`.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ pytest tests/ -q --continue-on-collection-errors
main @04cdf79a : 1456 failed, 9668 passed, 891 skipped, 191 errors in 232.47s
this branch    : 1456 failed, 9692 passed, 891 skipped, 191 errors in 199.88s
```

Identical failure and error counts; **+24 passed is exactly the 24 tests this PR
adds** (20 plus the four regressions from @JerrettDavis's review). The
pre-existing failures are my sandbox — no network, optional extras absent — and
reproduce byte-for-byte on `main`.

```text
$ pytest <10 code-compressor / detector / router suites> -q
255 passed

$ mypy headroom/
Success: no issues found in 532 source files
$ ruff check headroom/ tests/...   &&   ruff format --check <changed files>
All checks passed! / already formatted        (ruff pinned 0.16.4)
```

Fail-before, Elixir-scoped selection with both sources reverted to `main`:
10 failed / 4 passed (the 4 are negative guards that pass trivially when Elixir
is unsupported). On the branch: 23 passed. The four review regressions fail
before their fix commit and pass after.

Rebased onto `main` @04cdf79a and fully re-verified there, including #3531 which
moved the Rust `tree-sitter` pin to `=0.26.12`. None of the 32 intervening
commits touch the files this PR changes; the rebase was conflict-free.

## Real Behavior Proof

- Environment: macOS 15 (Darwin 25.6.0, arm64), Python 3.14 venv, the real
  `CodeAwareCompressor` with `CodeCompressorConfig(enable_ccr=False)`, no mocks,
  `tree-sitter-language-pack==0.13.0`. Independently validated with **Elixir
  1.20.0 / Erlang OTP 28** `Code.string_to_quoted/2` — the compiler front end,
  not tree-sitter. Separately, the branch is installed from my fork and running
  as a live local proxy serving real Claude Code traffic.

- Exact command / steps: cloned 8 public Elixir repos at depth 1 and ran
  every `.ex`/`.exs` file through the **routed** entry point
  (`_try_compress_text`, default config, **no** language hint — what a tool
  result actually hits at the proxy), plus 4 private Elixir/Phoenix codebases of
  our own. Every rewritten file was written to disk and fed to
  `Code.string_to_quoted/2`. A separate pass counted every non-generated line in
  input vs output to detect duplication, and replayed the 30 recorded
  `code_aware_compressor` parity fixtures through Python on both `main` and this
  branch.

- Observed result: 12 repos, 9,211 files, **18,506,612 → 14,607,815 tokens,
  3,898,797 saved (21.1%)**. `main` saves **0** on the same corpus.

  | repo | ★ | files | before | after | saved |
  |---|---|---|---|---|---|
  | `plausible/analytics` @e74d6fb | 29.0k | 1,256 | 1,794,081 | 1,445,298 | 19.4% |
  | `elixir-lang/elixir` @36351ae | 26.6k | 559 | 2,438,899 | 2,052,748 | 15.8% |
  | `firezone/firezone` @c15d759 | 9.1k | 1,515 | 2,438,521 | 1,701,101 | 30.2% |
  | `livebook-dev/livebook` @9714e05 | 5.9k | 443 | 843,756 | 625,858 | 25.8% |
  | `ash-project/ash` @ca57d67 | 2.5k | 1,019 | 1,766,510 | 1,386,042 | 21.5% |
  | `phoenixframework/phoenix` @1e6183e | | 204 | 427,478 | 356,221 | 16.7% |
  | `elixir-ecto/ecto` @97437d5 | | 126 | 643,798 | 470,404 | 26.9% |
  | `phoenix_live_view` @441dc69 | | 232 | 597,992 | 462,270 | 22.7% |
  | **public total** | | **5,354** | **10,951,035** | **8,499,942** | **22.4%** |
  | 4 private codebases (web app, distributed Phoenix, 9-app umbrella, LiveView Native mobile) | | 3,857 | 7,555,577 | 6,107,873 | 19.2% |

  **4,360 / 4,360** rewritten files re-parse under real Elixir 1.20 / OTP 28.
  **Zero** content duplication in any repo. Worst-case inflation +28 chars, an
  omitted-line marker longer than the line it replaced. Latency P50 0.6–3.1 ms,
  P99 ≤ 75 ms (worst is `elixir-lang/elixir`, whose 1,800+-line modules hit the
  pre-existing symbol-analysis cost shared with every language). All 30 parity
  fixtures byte-identical to `main`.

  Detection across the corpus, by token: 74.1% `source_code/elixir` (8,392
  files) → the AST path; 22.7% `text` (852 files, mostly generated seed data);
  2.5% `build`; 0.03% still `source_code/python` (18 short modules carrying only
  one Elixir-exclusive marker, 8,378 tokens).

  Savings track the **body-to-signature ratio**, not repo size — only bodies
  compress. The two lowest rows are the two most documentation-dense repos,
  measured as share of tokens inside preserved `@doc`/`@moduledoc` heredocs:
  `elixir` 16.2%, `phoenix` 12.2%, `ash` 6.6%, `livebook` 3.9%, `firezone` 2.8%.
  `ecto` is the honest counter-example — 14.2% docs but 26.9% saved, because its
  planner and changeset modules have unusually long bodies. Libraries compress
  least, applications most.

  One of the private codebases measures 5.6% across its whole tree but 20.2% on
  `lib/` + `test/`: 73.5% of its tokens are four generated seed `.exs` files of
  map and aircraft data, the largest 8.0M tokens alone. Those are data literals,
  the detector classifies them `text`, and they never reach the AST compressor.
  Correct — but it means whole-tree percentages are meaningless on repos that
  vendor generated data, so the table uses `lib/` + `test/` for that codebase.

  **In production:** across 632 completed turns from 8 distinct Claude Code
  sessions on contexts up to 463k tokens, the AST path fired 35 times at ratio
  0.09 (`router:code_aware:0.09`) with no syntax failures and no user-visible
  breakage.

  **On @JerrettDavis's review finding:** confirmed, and it is more severe than
  reported. For `defmodule(...)\n) do` it does fall back to uncompressed input
  as described. For `defimpl Foo,\n  for: Bar do` and a wrapped `describe`
  head, the mutilated output contains no ERROR or MISSING node, so
  `_verify_syntax` passes it and the compressor **ships it** — the `for:` target
  is silently gone, and `Code.string_to_quoted/2` rejects the result with
  `unexpected reserved word: end`. tree-sitter-elixir is more permissive than
  the compiler for this shape, so the never-serve-broken-code guarantee leaked.
  Fixed by routing the head check through `LangConfig.body_open_token`;
  punctuation delimiters keep the original start-of-line rule so brace languages
  are byte-for-byte unchanged (all 30 parity fixtures confirm), and a word
  delimiter must be the final whitespace-separated token so neither `weirdo` nor
  the atom `:do` qualifies. All three shapes now compress, stay shorter, and
  parse under the real compiler.

- Not tested: the proxy over HTTP as a *test* (it is running in production,
  but the measurements call the transform and its routed entry point directly);
  CCR retrieval round-trips (`enable_ccr=False` throughout); the Rust port in
  `headroom-core` — Elixir is Python-only, as C#/PHP/Perl/Bash already are, so
  no parity fixtures are affected; Windows and Linux (macOS only); `.heex`
  templates (the `heex` grammar ships in the same wheel but is out of scope).

## Runtime Rollout Safety

- Rollout-managed feature(s): none. This adds a language to an existing
  transform; `headroom/rollout.py` has no `code_aware` gate and this PR adds no
  rollout channel, flag or qualification.
- Minimum rollout channel: n/a — not rollout-managed.
- Stable/default behavior changed: yes, two, both scoped to Elixir input.
  (1) `.ex`/`.exs` content now takes the AST path instead of passing through
  unchanged. (2) `_try_detect_code` no longer labels Elixir source `python`;
  guarded by a test, and 0 of headroom's own 1,478 `.py` files change label. No
  other language's output moves — all 30 parity fixtures byte-identical.
- Kill switch / disable path: `HEADROOM_CODE_AWARE_ENABLED=0` disables
  code-aware compression wholesale, as today. Installing without the `code`
  extra leaves tree-sitter absent and the compressor inert. The existing
  per-language syntax breaker (`HEADROOM_CODE_SYNTAX_BREAKER`) auto-pauses
  Elixir after repeated invalid-output discards without touching other
  languages.
- Unsafe override required: no.
- Qualification impact: none. No new gates, no change to existing
  qualification criteria.
- Rollback path: revert the commits. No migration, no persisted state, no
  config-schema change, no wire-format change; `uv.lock` untouched.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A — terminal evidence above.

## Additional Notes

**On the Codecov patch-coverage report (26.38%, 53 lines).** That number is a CI
artifact, not a gap in the tests. No CI job installs the `code` extra — the
shards install `"${WHEEL}[dev]"`, and `dev` does not carry `tree-sitter` or
`tree-sitter-language-pack`. Every class in `test_code_compressor.py` gated on
`@pytest.mark.skipif(not TREE_SITTER_INSTALLED)` is therefore skipped in
coverage, which is seven classes including `TestCSharpSupport`,
`TestPhpSupport`, `TestRealASTRuns` and this PR's `TestElixirSupport`. Measured
locally with the extra installed, patch coverage is **70/71 executable added
lines (98.6%)** on `code_compressor.py` and **2/2** on `content_detector.py`;
the single miss is a `current is None` guard I do not believe is reachable from
a real parse. Project coverage of both changed modules holds (86% → 86%,
48% → 48%).

This is pre-existing and repo-wide rather than something this PR introduces, so
I have not changed CI here. Adding `tree-sitter`/`tree-sitter-language-pack` to
the `dev` extra would make those seven classes actually run — no new package,
both already pinned under `code` — but it is a dependency change and squarely a
maintainer call. Happy to do it here or in a separate PR, whichever you prefer.

**Dependency justification:** none added, none bumped; `uv.lock` untouched.

**Architecture:** malformed input passes through byte-identical; every risky
construct prefers the false negative (verbatim) over corruption; invalid
reassembly falls back via the existing validation gate; no new imports at module
load; P99 < 75 ms across all 12 proof repos.

**Known v1 limitations, deliberate, happy to file as follow-ups:**
- A body that is a single `|>` pipeline is one AST statement and is kept whole,
  so pipeline-heavy modules compress less.
- `@doc`/`@moduledoc` heredocs are preserved rather than subject to
  `docstring_mode` — in Elixir they are siblings of the definition, not its
  first statement, so the Python docstring path does not reach them.
- Declarations nested inside a `for`/`if` macro wrapper stay verbatim.

**Two incidental findings, neither blocking, happy to file separately:**
- The router's transform label is `code_aware:<ratio>` with no language, while
  `_try_compress_text` emits `code_aware:<lang>:<ratio>`. The language is
  dropped at the router, so live traffic cannot be attributed per language —
  which is why I can report that the AST path fired 35 times in production but
  not how often it was Elixir.
- `tree-sitter` resolves to `0.26.0` on the Python side under the current pin
  (`>=0.25.2,<0.27`) while earlier testing here was on 0.25.2. Both work; the
  numbers above are from 0.26.0.
