### PR TITLE
feat(litellm): opt-in Bedrock prompt caching on the OpenAI-compatible path

### DIFF
--- a/headroom/backends/litellm.py
+++ b/headroom/backends/litellm.py
@@ -58,6 +58,7 @@ try:
     _env_snapshot = set(_os.environ)
     import litellm
     from litellm import acompletion
+    from litellm.utils import supports_prompt_caching
 
     for _leaked_key in set(_os.environ) - _env_snapshot:
         del _os.environ[_leaked_key]
@@ -68,6 +69,7 @@ except ImportError:
     LITELLM_AVAILABLE = False
     litellm = None  # type: ignore
     acompletion = None  # type: ignore
+    supports_prompt_caching = None  # type: ignore
 
 
 # =============================================================================
@@ -170,6 +172,49 @@ def _build_openai_extra_body(body: dict[str, Any]) -> dict[str, Any]:
         and not key.startswith("x-headroom-")
         and not key.startswith("x_headroom_")
     }
+
+
+def _place_system_cache_control(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return ``messages`` with an ephemeral cache breakpoint on the first system message.
+
+    litellm turns the marker into a Bedrock Converse ``cachePoint``, which caches
+    every tool and system block before it. The first system message is marked
+    (not the last) so a client that appends volatile system messages later does
+    not turn every turn into a cache write. Returned unchanged when the client
+    already placed markers anywhere (it owns breakpoint placement then) or when
+    there is no system message with content to mark. Never mutates the input:
+    the proxy still reads ``body["messages"]`` after the request is built.
+    """
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if "cache_control" in message or (
+            isinstance(content, list)
+            and any(isinstance(block, dict) and "cache_control" in block for block in content)
+        ):
+            return messages
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict) or message.get("role") != "system":
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content:
+            marked = {**message, "cache_control": {"type": "ephemeral"}}
+        elif isinstance(content, list):
+            # litellm only reads block-level markers off list content.
+            blocks = list(content)
+            for block_index in range(len(blocks) - 1, -1, -1):
+                block = blocks[block_index]
+                if isinstance(block, dict) and block.get("type") == "text" and block.get("text"):
+                    blocks[block_index] = {**block, "cache_control": {"type": "ephemeral"}}
+                    break
+            else:
+                continue
+            marked = {**message, "content": blocks}
+        else:
+            continue
+        return [*messages[:index], marked, *messages[index + 1 :]]
+    return messages
 
 
 def _fetch_bedrock_inference_profiles(
@@ -656,6 +701,15 @@ class LiteLLMBackend(Backend):
                 f"Loaded {len(self._model_overrides)} Bedrock model override(s) "
                 f"from HEADROOM_BEDROCK_MODEL_MAP: {sorted(self._model_overrides)}"
             )
+
+        # Opt-in (rollout feature): mark the system prompt for Bedrock prompt
+        # caching on the OpenAI-format path, where clients such as OpenAI-compat
+        # gateways never send `cache_control` themselves.
+        from headroom.rollout import resolve_rollout
+
+        self._openai_prompt_caching = provider == "bedrock" and resolve_rollout().is_enabled(
+            "bedrock_openai_prompt_caching"
+        )
 
         logger.info(f"LiteLLM backend initialized (provider={provider}, region={region})")
 
@@ -1363,6 +1417,9 @@ class LiteLLMBackend(Backend):
             if extra_body:
                 kwargs["extra_body"] = extra_body
 
+            if self._openai_prompt_caching and supports_prompt_caching(model=litellm_model):
+                kwargs["messages"] = _place_system_cache_control(kwargs["messages"])
+
             # Provider-specific region config
             if self.region:
                 if self.provider == "bedrock":
@@ -1547,6 +1604,9 @@ class LiteLLMBackend(Backend):
             extra_body = _build_openai_extra_body(body)
             if extra_body:
                 kwargs["extra_body"] = extra_body
+
+            if self._openai_prompt_caching and supports_prompt_caching(model=litellm_model):
+                kwargs["messages"] = _place_system_cache_control(kwargs["messages"])
 
             # Provider-specific region config
             if self.region:

--- a/headroom/rollout.py
+++ b/headroom/rollout.py
@@ -119,6 +119,17 @@ FEATURES: dict[str, FeatureSpec] = {
         legacy_env=("HEADROOM_READ_MATURATION",),
         description="Hold-back Read maturation before provider cache entry.",
     ),
+    "bedrock_openai_prompt_caching": FeatureSpec(
+        name="bedrock_openai_prompt_caching",
+        available_in=RolloutChannel.STABLE,
+        # Deliberately NOT default-enabled. A cache breakpoint bills the system
+        # prompt at the cache-write rate (1.25x) until it is read back, so a
+        # one-shot caller who did not ask for it would pay more, not less.
+        description=(
+            "Place a system-prompt cache breakpoint on OpenAI-compatible requests "
+            "to Bedrock models that support prompt caching (opt-in)."
+        ),
+    ),
 }
 
 

--- a/tests/test_backends/test_litellm_bedrock_prompt_caching.py
+++ b/tests/test_backends/test_litellm_bedrock_prompt_caching.py
@@ -1,0 +1,310 @@
+"""Opt-in Bedrock prompt caching on `LiteLLMBackend`'s OpenAI-format path (#3554).
+
+The OpenAI-compatible route forwards `messages` verbatim, so a client that never
+sends `cache_control` (OpenAI-compat gateways such as Bifrost) gets no Bedrock
+`cachePoint` and therefore never sees `cache_read_input_tokens`. With the
+`bedrock_openai_prompt_caching` rollout feature enabled, the backend marks the
+first system message when litellm reports the *mapped* model supports prompt
+caching. Default behaviour (feature off) is untouched.
+"""
+
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests._dotenv import importorskip_no_env_leak
+
+importorskip_no_env_leak("litellm")
+
+import litellm  # noqa: E402
+
+from headroom.backends.litellm import (  # noqa: E402  (must follow importorskip)
+    LiteLLMBackend,
+    _place_system_cache_control,
+)
+
+FEATURE = "bedrock_openai_prompt_caching"
+CACHING_MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+EPHEMERAL = {"type": "ephemeral"}
+
+
+class _FakeAsyncStream:
+    def __init__(self, items: list[Any]) -> None:
+        self._items = list(items)
+
+    def __aiter__(self) -> _FakeAsyncStream:
+        self._iter = iter(self._items)
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+def _make_response() -> SimpleNamespace:
+    return SimpleNamespace(
+        id="resp_123",
+        created=123456,
+        choices=[
+            SimpleNamespace(
+                index=0,
+                finish_reason="stop",
+                message=SimpleNamespace(role="assistant", content="ok", tool_calls=None),
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=2, completion_tokens=3, total_tokens=5),
+    )
+
+
+def _make_backend(provider: str = "bedrock") -> LiteLLMBackend:
+    # Patch the inference-profile fetch so `__init__` doesn't try to talk to AWS.
+    with patch("headroom.backends.litellm._fetch_bedrock_inference_profiles", return_value={}):
+        return LiteLLMBackend(provider=provider, region="us-east-1")
+
+
+def _request_body(model: str = CACHING_MODEL) -> dict[str, Any]:
+    return {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": "You are terse."},
+            {"role": "user", "content": "hello"},
+        ],
+        "max_tokens": 32,
+    }
+
+
+async def _send(backend: LiteLLMBackend, body: dict[str, Any]) -> dict[str, Any]:
+    with patch("headroom.backends.litellm.acompletion", new_callable=AsyncMock) as mock_acomp:
+        mock_acomp.return_value = _make_response()
+        await backend.send_openai_message(body, {})
+    return mock_acomp.await_args.kwargs
+
+
+async def _stream(backend: LiteLLMBackend, body: dict[str, Any]) -> dict[str, Any]:
+    stream = _FakeAsyncStream(
+        [SimpleNamespace(model_dump=lambda **kwargs: {"id": "chunk1", "choices": []})]
+    )
+    with patch("headroom.backends.litellm.acompletion", new_callable=AsyncMock) as mock_acomp:
+        mock_acomp.return_value = stream
+        chunks = [chunk async for chunk in backend.stream_openai_message(body, {})]
+    assert chunks[-1] == "data: [DONE]\n\n"
+    return mock_acomp.await_args.kwargs
+
+
+@pytest.fixture
+def feature_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEADROOM_FEATURES", FEATURE)
+    monkeypatch.delenv("HEADROOM_DISABLE_FEATURES", raising=False)
+
+
+@pytest.fixture
+def feature_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HEADROOM_FEATURES", raising=False)
+    monkeypatch.delenv("HEADROOM_DISABLE_FEATURES", raising=False)
+
+
+# =============================================================================
+# _place_system_cache_control (pure)
+# =============================================================================
+
+
+def test_marks_first_system_message_string_content() -> None:
+    messages = [
+        {"role": "system", "content": "a"},
+        {"role": "user", "content": "b"},
+        {"role": "system", "content": "c"},
+    ]
+    before = copy.deepcopy(messages)
+
+    out = _place_system_cache_control(messages)
+
+    assert out[0] == {"role": "system", "content": "a", "cache_control": EPHEMERAL}
+    assert out[1] is messages[1]
+    assert out[2] is messages[2]  # only the first system message is marked
+    assert messages == before  # caller-owned input never mutated
+
+
+def test_marks_last_text_block_of_list_content() -> None:
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "a"},
+                {"type": "text", "text": "b"},
+                {"type": "text", "text": ""},
+            ],
+        },
+        {"role": "user", "content": "hi"},
+    ]
+    before = copy.deepcopy(messages)
+
+    out = _place_system_cache_control(messages)
+
+    blocks = out[0]["content"]
+    assert blocks[0] is messages[0]["content"][0]
+    assert blocks[1] == {"type": "text", "text": "b", "cache_control": EPHEMERAL}
+    assert blocks[2] is messages[0]["content"][2]  # empty text is not a breakpoint
+    assert messages == before
+
+
+def test_system_message_anywhere_in_the_list() -> None:
+    messages = [{"role": "user", "content": "hi"}, {"role": "system", "content": "s"}]
+
+    out = _place_system_cache_control(messages)
+
+    assert out[0] is messages[0]
+    assert out[1]["cache_control"] == EPHEMERAL
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["", [], None, 7, [{"type": "image_url", "image_url": {"url": "x"}}], ["plain string"]],
+)
+def test_unmarkable_system_content_is_skipped(content: Any) -> None:
+    messages = [{"role": "system", "content": content}, {"role": "system", "content": "s"}]
+
+    out = _place_system_cache_control(messages)
+
+    assert out[0] is messages[0]
+    assert out[1]["cache_control"] == EPHEMERAL
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [],
+        [{"role": "user", "content": "hi"}],
+        [{"role": "system", "content": ""}],
+        ["not a dict", {"role": "user", "content": "hi"}],
+        # The client already owns breakpoint placement -- anywhere, any shape.
+        [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "u", "cache_control": EPHEMERAL},
+        ],
+        [
+            {"role": "system", "content": "s"},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "u", "cache_control": EPHEMERAL}],
+            },
+        ],
+        [
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "s", "cache_control": EPHEMERAL}],
+            }
+        ],
+    ],
+)
+def test_returns_input_unchanged_when_nothing_to_do(messages: list[Any]) -> None:
+    before = copy.deepcopy(messages)
+
+    assert _place_system_cache_control(messages) is messages
+    assert messages == before
+
+
+# =============================================================================
+# Backend gate
+# =============================================================================
+
+
+@pytest.mark.usefixtures("feature_default")
+@pytest.mark.parametrize("call", [_send, _stream])
+async def test_feature_off_by_default_forwards_messages_verbatim(call: Any) -> None:
+    body = _request_body()
+
+    kwargs = await call(_make_backend(), body)
+
+    assert kwargs["messages"] is body["messages"]
+    assert "cache_control" not in kwargs["messages"][0]
+
+
+@pytest.mark.usefixtures("feature_enabled")
+@pytest.mark.parametrize("call", [_send, _stream])
+async def test_feature_on_marks_system_prompt_for_caching_model(call: Any) -> None:
+    body = _request_body()
+    client_messages = copy.deepcopy(body["messages"])
+
+    kwargs = await call(_make_backend(), body)
+
+    assert kwargs["messages"][0]["cache_control"] == EPHEMERAL
+    assert kwargs["messages"][1] is body["messages"][1]
+    assert body["messages"] == client_messages  # proxy re-reads body["messages"] after send
+
+
+@pytest.mark.usefixtures("feature_enabled")
+async def test_feature_on_skips_models_without_prompt_caching() -> None:
+    body = _request_body(model="meta.llama3-1-70b-instruct-v1:0")
+
+    with patch("headroom.backends.litellm.supports_prompt_caching", return_value=False):
+        kwargs = await _send(_make_backend(), body)
+
+    assert kwargs["messages"] is body["messages"]
+
+
+@pytest.mark.usefixtures("feature_enabled")
+async def test_gate_checks_the_mapped_litellm_model() -> None:
+    # A bare alias such as `claude-sonnet-4-20250514` is not a Bedrock entry in
+    # litellm's registry; the resolved `bedrock/<region>.anthropic...` id is.
+    body = _request_body(model="claude-sonnet-4-20250514")
+    backend = _make_backend()
+
+    with patch(
+        "headroom.backends.litellm.supports_prompt_caching", return_value=True
+    ) as mock_supports:
+        kwargs = await _send(backend, body)
+
+    mock_supports.assert_called_once_with(model=backend.map_model_id("claude-sonnet-4-20250514"))
+    assert kwargs["messages"][0]["cache_control"] == EPHEMERAL
+
+
+@pytest.mark.usefixtures("feature_enabled")
+async def test_feature_on_is_a_no_op_for_non_bedrock_providers() -> None:
+    body = _request_body(model="anthropic/claude-3-5-sonnet-20241022")
+
+    with patch("headroom.backends.litellm.supports_prompt_caching") as mock_supports:
+        kwargs = await _send(_make_backend(provider="openrouter"), body)
+
+    mock_supports.assert_not_called()
+    assert kwargs["messages"] is body["messages"]
+
+
+@pytest.mark.usefixtures("feature_enabled")
+async def test_feature_on_respects_client_placed_markers() -> None:
+    body = _request_body()
+    body["messages"][1]["cache_control"] = EPHEMERAL
+
+    kwargs = await _send(_make_backend(), body)
+
+    assert kwargs["messages"] is body["messages"]
+
+
+def test_disable_features_is_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEADROOM_FEATURES", FEATURE)
+    monkeypatch.setenv("HEADROOM_DISABLE_FEATURES", FEATURE)
+
+    assert _make_backend()._openai_prompt_caching is False
+
+
+@pytest.mark.usefixtures("feature_enabled")
+async def test_marker_becomes_a_bedrock_converse_cache_point() -> None:
+    """The marker shape must be the one litellm's Converse transform consumes."""
+    body = _request_body()
+
+    kwargs = await _send(_make_backend(), body)
+    request = litellm.AmazonConverseConfig().transform_request(
+        model=CACHING_MODEL,
+        messages=kwargs["messages"],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert request["system"] == [{"text": "You are terse."}, {"cachePoint": {"type": "default"}}]

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -396,7 +396,7 @@ def test_cli_json_status_and_strict_error() -> None:
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert payload["channel"] == "canary"
-    assert payload["features"][2]["name"] == "tool_result_interceptors"
+    assert "tool_result_interceptors" in [feature["name"] for feature in payload["features"]]
     assert invalid.exit_code != 0
     assert "unknown rollout feature" in invalid.output
 


### PR DESCRIPTION
## Description

On `--backend bedrock`, the OpenAI-compatible route (`send_openai_message` / `stream_openai_message`) forwards the client's `messages` verbatim. A client that never sends `cache_control` — OpenAI-compat gateways such as Bifrost strip it — therefore never gets a Bedrock `cachePoint`, and `cache_read_input_tokens` never appears in usage even for models litellm reports as caching-capable.

Note on the issue's stated root cause: there is no `litellm.get_supported_openai_params` gate anywhere in headroom (checked `main` and the v0.37.0 commit the reporter pinned), and litellm's Converse transform honours `cache_control` unconditionally. The caching half of #3554 is a missing behaviour, not a wrong API call, so this PR adds it **opt-in** rather than changing the default. The `max_completion_tokens` half is #3558.

Design:
- New rollout feature `bedrock_openai_prompt_caching` (stable channel, **not** default-enabled): a breakpoint bills the system prompt at the cache-write rate until it is read back, so a one-shot caller who did not ask for it would pay more. `HEADROOM_FEATURES=bedrock_openai_prompt_caching` turns it on; flipping the default later is a one-line `default_enabled_in` change if you want it.
- When enabled and `litellm.utils.supports_prompt_caching()` is true for the **mapped** litellm model (`bedrock/us.anthropic.claude-sonnet-5-v1:0`, not the client alias — `claude-sonnet-5` alone is answered from litellm's Anthropic-direct registry entry, not the Bedrock one), the first system message gets `cache_control: {"type": "ephemeral"}`; litellm turns it into a Converse `cachePoint` covering tools + system prefix. First (not last) so volatile trailing system messages cannot turn every turn into a cache write.
- Untouched: requests that already carry client-placed markers anywhere (the client owns placement, as on the Anthropic route), models without prompt caching (incl. ARN-mapped inference profiles, which litellm cannot look up), non-Bedrock providers. The caller's `body["messages"]` is never mutated (the proxy re-reads it for `POST_SEND`).

Refs #3554 (the `max_completion_tokens` half is #3558)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- `headroom/rollout.py`: register `bedrock_openai_prompt_caching` (available in `stable`, opt-in, no legacy env alias).
- `headroom/backends/litellm.py`: import `litellm.utils.supports_prompt_caching` alongside `acompletion`; add pure helper `_place_system_cache_control()`; resolve the rollout decision once in `LiteLLMBackend.__init__` (Bedrock only); gate both OpenAI call sites on the decision + capability lookup (~20 µs/call, no memoisation needed).
- `tests/test_backends/test_litellm_bedrock_prompt_caching.py`: 26 tests — helper edge cases (empty/none/wrong-type content, list vs string content, non-dict entries, first-of-several, client-placed markers anywhere, input never mutated), gate off by default (identity), on for buffered + streaming, skips non-caching models, non-Bedrock no-op (lookup not even called), uses the mapped id, kill switch, and litellm's real Converse transform emitting `cachePoint` from the produced messages.
- `tests/test_rollout.py`: one assertion pinned a positional index into the alphabetically sorted feature list; made it name-based so adding a feature does not shift it.

## Testing

- [x] Unit tests pass (`pytest`)
- [x] Linting passes (`ruff check .`)
- [x] Type checking passes (`mypy headroom`)
- [x] New tests added for new functionality
- [x] Manual testing performed

### Test Output

```text
$ python -m pytest tests/test_backends/test_litellm_bedrock_prompt_caching.py -q
26 passed in 4.11s

# same file on unpatched main (helper does not exist):
E   ImportError: cannot import name '_place_system_cache_control' from 'headroom.backends.litellm'

$ python -m pytest tests/test_backends tests/test_litellm_openai_passthrough.py tests/test_litellm_caller_key.py \
    tests/test_litellm_nonstream_cache_usage.py tests/test_litellm_optional.py tests/test_litellm_upstream_timeout.py \
    tests/test_rollout.py tests/test_bedrock_region.py tests/test_bedrock_streaming_input_tokens.py \
    tests/test_bedrock_tool_result_cache_and_streaming_stats.py tests/test_bedrock_prefix_tracker_wiring.py \
    tests/test_proxy/test_openai_backend_path.py tests/test_proxy/test_bedrock_passthrough.py -q
189 passed  (after the test_rollout.py assertion fix; 188 passed, 1 failed before it)

$ ruff check headroom/backends/litellm.py headroom/rollout.py tests/test_backends/test_litellm_bedrock_prompt_caching.py tests/test_rollout.py
All checks passed!
$ ruff format --check headroom/backends/litellm.py headroom/rollout.py tests/test_backends/test_litellm_bedrock_prompt_caching.py tests/test_rollout.py
4 files already formatted
$ mypy headroom/backends/litellm.py headroom/rollout.py
Success: no issues found in 2 source files

# Full local suite (12,650 collected; Windows, borrowed 0.35.0 headroom._core, known Windows-only
# CLI tests deselected) was still running when this PR was opened; result will be added below.
```

## Real Behavior Proof

- Environment: Windows 11, Python 3.11.9, litellm 1.97.0 (issue reports 1.96.2; same `supports_prompt_caching` / Converse behaviour), boto3 1.43.93, headroom source checkout at this branch, `LiteLLMBackend(provider="bedrock", region="us-east-1")`, model `global.anthropic.claude-sonnet-5`. No live AWS account available to me, so the request was driven through litellm's real pipeline (message validation, Converse transformation, SigV4 signing) and the outgoing `AsyncHTTPHandler.post` was intercepted to capture the exact wire body and return a canned Bedrock response.
- Exact command / steps: `HEADROOM_FEATURES=bedrock_openai_prompt_caching python wire_proof.py` (script in the PR discussion) calling `backend.send_openai_message({"model": "global.anthropic.claude-sonnet-5", "max_tokens": 64, "messages": [{"role": "system", "content": <~1800 tokens>}, {"role": "user", "content": "hi"}]}, {})`; then the same command without the env var.
- Observed result: with the feature on, the captured POST to `https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-sonnet-5/converse` carries `"system": [{"text": ...}, {"cachePoint": {"type": "default"}}]`, SigV4 `Authorization` header present, and the client's `body["messages"]` still contains no `cache_control`. Without the env var (default) the same request carries `"system": [{"text": ...}]` only — byte-identical to today's behaviour. `headroom rollout status` lists `bedrock_openai_prompt_caching: enabled=false decision=not_requested` by default.
- Not tested: a live Bedrock round trip (no AWS credentials here), so the returned `cache_creation_input_tokens` / `cache_read_input_tokens` were not observed from Bedrock itself; Bifrost/Cline in front of the proxy; Nova models (litellm reports `supports_prompt_caching=True` for them, so they would be marked too); the Anthropic-format route is untouched by this change.

## Runtime Rollout Safety

- Rollout-managed feature(s): `bedrock_openai_prompt_caching` (new entry in `headroom/rollout.py` FEATURES).
- Minimum rollout channel: stable (explicit request required in every channel; no `default_enabled_in`).
- Stable/default behavior changed: no. Without `HEADROOM_FEATURES=bedrock_openai_prompt_caching` the backend forwards the client's `messages` object untouched (pinned by an identity assertion for buffered and streaming). Only `--backend bedrock` can ever be affected.
- Kill switch / disable path: unset `HEADROOM_FEATURES`, or `HEADROOM_DISABLE_FEATURES=bedrock_openai_prompt_caching` (explicit disable wins over an explicit request; tested).
- Unsafe override required: no.
- Qualification impact: none; the feature is `not_requested` in the default snapshot, so the snapshot digest of an unconfigured deployment only changes by the registry digest (as for any new feature).
- Rollback path: revert the commit; no persisted state, schema, or config format involved.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I did **not** edit `CHANGELOG.md` — it is generated by release-please from my Conventional Commit PR title (a CI guard enforces this)

## Screenshots (if applicable)

N/A

## Additional Notes

- Documentation: not changed on purpose — there is no catalogue of rollout features in `docs/`; the `FeatureSpec.description` is what `headroom rollout status` prints. Happy to add a line to `docs/content/docs/runtime-rollouts.mdx` if you want one.
- Open questions for the maintainer: (1) default-on for Bedrock instead of opt-in? One-line change (`default_enabled_in=RolloutChannel.STABLE`), but it changes billing for one-shot callers. (2) Prefer the *last* system message (max cache coverage) over the first (robust to volatile trailing system messages)? (3) ARN-mapped application inference profiles (`HEADROOM_BEDROCK_MODEL_MAP`) get nothing because litellm cannot look them up — acceptable, or gate on the underlying model family instead?
- Alternatives considered: default-on with no flag (rejected: silent cost change, no kill switch); reusing `AnthropicCacheOptimizer._insert_breakpoints` (Anthropic-format only, mutates in place); doing it in the OpenAI handler (provider-agnostic, lacks the mapped model id).
- Verification for someone with Bedrock access: run the proxy with `--backend bedrock` and `HEADROOM_FEATURES=bedrock_openai_prompt_caching`, send two identical OpenAI chat completions with a >1024-token system prompt within 5 minutes; the second response's `usage` should carry non-zero `cache_read_input_tokens` / `prompt_tokens_details.cached_tokens`.

