### PR TITLE
fix(proxy/openai): inject CCR retrieval tool for Responses API

### DIFF
--- a/headroom/ccr/tool_injection.py
+++ b/headroom/ccr/tool_injection.py
@@ -44,7 +44,7 @@ def create_ccr_tool_definition(
     uncompressed content.
 
     Args:
-        provider: The provider type ("anthropic", "openai", "google").
+            provider: The provider type ("anthropic", "openai", "openai_responses", "google").
                   Affects the tool definition format.
 
     Returns:
@@ -75,6 +75,14 @@ def create_ccr_tool_definition(
 
     if provider == "openai":
         return openai_definition
+
+    elif provider == "openai_responses":
+        return {
+            "type": "function",
+            "name": CCR_TOOL_NAME,
+            "description": openai_definition["function"]["description"],
+            "parameters": openai_definition["function"]["parameters"],
+        }
 
     elif provider == "anthropic":
         # Anthropic uses a slightly different format

--- a/headroom/proxy/ccr_golden_policy.py
+++ b/headroom/proxy/ccr_golden_policy.py
@@ -40,7 +40,7 @@ def replay_golden_ccr_tool_definition(golden_tool_bytes: bytes) -> CcrToolDefini
 
 
 def create_fresh_ccr_tool_definition(
-    provider: Literal["anthropic", "openai", "google"],
+    provider: Literal["anthropic", "openai", "openai_responses", "google"],
 ) -> CcrToolDefinitionReplay:
     """Create and canonicalize a fresh CCR tool definition for ``provider``."""
 

--- a/headroom/proxy/handlers/openai.py
+++ b/headroom/proxy/handlers/openai.py
@@ -5998,6 +5998,28 @@ class OpenAIHandlerMixin:
                     ) from _e
 
         if not _bypass:
+            if self.config.ccr_inject_tool:
+                from headroom.ccr import CCRToolInjector
+                from headroom.proxy.helpers import apply_session_sticky_ccr_tool
+
+                ccr_injector = CCRToolInjector(
+                    provider="openai_responses",
+                    inject_tool=False,
+                    inject_system_instructions=False,
+                )
+                ccr_injector.scan_for_markers(_responses_input_to_items(body.get("input")))
+                ccr_injector.verify_ownership()
+                response_tools, ccr_tool_injected = apply_session_sticky_ccr_tool(
+                    provider="openai_responses",
+                    session_id=_responses_session_id,
+                    request_id=request_id,
+                    existing_tools=body.get("tools"),
+                    has_compressed_content_this_turn=ccr_injector.has_compressed_content,
+                )
+                if ccr_tool_injected:
+                    body["tools"] = response_tools
+                    body_mutation_tracker.mark_mutated("responses_ccr_retrieve_tool")
+
             _http_conversation_key = request.headers.get("x-headroom-session-id")
             _shape_result = _shape_openai_responses_for_output(
                 body,

--- a/headroom/proxy/helpers.py
+++ b/headroom/proxy/helpers.py
@@ -2363,7 +2363,7 @@ def has_new_ccr_markers(
     *,
     current_detected_hashes: list[str],
     previous_forwarded_messages: list[dict[str, Any]] | None,
-    provider: Literal["anthropic", "openai", "google"],
+    provider: Literal["anthropic", "openai", "openai_responses", "google"],
 ) -> bool:
     """Whether the about-to-forward content carries CCR markers NOT already forwarded.
 
@@ -2425,7 +2425,7 @@ def history_references_ccr_tool(messages: Any) -> bool:
 
 def apply_session_sticky_ccr_tool(
     *,
-    provider: Literal["anthropic", "openai", "google"],
+    provider: Literal["anthropic", "openai", "openai_responses", "google"],
     session_id: str | None,
     request_id: str | None,
     existing_tools: list[dict[str, Any]] | None,
@@ -2458,7 +2458,7 @@ def apply_session_sticky_ccr_tool(
     """
     from headroom.ccr.tool_injection import CCR_TOOL_NAME
 
-    if provider not in ("anthropic", "openai", "google"):
+    if provider not in ("anthropic", "openai", "openai_responses", "google"):
         raise ValueError(f"unsupported provider: {provider!r}")
 
     tools_out: list[dict[str, Any]] = list(existing_tools) if existing_tools else []

--- a/tests/test_ccr_tool_always_on.py
+++ b/tests/test_ccr_tool_always_on.py
@@ -94,6 +94,32 @@ def test_tool_registered_on_every_request_after_first_ccr():
     assert _has_ccr_tool(tools_3)
 
 
+def test_responses_session_injects_flat_retrieve_tool():
+    tools, injected = apply_session_sticky_ccr_tool(
+        provider="openai_responses",
+        session_id="responses-session",
+        request_id="req-1",
+        existing_tools=None,
+        has_compressed_content_this_turn=True,
+    )
+
+    assert injected is True
+    assert tools[0]["name"] == CCR_TOOL_NAME
+    assert "function" not in tools[0]
+
+    replayed_tools, replayed = apply_session_sticky_ccr_tool(
+        provider="openai_responses",
+        session_id="responses-session",
+        request_id="req-2",
+        existing_tools=None,
+        has_compressed_content_this_turn=False,
+    )
+
+    assert replayed is True
+    assert replayed_tools[0]["name"] == CCR_TOOL_NAME
+    assert "function" not in replayed_tools[0]
+
+
 def test_tool_not_registered_if_session_never_did_ccr():
     """A session that never produced CCR markers gets no tool injection."""
     session_id = "fresh-session-no-ccr"

--- a/tests/test_ccr_tool_injection.py
+++ b/tests/test_ccr_tool_injection.py
@@ -55,6 +55,15 @@ class TestCCRToolDefinition:
         assert "parameters" in tool
         assert tool["parameters"]["required"] == ["hash"]
 
+    def test_openai_responses_format(self):
+        """Responses API tool definition uses its flat function format."""
+        tool = create_ccr_tool_definition("openai_responses")
+
+        assert tool["type"] == "function"
+        assert tool["name"] == CCR_TOOL_NAME
+        assert "function" not in tool
+        assert tool["parameters"]["required"] == ["hash"]
+
 
 class TestCCRToolInjector:
     """Test CCRToolInjector functionality."""

--- a/tests/test_proxy/test_openai_responses_ccr.py
+++ b/tests/test_proxy/test_openai_responses_ccr.py
@@ -24,8 +24,14 @@ from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from starlette.requests import Request  # noqa: E402
 
-from headroom.cache.compression_store import reset_compression_store  # noqa: E402
-from headroom.ccr.tool_injection import CCR_TOOL_NAME  # noqa: E402
+from headroom.cache.compression_store import (  # noqa: E402
+    get_compression_store,
+    reset_compression_store,
+)
+from headroom.ccr.tool_injection import (  # noqa: E402
+    CCR_TOOL_NAME,
+    create_ccr_tool_definition,
+)
 from headroom.proxy.loopback_guard import require_loopback  # noqa: E402
 from headroom.proxy.server import ProxyConfig, create_app  # noqa: E402
 
@@ -39,6 +45,105 @@ _RETRIEVE_TOOL = {
         "required": ["hash"],
     },
 }
+
+
+def test_responses_ccr_tool_uses_flat_function_schema():
+    """Responses clients need the flat tool schema used by Copilot."""
+    tool = create_ccr_tool_definition("openai_responses")
+
+    assert tool["type"] == "function"
+    assert tool["name"] == CCR_TOOL_NAME
+    assert "function" not in tool
+
+
+async def test_responses_compression_injects_retrieve_tool():
+    app = _make_app()
+    hash_key = "abc123def456abc123def456"
+    get_compression_store().store(
+        original="full Jira description",
+        compressed="<<ccr:abc123def456abc123def456,string,1.9KB>>",
+        explicit_hash=hash_key,
+    )
+
+    server = app.state.proxy
+    server.config.optimize = True
+    server.config.ccr_inject_tool = True
+    calls = _install_two_call_retry(app, hash_key)
+
+    async def fake_compress(body, **kwargs):  # noqa: ANN001, ARG001
+        compressed = dict(body)
+        compressed["input"] = [{"role": "tool", "content": f"<<ccr:{hash_key},string,1.9KB>>"}]
+        return compressed, True, 10, ["fake:ccr"], None, 100, 50, 20, {}
+
+    server._compress_openai_responses_payload_in_executor = fake_compress
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/responses",
+            json={"model": "gpt-5.6-luna", "input": "read the Jira issue", "stream": False},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert calls[0]["body"]["tools"][0]["name"] == CCR_TOOL_NAME
+    assert "function" not in calls[0]["body"]["tools"][0]
+
+
+def test_responses_ccr_tool_replays_on_marker_free_turn():
+    app = _make_app()
+    hash_key = "abc123def456abc123def456"
+    get_compression_store().store(
+        original="full Jira description",
+        compressed="<<ccr:abc123def456abc123def456,string,1.9KB>>",
+        explicit_hash=hash_key,
+    )
+    server = app.state.proxy
+    server.config.optimize = True
+    server.config.ccr_inject_tool = True
+    server.session_tracker_store.compute_session_id = lambda *args: "responses-session"
+    calls: list[dict] = []
+    compression_calls = 0
+
+    async def fake_compress(body, **kwargs):  # noqa: ANN001, ARG001
+        nonlocal compression_calls
+        compression_calls += 1
+        compressed = dict(body)
+        if compression_calls == 1:
+            compressed["input"] = [{"role": "tool", "content": f"<<ccr:{hash_key},string,1.9KB>>"}]
+            return compressed, True, 10, ["fake:ccr"], None, 100, 50, 20, {}
+        return compressed, False, 0, [], "unchanged", 50, 50, 0, {}
+
+    async def fake_retry(method, url, headers, body, stream=False, **kwargs):  # noqa: ANN001
+        calls.append(body)
+        return _final_response(url)
+
+    server._compress_openai_responses_payload_in_executor = fake_compress
+    server._retry_request = fake_retry
+
+    client_tools = [{"type": "function", "name": "client_tool"}]
+    with TestClient(app) as client:
+        for prompt in ("first turn", "marker-free follow-up"):
+            response = client.post(
+                "/v1/responses",
+                json={
+                    "model": "gpt-5.6-luna",
+                    "input": prompt,
+                    "tools": client_tools,
+                    "stream": False,
+                },
+                headers={
+                    "Authorization": "Bearer sk-test",
+                    "x-headroom-session-id": "responses-session",
+                },
+            )
+            assert response.status_code == 200, response.text
+
+    assert len(calls) == 2
+    for body in calls:
+        names = {tool["name"] for tool in body["tools"]}
+        assert names == {"client_tool", CCR_TOOL_NAME}
+        ccr_tool = next(tool for tool in body["tools"] if tool["name"] == CCR_TOOL_NAME)
+        assert "function" not in ccr_tool
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Description

When a compressed tool result reaches an OpenAI Responses client through the Copilot proxy, CCR can leave a `<<ccr:...>>` marker in `input` without registering the retrieval tool, so clients such as GitHub Copilot cannot fetch the original content.

This change adds the flat Responses API tool schema and injects it after compression using the existing session-sticky CCR policy. The tool stays registered on later marker-free turns in the same session.

Closes #3560

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [x] Tests added

## Changes Made

- Added a flat `openai_responses` CCR tool definition (`type` / `name` / `description` / `parameters`) alongside the existing provider formats.
- `handle_openai_responses` now scans `input` for CCR markers and injects the retrieval tool through the session-sticky `apply_session_sticky_ccr_tool` policy when `ccr_inject_tool` is enabled.
- Extended the supported provider literal to `openai_responses` in `headroom/proxy/helpers.py` and `headroom/proxy/ccr_golden_policy.py`.
- Added tests for the flat schema, injection after compression, and replay on a marker-free turn.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ env -u ALL_PROXY -u HTTPS_PROXY -u HTTP_PROXY -u all_proxy -u https_proxy -u http_proxy \
    .venv/bin/python -m pytest tests/test_proxy/test_openai_responses_ccr.py tests/test_ccr_tool_injection.py tests/test_ccr_tool_always_on.py -q
76 passed
```

## Real Behavior Proof

- Environment: Linux, Python 3.14, local proxy test app with a seeded CCR store and a stubbed upstream.
- Exact command / steps: run the targeted pytest command above. The test compresses a Responses payload into a CCR marker, forwards it through `/v1/responses`, and inspects the upstream body; a second request reuses the same session with no fresh marker.
- Observed result: 76 tests passed; both upstream request bodies contain the flat `headroom_retrieve` definition alongside the client tool.
- Not tested: live VS Code or GitHub Copilot traffic, live Jira MCP responses, and upstream CI.

## Runtime Rollout Safety

- Rollout-managed feature(s): None. Responses tool injection rides the existing `ccr_inject_tool` proxy config.
- Minimum rollout channel: existing channels; no new channel gate.
- Stable/default behavior changed: No. A Responses request gains the extra tool only when the turn produced a CCR marker and `ccr_inject_tool` is enabled.
- Kill switch / disable path: set `ccr_inject_tool` to false.
- Unsafe override required: No.
- Qualification impact: None. The Anthropic/OpenAI/Google injection paths are unchanged and the new provider value is additive.
- Rollback path: revert this commit.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

Not applicable — proxy change with no UI surface.

## Additional Notes

None.

